### PR TITLE
Perform log file parsing using a regular expression instead of hard-c…

### DIFF
--- a/EDDiscovery/SystemPosition.cs
+++ b/EDDiscovery/SystemPosition.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace EDDiscovery
@@ -48,20 +49,31 @@ namespace EDDiscovery
 
             try
             {
-                if (line.Length < 15)
-                    return null;
+                /* MKW: Use regular expressions to parse the log; much more readable and robust.
+                 * Example log entry:
+                 * {09:36:16} System:0(Thuechea JE-O b11-0) Body:1 Pos:(-6.67432e+009,7.3151e+009,-1.19125e+010) Supercruise
+                 *
+                 * Also, please note that due to E:D bugs, these entries can be at the end of a line as well, not just on a line of their own.
+                 * The RegExp below actually just finds the pattern somewhere in the line, so it caters for rubbish at the end too.
+                 */
+                Regex pattern = new Regex(@"{(?<Hour>\d+):(?<Minute>\d+):(?<Second>\d+)} System:\d+\((?<SystemName>.*?)\) Body:(?<Body>\d+) Pos:\(.*?\) (?<TravelMode>\w+)");
 
-                if (line.StartsWith("<data>"))
-                    return null;
+                Match match = pattern.Match(line);
 
-                string str = line.Substring(1, 2);
+                int hour = int.Parse(match.Groups["Hour"].Value);
+                int min = int.Parse(match.Groups["Minute"].Value);
+                int sec = int.Parse(match.Groups["Second"].Value);
 
-                int hour = int.Parse(str);
-                int min = int.Parse(line.Substring(4, 2));
-                int sec = int.Parse(line.Substring(7, 2));
+                sp.Nr = int.Parse(match.Groups["Body"].Value);
+                sp.Name = match.Groups["SystemName"].Value;
+
+                // Debug
+                string travelMode = match.Groups["TravelMode"].Value;
 
                 if (hour >= lasttime.Hour)
-                { sp.time = new DateTime(lasttime.Year, lasttime.Month, lasttime.Day, hour, min, sec); }
+                {
+                    sp.time = new DateTime(lasttime.Year, lasttime.Month, lasttime.Day, hour, min, sec);
+                }
                 else
                 {
                     DateTime tomorrow = lasttime.AddDays(1);
@@ -69,16 +81,14 @@ namespace EDDiscovery
                 }
 
                 if (sp.time.Subtract(lasttime).TotalHours < -4)
+                {
                     sp.time = sp.time.AddDays(1);
-
-                str = line.Substring(18, line.IndexOf(" Body:")-19);
-
-                sp.Nr = int.Parse(str.Substring(0, str.IndexOf("(")));
-                sp.Name = str.Substring(str.IndexOf("(")+1);
+                }
                 return sp;
             }
             catch
             {
+                // MKW TODO: should we log bad lines?
                 return null;
             }
         }


### PR DESCRIPTION
…oded substring extraction.

Also fix issue when the system entry is not at the start of a line, which can sometimes happen.


To test, recommed : https://regex101.com/

```
{01:02:03} System:0(Sagittarius A*) Body:1 Pos:(1,2,3) Supercruise
{01:02:03} System:0(Some System (with) [brackets] {and} `stuff` 'in' @it@ #which# +should+ be *hard*) Body:1 Pos:(1,2,3) Supercruise
```