### PR TITLE
Slew camera when changing centered system

### DIFF
--- a/EDDiscovery/3DMap/KeyboardActions.cs
+++ b/EDDiscovery/3DMap/KeyboardActions.cs
@@ -40,5 +40,9 @@ namespace EDDiscovery2._3DMap
             ZoomOut = false;
         }
 
+        public bool Any()
+        {
+            return Left || Right || Up || Down || Forwards || Backwards || Pitch || Dive || YawLeft || YawRight || RollLeft || RollRight || ZoomIn || ZoomOut;
+        }
     }
 }


### PR DESCRIPTION
It was suggested in #160 that when the centered system is changed, the camera angle should not change.  This implements this, and also slews the camera in order to reduce confusion as to where the camera moved to.

This currently uses a sinusoidal velocity curve with a fixed 1 second slew duration regardless of distance or zoom.  Clicking the mouse or pressing a movement button cancels the slew.