### PR TITLE
Trilateration GUI: Skip over read-only cells when using keyboard.

### DIFF
--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -103,6 +103,7 @@
             this.dataGridViewDistances.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewDistances_CellValidating);
             this.dataGridViewDistances.CurrentCellChanged += new System.EventHandler(this.dataGridViewDistances_CurrentCellChanged);
             this.dataGridViewDistances.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewDistances_EditingControlShowing);
+            this.dataGridViewDistances.KeyDown += new System.KeyEventHandler(this.dataGridViewDistances_KeyDown);
             // 
             // ColumnSystem
             // 

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -101,6 +101,7 @@
             this.dataGridViewDistances.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellEndEdit);
             this.dataGridViewDistances.CellLeave += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellLeave);
             this.dataGridViewDistances.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewDistances_CellValidating);
+            this.dataGridViewDistances.CurrentCellChanged += new System.EventHandler(this.dataGridViewDistances_CurrentCellChanged);
             this.dataGridViewDistances.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewDistances_EditingControlShowing);
             // 
             // ColumnSystem


### PR DESCRIPTION
Tested and works (for me (tm)); now pressing "Tab" after entering a distance in the Trilateration jumps to the next system name (on the next row), instead of to the calculated distance.

Implementation is slightly more complicated and generic than absolutely necessary - instead of hard-coding jumping to the first column of the next row, it skips over any intervening rows which are read-only. This could be reused elsewhere.