### PR TITLE
Inverted the Z axis

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -569,9 +569,9 @@ namespace EDDiscovery2
 
             GL.MatrixMode(MatrixMode.Modelview);
             GL.LoadIdentity();
-            GL.Rotate(-90.0, 1, 0, 0);
+            GL.Rotate(90.0, 1, 0, 0);
 
-            GL.Scale(_zoom, _zoom, _zoom);
+            GL.Scale(_zoom, _zoom, -_zoom);
             GL.Rotate(_cameraDir.Z, 0.0, 0.0, -1.0);
             GL.Rotate(_cameraDir.X, -1.0, 0.0, 0.0);
             GL.Rotate(_cameraDir.Y, 0.0, -1.0, 0.0);


### PR DESCRIPTION
Fixed the Z axis by inverting the zoom (#55).

I confirmed Crab Pulsar and checking it was below Sol.
Zoom keys still seem to work ok, but wasn't able to confirm mouse wheel is still working:

Note: When testing the in map Center feature isn't working right now. I hope to fix that soon. In the meantime, you an test by filtering on the list of systems and clicking the 3d Map when filtered on the desired test point.