### PR TITLE
Allow devs to optionally skip over slow EDSM updates when in Develop build

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -11,8 +11,9 @@ namespace EDDiscovery2
         private bool _useDistances;
         private bool _EDSMLog;
         readonly public string LogIndex;
+        private bool _canSkipSlowUpdates = false;
 
-        SQLiteDBClass db = new SQLiteDBClass();
+        SQLiteDBClass _db = new SQLiteDBClass();
 
         public EDDConfig()
         {
@@ -29,8 +30,7 @@ namespace EDDiscovery2
             set
             {
                 _useDistances = value;
-                db.PutSettingBool("EDSMDistances", value);
-
+                _db.PutSettingBool("EDSMDistances", value);
             }
         }
 
@@ -44,16 +44,28 @@ namespace EDDiscovery2
             set
             {
                 _EDSMLog = value;
-                db.PutSettingBool("EDSMLog", value);
+                _db.PutSettingBool("EDSMLog", value);
+            }
+        }
+
+        public bool CanSkipSlowUpdates
+        {
+            get
+            {
+                return _canSkipSlowUpdates;
+            }
+            set
+            {
+                _canSkipSlowUpdates = value;
+                _db.PutSettingBool("CanSkipSlowUpdates", value);
             }
         }
 
         public void Update()
         {
-            _useDistances = db.GetSettingBool("EDSMDistances", false);
-            _EDSMLog = db.GetSettingBool("EDSMLog", false);
+            _useDistances = _db.GetSettingBool("EDSMDistances", false);
+            _EDSMLog = _db.GetSettingBool("EDSMLog", false);
+            _canSkipSlowUpdates = _db.GetSettingBool("CanSkipSlowUpdates", false);
         }
-
-        
     }
 }

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -51,6 +51,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup>
     <ManifestCertificateThumbprint>6586052CF2C6A2D8348CC25AA17842FA028AED2F</ManifestCertificateThumbprint>
@@ -66,6 +67,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>fge-logo-001-dark.ico</ApplicationIcon>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -40,6 +40,7 @@
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.routeControl1 = new EDDiscovery.RouteControl();
             this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.checkboxSkipSlowUpdates = new System.Windows.Forms.CheckBox();
             this.checkBoxEDSMLog = new System.Windows.Forms.CheckBox();
             this.checkBox_Distances = new System.Windows.Forms.CheckBox();
             this.label2 = new System.Windows.Forms.Label();
@@ -60,13 +61,13 @@
             this.show2DMapsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statisticsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setDefaultMapColourToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.adminToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.forceEDDBUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.eDDiscoveryHomepageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.frontierForumThreadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.panelInfo = new System.Windows.Forms.Panel();
             this.labelPanelText = new System.Windows.Forms.Label();
-            this.adminToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.forceEDDBUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabControl1.SuspendLayout();
             this.tabPageTravelHistory.SuspendLayout();
             this.tabPageTriletaration.SuspendLayout();
@@ -173,6 +174,7 @@
             // 
             // tabPage3
             // 
+            this.tabPage3.Controls.Add(this.checkboxSkipSlowUpdates);
             this.tabPage3.Controls.Add(this.checkBoxEDSMLog);
             this.tabPage3.Controls.Add(this.checkBox_Distances);
             this.tabPage3.Controls.Add(this.label2);
@@ -187,6 +189,18 @@
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Settings";
             this.tabPage3.UseVisualStyleBackColor = true;
+            // 
+            // checkboxSkipSlowUpdates
+            // 
+            this.checkboxSkipSlowUpdates.AutoSize = true;
+            this.checkboxSkipSlowUpdates.BackColor = System.Drawing.Color.Gold;
+            this.checkboxSkipSlowUpdates.Location = new System.Drawing.Point(653, 96);
+            this.checkboxSkipSlowUpdates.Name = "checkboxSkipSlowUpdates";
+            this.checkboxSkipSlowUpdates.Size = new System.Drawing.Size(238, 17);
+            this.checkboxSkipSlowUpdates.TabIndex = 11;
+            this.checkboxSkipSlowUpdates.Text = "DEBUG ONLY: Skip slow updates on startup";
+            this.checkboxSkipSlowUpdates.UseVisualStyleBackColor = false;
+            this.checkboxSkipSlowUpdates.Visible = false;
             // 
             // checkBoxEDSMLog
             // 
@@ -335,7 +349,7 @@
             this.statisticsToolStripMenuItem,
             this.setDefaultMapColourToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
             this.toolsToolStripMenuItem.Text = "Tools";
             // 
             // addNewStarToolStripMenuItem
@@ -379,6 +393,21 @@
             this.setDefaultMapColourToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
             this.setDefaultMapColourToolStripMenuItem.Text = "Set Default Map Colour";
             this.setDefaultMapColourToolStripMenuItem.Click += new System.EventHandler(this.setDefaultMapColourToolStripMenuItem_Click);
+            // 
+            // adminToolStripMenuItem
+            // 
+            this.adminToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.forceEDDBUpdateToolStripMenuItem});
+            this.adminToolStripMenuItem.Name = "adminToolStripMenuItem";
+            this.adminToolStripMenuItem.Size = new System.Drawing.Size(55, 20);
+            this.adminToolStripMenuItem.Text = "Admin";
+            // 
+            // forceEDDBUpdateToolStripMenuItem
+            // 
+            this.forceEDDBUpdateToolStripMenuItem.Name = "forceEDDBUpdateToolStripMenuItem";
+            this.forceEDDBUpdateToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+            this.forceEDDBUpdateToolStripMenuItem.Text = "Force EDDB update";
+            this.forceEDDBUpdateToolStripMenuItem.Click += new System.EventHandler(this.forceEDDBUpdateToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -424,21 +453,6 @@
             this.labelPanelText.Text = "Loading. Please wait!";
             this.labelPanelText.Click += new System.EventHandler(this.label1_Click);
             // 
-            // adminToolStripMenuItem
-            // 
-            this.adminToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.forceEDDBUpdateToolStripMenuItem});
-            this.adminToolStripMenuItem.Name = "adminToolStripMenuItem";
-            this.adminToolStripMenuItem.Size = new System.Drawing.Size(55, 20);
-            this.adminToolStripMenuItem.Text = "Admin";
-            // 
-            // forceEDDBUpdateToolStripMenuItem
-            // 
-            this.forceEDDBUpdateToolStripMenuItem.Name = "forceEDDBUpdateToolStripMenuItem";
-            this.forceEDDBUpdateToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
-            this.forceEDDBUpdateToolStripMenuItem.Text = "Force EDDB update";
-            this.forceEDDBUpdateToolStripMenuItem.Click += new System.EventHandler(this.forceEDDBUpdateToolStripMenuItem_Click);
-            // 
             // EDDiscoveryForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -451,9 +465,9 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "EDDiscoveryForm";
-            this.Text = "Form1";
+            this.Text = "EDDiscovery";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.EDDiscoveryForm_FormClosing);
-            this.Load += new System.EventHandler(this.Form1_Load);
+            this.Load += new System.EventHandler(this.EDDiscoveryForm_Load);
             this.Shown += new System.EventHandler(this.EDDiscoveryForm_Shown);
             this.tabControl1.ResumeLayout(false);
             this.tabPageTravelHistory.ResumeLayout(false);
@@ -513,6 +527,7 @@
         private System.Windows.Forms.CheckBox checkBoxEDSMLog;
         private System.Windows.Forms.ToolStripMenuItem adminToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem forceEDDBUpdateToolStripMenuItem;
+        private System.Windows.Forms.CheckBox checkboxSkipSlowUpdates;
     }
 }
 


### PR DESCRIPTION
So, I was about to start hacking when I realized waiting on the full EDD Load process takes rather a long time. So... I've put together a proposed where in Debug build only a developer can flip a setting which allows them to skip over those pesky slow EDSM updates.

In my hubris I also made a number of minor tweaks while I was in the codes. I can go back and remove any you don't like:
* Fixed a bug with "Log EDSM requests" checkbox not getting populated correctly on startup
* Renamed `Form1_Load` event to `EDDiscoveryForm_Load`. I tweaked the setting to load through program.cs to enable this to work.
* Renamed EDDConfig's `db` instance variable to `_db` to be match the code style of other instance variables.
* Added a `LogLine` delegatation variant in EDD for when theres a single argument.