### PR TITLE
Fix keyboard Zoom and Keyboard rotation

### DIFF
--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -80,6 +80,7 @@ namespace EDDiscovery2
             this.textboxFrom.Name = "textboxFrom";
             this.textboxFrom.Size = new System.Drawing.Size(125, 20);
             this.textboxFrom.TabIndex = 16;
+            this.textboxFrom.TabStop = false;
             this.textboxFrom.Text = "Sol";
             // 
             // buttonCenter
@@ -89,6 +90,7 @@ namespace EDDiscovery2
             this.buttonCenter.Name = "buttonCenter";
             this.buttonCenter.Size = new System.Drawing.Size(75, 23);
             this.buttonCenter.TabIndex = 17;
+            this.buttonCenter.TabStop = false;
             this.buttonCenter.Text = "Center";
             this.buttonCenter.UseVisualStyleBackColor = true;
             this.buttonCenter.Click += new System.EventHandler(this.buttonCenter_Click);
@@ -185,6 +187,7 @@ namespace EDDiscovery2
             this.buttonSetDefault.Name = "buttonSetDefault";
             this.buttonSetDefault.Size = new System.Drawing.Size(75, 23);
             this.buttonSetDefault.TabIndex = 20;
+            this.buttonSetDefault.TabStop = false;
             this.buttonSetDefault.Text = "Set Default";
             this.buttonSetDefault.UseCompatibleTextRendering = true;
             this.buttonSetDefault.UseVisualStyleBackColor = true;

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -474,13 +474,13 @@ namespace EDDiscovery2
             // I'll probably hide away the less useful options later from the Release build
             _kbdActions.Forwards = state[Key.R];
             _kbdActions.Backwards = state[Key.F];
- 
+
+            _kbdActions.YawLeft = state[Key.Keypad4];
+            _kbdActions.YawRight = state[Key.Keypad6];
             _kbdActions.Pitch = state[Key.Keypad8];
-            _kbdActions.Dive = state[Key.Keypad5];
-            _kbdActions.RollLeft = state[Key.Keypad4];
-            _kbdActions.RollRight = state[Key.Keypad6];
-            _kbdActions.YawLeft = state[Key.Keypad7];
-            _kbdActions.YawRight = state[Key.Keypad9];
+            _kbdActions.Dive = (state[Key.Keypad5] || state[Key.Keypad2]);
+            _kbdActions.RollLeft = state[Key.Keypad7];
+            _kbdActions.RollRight = state[Key.Keypad9];
         }
 
         private void HandleTurningAdjustments()
@@ -488,6 +488,14 @@ namespace EDDiscovery2
             _cameraActionRotation = Vector3.Zero;
 
             var angle = (float)  _ticks * 0.1f;
+            if (_kbdActions.YawLeft)
+            {
+                _cameraActionRotation.Z = -angle;
+            }
+            if (_kbdActions.YawRight)
+            {
+                _cameraActionRotation.Z = angle;
+            }
             if (_kbdActions.Dive)
             {
                 _cameraActionRotation.X = -angle;
@@ -503,14 +511,6 @@ namespace EDDiscovery2
             if (_kbdActions.RollRight)
             {
                 _cameraActionRotation.Y = angle;
-            }
-            if (_kbdActions.YawLeft)
-            {
-                _cameraActionRotation.Z = -angle;
-            }
-            if (_kbdActions.YawRight)
-            {
-                _cameraActionRotation.Z = angle;
             }
 
         }
@@ -693,21 +693,19 @@ namespace EDDiscovery2
 
         private void UpdateCamera()
         {
-            GL.PushMatrix();
             var camera = Matrix4.Identity;
+            _cameraDir.Z = BoundedAngle(_cameraDir.Z + _cameraActionRotation.Z);
             _cameraDir.X = BoundedAngle(_cameraDir.X + _cameraActionRotation.X);
             _cameraDir.Y = BoundedAngle(_cameraDir.Y + _cameraActionRotation.Y);
-            _cameraDir.Z = BoundedAngle(_cameraDir.Z + _cameraActionRotation.Z);
-            var rotY = Matrix4.CreateRotationY( DegreesToRadians(_cameraDir.Y) );
+            var rotZ = Matrix4.CreateRotationZ(DegreesToRadians(_cameraDir.Z));
             var rotX = Matrix4.CreateRotationX( DegreesToRadians(_cameraDir.X) );
-            var rotZ = Matrix4.CreateRotationZ( DegreesToRadians(_cameraDir.Y) );
+            var rotY = Matrix4.CreateRotationY(DegreesToRadians(_cameraDir.Y));
             var translation = Matrix4.CreateTranslation(_cameraActionMovement);
             camera *= translation;
-            camera *= rotY;
-            camera *= rotX;
             camera *= rotZ;
+            camera *= rotX;
+            camera *= rotY;
             _cameraPos += camera.ExtractTranslation();
-            GL.PopMatrix();
         }
 
         private float BoundedAngle(float angle)


### PR DESCRIPTION
1) I went to add Z and X zoom keys bindings only to realize that zoom keys weren't even implemented yet. Fixed that.
2) I noticed I keyboard controlled rotations (num pad) weren't behaving quite right so fixed the rotation ordering.
3) Made it so the Center text control can't get the focus through tab ordering because it kept finding a way to steal the focus
4) Reduced the Zoom range a little