### PR TITLE
Improve scrolling performance in travel history

### DIFF
--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -405,7 +405,14 @@ namespace EDDiscovery
             //    RefreshHistory();
             comboBoxHistoryWindow.SelectedIndex = 4;
 
-
+            // this improves dataGridView's scrolling performance
+            typeof(DataGridView).InvokeMember(
+                "DoubleBuffered",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.SetProperty,
+                null,
+                dataGridView1,
+                new object[] { true }
+            );
         }
 
         private void comboBoxHistoryWindow_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
Based on [SO answer](http://stackoverflow.com/a/1506066).
Improves scrolling performance once the grid is loaded.