### PR TITLE
Production ed-materializer server is now AWS based

### DIFF
--- a/EDDiscovery/PlanetSystems/edmaterializer.cs
+++ b/EDDiscovery/PlanetSystems/edmaterializer.cs
@@ -13,7 +13,13 @@ namespace EDDiscovery2.PlanetSystems
 
         public EdMaterializer()
         {
+#if Debug
+            // Dev server. Mess with data as much as you like here
             ServerAdress = "https://ed-materializer.herokuapp.com/";
+#else
+            // Production
+            ServerAdress = "http://ed-materializer-env.elasticbeanstalk.com/";
+#endif
         }
 
 


### PR DESCRIPTION
Configured ed-materializer server string to use the Amazon based hosting for the Release build. The old Heroku server will now be a sandbox for testing in the Debug build.

I've not seeded any dummy data into the Release database, so it will initially have zero rows.