### PR TITLE
Trilateration fixes and enhancements

### DIFF
--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -311,7 +311,7 @@ namespace EDDiscovery2.EDSM
             if (json == null)
                 return 0;
 
-            JObject msg = (JObject)JObject.Parse(json);
+            JObject msg = JObject.Parse(json);
             int msgnr = msg["msgnum"].Value<int>();
 
             JArray logs = (JArray)msg["logs"];
@@ -336,9 +336,16 @@ namespace EDDiscovery2.EDSM
             return msgnr;
         }
 
+        public bool IsKnownSystem(string sysName)
+        {
+            string query = "system?sysname=" + HttpUtility.UrlEncode(sysName) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey;
+            var response = RequestGet("api-v1/" + query);
+            var json = response.Body;
+            if (json == null)
+                return false;
 
-        
-
+            return (json.ToString() != "-1");
+        }
 
     }
 }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -166,9 +166,7 @@ namespace EDDiscovery
 
             if (visitedSystems == null)
                 return;
-
-            //var result = visitedSystems.OrderByDescending(a => a.time).ToList<SystemPosition>();
-
+            
             List<SystemPosition> result;
             if (atMost > 0)
             {
@@ -180,20 +178,10 @@ namespace EDDiscovery
                 result = (from systems in visitedSystems where systems.time > oldestData orderby systems.time descending select systems).ToList();
             }
 
-            //DataTable dt = new DataTable();
-            //dataGridView1.Columns.Clear();
-            //dt.Columns.Add("Time");
-            //dt.Columns.Add("System");
-            //dt.Columns.Add("Distance");
-
-
             dataGridView1.Rows.Clear();
 
-            //dataGridView1.DataSource = dt;
-
             System.Diagnostics.Trace.WriteLine("SW1: " + (sw1.ElapsedMilliseconds / 1000.0).ToString("0.000"));
-
-
+            
             for (int ii = 0; ii < result.Count; ii++) //foreach (var item in result)
             {
       
@@ -208,10 +196,31 @@ namespace EDDiscovery
                 AddHistoryRow(false, item, item2);
             }
 
+            if (result.Count != visitedSystems.Count)
+            {
+                // we didn't put all the systems in the history grid
+                // make sure that the LastKnown system is properly loaded if it's not visible so trilateration can find it...
+                var lastKnown = (from systems
+                                 in visitedSystems
+                                 where systems.curSystem != null && systems.curSystem.HasCoordinate
+                                 orderby systems.time descending
+                                 select systems.curSystem).FirstOrDefault();
+                if (lastKnown == null)
+                {
+                    for (int ii = visitedSystems.Count - 1; ii > 0; ii--)
+                    {
+                        SystemClass sys = SystemData.GetSystem(visitedSystems[ii].Name);
+                        if (visitedSystems[ii].curSystem == null && sys != null)
+                        {
+                            visitedSystems[ii].curSystem = sys;
+                            if (sys.HasCoordinate) break;
+                        }
+                    }
+                }
+            }
+
             System.Diagnostics.Trace.WriteLine("SW2: " + (sw1.ElapsedMilliseconds / 1000.0).ToString("0.000"));
-
-            //setRowNumber(dataGridView1);
-
+            
             if (dataGridView1.Rows.Count > 0)
             {
                 lastRowIndex = 0;

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -152,14 +152,23 @@ namespace EDDiscovery
                 {
                     return;
                 }
+
+                var enteredSystems = GetEnteredSystems();
+                if (enteredSystems.Where(es => es.name == value).Count() > 0)
+                {
+                    LogText("Duplicate system entry is not allowed" + Environment.NewLine, Color.Red);
+                    dataGridViewDistances.Rows.Remove(dataGridViewDistances.Rows[e.RowIndex]);
+                    return;
+                }
+
                 var system = SystemData.GetSystem(value);
 
                 if (system == null)
                 {
                     if (!edsm.IsKnownSystem(value))
                     {
-                        LogText("Only systems with coordinates or already known to EDSM can be added");
-                        cell.Value = null;
+                        LogText("Only systems with coordinates or already known to EDSM can be added" + Environment.NewLine, Color.Red);
+                        dataGridViewDistances.Rows.Remove(dataGridViewDistances.Rows[e.RowIndex]);
                         return;
                     }
                     else


### PR DESCRIPTION
Distances to systems known to EDSM but without coordinates can now be entered (and user notified if they become known).
Starting new trilateration no longer breaks the exclusion of Entered Systems from the auto-complete list.
System details for Last Known system are now loaded when filtered out of initial Travel History grid population to ensure they are available to trilateration.

Resolves:
https://github.com/EDDiscovery/EDDiscovery/issues/87
https://github.com/EDDiscovery/EDDiscovery/issues/84
https://github.com/EDDiscovery/EDDiscovery/issues/81