### PR TITLE
Optimise routeplanner

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -144,7 +144,8 @@ namespace EDDiscovery
                 Text += "         Systems:  " + SystemData.SystemList.Count;
 
                 imageHandler1.StartWatcher();
-
+                routeControl1.UpdateRouteButtonState(); // now we have systems, we can update this..
+                
                 routeControl1.travelhistorycontrol1 = travelHistoryControl1;
                 travelHistoryControl1.netlog.OnNewPosition += new NetLogEventHandler(routeControl1.NewPosition);
                 travelHistoryControl1.netlog.OnNewPosition += new NetLogEventHandler(travelHistoryControl1.NewPosition);
@@ -758,6 +759,9 @@ namespace EDDiscovery
             _db.PutSettingString("DefaultMapCenter", textBoxHomeSystem.Text);
             _db.PutSettingDouble("DefaultMapZoom", Double.Parse(textBoxDefaultZoom.Text));
             _db.PutSettingBool("CentreMapOnSelection", radioButtonHistorySelection.Checked);
+            _db.PutSettingString("RouteFrom", routeControl1.textBox_From.Text);
+            _db.PutSettingString("RouteTo", routeControl1.textBox_To.Text);
+            _db.PutSettingString("RouteRange", routeControl1.textBox_Range.Text);
             EDDConfig.UseDistances = checkBox_Distances.Checked;
             EDDConfig.EDSMLog = checkBoxEDSMLog.Checked;
             EDDConfig.CanSkipSlowUpdates = checkboxSkipSlowUpdates.Checked;
@@ -970,6 +974,7 @@ namespace EDDiscovery
             panelInfo.BackColor = Color.Gold;
 
             routeControl1.travelhistorycontrol1 = travelHistoryControl1;
+            routeControl1.SetFromTo(_db.GetSettingString("RouteFrom", ""), _db.GetSettingString("RouteTo", ""), _db.GetSettingString("RouteRange", "15"));
         }
 
         private void UpdateTitle()

--- a/EDDiscovery/EMK/Graph.cs
+++ b/EDDiscovery/EMK/Graph.cs
@@ -16,29 +16,33 @@ using System.Collections.Generic;
 
 namespace EMK.Cartography
 {
-	/// <summary>
-	/// Graph structure. It is defined with :
-	/// It is defined with both a list of nodes and a list of arcs.
-	/// </summary>
-	[Serializable]
-	public class Graph
-	{
-		List<Node> LN;
-		List<Arc> LA;
+    /// <summary>
+    /// Graph structure. It is defined with :
+    /// It is defined with both a list of nodes and a list of arcs.
+    /// </summary>
+    [Serializable]
+    public class Graph
+    {
+        List<Node> LN;
+        List<Arc> LA;
 
-		/// <summary>
-		/// Constructor.
-		/// </summary>
-		public Graph()
-		{
-			LN = new List<Node>();
-			LA = new List<Arc>();
-		}
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public Graph()
+        {
+            LN = new List<Node>();
+            LA = new List<Arc>();
+        }
 
-		/// <summary>
-		/// Gets the List interface of the nodes in the graph.
-		/// </summary>
-		public List<Node> Nodes { get { return LN; } }
+        public int Count { get { return LN.Count; } }
+        public Node GetN(int i) { return LN[i]; }
+        public List<Node> GetNodes { get { return LN; } }
+
+        /// <summary>
+        /// Gets the List interface of the nodes in the graph.
+        /// </summary>
+        public List<Node> Nodes { get { return LN; } }
 
 		/// <summary>
 		/// Gets the List interface of the arcs in the graph.

--- a/EDDiscovery/RouteControl.Designer.cs
+++ b/EDDiscovery/RouteControl.Designer.cs
@@ -39,8 +39,6 @@
             this.textBox_Range = new System.Windows.Forms.TextBox();
             this.textBoxCurrent = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // richTextBox1
@@ -48,6 +46,7 @@
             this.richTextBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.richTextBox1.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.richTextBox1.Location = new System.Drawing.Point(3, 55);
             this.richTextBox1.Name = "richTextBox1";
             this.richTextBox1.Size = new System.Drawing.Size(627, 358);
@@ -62,6 +61,7 @@
             this.textBox_From.Name = "textBox_From";
             this.textBox_From.Size = new System.Drawing.Size(125, 20);
             this.textBox_From.TabIndex = 15;
+            this.textBox_From.TextChanged += new System.EventHandler(this.textBox_From_TextChanged);
             // 
             // label3
             // 
@@ -118,6 +118,7 @@
             this.textBox_To.Name = "textBox_To";
             this.textBox_To.Size = new System.Drawing.Size(125, 20);
             this.textBox_To.TabIndex = 16;
+            this.textBox_To.TextChanged += new System.EventHandler(this.textBox_To_TextChanged);
             // 
             // textBox_Range
             // 
@@ -126,7 +127,6 @@
             this.textBox_Range.Size = new System.Drawing.Size(57, 20);
             this.textBox_Range.TabIndex = 17;
             this.textBox_Range.Text = "15";
-            this.textBox_Range.TextChanged += new System.EventHandler(this.textBox_Range_TextChanged);
             this.textBox_Range.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBox_Range_KeyPress);
             // 
             // textBoxCurrent
@@ -138,7 +138,6 @@
             this.textBoxCurrent.ReadOnly = true;
             this.textBoxCurrent.Size = new System.Drawing.Size(125, 20);
             this.textBoxCurrent.TabIndex = 22;
-            this.textBoxCurrent.TextChanged += new System.EventHandler(this.textBoxCurrent_TextChanged);
             this.textBoxCurrent.DoubleClick += new System.EventHandler(this.textBoxCurrent_DoubleClick);
             // 
             // label5
@@ -150,31 +149,10 @@
             this.label5.TabIndex = 23;
             this.label5.Text = "Current";
             // 
-            // textBox2
-            // 
-            this.textBox2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.textBox2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.textBox2.Location = new System.Drawing.Point(251, 30);
-            this.textBox2.Name = "textBox2";
-            this.textBox2.ReadOnly = true;
-            this.textBox2.Size = new System.Drawing.Size(125, 20);
-            this.textBox2.TabIndex = 24;
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(216, 33);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(29, 13);
-            this.label6.TabIndex = 25;
-            this.label6.Text = "Next";
-            // 
             // RouteControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.textBox2);
-            this.Controls.Add(this.label6);
             this.Controls.Add(this.textBoxCurrent);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.richTextBox1);
@@ -204,10 +182,8 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label1;
         internal System.Windows.Forms.TextBox textBox_To;
-        private System.Windows.Forms.TextBox textBox_Range;
         internal System.Windows.Forms.TextBox textBoxCurrent;
         private System.Windows.Forms.Label label5;
-        internal System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.Label label6;
+        internal System.Windows.Forms.TextBox textBox_Range;
     }
 }

--- a/EDDiscovery/RouteControl.cs
+++ b/EDDiscovery/RouteControl.cs
@@ -13,22 +13,22 @@ using Newtonsoft.Json;
 using System.Diagnostics;
 using EDDiscovery.DB;
 using System.Threading;
+using EMK.LightGeometry;
 
 namespace EDDiscovery
 {
     public partial class RouteControl : UserControl
     {
         Graph G;
-        List<Node> nodes;
-        float lastJumprange = -1;
         internal TravelHistoryControl travelhistorycontrol1;
 
         public RouteControl()
         {
             InitializeComponent();
+            button_Route.Enabled = false;
         }
 
-             private Thread ThreadRoute;
+        private Thread ThreadRoute;
 
         private void button_Route_Click_1(object sender, EventArgs e)
         {
@@ -38,55 +38,56 @@ namespace EDDiscovery
             ThreadRoute = new System.Threading.Thread(new System.Threading.ThreadStart(RouteMain));
             ThreadRoute.Name = "Thread Route";
             ThreadRoute.Start();
-
-            
-            //Route(textBox_From.Text, textBox_To.Text, maxrange, 0); 
-            //Route(textBox_From.Text, textBox_To.Text, maxrange, 1);
-
         }
 
         private void RouteMain()
         {
             float maxrange = float.Parse(textBox_Range.Text);
-
-            //button_Route.Enabled = false;
             Route(textBox_From.Text, textBox_To.Text, maxrange, 0);
-            //button_Route.Enabled = true;
+            this.Invoke(new Action(() => button_Route.Enabled = true));
         }
 
         private void Route(string s1, string s2, float maxrange, int mode)
         {
+            EDDiscovery2.DB.ISystem ds1 = SystemData.GetSystem(s1);
+            EDDiscovery2.DB.ISystem ds2 = SystemData.GetSystem(s2);
 
-
-            Stopwatch sw = new Stopwatch();
-
-            if (lastJumprange != maxrange)
-            {
-                G = new Graph();
-                PrepareNodes(G, out nodes, maxrange, mode);
-                //Console.WriteLine("Prepare nodes time: {0}", sw.Elapsed);
-                lastJumprange = maxrange;
-            }
-
-            AStar AS = new AStar(G);
-
-            Node start, stop;
-
-
-            start = nodes.FirstOrDefault(x => x.System.SearchName == s1.ToLower());
-            stop = nodes.FirstOrDefault(x => x.System.SearchName == s2.ToLower());
-            bool res;
-
-            if (start == null)
+            if (ds1 == null)          // warn here, quicker to complain than waiting for nodes to populate.
             {
                 AppendText("Start system:  " + s1 + " unknown");
                 return;
             }
-            if (stop == null)
+            if (ds2 == null)
             {
                 AppendText("Destination system:  " + s2 + " unknown");
                 return;
             }
+
+            double earea = 10.0;            // add a little to the box for first/end points allowing out of box systems
+            Point3D minpos = new EMK.LightGeometry.Point3D(
+                    Math.Min(ds1.x, ds2.x) - earea,
+                    Math.Min(ds1.y, ds2.y) - earea,
+                    Math.Min(ds1.z, ds2.z) - earea );
+            Point3D maxpos = new EMK.LightGeometry.Point3D(
+                    Math.Max(ds1.x, ds2.x) + earea,
+                    Math.Max(ds1.y, ds2.y)+ earea,
+                    Math.Max(ds1.z, ds2.z) + earea );
+
+            AppendText("Bounding Box " + minpos.X + "," + minpos.Y + "," + minpos.Z + " to " + maxpos.X + "," + maxpos.Y + "," + maxpos.Z + Environment.NewLine);
+
+            Stopwatch sw = new Stopwatch();
+
+            G = new Graph();                    // need to compute each time as systems in range changes each time
+            PrepareNodes(G, maxrange, mode,minpos,maxpos);
+        
+            AStar AS = new AStar(G);
+
+            Node start, stop;
+
+            start = G.GetNodes.FirstOrDefault(x => x.System.SearchName == s1.ToLower());
+            stop = G.GetNodes.FirstOrDefault(x => x.System.SearchName == s2.ToLower());
+
+            bool res;
 
             sw = new Stopwatch();
 
@@ -95,34 +96,36 @@ namespace EDDiscovery
             sw.Stop();
 
 
-            AppendText("Searching route from " + s1 + " to " + s2 + Environment.NewLine);
+            AppendText("Searching route from " + ds1.name + " to " + ds2.name + Environment.NewLine);
             AppendText("Find route Time: " + sw.Elapsed.TotalSeconds.ToString("0.000s") + Environment.NewLine);
             AppendText("Total distance: " + SystemData.Distance(s1, s2).ToString("0.00") + Environment.NewLine);
             AppendText("Max jumprange:" + maxrange + Environment.NewLine);
 
-            double totdist = 0;
-            int jumps = 0;
-
             if (res)
             {
+                AppendText(Environment.NewLine + "Depart " + ds1.name + Environment.NewLine);
+
+                double totdist = 0;
+                int jumps = 0;
+
                 foreach (Arc A in AS.PathByArcs)
                 {
                     double dist = SystemData.Distance(A.StartNode.System.name, A.EndNode.System.name);
-                    AppendText(A.EndNode.System.name + " \tDist: " + dist.ToString("0.00") + " ly" + Environment.NewLine);
+                    AppendText(string.Format("{0,-30}Dist: {1:0.00} ly" + Environment.NewLine, A.EndNode.System.name, dist));
+
                     totdist += dist;
                     jumps++;
 
                     Console.WriteLine(A.ToString());
                 }
 
-               // JArray ja = Path2JSON(AS);
+                AppendText(Environment.NewLine + "Total distance: " + totdist.ToString("0.00") + Environment.NewLine);
+                AppendText("Jumps: " + jumps + Environment.NewLine);
+
+                // JArray ja = Path2JSON(AS);
             }
-            else Console.WriteLine("No result !");
-
-
-            AppendText("Total distance: " + totdist.ToString("0.00") + Environment.NewLine);
-            AppendText("Jumps: " + jumps + Environment.NewLine);
-            this.Invoke(new Action(() => button_Route.Enabled = true));
+            else
+                AppendText(Environment.NewLine + "NO Solution found - jump distance is too small or not enough star data between systems" + Environment.NewLine);
         }
 
 
@@ -163,13 +166,11 @@ namespace EDDiscovery
             return ja;
         }
 
-        private  void PrepareNodes(Graph G, out List<Node> nodes, float maxrange, int mode)
+        private  void PrepareNodes(Graph G, float maxrange, int mode, Point3D minpos , Point3D maxpos)
         {
             List<SystemClass> systems = SystemData.SystemList;
-            nodes = new List<Node>();
-            SystemClass arcsystem;
             float distance, maxrangex2 = maxrange * maxrange;
-            Node N2;
+            Node N1,N2;
             float weight = 1;
             float dx, dy, dz;
 
@@ -178,47 +179,43 @@ namespace EDDiscovery
             sw.Start();
 
             SystemClass system;
-            Node N1;
 
             for (int ii = 0; ii < systems.Count; ii++)
             {
                 system = systems[ii];
-                N1 = new Node(system.x, system.y, system.z, system);
-
-                G.AddNodeWithNoChk(N1);
-                nodes.Add(N1);
+                                                    // screening out stars reduces number and makes the arc calculator much quicker.
+                if (system.x >= minpos.X && system.x <= maxpos.X &&
+                    system.y >= minpos.Y && system.y <= maxpos.Y &&
+                    system.z >= minpos.Z && system.z <= maxpos.Z )
+                {
+                    N1 = new Node(system.x, system.y, system.z, system);
+                    G.AddNodeWithNoChk(N1);
+                }
             }
 
             sw.Stop();
-            
+
             AppendText("Add stars: " + sw.Elapsed.TotalSeconds.ToString("0.000s") + Environment.NewLine);
+            AppendText("No stars within bounds " + G.Count + Environment.NewLine);
 
             sw.Restart();
-            for (int ii = 0; ii < systems.Count; ii++)
+            for (int ii = 0; ii < G.Count; ii++)
             {
-                system = systems[ii];
-                N1 = nodes[ii];
+                N1 = G.GetN(ii);
 
-
-                for (int jj = ii; jj < systems.Count; jj++)
+                for (int jj = ii; jj < G.Count; jj++)
                 {
-                    arcsystem = systems[jj];
+                    N2 = G.GetN(jj);
 
-                    dx = (float)(system.x - arcsystem.x);
-                    dy = (float)(system.y - arcsystem.y);
-                    dz = (float)(system.z - arcsystem.z);
+                    dx = (float)(N1.X - N2.X);
+                    dy = (float)(N1.Y - N2.Y);
+                    dz = (float)(N1.Z - N2.Z);
                     distance = dx * dx + dy * dy + dz * dz;
-
-                    //distance = (float)((system.x - arcsystem.x) * (system.x - arcsystem.x) + (system.y - arcsystem.y) * (system.y - arcsystem.y) + (system.z - arcsystem.z) * (system.z - arcsystem.z));
 
                     if (distance > 0 && distance <= maxrangex2)
                     {
-                        N2 = nodes[jj];
-
-
                         if (mode == 1)
                             weight = (float)(1 / distance);
-
 
                         G.AddArcWithNoChk(N1, N2, weight);
                         G.AddArcWithNoChk(N2, N1, weight);
@@ -232,11 +229,6 @@ namespace EDDiscovery
 
         }
 
-        private void textBox_Range_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void textBox_Range_KeyPress(object sender, KeyPressEventArgs e)
         {
             Tools.TextBox_Numeric_KeyPress(sender, e);
@@ -244,11 +236,9 @@ namespace EDDiscovery
 
         private void RouteControl_Load(object sender, EventArgs e)
         {
-
             //travelhistorycontrol1.netlog.OnNewPosition += new NetLogEventHandler(NewPosition);
-
-         
-        }
+       
+       }
 
         internal void NewPosition(object source)
         {
@@ -259,12 +249,7 @@ namespace EDDiscovery
             });
         }
 
-        private void textBoxCurrent_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void textBoxCurrent_DoubleClick(object sender, EventArgs e)
+         private void textBoxCurrent_DoubleClick(object sender, EventArgs e)
         {
             textBox_From.Text = textBoxCurrent.Text;
         }
@@ -284,6 +269,33 @@ namespace EDDiscovery
             }
         }
 
+        private void textBox_From_TextChanged(object sender, EventArgs e)
+        {
+            button_Route.Enabled = IsRouteValid();
+        }
 
+        private void textBox_To_TextChanged(object sender, EventArgs e)
+        {
+            button_Route.Enabled = IsRouteValid();
+        }
+
+        private bool IsRouteValid() 
+        {
+            EDDiscovery2.DB.ISystem ds1 = SystemData.GetSystem(textBox_From.Text);
+            EDDiscovery2.DB.ISystem ds2 = SystemData.GetSystem(textBox_To.Text);
+            return ds1 != null && ds2 != null;
+        }
+
+        public void SetFromTo(string from, string to , string range )
+        {
+            textBox_From.Text = from;
+            textBox_To.Text = to;
+            textBox_Range.Text = range;
+        }
+
+        public void UpdateRouteButtonState()
+        {
+            button_Route.Enabled = IsRouteValid();
+        }
     }
 }


### PR DESCRIPTION
 Optimise Route Planner and Fix up Dialogs

This optimises the route planner by only searching stars within a bounding box - this speeds up finding paths thru the known star area greatly. Also, 
fixes so it remembers across invocations the last stars and range, 
only allowing the find route button to be enabled when star data is available and the systems entered in the dialog exist
Cleaned up output of dialog so easier to read.
Removed unnecessary duplication of data into other variables, the Graph has all the data you need to added a few simple accessor functions to it
Graph needs computing each time as bounding box changes, overall limiting stars is the most important to the speed as its limiting the
 number of arcs is the important part to the overall speed.
