### PR TITLE
Implement full camera transformations

### DIFF
--- a/EDDiscovery/2DMap/FormSagCarinaMission.cs
+++ b/EDDiscovery/2DMap/FormSagCarinaMission.cs
@@ -1,6 +1,6 @@
 ﻿using EDDiscovery;
 using EDDiscovery.DB;
-using EDDiscovery2.DB.Offline;
+using EDDiscovery2.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -17,7 +17,7 @@ namespace EDDiscovery2._3DMap
     {
         private List<IData3DSet> _datasets;
 
-        public ISystem Origin { get; set; } = new SystemClass();
+        public ISystem CenterSystem { get; set; } = new SystemClass();
         public List<ISystem> StarList { get; set; } = new List<ISystem>();
         public List<ISystem> ReferenceSystems { get; set; } = new List<ISystem>();
         public List<SystemPosition> VisitedSystems { get; set; }
@@ -58,21 +58,11 @@ namespace EDDiscovery2._3DMap
 
                 for (float x = MinGridPos.X; x <= MaxGridPos.X; x += unitSize)
                 {
-                    datasetGrid.Add(new LineData(x - Origin.x,
-                        0 - Origin.y,
-                        Origin.x - MinGridPos.Y,
-                        x - Origin.x,
-                        0 - Origin.y,
-                        Origin.z - MaxGridPos.Y));
+                    datasetGrid.Add(new LineData(x, 0, -MinGridPos.Y, x,0,-MaxGridPos.Y));
                 }
                 for (float z = MinGridPos.Y; z <= MaxGridPos.Y; z += unitSize)
                 {
-                    datasetGrid.Add(new LineData(MinGridPos.X - Origin.x,
-                        0 - Origin.y,
-                        Origin.z - z,
-                        MaxGridPos.Y - Origin.x,
-                        0 - Origin.y,
-                        Origin.z - z));
+                    datasetGrid.Add(new LineData(MinGridPos.X, 0, z, MaxGridPos.Y, 0, z));
                 }
 
                 _datasets.Add(datasetGrid);
@@ -132,8 +122,8 @@ namespace EDDiscovery2._3DMap
                         {
                             if (sp.curSystem != null && sp.curSystem.HasCoordinate && sp.lastKnownSystem != null && sp.lastKnownSystem.HasCoordinate)
                             {
-                                datasetl.Add(new LineData(sp.curSystem.x - Origin.x, sp.curSystem.y - Origin.y, Origin.z - sp.curSystem.z,
-                                    sp.lastKnownSystem.x - Origin.x, sp.lastKnownSystem.y - Origin.y, Origin.z - sp.lastKnownSystem.z));
+                                datasetl.Add(new LineData(sp.curSystem.x, sp.curSystem.y, sp.curSystem.z,
+                                    sp.lastKnownSystem.x , sp.lastKnownSystem.y, sp.lastKnownSystem.z));
 
                             }
                         }
@@ -165,7 +155,7 @@ namespace EDDiscovery2._3DMap
             var dataset = new Data3DSetClass<PointData>("Center", Color.Yellow, 5.0f);
 
             //GL.Enable(EnableCap.ProgramPointSize);
-            dataset.Add(new PointData(0, 0, 0));
+            dataset.Add(new PointData(CenterSystem.x, CenterSystem.y, CenterSystem.z));
             _datasets.Add(dataset);
         }
 
@@ -185,7 +175,7 @@ namespace EDDiscovery2._3DMap
                 var referenceLines = new Data3DSetClass<LineData>("CurrentReference", Color.Green, 5.0f);
                 foreach (var refSystem in ReferenceSystems)
                 {
-                    referenceLines.Add(new LineData(0, 0, 0, refSystem.x - Origin.x, refSystem.y - Origin.y, Origin.z - refSystem.z));
+                    referenceLines.Add(new LineData(0, 0, 0, refSystem.x, refSystem.y, refSystem.z));
                 }
 
                 _datasets.Add(referenceLines);
@@ -195,7 +185,7 @@ namespace EDDiscovery2._3DMap
 
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
-                SuggestedReferences references = new SuggestedReferences(Origin.x, Origin.y, Origin.z);
+                SuggestedReferences references = new SuggestedReferences(0.0, 0.0, 0.0);
 
                 for (int ii = 0; ii < 16; ii++)
                 {
@@ -205,7 +195,7 @@ namespace EDDiscovery2._3DMap
                     references.AddReferenceStar(system);
                     if (ReferenceSystems != null && ReferenceSystems.Any(s => s.name == system.name)) continue;
                     System.Diagnostics.Trace.WriteLine(string.Format("{0} Dist: {1} x:{2} y:{3} z:{4}", system.name, rsys.Distance.ToString("0.00"), system.x, system.y, system.z));
-                    lineSet.Add(new LineData(0, 0, 0, system.x - Origin.x, system.y - Origin.y, Origin.z - system.z));
+                    lineSet.Add(new LineData(0, 0, 0, system.x, system.y, system.z));
                 }
                 sw.Stop();
                 System.Diagnostics.Trace.WriteLine("Reference stars time " + sw.Elapsed.TotalSeconds.ToString("0.000s"));
@@ -222,7 +212,7 @@ namespace EDDiscovery2._3DMap
         {
             if (system != null && system.HasCoordinate)
             {
-                dataset.Add(new PointData(system.x - Origin.x, system.y - Origin.y, Origin.z - system.z));
+                dataset.Add(new PointData(system.x, system.y, system.z));
             }
         }
 

--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using EDDiscovery;
 using EDDiscovery.DB;
-using EDDiscovery2.DB.Offline;
+using EDDiscovery2.DB;
 
 using System;
 using System.Collections.Generic;
@@ -158,6 +158,8 @@ namespace EDDiscovery2._3DMap
             }
         }
 
+        // Planned change: Centered system will be marked but won't be "center" of the galaxy
+        // dataset anymore. The origin will stay at Sol.
         public void AddCenterPointToDataset()
         {
             var dataset = new Data3DSetClass<PointData>("Center", Color.Yellow, 5.0f);

--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -28,7 +28,7 @@ namespace EDDiscovery2._3DMap
         public bool Stations { get; set; } = false;
 
         public Vector2 MinGridPos { get; set; } = new Vector2(-50000.0f, -20000.0f);
-        public Vector2 MaxGridPos { get; set; } = new Vector2(50000.0f, 70000.0f);
+        public Vector2 MaxGridPos { get; set; } = new Vector2(50000.0f, 80000.0f);
 
         public DatasetBuilder()
         {            
@@ -58,11 +58,11 @@ namespace EDDiscovery2._3DMap
 
                 for (float x = MinGridPos.X; x <= MaxGridPos.X; x += unitSize)
                 {
-                    datasetGrid.Add(new LineData(x, 0, -MinGridPos.Y, x,0,-MaxGridPos.Y));
+                    datasetGrid.Add(new LineData(x, 0, MinGridPos.Y, x,0,MaxGridPos.Y));
                 }
                 for (float z = MinGridPos.Y; z <= MaxGridPos.Y; z += unitSize)
                 {
-                    datasetGrid.Add(new LineData(MinGridPos.X, 0, z, MaxGridPos.Y, 0, z));
+                    datasetGrid.Add(new LineData(MinGridPos.X, 0, z, MaxGridPos.X, 0, z));
                 }
 
                 _datasets.Add(datasetGrid);
@@ -175,7 +175,7 @@ namespace EDDiscovery2._3DMap
                 var referenceLines = new Data3DSetClass<LineData>("CurrentReference", Color.Green, 5.0f);
                 foreach (var refSystem in ReferenceSystems)
                 {
-                    referenceLines.Add(new LineData(0, 0, 0, refSystem.x, refSystem.y, refSystem.z));
+                    referenceLines.Add(new LineData(CenterSystem.x, CenterSystem.y, CenterSystem.z, refSystem.x, refSystem.y, refSystem.z));
                 }
 
                 _datasets.Add(referenceLines);
@@ -185,7 +185,7 @@ namespace EDDiscovery2._3DMap
 
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
-                SuggestedReferences references = new SuggestedReferences(0.0, 0.0, 0.0);
+                SuggestedReferences references = new SuggestedReferences(CenterSystem.x, CenterSystem.y, CenterSystem.z);
 
                 for (int ii = 0; ii < 16; ii++)
                 {
@@ -195,7 +195,7 @@ namespace EDDiscovery2._3DMap
                     references.AddReferenceStar(system);
                     if (ReferenceSystems != null && ReferenceSystems.Any(s => s.name == system.name)) continue;
                     System.Diagnostics.Trace.WriteLine(string.Format("{0} Dist: {1} x:{2} y:{3} z:{4}", system.name, rsys.Distance.ToString("0.00"), system.x, system.y, system.z));
-                    lineSet.Add(new LineData(0, 0, 0, system.x, system.y, system.z));
+                    lineSet.Add(new LineData(CenterSystem.x, CenterSystem.y, CenterSystem.z, system.x, system.y, system.z));
                 }
                 sw.Stop();
                 System.Diagnostics.Trace.WriteLine("Reference stars time " + sw.Elapsed.TotalSeconds.ToString("0.000s"));

--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -36,7 +36,7 @@ namespace EDDiscovery2
             private void InitializeComponent()
             {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormMap));
-            this.glControl1 = new OpenTK.GLControl();
+            this.glControl = new OpenTK.GLControl();
             this.textboxFrom = new System.Windows.Forms.TextBox();
             this.buttonCenter = new System.Windows.Forms.Button();
             this.labelSystemCoords = new System.Windows.Forms.Label();
@@ -53,24 +53,23 @@ namespace EDDiscovery2
             this.statusStrip.SuspendLayout();
             this.SuspendLayout();
             // 
-            // glControl1
+            // glControl
             // 
-            this.glControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.glControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.glControl1.BackColor = System.Drawing.Color.Black;
-            this.glControl1.Location = new System.Drawing.Point(0, 33);
-            this.glControl1.Name = "glControl1";
-            this.glControl1.Size = new System.Drawing.Size(918, 521);
-            this.glControl1.TabIndex = 0;
-            this.glControl1.VSync = false;
-            this.glControl1.Load += new System.EventHandler(this.glControl1_Load);
-            this.glControl1.Paint += new System.Windows.Forms.PaintEventHandler(this.glControl1_Paint);
-            this.glControl1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.glControl1_KeyPress);
-            this.glControl1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.glControl1_MouseDown);
-            this.glControl1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.glControl1_MouseMove);
-            this.glControl1.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.glControl1_OnMouseWheel);
-            this.glControl1.Resize += new System.EventHandler(this.glControl1_Resize);
+            this.glControl.BackColor = System.Drawing.Color.Black;
+            this.glControl.Location = new System.Drawing.Point(0, 44);
+            this.glControl.Name = "glControl";
+            this.glControl.Size = new System.Drawing.Size(918, 485);
+            this.glControl.TabIndex = 0;
+            this.glControl.VSync = false;
+            this.glControl.Load += new System.EventHandler(this.glControl_Load);
+            this.glControl.Paint += new System.Windows.Forms.PaintEventHandler(this.glControl_Paint);
+            this.glControl.MouseDown += new System.Windows.Forms.MouseEventHandler(this.glControl_MouseDown);
+            this.glControl.MouseMove += new System.Windows.Forms.MouseEventHandler(this.glControl_MouseMove);
+            this.glControl.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.glControl_OnMouseWheel);
+            this.glControl.Resize += new System.EventHandler(this.glControl_Resize);
             // 
             // textboxFrom
             // 
@@ -200,7 +199,6 @@ namespace EDDiscovery2
             this.statusStrip.Size = new System.Drawing.Size(918, 22);
             this.statusStrip.TabIndex = 21;
             this.statusStrip.Text = "statusStrip1";
-            this.statusStrip.Visible = false;
             // 
             // statusLabel
             // 
@@ -218,7 +216,7 @@ namespace EDDiscovery2
             this.Controls.Add(this.labelSystemCoords);
             this.Controls.Add(this.buttonCenter);
             this.Controls.Add(this.textboxFrom);
-            this.Controls.Add(this.glControl1);
+            this.Controls.Add(this.glControl);
             this.Controls.Add(this.toolStripShowAllStars);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "FormMap";
@@ -237,7 +235,7 @@ namespace EDDiscovery2
 
             #endregion
 
-            private OpenTK.GLControl glControl1;
+            private OpenTK.GLControl glControl;
             internal TextBox textboxFrom;
             private Button buttonCenter;
             private Label labelSystemCoords;

--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -221,6 +221,7 @@ namespace EDDiscovery2
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "FormMap";
             this.Text = "3D Star Map";
+            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMap_FormClosing);
             this.Load += new System.EventHandler(this.FormMap_Load);
             this.toolStripShowAllStars.ResumeLayout(false);

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using OpenTK.Input;
 
 namespace EDDiscovery2
 {
@@ -43,13 +44,19 @@ namespace EDDiscovery2
         private ISystem _centerSystem;
         private bool _loaded = false;
 
-        private float _systemOffsetX = 0.0f;
-        private float _systemOffsetY = 0.0f;
         private float _zoom = 1.0f;
         private float _xAng = 0.0f;
         private float _yAng = 0.0f;
 
-        private Vector3 _cursorPosition;
+        private Vector3 _cameraPos = Vector3.Zero;
+        private Vector3 _cameraDir = Vector3.Zero;
+
+        private Vector3 _cameraActionMovement = Vector3.Zero;
+        private Vector3 _cameraActionRotation = Vector3.Zero;
+
+        private KeyboardActions _kbdActions = new KeyboardActions();
+        private int _oldTickCount = Environment.TickCount;
+        private int _ticks = 0;
 
         private Point _mouseStartRotate;
         private Point _mouseStartTranslate;
@@ -136,11 +143,11 @@ namespace EDDiscovery2
 
         private void ResetCamera()
         {
-            _systemOffsetX = 0.0f;
-            _systemOffsetY = 0.0f;
+            _cameraPos = Vector3.Zero;
+            _cameraDir = Vector3.Zero;
 
             _xAng = 0.0f;
-            _yAng = -90.0f;
+            _yAng = 0.0f;
 
             _zoom = 1.0f;
         }
@@ -153,8 +160,8 @@ namespace EDDiscovery2
             GL.MatrixMode(MatrixMode.Projection);
             GL.LoadIdentity();
 
-            int w = glControl1.Width;
-            int h = glControl1.Height;
+            int w = glControl.Width;
+            int h = glControl.Height;
 
             if (w == 0 || h == 0) return;
 
@@ -164,6 +171,7 @@ namespace EDDiscovery2
             float orthoheight = 1000.0f * h / w;
 
             GL.Ortho(-1000.0f, 1000.0f, -orthoheight, orthoheight, -5000.0f, 5000.0f);
+            //GL.Ortho(-100000.0, 100000.0, -100000.0, 100000.0, -100000.0, 100000.0); // Bottom-left corner pixel has coordinate (0, 0)
             //GL.Ortho(0, orthoW, 0, orthoH, -1, 1); // Bottom-left corner pixel has coordinate (0, 0)
             GL.Viewport(0, 0, w, h); // Use all of the glControl painting area
         }
@@ -183,7 +191,7 @@ namespace EDDiscovery2
                         _visitedStars[star.SearchName] = star;
                     }
                 }
-            }        
+            }
         }
 
 
@@ -323,7 +331,7 @@ namespace EDDiscovery2
         public void Reset()
         {
             CenterSystem = null;
-            ReferenceSystems = null;        
+            ReferenceSystems = null;
         }
 
         /*
@@ -387,8 +395,8 @@ namespace EDDiscovery2
         /// </summary>
         private void SetupCursorXYZ()
         {
-            //                x =   (PointToClient(Cursor.Position).X - glControl1.Width/2 ) * (zoom + 1);
-            //                y = (-PointToClient(Cursor.Position).Y + glControl1.Height/2) * (zoom + 1);
+            //                x =   (PointToClient(Cursor.Position).X - glControl.Width/2 ) * (zoom + 1);
+            //                y = (-PointToClient(Cursor.Position).Y + glControl.Height/2) * (zoom + 1);
 
             //                System.Diagnostics.Trace.WriteLine("X:" + x + " Y:" + y + " Z:" + zoom);
         }
@@ -401,7 +409,7 @@ namespace EDDiscovery2
             ShowCenterSystem();
 
             GenerateDataSets();
-            glControl1.Invalidate();
+            glControl.Invalidate();
         }
 
         private void ShowCenterSystem()
@@ -415,9 +423,12 @@ namespace EDDiscovery2
 
         private void UpdateStatus()
         {
-            statusLabel.Text = $"Coordinates: x={_cursorPosition.X} y={_cursorPosition.Y} z={_cursorPosition.Z}";
-        }    
-        
+            statusLabel.Text = $"Coordinates: x={_cameraPos.X} y={_cameraPos.Y} z={_cameraPos.Z}";
+#if DEBUG
+            statusLabel.Text += $", Direction: x={_cameraDir.X} y={_cameraDir.Y} z={_cameraDir.Z}";
+#endif        
+        }
+
         private void OrientateMapAroundSystem(String systemName)
         {
             if (!String.IsNullOrWhiteSpace(systemName))
@@ -433,12 +444,171 @@ namespace EDDiscovery2
             textboxFrom.Text = system.name;
             SetCenterSystem(system);
         }
+        private void CalculateTimeDelta()
+        {
+            var tickCount = Environment.TickCount;
+            _ticks = tickCount - _oldTickCount;
+            _oldTickCount = tickCount;
+        }
+
+        private void HandleInputs()
+        {
+            ReceiveKeybaordActions();
+            HandleTurningAdjustments();
+            HandleMovementAdjustments();
+        }
+
+        private void ReceiveKeybaordActions()
+        {
+            _kbdActions.Reset();
+
+            var state = OpenTK.Input.Keyboard.GetState();
+
+            _kbdActions.Left = (state[Key.Left] || state[Key.A]);
+            _kbdActions.Right = (state[Key.Right] || state[Key.D]);
+            _kbdActions.Up = (state[Key.Up] || state[Key.W]);
+            _kbdActions.Down = (state[Key.Down] || state[Key.S]);
+
+            _kbdActions.ZoomIn = state[Key.Minus];
+            _kbdActions.ZoomOut = state[Key.Plus];
+
+            // Yes, much of this is overkill. but useful while development is happening
+            // I'll probably hide away the less useful options later from the Release build
+            _kbdActions.Forwards = state[Key.R];
+            _kbdActions.Backwards = state[Key.F];
+ 
+            _kbdActions.Pitch = state[Key.Keypad8];
+            _kbdActions.Dive = state[Key.Keypad5];
+            _kbdActions.RollLeft = state[Key.Keypad4];
+            _kbdActions.RollRight = state[Key.Keypad6];
+            _kbdActions.YawLeft = state[Key.Keypad7];
+            _kbdActions.YawRight = state[Key.Keypad9];
+        }
+
+        private void HandleTurningAdjustments()
+        {
+            _cameraActionRotation = Vector3.Zero;
+
+            var angle = (float)  _ticks * 0.1f;
+            if (_kbdActions.Dive)
+            {
+                _cameraActionRotation.X = -angle;
+            }
+            if (_kbdActions.Pitch)
+            {
+                _cameraActionRotation.X = angle;
+            }
+            if (_kbdActions.RollLeft)
+            {
+                _cameraActionRotation.Y = -angle;
+            }
+            if (_kbdActions.RollRight)
+            {
+                _cameraActionRotation.Y = angle;
+            }
+            if (_kbdActions.YawLeft)
+            {
+                _cameraActionRotation.Z = -angle;
+            }
+            if (_kbdActions.YawRight)
+            {
+                _cameraActionRotation.Z = angle;
+            }
+
+        }
+
+        private void HandleMovementAdjustments()
+        {
+            _cameraActionMovement = Vector3.Zero;
+            var distance = _ticks;
+            if (_kbdActions.Left)
+            {
+                _cameraActionMovement.X = -distance;
+            }
+            if (_kbdActions.Right)
+            {
+                _cameraActionMovement.X = distance;
+            }
+            if (_kbdActions.Forwards)
+            {
+                _cameraActionMovement.Y = -distance;
+            }
+            if (_kbdActions.Backwards)
+            {
+                _cameraActionMovement.Y = distance;
+            }
+            if (_kbdActions.Up)
+            {
+                _cameraActionMovement.Z = distance;
+            }
+            if (_kbdActions.Down)
+            {
+                _cameraActionMovement.Z = -distance;
+            }
+        }
+
+        private void Render()
+        {
+            if (!_loaded) // Play nice
+                return;
+
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+
+            GL.MatrixMode(MatrixMode.Modelview);
+            GL.LoadIdentity();
+            GL.Scale(_zoom, _zoom, _zoom);
+            GL.Rotate(-90.0, 1, 0, 0);
+
+            GL.Rotate(_cameraDir.Z, 0.0, 0.0, -1.0);
+            GL.Rotate(_cameraDir.X, -1.0, 0.0, 0.0);
+            GL.Rotate(_cameraDir.Y, 0.0, -1.0, 0.0);
+            GL.Translate(-_cameraPos.X, -_cameraPos.Y, -_cameraPos.Z);
+            //GL.Scale(_zoom, _zoom, _zoom);
+
+
+            //GL.Rotate(_xAng, 0, 1, 0);
+            //GL.Rotate(_yAng, 1, 0, 0);
+            //GL.Translate(-_cameraPos.X, -_cameraPos.Y, -_cameraPos.Z);
+
+            //var lookat = Matrix4.LookAt(_cursorX, _cursorY, _cursorZ, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f);
+            //var lookat = Matrix4.LookAt(new Vector3(0.01f, 10.0f, 0.01f), 
+            //                            Vector3.Zero, 
+            //                            Vector3.UnitY);
+            //GL.MatrixMode(MatrixMode.Modelview);
+            //GL.LoadMatrix(ref lookat);
+
+            //GL.Translate(-_cursorX, 0.0f, -_cursorZ);
+            //GL.Rotate(_xAng, 0, 1, 0);
+            //GL.Rotate(_yAng, 1, 0, 0);
+            //GL.Scale(_zoom, _zoom, _zoom);
+            //GL.Scale(_zoom, _zoom, _zoom);
+            //                GL.Enable(EnableCap.PointSmooth);
+            //                GL.Enable(EnableCap.Blend);
+
+            RenderGalaxy();
+
+            glControl.SwapBuffers();
+            UpdateStatus();
+        }
+
+        private void RenderGalaxy()
+        {
+            GL.Enable(EnableCap.PointSmooth);
+            GL.Hint(HintTarget.PointSmoothHint, HintMode.Nicest);
+            GL.Enable(EnableCap.Blend);
+            GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
+
+            GL.PushMatrix();
+            DrawStars();
+            GL.PopMatrix();
+        }
 
         private void FormMap_Load(object sender, EventArgs e)
         {
             textboxFrom.AutoCompleteCustomSource = _systemNames;
             ShowCenterSystem();
             GenerateDataSets();
+
             //GenerateDataSetsAllegiance();
             //GenerateDataSetsGovernment();
         }
@@ -501,62 +671,69 @@ namespace EDDiscovery2
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void glControl1_Load(object sender, EventArgs e)
+        private void glControl_Load(object sender, EventArgs e)
         {
-            _loaded = true;
 
-            GL.ClearColor((Color)System.Drawing.ColorTranslator.FromHtml("#0D0D10")); 
+            GL.ClearColor((Color)System.Drawing.ColorTranslator.FromHtml("#0D0D10"));
 
             SetupViewport();
+
+            _loaded = true;
+
+            Application.Idle += Application_Idle;
+
         }
 
-        /// <summary>
-        /// Paint The control.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void glControl1_Paint(object sender, PaintEventArgs e)
+
+        private void Application_Idle(object sender, EventArgs e)
         {
-            if (!_loaded) // Play nice
-                return;
-
-            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-
-            GL.MatrixMode(MatrixMode.Modelview);
-            GL.LoadIdentity();
-
-            GL.Translate(_systemOffsetX, _systemOffsetY, 0); // position triangle according to our x variable
-            GL.Rotate(_xAng, 0, 1, 0);
-            GL.Rotate(_yAng, 1, 0, 0);
-            GL.Scale(_zoom, _zoom, _zoom);
-            //                GL.Enable(EnableCap.PointSmooth);
-            //                GL.Enable(EnableCap.Blend);
-
-
-            GL.Enable(EnableCap.PointSmooth);
-            GL.Hint(HintTarget.PointSmoothHint, HintMode.Nicest);
-            GL.Enable(EnableCap.Blend);
-            GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
-
-            //GL.Color3(Color.Yellow);
-            //GL.Begin(BeginMode.Triangles);
-            //GL.Vertex2(10, 20);
-            //GL.Vertex2(100, 20);
-            //GL.Vertex2(100, 50);
-            //GL.End();
-
-            DrawStars();
-
-            glControl1.SwapBuffers();
-            UpdateStatus();
+            glControl.Invalidate();
+            //while (glControl.IsIdle)
+            //{
+            //    glControl.MakeCurrent();
+            //    Render();
+            //    glControl.SwapBuffers();
+            //}
         }
 
-        /// <summary>
-        /// We need to setup each time our viewport and Ortho.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void glControl1_Resize(object sender, EventArgs e)
+        private void glControl_Paint(object sender, PaintEventArgs e)
+        {
+            CalculateTimeDelta();
+            HandleInputs();
+            UpdateCamera();
+            Render();
+        }
+
+        private void UpdateCamera()
+        {
+            GL.PushMatrix();
+            var camera = Matrix4.Identity;
+            _cameraDir.X = BoundedAngle(_cameraDir.X + _cameraActionRotation.X);
+            _cameraDir.Y = BoundedAngle(_cameraDir.Y + _cameraActionRotation.Y);
+            _cameraDir.Z = BoundedAngle(_cameraDir.Z + _cameraActionRotation.Z);
+            var rotY = Matrix4.CreateRotationY( DegreesToRadians(_cameraDir.Y) );
+            var rotX = Matrix4.CreateRotationX( DegreesToRadians(_cameraDir.X) );
+            var rotZ = Matrix4.CreateRotationZ( DegreesToRadians(_cameraDir.Y) );
+            var translation = Matrix4.CreateTranslation(_cameraActionMovement);
+            camera *= translation;
+            camera *= rotY;
+            camera *= rotX;
+            camera *= rotZ;
+            _cameraPos += camera.ExtractTranslation();
+            GL.PopMatrix();
+        }
+
+        private float BoundedAngle(float angle)
+        {
+            return ((angle + 360 + 180) % 360) - 180;
+        }
+
+        private float DegreesToRadians(float angle)
+        {
+            return (float) (Math.PI * angle / 180.0);
+        }
+
+        private void glControl_Resize(object sender, EventArgs e)
         {
             if (!_loaded)
                 return;
@@ -564,7 +741,7 @@ namespace EDDiscovery2
             SetupViewport();
         }
 
-        private void glControl1_MouseDown(object sender, MouseEventArgs e)
+        private void glControl_MouseDown(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             if (e.Button == System.Windows.Forms.MouseButtons.Left)
             {
@@ -587,7 +764,7 @@ namespace EDDiscovery2
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void glControl1_MouseMove(object sender, MouseEventArgs e)
+        private void glControl_MouseMove(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             if (e.Button == System.Windows.Forms.MouseButtons.Left)
             {
@@ -604,7 +781,7 @@ namespace EDDiscovery2
 
                 SetupCursorXYZ();
 
-                glControl1.Invalidate();
+                glControl.Invalidate();
             }
             if (e.Button == System.Windows.Forms.MouseButtons.Right)
             {
@@ -616,16 +793,16 @@ namespace EDDiscovery2
                 //System.Diagnostics.Trace.WriteLine("dx" + dx.ToString() + " dy " + dy.ToString() + " Button " + e.Button.ToString());
 
 
-                _systemOffsetX += dx * _zoom;
-                _systemOffsetY += -dy * _zoom;
+                _cameraPos.X += dx * _zoom;
+                _cameraPos.Y += -dy * _zoom;
 
                 SetupCursorXYZ();
 
-                glControl1.Invalidate();
+                glControl.Invalidate();
             }
         }
 
-        private void glControl1_OnMouseWheel(object sender, System.Windows.Forms.MouseEventArgs e)
+        private void glControl_OnMouseWheel(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             if (e.Delta > 0 && _zoom < ZoomMax) _zoom *= (float)ZoomFact;
             if (e.Delta < 0 && _zoom > ZoomMin) _zoom /= (float)ZoomFact;
@@ -634,11 +811,7 @@ namespace EDDiscovery2
             SetupCursorXYZ();
 
             SetupViewport();
-            glControl1.Invalidate();
-        }
-
-        private void glControl1_KeyPress(object sender, System.Windows.Forms.KeyPressEventArgs e)
-        {
+            glControl.Invalidate();
         }
     }
 }

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -47,7 +47,7 @@ namespace EDDiscovery2
         private float _systemOffsetY = 0.0f;
         private float _zoom = 1.0f;
         private float _xAng = 0.0f;
-        private float _yAng = 90.0f;
+        private float _yAng = 0.0f;
 
         private Vector3 _cursorPosition;
 
@@ -140,7 +140,7 @@ namespace EDDiscovery2
             _systemOffsetY = 0.0f;
 
             _xAng = 0.0f;
-            _yAng = 90.0f;
+            _yAng = -90.0f;
 
             _zoom = 1.0f;
         }
@@ -200,7 +200,7 @@ namespace EDDiscovery2
             {
                 // TODO: I'm working on deprecating "Origin" so that everything is build with an origin of (0,0,0) and the camera moves instead.
                 // This will allow us a little more flexibility with moving the cursor around and improving translation/rotations.
-                Origin = CenterSystem,
+                CenterSystem = CenterSystem,
 
                 VisitedSystems = VisitedSystems,
 

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1,6 +1,6 @@
 ﻿using EDDiscovery;
 using EDDiscovery.DB;
-using EDDiscovery2.DB.Offline;
+using EDDiscovery2.DB;
 using EDDiscovery2._3DMap;
 using EDDiscovery2.Trilateration;
 using OpenTK;

--- a/EDDiscovery/3DMap/KeyboardActions.cs
+++ b/EDDiscovery/3DMap/KeyboardActions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EDDiscovery2._3DMap
+{
+    public class KeyboardActions
+    {
+        public bool Left { get; set; }
+        public bool Right { get; set; }
+        public bool Up { get; set; }
+        public bool Down { get; set; }
+        public bool Forwards { get; set; }
+        public bool Backwards { get; set; }
+        public bool Pitch { get; set; }
+        public bool Dive { get; set; }
+        public bool YawLeft { get; set; }
+        public bool YawRight { get; set; }
+        public bool RollLeft { get; set;  }
+        public bool RollRight { get; set; }
+        public bool ZoomIn { get; set; }
+        public bool ZoomOut { get; set; }
+
+        public void Reset()
+        {
+            Left = false;
+            Right = false;
+            Up = false;
+            Down = false;
+            Forwards = false;
+            Backwards = false;
+            Pitch = false;
+            Dive = false;
+            YawLeft = false;
+            YawRight = false;
+            RollLeft = false;
+            RollRight = false;
+            ZoomIn = false;
+            ZoomOut = false;
+        }
+
+    }
+}

--- a/EDDiscovery/DB/ISystem.cs
+++ b/EDDiscovery/DB/ISystem.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace EDDiscovery2.DB.Offline
+namespace EDDiscovery2.DB
 {
     // Definition of the core interface so we can swap out an "offline" version during testing
     public interface ISystem

--- a/EDDiscovery/DB/IVisitedSystems.cs
+++ b/EDDiscovery/DB/IVisitedSystems.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace EDDiscovery2.DB
+{
+    public interface IVisitedSystems
+    {
+        int id { get; set; }
+        string Name { get; set; }
+        DateTime Time { get; set; }
+        int Commander { get; set; }
+        int Source { get; set; }
+        string Unit { get; set; }
+        bool EDSM_sync { get; set; }
+        int MapColour { get; set; }
+
+        bool Update();
+    }
+}

--- a/EDDiscovery/DB/InMemory/SystemClass.cs
+++ b/EDDiscovery/DB/InMemory/SystemClass.cs
@@ -1,14 +1,10 @@
-﻿using EDDiscovery2.DB;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System;
 
-namespace EDDiscovery2.DB.Offline
+namespace EDDiscovery2.DB.InMemory
 {
     // For when you need a minimal version and don't want to mess up the database. 
     // Useful for creation of test doubles
-    public class OfflineSystemClass : ISystem
+    public class SystemClass : ISystem
     {
         public int id { get; set; }
         public string name { get; set; }

--- a/EDDiscovery/DB/InMemory/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/InMemory/VisitedSystemsClass.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EDDiscovery2.DB.InMemory
+{
+    public class VisitedSystemsClass : IVisitedSystems
+    {
+        // For when you need a minimal version and don't want to mess up the database. 
+        // Useful for creation of test doubles
+        public int id { get; set; }
+        public string Name { get; set; }
+        public DateTime Time { get; set; }
+        public int Commander { get; set; }
+        public int Source { get; set; }
+        public string Unit { get; set; }
+        public bool EDSM_sync { get; set; }
+        public int MapColour { get; set; }
+
+        public bool Update()
+        {
+            // Nothing to persist to
+            return true;
+        }
+    }
+}

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1,5 +1,5 @@
 ﻿using EDDiscovery2;
-using EDDiscovery2.DB.Offline;
+using EDDiscovery2.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -24,7 +24,7 @@ namespace EDDiscovery.DB
     }
 
     [DebuggerDisplay("System {name} ({x,nq},{y,nq},{z,nq})")]
-    public class SystemClass : OfflineSystemClass
+    public class SystemClass : EDDiscovery2.DB.InMemory.SystemClass
     {
         public SystemClass()
         {

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -8,17 +8,8 @@ using System.Text;
 
 namespace EDDiscovery2.DB
 {
-    public class VisitedSystemsClass
+    public class VisitedSystemsClass : InMemory.VisitedSystemsClass
     {
-        public int id;
-        public string Name;
-        public DateTime Time;
-        public int Commander;
-        public int Source;
-        public string Unit;
-        public bool EDSM_sync;
-        public int MapColour;
-
         public VisitedSystemsClass()
         {
         }

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -129,6 +129,7 @@
     <Compile Include="3DMap\Data3DSetClass.cs" />
     <Compile Include="3DMap\DatasetBuilder.cs" />
     <Compile Include="3DMap\MapManager.cs" />
+    <Compile Include="3DMap\KeyboardActions.cs" />
     <Compile Include="DB\InMemory\VisitedSystemsClass.cs" />
     <Compile Include="DB\ISystem.cs" />
     <Compile Include="DB\InMemory\SystemClass.cs" />

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -129,8 +129,10 @@
     <Compile Include="3DMap\Data3DSetClass.cs" />
     <Compile Include="3DMap\DatasetBuilder.cs" />
     <Compile Include="3DMap\MapManager.cs" />
-    <Compile Include="DB\Offline\ISystem.cs" />
-    <Compile Include="DB\Offline\OfflineSystemClass.cs" />
+    <Compile Include="DB\InMemory\VisitedSystemsClass.cs" />
+    <Compile Include="DB\ISystem.cs" />
+    <Compile Include="DB\InMemory\SystemClass.cs" />
+    <Compile Include="DB\IVisitedSystems.cs" />
     <Compile Include="DB\StationClass.cs" />
     <Compile Include="DB\TravelLogUnit.cs" />
     <Compile Include="DB\VisitedSystemsClass.cs" />

--- a/EDDiscovery/SystemPosition.cs
+++ b/EDDiscovery/SystemPosition.cs
@@ -1,6 +1,5 @@
 ﻿using EDDiscovery.DB;
 using EDDiscovery2.DB;
-using EDDiscovery2.DB.Offline;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,14 +19,14 @@ namespace EDDiscovery
         public ISystem prevSystem;
         public ISystem lastKnownSystem;
         public string strDistance;
-        public VisitedSystemsClass vs;
+        public IVisitedSystems vs;
         
 
         public SystemPosition()
         {
         }
 
-        public SystemPosition(VisitedSystemsClass vs)
+        public SystemPosition(IVisitedSystems vs)
         {
             Name = vs.Name;
             time = vs.Time;

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -18,7 +18,6 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using EDDiscovery2.Trilateration;
 using EDDiscovery2.EDSM;
-using EDDiscovery2.DB.Offline;
 
 namespace EDDiscovery
 {

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -12,7 +12,7 @@ using EDDiscovery2;
 using ThreadState = System.Threading.ThreadState;
 using EDDiscovery2.Trilateration;
 using EDDiscovery2.EDSM;
-using EDDiscovery2.DB.Offline;
+using EDDiscovery2.DB;
 
 namespace EDDiscovery
 {

--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using EDDiscovery;
+using EDDiscovery2.DB;
+using EDDiscovery.DB;
 using EDDiscovery2._3DMap;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using EDDiscovery.DB;
-using EDDiscovery2.DB.Offline;
 using System.Drawing;
 using OpenTK;
 
@@ -15,26 +16,55 @@ namespace EDDiscovery2._3DMap.Tests
     public class DatasetBuilderTests
     {
         private DatasetBuilder _subject;
+        private List<ISystem> _starList;
         private List<ISystem> SpawnStars()
         {
-            return new List<ISystem>()
+            _starList = new List<ISystem>()
             {
-                new OfflineSystemClass() { id=1000, name="Sol", x=0.0, y=0.0, z=0.0, population=16999999880 },
-                new OfflineSystemClass() { id=1100, name="Sagittarius A*", x=25.21875, y=-20.90625, z=25899.96875 },
-                new OfflineSystemClass() { id=1200, name="Beagle Point", x=-1111.562, y=-134.21875, z=65269.75 },
-                new OfflineSystemClass() { id=1300, name="Eonorth PA-C d14-0", x=26134.6875, y=-236.34375, z=5287.78125 },
-                new OfflineSystemClass() { id=1400, name="Void's Brink", x=39307.25, y=-92.4375, z=19338.375 },
-                new OfflineSystemClass() { id=1500, name="HIP 72043", x=-22.0, y=118.5, z=58.78125, population=2166322767 },
-                new OfflineSystemClass() { id=1600, name="Achenar", x=67.5, y=-119.46875, z=24.84375, population=12999999523 },
-                new OfflineSystemClass() { id=1600, name="Alioth", x=-33.65625, y=72.46875, z=-20.65625, population=10000000000 },
-                new OfflineSystemClass() { id=1700, name="Legoworld", x=100.0, y=50.0, z=200.0, population=1000 },
-                new OfflineSystemClass() { id=1800, name="Reverse Legoworld", x=-100.0, y=-50.0, z=-200.0, population=1001 },
+                new DB.InMemory.SystemClass() { id=1000, name="Sol", x=0.0, y=0.0, z=0.0, population=16999999880 },
+                new DB.InMemory.SystemClass() { id=1100, name="Sagittarius A*", x=25.21875, y=-20.90625, z=25899.96875 },
+                new DB.InMemory.SystemClass() { id=1200, name="Beagle Point", x=-1111.562, y=-134.21875, z=65269.75 },
+                new DB.InMemory.SystemClass() { id=1300, name="Eonorth PA-C d14-0", x=26134.6875, y=-236.34375, z=5287.78125 },
+                new DB.InMemory.SystemClass() { id=1400, name="Void's Brink", x=39307.25, y=-92.4375, z=19338.375 },
+                new DB.InMemory.SystemClass() { id=1500, name="HIP 72043", x=-22.0, y=118.5, z=58.78125, population=2166322767 },
+                new DB.InMemory.SystemClass() { id=1600, name="Achenar", x=67.5, y=-119.46875, z=24.84375, population=12999999523 },
+                new DB.InMemory.SystemClass() { id=1600, name="Alioth", x=-33.65625, y=72.46875, z=-20.65625, population=10000000000 },
+                new DB.InMemory.SystemClass() { id=1700, name="Legoworld", x=100.0, y=50.0, z=200.0, population=1000 },
+                new DB.InMemory.SystemClass() { id=1800, name="Reverse Legoworld", x=-100.0, y=-50.0, z=-200.0, population=1001 },
             };
+
+            return _starList;
         }
 
-        private OfflineSystemClass SpawnOrigin()
+        private List<SystemPosition> SpawnVisitedSystems()
         {
-            return new OfflineSystemClass()
+            var blueVS = new DB.InMemory.VisitedSystemsClass() { MapColour = Color.Blue.ToArgb() };
+            var greenVS = new DB.InMemory.VisitedSystemsClass() { MapColour = Color.Green.ToArgb() };
+
+            return new List<SystemPosition>()
+            {
+                new SystemPosition() {
+                    Name = "Sol",
+                    curSystem = _starList.Find( s => s.name == "Sol" ),
+                    vs = blueVS
+                },
+                new SystemPosition() {
+                    Name = "HIP 723403",
+                    curSystem = _starList.Find( s => s.name == "HIP 723403"),
+                    lastKnownSystem =  _starList.Find( s => s.name == "Sol" ),
+                    vs = greenVS
+                },
+                new SystemPosition() {
+                    Name = "Sagittarius A*",
+                    curSystem = _starList.Find( s => s.name == "Sagittarius A*"),
+                    lastKnownSystem =  _starList.Find( s => s.name == "HIP 723403" ),
+                    vs = greenVS
+                }
+            };
+        }
+        private DB.InMemory.SystemClass SpawnOrigin()
+        {
+            return new DB.InMemory.SystemClass()
             {
                 x = 1000.0,
                 y = 1000.0,
@@ -48,7 +78,7 @@ namespace EDDiscovery2._3DMap.Tests
         {
             _subject = new DatasetBuilder
             {
-                Origin = new OfflineSystemClass(),
+                Origin = new DB.InMemory.SystemClass(),
                 StarList = SpawnStars()
             };
         }
@@ -61,7 +91,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.MaxGridPos = new Vector2(4000.0f, 14000.0f);
             var datasets = _subject.Build();
 
-            Data3DSetClass<LineData> dataset = (Data3DSetClass<LineData>)datasets[0];
+            var dataset = (Data3DSetClass<LineData>)datasets[0];
             Assert.AreEqual(2000.0, dataset.Primatives[0].x1);
             Assert.AreEqual(-12000.0, dataset.Primatives[0].z1);
         }
@@ -76,7 +106,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.Origin = SpawnOrigin();
             var datasets = _subject.Build();
 
-            Data3DSetClass<LineData> dataset = (Data3DSetClass<LineData>)datasets[0];
+            var dataset = (Data3DSetClass<LineData>)datasets[0];
 
             // Note: Looks like the grid is drawn directly over the origin
             Assert.AreEqual(2000.0, dataset.Primatives[0].x1);
@@ -90,7 +120,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.AllSystems = true;
             var datasets = _subject.Build();
 
-            Data3DSetClass<PointData> dataset = (Data3DSetClass<PointData>)datasets[0];
+            var dataset = (Data3DSetClass<PointData>)datasets[0];
 
             Assert.AreEqual("stars", dataset.Name);
 
@@ -111,7 +141,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.Origin = SpawnOrigin();
             var datasets = _subject.Build();
 
-            Data3DSetClass<PointData> dataset = (Data3DSetClass<PointData>)datasets[0];
+            var dataset = (Data3DSetClass<PointData>)datasets[0];
             var sagA = dataset.Primatives[1];
 
             Assert.AreEqual(-974.78125, sagA.x); // -1000
@@ -128,7 +158,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.Origin = SpawnOrigin();
             var datasets = _subject.Build();
 
-            Data3DSetClass<PointData> dataset = (Data3DSetClass<PointData>)datasets[0];
+            var dataset = (Data3DSetClass<PointData>)datasets[0];
             const int LegoWorldIndex = 8;
             var legoWorld = dataset.Primatives[LegoWorldIndex];
 
@@ -150,7 +180,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.Origin = SpawnOrigin();
             var datasets = _subject.Build();
 
-            Data3DSetClass<PointData> dataset = (Data3DSetClass<PointData>)datasets[0];
+            var dataset = (Data3DSetClass<PointData>)datasets[0];
             const int LegoWorldIndex = 9;
             var legoWorld = dataset.Primatives[LegoWorldIndex];
 
@@ -169,7 +199,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.Stations = true;
             var datasets = _subject.Build();
 
-            Data3DSetClass<PointData> dataset = (Data3DSetClass<PointData>)datasets[0];
+            var dataset = (Data3DSetClass<PointData>)datasets[0];
 
             Assert.AreEqual("stations", dataset.Name);
 
@@ -188,7 +218,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.Origin = SpawnOrigin();
             var datasets = _subject.Build();
 
-            Data3DSetClass<PointData> dataset = (Data3DSetClass<PointData>)datasets[0];
+            var dataset = (Data3DSetClass<PointData>)datasets[0];
 
             Assert.AreEqual("stations", dataset.Name);
 
@@ -200,11 +230,25 @@ namespace EDDiscovery2._3DMap.Tests
             Assert.AreEqual(6, dataset.Primatives.Count);
         }
 
+        // This one's a pain. Will manually test for now.
+
         //[TestMethod()]
-        //public void When_building_visited_systems()
+        //public void When_building_visited_systems_as_points()
         //{
         //    _subject.VisitedSystems = SpawnVisitedSystems();
+        //    _subject.DrawLines = false;
         //    var datasets = _subject.Build();
+            
+        //    Assert.AreEqual("visitedstars-16776961", datasets[0].Name);
+        //    Assert.AreEqual("visitedstars-16744448", datasets[1].Name);
+
+        //    var dataset = (Data3DSetClass<PointData>) datasets[0];
+        //    var iger = dataset.Primatives[1];
+
+        //    Assert.AreEqual(-1022.0, iger.x);   // -1000
+        //    Assert.AreEqual(-881.5, iger.y);    // -1000
+        //    Assert.AreEqual(941.21875, iger.z); // inverted then -1000
+        //    Assert.AreEqual(2, dataset.Primatives.Count);
         //}
 
 

--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -78,7 +78,7 @@ namespace EDDiscovery2._3DMap.Tests
         {
             _subject = new DatasetBuilder
             {
-                Origin = new DB.InMemory.SystemClass(),
+                CenterSystem = new DB.InMemory.SystemClass(),
                 StarList = SpawnStars()
             };
         }
@@ -103,7 +103,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.GridLines = true;
             _subject.MinGridPos = new Vector2(2000.0f, 12000.0f);
             _subject.MaxGridPos = new Vector2(4000.0f, 14000.0f);
-            _subject.Origin = SpawnOrigin();
+            _subject.CenterSystem = SpawnOrigin();
             var datasets = _subject.Build();
 
             var dataset = (Data3DSetClass<LineData>)datasets[0];
@@ -128,69 +128,8 @@ namespace EDDiscovery2._3DMap.Tests
 
             Assert.AreEqual(25.21875, sagA.x);
             Assert.AreEqual(-20.90625, sagA.y);
-            Assert.AreEqual(-25899.96875, sagA.z);
+            Assert.AreEqual(25899.96875, sagA.z);
             Assert.IsTrue(dataset.Primatives.Count >= 10);
-        }
-
-        // Probably won't need this test for long. 
-        // Just want to be sure of how the offsets are configured for a "centered" system
-        [TestMethod()]
-        public void When_building_all_systems_with_an_origin()
-        { 
-            _subject.AllSystems = true;
-            _subject.Origin = SpawnOrigin();
-            var datasets = _subject.Build();
-
-            var dataset = (Data3DSetClass<PointData>)datasets[0];
-            var sagA = dataset.Primatives[1];
-
-            Assert.AreEqual(-974.78125, sagA.x); // -1000
-            Assert.AreEqual(-1020.90625, sagA.y); // -1000
-            Assert.AreEqual(-24899.96875, sagA.z); // -1000 then inverted
-        }
-
-        // Probably won't need this test for long. 
-        // Just want to be sure of how the offsets are configured for a "centered" system
-        [TestMethod()]
-        public void When_building_all_systems_with_an_origin_on_legoland()
-        {
-            _subject.AllSystems = true;
-            _subject.Origin = SpawnOrigin();
-            var datasets = _subject.Build();
-
-            var dataset = (Data3DSetClass<PointData>)datasets[0];
-            const int LegoWorldIndex = 8;
-            var legoWorld = dataset.Primatives[LegoWorldIndex];
-
-            // Confirm we pulled the correct fixture
-            Assert.AreEqual("Legoworld", _subject.StarList[LegoWorldIndex].name);
-
-            // And the real tests...
-            Assert.AreEqual(-900, legoWorld.x); // -1000
-            Assert.AreEqual(-950, legoWorld.y); // -1000
-            Assert.AreEqual(800, legoWorld.z);  // -1000 then inverted 
-        }
-
-        // Probably won't need this test for long. 
-        // Just want to be sure of how the offsets are configured for a "centered" system
-        [TestMethod()]
-        public void When_building_all_systems_with_an_origin_on_reverse_legoland()
-        {
-            _subject.AllSystems = true;
-            _subject.Origin = SpawnOrigin();
-            var datasets = _subject.Build();
-
-            var dataset = (Data3DSetClass<PointData>)datasets[0];
-            const int LegoWorldIndex = 9;
-            var legoWorld = dataset.Primatives[LegoWorldIndex];
-
-            // Confirm we pulled the correct fixture
-            Assert.AreEqual("Reverse Legoworld", _subject.StarList[LegoWorldIndex].name);
-
-            // And the real tests...
-            Assert.AreEqual(-1100, legoWorld.x); // -1000
-            Assert.AreEqual(-1050, legoWorld.y); // -1000
-            Assert.AreEqual(1200, legoWorld.z);  // -1000 then inverted 
         }
 
         [TestMethod()]
@@ -207,28 +146,10 @@ namespace EDDiscovery2._3DMap.Tests
 
             Assert.AreEqual(-22.0, iger.x);
             Assert.AreEqual(118.5, iger.y);
-            Assert.AreEqual(-58.78125, iger.z); // Inverted
+            Assert.AreEqual(58.78125, iger.z);
             Assert.AreEqual(6, dataset.Primatives.Count);
         }
 
-        [TestMethod()]
-        public void When_building_stations_with_an_origin()
-        {
-            _subject.Stations = true;
-            _subject.Origin = SpawnOrigin();
-            var datasets = _subject.Build();
-
-            var dataset = (Data3DSetClass<PointData>)datasets[0];
-
-            Assert.AreEqual("stations", dataset.Name);
-
-            var iger = dataset.Primatives[1];
-
-            Assert.AreEqual(-1022.0, iger.x);   // -1000
-            Assert.AreEqual(-881.5, iger.y);    // -1000
-            Assert.AreEqual(941.21875, iger.z); // inverted then -1000
-            Assert.AreEqual(6, dataset.Primatives.Count);
-        }
 
         // This one's a pain. Will manually test for now.
 

--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -93,26 +93,8 @@ namespace EDDiscovery2._3DMap.Tests
 
             var dataset = (Data3DSetClass<LineData>)datasets[0];
             Assert.AreEqual(2000.0, dataset.Primatives[0].x1);
-            Assert.AreEqual(-12000.0, dataset.Primatives[0].z1);
+            Assert.AreEqual(12000.0, dataset.Primatives[0].z1);
         }
-
-        // Probably won't need this test for long. 
-        // Just want to be sure of how the offsets are configured for a "centered" system
-        public void When_building_a_grid_with_an_origin()
-        {
-            _subject.GridLines = true;
-            _subject.MinGridPos = new Vector2(2000.0f, 12000.0f);
-            _subject.MaxGridPos = new Vector2(4000.0f, 14000.0f);
-            _subject.CenterSystem = SpawnOrigin();
-            var datasets = _subject.Build();
-
-            var dataset = (Data3DSetClass<LineData>)datasets[0];
-
-            // Note: Looks like the grid is drawn directly over the origin
-            Assert.AreEqual(2000.0, dataset.Primatives[0].x1);
-            Assert.AreEqual(-12000.0, dataset.Primatives[0].z1);
-        }
-
 
         [TestMethod()]
         public void When_building_all_systems()


### PR DESCRIPTION
Got all the Camera transforms worked out! :D
So the only dataset's now married to to the CenterSystem are CenterSystem point and the Trilateration lines.

New features/side effects:
* The Camera's position and zoom level is now visible in the status bar
* Implemented a whole bunch of keybindings for movement and rotation. Will restrict the less useful rotation key bindings to DEBUG build later, because the user doesn't really need to know about them.
The main keys are WASD/Arrow keys to translate. +/- to zoom.
* Movement speed is the same whether you're zoomed in or out now.
* Map now defaults to Maximized. I feel it's the more useful default so that the glControl is immediately under the mouse cursor where it can receive keyboard commands.
* There was a small bug with the Z axis being inconsistant with offsetting the CenterSystem. No longer applies.
* Z Axis for points is no longer inverted.

Still got lots of improvements to roll in, but this is the first time things have been stable in a a couple of days...