### PR TITLE
Use ed-materializer auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages
 /Installer/EDDiscovery-cache
 /Installer/AnyCPU_DebugSetupFiles
 /Installer/EDDiscovery
+*/*Secrets.config

--- a/EDDiscovery/App.config
+++ b/EDDiscovery/App.config
@@ -18,9 +18,12 @@
             </setting>
         </EDDiscovery.Properties.Settings>
     </userSettings>
-<system.data>
+    <system.data>
     <DbProviderFactories>
       <remove invariant="System.Data.SQLite" />
       <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
     </DbProviderFactories>
-  </system.data></configuration>
+  </system.data>
+  <appSettings configSource="AppSettingsSecrets.config">
+  </appSettings>
+</configuration>

--- a/EDDiscovery/App.config
+++ b/EDDiscovery/App.config
@@ -24,6 +24,6 @@
       <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
     </DbProviderFactories>
   </system.data>
-  <appSettings configSource="AppSettingsSecrets.config">
+  <appSettings file="..\..\AppSettingsSecrets.config">
   </appSettings>
 </configuration>

--- a/EDDiscovery/AppSettingsSecrets.config.example
+++ b/EDDiscovery/AppSettingsSecrets.config.example
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="EDMaterializerUsername" value="USERNAME_HERE"/>
+    <add key="EDMaterializerPassword" value="PASSWORD_HERE"/>
+  </appSettings>
+</configuration>

--- a/EDDiscovery/AppSettingsSecrets.config.example
+++ b/EDDiscovery/AppSettingsSecrets.config.example
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="EDMaterializerUsername" value="USERNAME_HERE"/>
-    <add key="EDMaterializerPassword" value="PASSWORD_HERE"/>
-  </appSettings>
-</configuration>
+﻿<appSettings>
+  <add key="EDMaterializerUsername" value="USERNAME_HERE"/>
+  <add key="EDMaterializerPassword" value="PASSWORD_HERE"/>
+</appSettings>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -200,6 +200,7 @@
     <Compile Include="DB\SystemNoteClass.cs" />
     <Compile Include="HTTP\EDMaterializerCom.cs" />
     <Compile Include="HTTP\HttpCom.cs" />
+    <Compile Include="HTTP\ResponseData.cs" />
     <Compile Include="PlanetSystems\AddMaterialNodeControl.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -127,6 +127,7 @@
       <HintPath>..\packages\OpenTK.GLControl.1.1.1589.5942\lib\NET40\OpenTK.GLControl.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite, Version=1.0.99.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.99.0\lib\net40\System.Data.SQLite.dll</HintPath>
@@ -138,6 +139,7 @@
     </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions">
@@ -292,6 +294,9 @@
     <Content Include="x86\SQLite.Interop.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="AppSettingsSecrets.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Resources\Home-icon.png" />
     <None Include="Resources\Travelicon.png" />
     <None Include="Resources\save.png" />

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -196,7 +196,8 @@
     <Compile Include="DB\SQLiteDBClass.cs" />
     <Compile Include="DB\SystemClass.cs" />
     <Compile Include="DB\SystemNoteClass.cs" />
-    <Compile Include="HttpCom.cs" />
+    <Compile Include="HTTP\EDMaterializerCom.cs" />
+    <Compile Include="HTTP\HttpCom.cs" />
     <Compile Include="PlanetSystems\AddMaterialNodeControl.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -294,6 +294,9 @@
     <Content Include="x86\SQLite.Interop.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="AppSettingsSecrets.config.example">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="AppSettingsSecrets.config">
       <SubType>Designer</SubType>
     </None>

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -1,6 +1,7 @@
 ﻿using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2.DB;
+using EDDiscovery2.HTTP;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -29,7 +30,7 @@ namespace EDDiscovery2.EDSM
         public EDSMClass()
         {
             fromSoftware = "EDDiscovery";
-            ServerAdress = "http://www.edsm.net/";
+            _serverAddress = "http://www.edsm.net/";
 
             var assemblyFullName = Assembly.GetExecutingAssembly().FullName;
             fromSoftwareVersion = assemblyFullName.Split(',')[1].Split('=')[1];
@@ -65,7 +66,9 @@ namespace EDDiscovery2.EDSM
 
             query += "] } ";
 
-            return RequestPost("{ \"data\": " + query + " }", "api-v1/submit-distances");
+            var response = RequestPost("{ \"data\": " + query + " }", "api-v1/submit-distances");
+            var data = response.Content;
+            return response.Content;
         }
 
 
@@ -136,9 +139,9 @@ namespace EDDiscovery2.EDSM
 
             query = "?startdatetime=" + HttpUtility.UrlEncode(date);
             //json1= RequestGet("systems" + query + "&coords=1&submitted=1");
-            json2=  RequestGet("api-v1/systems" + query + "&coords=1&submitted=1&known=1");
-
-            return json2;
+            var response = RequestGet("api-v1/systems" + query + "&coords=1&submitted=1&known=1");
+            var data = response.Content;
+            return response.Content;
         }
 
         public string RequestDistances(string date)
@@ -146,7 +149,9 @@ namespace EDDiscovery2.EDSM
             string query;
             query = "?startdatetime=" + HttpUtility.UrlEncode(date);
 
-            return RequestGet("api-v1/distances" + query + "coords=1 & submitted=1");
+            var response = RequestGet("api-v1/distances" + query + "coords=1 & submitted=1");
+            var data = response.Content;
+            return response.Content;
         }
 
 
@@ -219,13 +224,11 @@ namespace EDDiscovery2.EDSM
             List<DistanceClass> listDistances = new List<DistanceClass>();
             try
             {
-                string json;
-
-
                 string query;
                 query = "?sysname=" + HttpUtility.UrlEncode(systemname) + "&coords=1&distances=1&submitted=1";
 
-                json = RequestGet("api-v1/system" + query);
+                var response = RequestGet("api-v1/system" + query);
+                var json = response.Content;
 
                 //http://www.edsm.net/api-v1/system?sysname=Col+359+Sector+CP-Y+c1-18&coords=1&include_hidden=1&distances=1&submitted=1
 
@@ -263,9 +266,8 @@ namespace EDDiscovery2.EDSM
 
             string query = "get-comments?startdatetime=" + HttpUtility.UrlEncode(starttime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) + "&apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             //string query = "get-comments?apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
-            string json = RequestGet("api-logs-v1/" + query);
-
-            return json;
+            var response = RequestGet("api-logs-v1/" + query);
+            return response.Content;
         }
 
 
@@ -274,26 +276,24 @@ namespace EDDiscovery2.EDSM
             string query;
             query = "get-comment?systemName=" + HttpUtility.UrlEncode(systemName);
 
-            string json =  RequestGet("api-logs-v1/" + query);
-            return json;
+            var response = RequestGet("api-logs-v1/" + query);
+            return response.Content;
         }
 
         public string SetComment(SystemNoteClass sn)
         {
             string query;
             query = "set-comment?systemName=" + HttpUtility.UrlEncode(sn.Name) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&comment=" + HttpUtility.UrlEncode(sn.Note);
-            string json = RequestGet("api-logs-v1/"+ query);
-
-            return json;
+            var response = RequestGet("api-logs-v1/" + query);
+            return response.Content;
         }
 
         public string SetLog(string systemName, DateTime dateVisited)
         {
             string query;
             query = "set-log?systemName=" + HttpUtility.UrlEncode(systemName) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&dateVisited=" + HttpUtility.UrlEncode(dateVisited.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
-            string json = RequestGet("api-logs-v1/" + query);
-
-            return json;
+            var response = RequestGet("api-logs-v1/" + query);
+            return response.Content;
         }
 
         public int GetLogs(DateTime starttime, out List<SystemPosition> log)
@@ -302,7 +302,8 @@ namespace EDDiscovery2.EDSM
 
             string query = "get-logs?startdatetime=" + HttpUtility.UrlEncode(starttime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) + "&apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             //string query = "get-logs?apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
-            string json = RequestGet("api-logs-v1/"+ query);
+            var response = RequestGet("api-logs-v1/" + query);
+            var json = response.Content;
 
             if (json == null)
                 return 0;

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -67,8 +67,8 @@ namespace EDDiscovery2.EDSM
             query += "] } ";
 
             var response = RequestPost("{ \"data\": " + query + " }", "api-v1/submit-distances");
-            var data = response.Content;
-            return response.Content;
+            var data = response.Body;
+            return response.Body;
         }
 
 
@@ -140,8 +140,8 @@ namespace EDDiscovery2.EDSM
             query = "?startdatetime=" + HttpUtility.UrlEncode(date);
             //json1= RequestGet("systems" + query + "&coords=1&submitted=1");
             var response = RequestGet("api-v1/systems" + query + "&coords=1&submitted=1&known=1");
-            var data = response.Content;
-            return response.Content;
+            var data = response.Body;
+            return response.Body;
         }
 
         public string RequestDistances(string date)
@@ -150,8 +150,8 @@ namespace EDDiscovery2.EDSM
             query = "?startdatetime=" + HttpUtility.UrlEncode(date);
 
             var response = RequestGet("api-v1/distances" + query + "coords=1 & submitted=1");
-            var data = response.Content;
-            return response.Content;
+            var data = response.Body;
+            return response.Body;
         }
 
 
@@ -228,7 +228,7 @@ namespace EDDiscovery2.EDSM
                 query = "?sysname=" + HttpUtility.UrlEncode(systemname) + "&coords=1&distances=1&submitted=1";
 
                 var response = RequestGet("api-v1/system" + query);
-                var json = response.Content;
+                var json = response.Body;
 
                 //http://www.edsm.net/api-v1/system?sysname=Col+359+Sector+CP-Y+c1-18&coords=1&include_hidden=1&distances=1&submitted=1
 
@@ -267,7 +267,7 @@ namespace EDDiscovery2.EDSM
             string query = "get-comments?startdatetime=" + HttpUtility.UrlEncode(starttime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) + "&apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             //string query = "get-comments?apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             var response = RequestGet("api-logs-v1/" + query);
-            return response.Content;
+            return response.Body;
         }
 
 
@@ -277,7 +277,7 @@ namespace EDDiscovery2.EDSM
             query = "get-comment?systemName=" + HttpUtility.UrlEncode(systemName);
 
             var response = RequestGet("api-logs-v1/" + query);
-            return response.Content;
+            return response.Body;
         }
 
         public string SetComment(SystemNoteClass sn)
@@ -285,7 +285,7 @@ namespace EDDiscovery2.EDSM
             string query;
             query = "set-comment?systemName=" + HttpUtility.UrlEncode(sn.Name) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&comment=" + HttpUtility.UrlEncode(sn.Note);
             var response = RequestGet("api-logs-v1/" + query);
-            return response.Content;
+            return response.Body;
         }
 
         public string SetLog(string systemName, DateTime dateVisited)
@@ -293,7 +293,7 @@ namespace EDDiscovery2.EDSM
             string query;
             query = "set-log?systemName=" + HttpUtility.UrlEncode(systemName) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&dateVisited=" + HttpUtility.UrlEncode(dateVisited.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
             var response = RequestGet("api-logs-v1/" + query);
-            return response.Content;
+            return response.Body;
         }
 
         public int GetLogs(DateTime starttime, out List<SystemPosition> log)
@@ -303,7 +303,7 @@ namespace EDDiscovery2.EDSM
             string query = "get-logs?startdatetime=" + HttpUtility.UrlEncode(starttime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) + "&apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             //string query = "get-logs?apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             var response = RequestGet("api-logs-v1/" + query);
-            var json = response.Content;
+            var json = response.Body;
 
             if (json == null)
                 return 0;

--- a/EDDiscovery/HTTP/EDMaterializerCom.cs
+++ b/EDDiscovery/HTTP/EDMaterializerCom.cs
@@ -1,0 +1,51 @@
+﻿using EDDiscovery;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace EDDiscovery2.HTTP
+{
+    public class EDMaterizliaerCom : HttpCom
+    {
+        private NameValueCollection _authTokens = null;
+
+        protected void AddAuthHeaders(WebRequest request)
+        {
+            if (_authTokens == null)
+            {
+                _authTokens = TokensFromSignIn();
+            }
+
+            if (_authTokens == null)
+            {
+                // TODO: Could potentially cut this step by checking the expiry date
+                // token. Though watch out for scenario where tokens are expired by other
+                // events, like a logout. It can be handled by validating the return value
+                // of the actual main request, but of course that's extra effort. :)
+                _authTokens = ValidatedTokens();
+            }
+
+            if (_authTokens != null)
+            {
+                request.Headers.Add(_authTokens);
+            }        
+        }
+
+        private NameValueCollection ValidatedTokens()
+        {
+            //RequestGet($"{authPath}/validate_token/$uid=");
+            // http://ed-materializer.heroku.com/api/v1/auth/validate_token/?uid=jenny@example.com&access-token=TOKEN_HERE&client=CLIENT_HERE
+            throw new NotImplementedException();
+        }
+
+        private NameValueCollection TokensFromSignIn()
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/EDDiscovery/HTTP/EDMaterializerCom.cs
+++ b/EDDiscovery/HTTP/EDMaterializerCom.cs
@@ -12,9 +12,9 @@ namespace EDDiscovery2.HTTP
     public class EDMaterizliaerCom : HttpCom
     {
         private NameValueCollection _authTokens = null;
-        private readonly string _authPath = "/api/v1/auth";
+        private readonly string _authPath = "api/v1/auth";
 
-        protected new void AddAuthHeaders(WebRequest request)
+        protected override void AddAuthHeaders(WebRequest request)
         {
             if (_authTokens == null)
             {
@@ -55,11 +55,11 @@ namespace EDDiscovery2.HTTP
             var appSettings = ConfigurationManager.AppSettings;
             var username = appSettings["EDMaterializerUsername"];
             var password = appSettings["EDMaterializerPassword"];
-            var json = $"email={username}&password{password}";
+            var json = $"{{\"email\": \"{username}\", \"password\": \"{password}\"}}";
             var response = RequestPost(json, $"{_authPath}/sign_in",false);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                return HttpUtility.ParseQueryString(response.Content);
+                return HttpUtility.ParseQueryString(response.Body);
             }
             else
             {

--- a/EDDiscovery/HTTP/EDMaterializerCom.cs
+++ b/EDDiscovery/HTTP/EDMaterializerCom.cs
@@ -14,57 +14,88 @@ namespace EDDiscovery2.HTTP
         private NameValueCollection _authTokens = null;
         private readonly string _authPath = "api/v1/auth";
 
-        protected override void AddAuthHeaders(WebRequest request)
+        //{
+        //    if (_authTokens == null)
+        //    {
+        //        _authTokens = TokensFromSignIn();
+        //    }
+
+        //    if (_authTokens == null)
+        //    {
+        //        // TODO: Could potentially cut this step by checking the expiry date
+        //        // token. Though watch out for scenario where tokens are expired by other
+        //        // events, like a logout. It can be handled by validating the return value
+        //        // of the actual main request, but of course that's extra effort. :)
+        //        _authTokens = ValidatedTokens();
+        //    }
+
+        //    if (_authTokens != null)
+        //    {
+        //        request.Headers.Add(_authTokens);
+        //    }
+        //}
+        //protected void AddAuthHeaders(WebRequest request)
+
+        //private NameValueCollection ValidatedTokens()
+        //{
+        //    var queryParams = $"uid={_authTokens["uid"]}&access-token={_authTokens["access_token"]}&client=email";
+        //    var response = RequestGet($"{_authPath}/validate_token/?{queryParams}");
+        //    if (response.StatusCode == HttpStatusCode.OK)
+        //    {
+        //        return _authTokens;
+        //    }
+        //    else
+        //    { 
+        //        return null;
+        //    }
+        //}
+        protected ResponseData RequestSecurePost(string json, string action)
         {
-            if (_authTokens == null)
-            {
-                _authTokens = TokensFromSignIn();
-            }
-
-            if (_authTokens == null)
-            {
-                // TODO: Could potentially cut this step by checking the expiry date
-                // token. Though watch out for scenario where tokens are expired by other
-                // events, like a logout. It can be handled by validating the return value
-                // of the actual main request, but of course that's extra effort. :)
-                _authTokens = ValidatedTokens();
-            }
-
+            ResponseData response = new ResponseData(HttpStatusCode.BadRequest);
+            // Attempt #1 with existing tokens
             if (_authTokens != null)
             {
-                request.Headers.Add(_authTokens);
+                response = RequestPost(json, action, _authTokens);
+                if (response.StatusCode == HttpStatusCode.Unauthorized ||
+                    response.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    _authTokens = null;
+                }
+                else
+                {
+                    return response;
+                }
             }
-        }
-
-        private NameValueCollection ValidatedTokens()
-        {
-            var queryParams = $"uid={_authTokens["uid"]}&access-token={_authTokens["access_token"]}&client=email";
-            var response = RequestGet($"{_authPath}/validate_token/?{queryParams}");
-            if (response.StatusCode == HttpStatusCode.OK)
+            // Attempt #2 by logging in and obtaining fresh tokens
+            if (_authTokens == null)
             {
-                return _authTokens;
+                response = SignIn();
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    response = RequestPost(json, action, _authTokens);
+                }
             }
-            else
-            { 
-                return null;
-            }
+            return response;
         }
 
-        private NameValueCollection TokensFromSignIn()
+        private ResponseData SignIn()
         {
+            _authTokens = null;
             var appSettings = ConfigurationManager.AppSettings;
             var username = appSettings["EDMaterializerUsername"];
             var password = appSettings["EDMaterializerPassword"];
             var json = $"{{\"email\": \"{username}\", \"password\": \"{password}\"}}";
-            var response = RequestPost(json, $"{_authPath}/sign_in",false);
+            var response = RequestPost(json, $"{_authPath}/sign_in");
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                return HttpUtility.ParseQueryString(response.Body);
+                var headers = response.Headers;
+                var tokens = new NameValueCollection();
+                tokens["access-token"] = headers["access-token"];
+                tokens["client"] = headers["client"];
+                tokens["provider"] = headers["email"];
+                _authTokens = tokens;
             }
-            else
-            {
-                return null;
-            }
+            return response;
         }
 
         private string AuthKeyToJson()

--- a/EDDiscovery/HTTP/HttpCom.cs
+++ b/EDDiscovery/HTTP/HttpCom.cs
@@ -7,33 +7,11 @@ using System.Text;
 
 namespace EDDiscovery2.HTTP
 {
-    public struct ResponseData
-    {
-        public ResponseData(HttpStatusCode statusCode)
-        {
-            StatusCode = statusCode;
-            Body = null;
-            Headers = null;
-        }
-
-        public ResponseData(HttpStatusCode statusCode, string content, NameValueCollection headers)
-        {
-            StatusCode = statusCode;
-            Body = content;
-            Headers = headers;
-        }
-
-        public HttpStatusCode StatusCode; // Sometimes you need the status code if you're in a
-                                   // converstation with the server
-        public string Body;
-        public NameValueCollection Headers;
-    }
-
     public class HttpCom
     {
         protected string _serverAddress;
 
-        protected ResponseData RequestPost(string json, string action, bool authenticate=true)
+        protected ResponseData RequestPost(string json, string action, NameValueCollection headers = null)
         {
             try
             {
@@ -42,9 +20,9 @@ namespace EDDiscovery2.HTTP
                     HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
                     // Set the Method property of the request to POST.
                     request.Method = "POST";
-                    if (authenticate)
+                    if (headers != null)
                     {
-                        AddAuthHeaders(request);
+                        request.Headers.Add(headers);
                     }
                     // Create POST data and convert it to a byte array.
                     //WRITE JSON DATA TO VARIABLE D
@@ -302,11 +280,6 @@ namespace EDDiscovery2.HTTP
                 return new ResponseData(HttpStatusCode.BadRequest);
             }
 
-        }
-
-        protected virtual void AddAuthHeaders(WebRequest request)
-        {
-            // Override me
         }
 
         private void WriteEDSMLog(string str1, string str2)

--- a/EDDiscovery/HTTP/HttpCom.cs
+++ b/EDDiscovery/HTTP/HttpCom.cs
@@ -103,54 +103,78 @@ namespace EDDiscovery2.HTTP
             }
         }
 
-        protected ResponseData RequestPatch(string json, string action)
+        protected ResponseData RequestPatch(string json, string action, NameValueCollection headers = null)
         {
             try
             {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
-                request.Method = "PATCH";
-                string postData = json;
-
-
-                byte[] byteArray = Encoding.UTF8.GetBytes(postData);
-                // Set the ContentType property of the WebRequest.
-                request.ContentType = "application/json; charset=utf-8";
-                //request.Headers.Add("Accept-Encoding", "gzip,deflate");
-                // Set the ContentLength property of the WebRequest.
-                request.ContentLength = byteArray.Length;
-                // Get the request stream.
-                Stream dataStream = request.GetRequestStream();
-                // Write the data to the request stream.
-                dataStream.Write(byteArray, 0, byteArray.Length);
-                // Close the Stream object.
-                dataStream.Close();
-                // Get the response.
-                //request.Timeout = 740 * 1000;
-
-                if (EDDiscoveryForm.EDDConfig.EDSMLog)
-                    WriteEDSMLog("PATCH " + request.RequestUri, postData);
-
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                // Display the status.
-                //            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
-                // Get the stream containing content returned by the server.
-                dataStream = response.GetResponseStream();
-                // Open the stream using a StreamReader for easy access.
-                StreamReader reader = new StreamReader(dataStream);
-                // Read the content.
-                var data = new ResponseData(response.StatusCode, reader.ReadToEnd(), response.Headers);
-                // Display the content.
-                // Clean up the streams.
-                reader.Close();
-                dataStream.Close();
-                response.Close();
-
-                if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                try
                 {
-                    WriteEDSMLog(data.Body, "");
-                }
+                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
+                    request.Method = "PATCH";
+                    if (headers != null)
+                    {
+                        request.Headers.Add(headers);
+                    }
+                    string postData = json;
 
-                return data;
+
+                    byte[] byteArray = Encoding.UTF8.GetBytes(postData);
+                    // Set the ContentType property of the WebRequest.
+                    request.ContentType = "application/json; charset=utf-8";
+                    //request.Headers.Add("Accept-Encoding", "gzip,deflate");
+                    // Set the ContentLength property of the WebRequest.
+                    request.ContentLength = byteArray.Length;
+                    // Get the request stream.
+                    Stream dataStream = request.GetRequestStream();
+                    // Write the data to the request stream.
+                    dataStream.Write(byteArray, 0, byteArray.Length);
+                    // Close the Stream object.
+                    dataStream.Close();
+                    // Get the response.
+                    //request.Timeout = 740 * 1000;
+
+                    if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                        WriteEDSMLog("PATCH " + request.RequestUri, postData);
+
+                    HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                    // Display the status.
+                    //            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
+                    // Get the stream containing content returned by the server.
+                    dataStream = response.GetResponseStream();
+                    // Open the stream using a StreamReader for easy access.
+                    StreamReader reader = new StreamReader(dataStream);
+                    // Read the content.
+                    var data = new ResponseData(response.StatusCode, reader.ReadToEnd(), response.Headers);
+                    // Display the content.
+                    // Clean up the streams.
+                    reader.Close();
+                    dataStream.Close();
+                    response.Close();
+
+                    if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                    {
+                        WriteEDSMLog(data.Body, "");
+                    }
+
+                    return data;
+                }
+                catch (WebException ex)
+                {
+                    using (WebResponse response = ex.Response)
+                    {
+                        HttpWebResponse httpResponse = (HttpWebResponse)response;
+                        System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+                        System.Diagnostics.Trace.WriteLine("WebException : " + ex.Message);
+                        System.Diagnostics.Trace.WriteLine($"HTTP Error code: {httpResponse.StatusCode}");
+                        System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+                        if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                        {
+                            WriteEDSMLog("WebException" + ex.Message, "");
+                            WriteEDSMLog($"HTTP Error code: {httpResponse.StatusCode}", "");
+                        }
+                        return new ResponseData(httpResponse.StatusCode);
+                    }
+                }
             }
             catch (Exception ex)
             {
@@ -167,47 +191,71 @@ namespace EDDiscovery2.HTTP
 
 
 
-        protected ResponseData RequestGet(string action)
+        protected ResponseData RequestGet(string action, NameValueCollection headers = null)
         {
             try
             {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
-                // Set the Method property of the request to POST.
-                request.Method = "GET";
-
-                // Set the ContentType property of the WebRequest.
-                request.ContentType = "application/json; charset=utf-8";
-                request.Headers.Add("Accept-Encoding", "gzip,deflate");
-                request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-
-                if (EDDiscoveryForm.EDDConfig.EDSMLog)
-                    WriteEDSMLog("GET " + request.RequestUri, "");
-
-
-                // Get the response.
-                //request.Timeout = 740 * 1000;
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                // Display the status.
-                //            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
-                // Get the stream containing content returned by the server.
-                Stream dataStream = response.GetResponseStream();
-                // Open the stream using a StreamReader for easy access.
-                StreamReader reader = new StreamReader(dataStream);
-                // Read the content.
-                var data = new ResponseData(response.StatusCode, reader.ReadToEnd(), response.Headers);
-                var statusCode = response.StatusCode;
-                // Display the content.
-                // Clean up the streams.
-                reader.Close();
-                dataStream.Close();
-                response.Close();
-
-                if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                try
                 {
-                    WriteEDSMLog(data.Body, "");
-                }
+                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
+                    // Set the Method property of the request to POST.
+                    request.Method = "GET";
 
-                return data;
+                    // Set the ContentType property of the WebRequest.
+                    request.ContentType = "application/json; charset=utf-8";
+                    request.Headers.Add("Accept-Encoding", "gzip,deflate");
+                    if (headers != null)
+                    {
+                        request.Headers.Add(headers);
+                    }
+                    request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+
+                    if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                        WriteEDSMLog("GET " + request.RequestUri, "");
+
+
+                    // Get the response.
+                    //request.Timeout = 740 * 1000;
+                    HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                    // Display the status.
+                    //            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
+                    // Get the stream containing content returned by the server.
+                    Stream dataStream = response.GetResponseStream();
+                    // Open the stream using a StreamReader for easy access.
+                    StreamReader reader = new StreamReader(dataStream);
+                    // Read the content.
+                    var data = new ResponseData(response.StatusCode, reader.ReadToEnd(), response.Headers);
+                    var statusCode = response.StatusCode;
+                    // Display the content.
+                    // Clean up the streams.
+                    reader.Close();
+                    dataStream.Close();
+                    response.Close();
+
+                    if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                    {
+                        WriteEDSMLog(data.Body, "");
+                    }
+
+                    return data;
+                }
+                catch (WebException ex)
+                {
+                    using (WebResponse response = ex.Response)
+                    {
+                        HttpWebResponse httpResponse = (HttpWebResponse)response;
+                        System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+                        System.Diagnostics.Trace.WriteLine("WebException : " + ex.Message);
+                        System.Diagnostics.Trace.WriteLine($"HTTP Error code: {httpResponse.StatusCode}");
+                        System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+                        if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                        {
+                            WriteEDSMLog("WebException" + ex.Message, "");
+                            WriteEDSMLog($"HTTP Error code: {httpResponse.StatusCode}", "");
+                        }
+                        return new ResponseData(httpResponse.StatusCode);
+                    }
+                }
             }
             catch (Exception ex)
             {
@@ -226,45 +274,69 @@ namespace EDDiscovery2.HTTP
         }
 
 
-        protected ResponseData RequestDelete(string action)
+        protected ResponseData RequestDelete(string action, NameValueCollection headers = null)
         {
             try
             {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
-                request.Method = "DELETE";
-
-                // Set the ContentType property of the WebRequest.
-                request.ContentType = "application/json; charset=utf-8";
-                request.Headers.Add("Accept-Encoding", "gzip,deflate");
-                request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-
-                if (EDDiscoveryForm.EDDConfig.EDSMLog)
-                    WriteEDSMLog("DELETE " + request.RequestUri, "");
-
-
-                // Get the response.
-                //request.Timeout = 740 * 1000;
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                // Display the status.
-                //            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
-                // Get the stream containing content returned by the server.
-                Stream dataStream = response.GetResponseStream();
-                // Open the stream using a StreamReader for easy access.
-                StreamReader reader = new StreamReader(dataStream);
-                // Read the content.
-                var data = new ResponseData(response.StatusCode, reader.ReadToEnd(), response.Headers);
-                // Display the content.
-                // Clean up the streams.
-                reader.Close();
-                dataStream.Close();
-                response.Close();
-
-                if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                try
                 {
-                    WriteEDSMLog(data.Body, "");
-                }
+                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_serverAddress + action);
+                    request.Method = "DELETE";
 
-                return data;
+                    // Set the ContentType property of the WebRequest.
+                    request.ContentType = "application/json; charset=utf-8";
+                    request.Headers.Add("Accept-Encoding", "gzip,deflate");
+                    if (headers != null)
+                    {
+                        request.Headers.Add(headers);
+                    }
+                    request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+
+                    if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                        WriteEDSMLog("DELETE " + request.RequestUri, "");
+
+
+                    // Get the response.
+                    //request.Timeout = 740 * 1000;
+                    HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                    // Display the status.
+                    //            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
+                    // Get the stream containing content returned by the server.
+                    Stream dataStream = response.GetResponseStream();
+                    // Open the stream using a StreamReader for easy access.
+                    StreamReader reader = new StreamReader(dataStream);
+                    // Read the content.
+                    var data = new ResponseData(response.StatusCode, reader.ReadToEnd(), response.Headers);
+                    // Display the content.
+                    // Clean up the streams.
+                    reader.Close();
+                    dataStream.Close();
+                    response.Close();
+
+                    if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                    {
+                        WriteEDSMLog(data.Body, "");
+                    }
+
+                    return data;
+                }
+                catch (WebException ex)
+                {
+                    using (WebResponse response = ex.Response)
+                    {
+                        HttpWebResponse httpResponse = (HttpWebResponse)response;
+                        System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+                        System.Diagnostics.Trace.WriteLine("WebException : " + ex.Message);
+                        System.Diagnostics.Trace.WriteLine($"HTTP Error code: {httpResponse.StatusCode}");
+                        System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+                        if (EDDiscoveryForm.EDDConfig.EDSMLog)
+                        {
+                            WriteEDSMLog("WebException" + ex.Message, "");
+                            WriteEDSMLog($"HTTP Error code: {httpResponse.StatusCode}", "");
+                        }
+                        return new ResponseData(httpResponse.StatusCode);
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/EDDiscovery/HTTP/ResponseData.cs
+++ b/EDDiscovery/HTTP/ResponseData.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Specialized;
+using System.Net;
+
+namespace EDDiscovery2.HTTP
+{
+    public struct ResponseData
+    {
+        public ResponseData(HttpStatusCode statusCode)
+        {
+            StatusCode = statusCode;
+            Body = null;
+            Headers = null;
+        }
+
+        public ResponseData(HttpStatusCode statusCode, string content, NameValueCollection headers)
+        {
+            StatusCode = statusCode;
+            Body = content;
+            Headers = headers;
+        }
+
+        public HttpStatusCode StatusCode; // Sometimes you need the status code if you're in a
+                                          // converstation with the server
+        public string Body;
+        public NameValueCollection Headers;
+    }
+
+}

--- a/EDDiscovery/PlanetSystems/Planets.cs
+++ b/EDDiscovery/PlanetSystems/Planets.cs
@@ -465,6 +465,9 @@ public enum AtmosphereEnum
 
         public MaterialEnum MaterialFromString(string v)
         {
+            if (v == null)
+                return MaterialEnum.Unknown;
+
             foreach (MaterialEnum mat in Enum.GetValues(typeof(MaterialEnum)))
             {
                 if (v.ToLower().Equals(mat.ToString().ToLower()))

--- a/EDDiscovery/PlanetSystems/PlanetsForm.cs
+++ b/EDDiscovery/PlanetSystems/PlanetsForm.cs
@@ -185,11 +185,6 @@ namespace EDDiscovery2.PlanetSystems
 
         private void toolStripButtonSave_Click(object sender, EventArgs e)
         {
-            var edo = new EDObject();
-            edo.system = "MarlonTest";
-            edo.objectName = "A 1";
-            edo.commander = "Marlon Blake";
-            edmat.Store(edo);
         }
 
         private void listView1_SelectedIndexChanged(object sender, EventArgs e)

--- a/EDDiscovery/PlanetSystems/PlanetsForm.cs
+++ b/EDDiscovery/PlanetSystems/PlanetsForm.cs
@@ -185,7 +185,11 @@ namespace EDDiscovery2.PlanetSystems
 
         private void toolStripButtonSave_Click(object sender, EventArgs e)
         {
-
+            var edo = new EDObject();
+            edo.system = "MarlonTest";
+            edo.objectName = "A 1";
+            edo.commander = "Marlon Blake";
+            edmat.Store(edo);
         }
 
         private void listView1_SelectedIndexChanged(object sender, EventArgs e)

--- a/EDDiscovery/PlanetSystems/edmaterializer.cs
+++ b/EDDiscovery/PlanetSystems/edmaterializer.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using EDDiscovery2.HTTP;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +8,7 @@ using System.Web;
 
 namespace EDDiscovery2.PlanetSystems
 {
-    public class EdMaterializer : HttpCom
+    public class EdMaterializer : EDMaterizliaerCom
     {
 
 
@@ -15,10 +16,10 @@ namespace EDDiscovery2.PlanetSystems
         {
 #if DEBUG
             // Dev server. Mess with data as much as you like here
-            ServerAdress = "https://ed-materializer.herokuapp.com/";
+            _serverAddress = "https://ed-materializer.herokuapp.com/";
 #else
             // Production
-            ServerAdress = "http://ed-materializer-env.elasticbeanstalk.com/";
+            _serverAddress = "http://ed-materializer-env.elasticbeanstalk.com/";
 #endif
         }
 
@@ -31,8 +32,8 @@ namespace EDDiscovery2.PlanetSystems
             if (!String.IsNullOrEmpty(system))
                 query = query + "/?q[system]="+HttpUtility.UrlEncode(system);
 
-            string json = RequestGet(query);
-
+            var response = RequestGet(query);
+            var json = response.Content;
 
             JArray jArray = null;
             JObject jObject = null;
@@ -112,18 +113,19 @@ namespace EDDiscovery2.PlanetSystems
 
             JObject joPost = new JObject(new JProperty("world_survey", jo));
 
-            string json;
-
             if (edobj.id == 0)
             {
-                json = RequestPost(joPost.ToString(), "api/v1/world_surveys");
+                var response = RequestPost(joPost.ToString(), "api/v1/world_surveys");
+                var json = response.Content;
 
                 JObject jo2 = (JObject)JObject.Parse(json);
                 JObject obj = (JObject)jo2["world_survey"];
                 edobj.id = obj["id"].Value<int>();
             }
             else
-                json = RequestPatch(joPost.ToString(), "api/v1/world_surveys/" + edobj.id.ToString());
+            {
+                var response = RequestPatch(joPost.ToString(), "api/v1/world_surveys/" + edobj.id.ToString());
+            }
             return true;
 
 
@@ -131,8 +133,8 @@ namespace EDDiscovery2.PlanetSystems
 
         public bool DeleteID(int id)
         {
-            string json = RequestDelete("api/v1/world_surveys/"+id.ToString());
-
+            var response = RequestDelete("api/v1/world_surveys/"+id.ToString());
+            
             return true;
         }
 

--- a/EDDiscovery/PlanetSystems/edmaterializer.cs
+++ b/EDDiscovery/PlanetSystems/edmaterializer.cs
@@ -33,7 +33,7 @@ namespace EDDiscovery2.PlanetSystems
                 query = query + "/?q[system]="+HttpUtility.UrlEncode(system);
 
             var response = RequestGet(query);
-            var json = response.Content;
+            var json = response.Body;
 
             JArray jArray = null;
             JObject jObject = null;
@@ -116,7 +116,7 @@ namespace EDDiscovery2.PlanetSystems
             if (edobj.id == 0)
             {
                 var response = RequestPost(joPost.ToString(), "api/v1/world_surveys");
-                var json = response.Content;
+                var json = response.Body;
 
                 JObject jo2 = (JObject)JObject.Parse(json);
                 JObject obj = (JObject)jo2["world_survey"];

--- a/EDDiscovery/PlanetSystems/edmaterializer.cs
+++ b/EDDiscovery/PlanetSystems/edmaterializer.cs
@@ -113,9 +113,16 @@ namespace EDDiscovery2.PlanetSystems
 
             JObject joPost = new JObject(new JProperty("world_survey", jo));
 
+            // Suggestion: Instead of checking local data, just try a POST first. if the response 
+            //             is a 422 then try again with a PATCH. This'll work even if the local data 
+            //             is out of sync with the server.
+            //
+            //             Note: There is no enum for 422, so you'd have to check it as:
+            //             response.StatusCode == (HttpStatusCode)422;
+            //             - Greg
             if (edobj.id == 0)
             {
-                var response = RequestPost(joPost.ToString(), "api/v1/world_surveys");
+                var response = RequestSecurePost(joPost.ToString(), "api/v1/world_surveys");
                 var json = response.Body;
 
                 JObject jo2 = (JObject)JObject.Parse(json);


### PR DESCRIPTION
Ok, tons of changes!

Primarily I've created `RequestSecurePost`, `RequestSecurePatch` and `RequestSecureDelete` to connect to the server automatically logging in and afterwards passing the auth tokens.

Other things:
1) @finwen will need to copy `AppSettingsSecrets.config.example` to `AppSettingsSecrets.config` and fill in the credentials on the machine that builds releases. This file is intentionally outside of the git repo. I'll send you the credentials separately
2) Moved HttpCon into a new HTTP namespace along with the new EDMaterializerCon which has the secure methods for auth token based requests
3) I made all the HttpCon return the StatusCode as well as the data (new Struct called ResponseData). I did this because we're getting into territory where the response codes need to be examined during server conversations.
4) Exceptions thrown in the Request methods will return the proper HTTP Status Code. I've also added the information to the logging.
5) Added a couple of assemblies. Watch out for that when building install media.
6) Some of the Planet enums methods were blowing up because of nulls, so added some "return if null" type logic.
7) I added something so that if a POST fails it'll try again as a PATCH. This will help if the server gets out of sync with the sqlite. At some point I may write a create_or_update action in EDMaterializer to negate the need for this.