### PR TITLE
Check for actual current system when clicking the Trilaterate button,…

### DIFF
--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -952,10 +952,15 @@ namespace EDDiscovery
         
         private void buttonTrilaterate_Click(object sender, EventArgs e)
         {
-            TrilaterationControl tctrl = _discoveryForm.trilaterationControl;
+            ISystem currSys = GetCurrentSystem();
 
-            _discoveryForm.ShowTrilaterationTab();
-            tctrl.Set(((SystemPosition)dataGridView1.CurrentRow.Cells[1].Tag).curSystem);
+            if (currSys != null)
+            {
+                TrilaterationControl tctrl = _discoveryForm.trilaterationControl;
+
+                _discoveryForm.ShowTrilaterationTab();
+                tctrl.Set(currSys);
+            }
         }
     
 		public ISystem CurrentSystem

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -154,11 +154,22 @@ namespace EDDiscovery
 
                 if (value == "")
                 {
+                    dataGridViewDistances.Rows[e.RowIndex].ErrorText = null;
                     return;
                 }
 
-                var regex = new Regex(@"^\d{1,5}([,.]\d{1,2})?$");
-                e.Cancel = !regex.Match(e.FormattedValue.ToString()).Success;
+                //var regex = new Regex(@"^((\d{1,2}[,.]\d{3})|(\d{1,5}))([,.]\d{1,2})?$");
+                //e.Cancel = !regex.Match(e.FormattedValue.ToString()).Success;
+                double dummy;
+                if ( double.TryParse(value, out dummy))
+                {
+                    dataGridViewDistances.Rows[e.RowIndex].ErrorText = null;
+                }
+                else
+                {
+                    e.Cancel = true;
+                    dataGridViewDistances.Rows[e.RowIndex].ErrorText = "Invalid number";
+                }
             }
         }
 
@@ -249,6 +260,8 @@ namespace EDDiscovery
             }
             else if (e.ColumnIndex == 1)
             {
+                double dist = double.Parse(dataGridViewDistances[1, e.RowIndex].Value.ToString());
+                dataGridViewDistances[1, e.RowIndex].Value = dist.ToString();
                 // trigger trilateration calculation
                 RunTrilateration();
             }
@@ -294,8 +307,8 @@ namespace EDDiscovery
                 var system = (SystemClass)systemCell.Tag;
                 if (system != null && system.HasCoordinate)
                 {
-                    var culture = new CultureInfo("en-US");
-                    var distance = double.Parse(distanceCell.Value.ToString().Replace(",", "."), culture);
+                    //var culture = new CultureInfo("en-US");
+                    var distance = double.Parse(distanceCell.Value.ToString());
 
                     var entry = new Trilateration.Entry(system.x, system.y, system.z, distance);
 
@@ -744,7 +757,6 @@ namespace EDDiscovery
                 edsm.commanderName = commanderName;
             }
             var distances = new Dictionary<string, double>();
-            var culture = new CultureInfo("en-US");
             for (int i = 0, count = dataGridViewDistances.Rows.Count - 1; i < count; i++)
             {
                 var systemCell = dataGridViewDistances[0, i];
@@ -752,7 +764,7 @@ namespace EDDiscovery
                 if (systemCell.Value != null && distanceCell.Value != null)
                 {
                     var system = systemCell.Value.ToString();
-                    var distance = double.Parse(distanceCell.Value.ToString().Replace(",", "."), culture);
+                    var distance = double.Parse(distanceCell.Value.ToString());
                     // can over-ride drop down now if it's a real system so you could add duplicates if you wanted (even once I've figured out issue #81 which makes it easy if not likely...)
                     if (!distances.Keys.Contains(system))
                     {

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -260,10 +260,13 @@ namespace EDDiscovery
             }
             else if (e.ColumnIndex == 1)
             {
-                double dist = double.Parse(dataGridViewDistances[1, e.RowIndex].Value.ToString());
-                dataGridViewDistances[1, e.RowIndex].Value = dist.ToString();
-                // trigger trilateration calculation
-                RunTrilateration();
+                if (dataGridViewDistances[1, e.RowIndex].Value != null && !string.IsNullOrEmpty(dataGridViewDistances[1, e.RowIndex].Value.ToString()))
+                {
+                    double dist = double.Parse(dataGridViewDistances[1, e.RowIndex].Value.ToString());
+                    dataGridViewDistances[1, e.RowIndex].Value = dist.ToString();
+                    // trigger trilateration calculation
+                    RunTrilateration();
+                }
             }
             /* skip to the next editable cell */
             skipReadOnlyCells = true;


### PR DESCRIPTION
… use Windows localisation settings for number formats for trilateration distance inputs.

Working grand for me locally - tried UK and German number formats without a problem.

I'll leave the pull request sitting for 24h in case anybody spots anything I've missed and then merge tomorrow if nobody does (or someone merges it in the meantime)