### PR TITLE
Set active commander when saving netlogs

### DIFF
--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -168,6 +168,7 @@ namespace EDDiscovery2.EDSM
                             vs.Time = system.time;
                             vs.MapColour = _defmapcolour;
                             vs.EDSM_sync = true;
+                            vs.Commander = EDDiscoveryForm.EDDConfig.CurrentCommander.Nr;
 
 
                             vs.Add();  // Add to DB;

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -32,6 +32,7 @@ namespace EDDiscovery
         bool Exit = false;
         bool NoEvents = false;
         public event NetLogEventHandler OnNewPosition;
+        public int ActiveCommander { get; set; }
 
         SQLiteDBClass db=null;
         public List<TravelLogUnit> tlUnits;
@@ -114,7 +115,7 @@ namespace EDDiscovery
 
 
 
-        public List<SystemPosition> ParseFiles(RichTextBox richTextBox_History, int defaultMapColour, int commander)
+        public List<SystemPosition> ParseFiles(RichTextBox richTextBox_History, int defaultMapColour)
         {
             string datapath;
             DirectoryInfo dirInfo;
@@ -152,7 +153,7 @@ namespace EDDiscovery
 
             tlUnits =  TravelLogUnit.GetAll();
 
-            List<VisitedSystemsClass> vsSystemsList = VisitedSystemsClass.GetAll(commander);
+            List<VisitedSystemsClass> vsSystemsList = VisitedSystemsClass.GetAll(ActiveCommander);
 
             visitedSystems.Clear();
             // Add systems in local DB.
@@ -225,6 +226,7 @@ namespace EDDiscovery
                             dbsys.EDSM_sync = false;
                             dbsys.Unit = fi.Name;
                             dbsys.MapColour = defaultMapColour;
+                            dbsys.Commander = ActiveCommander;
 
                             if (!lu.Beta)  // dont store  history in DB for beta (YET)
                             {
@@ -501,6 +503,7 @@ namespace EDDiscovery
                                         dbsys.Unit = fi.Name;
                                         dbsys.MapColour = db.GetSettingInt("DefaultMap", Color.Red.ToArgb());
                                         dbsys.Unit = fi.Name;
+                                        dbsys.Commander = 0;
                                         
                                         if (!tlUnit.Beta)  // dont store  history in DB for beta (YET)
                                         {

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -182,7 +182,7 @@ namespace EDDiscovery
 
 
             if (visitedSystems == null || visitedSystems.Count == 0)
-                GetVisitedSystems(activecommander);
+                GetVisitedSystems();
 
             if (visitedSystems == null)
                 return;
@@ -254,9 +254,9 @@ namespace EDDiscovery
                 FilterGridView();
         }
 
-        private void GetVisitedSystems(int commander)
+        private void GetVisitedSystems()
         {                                                       // for backwards compatibility, don't store RGB value.
-            visitedSystems = netlog.ParseFiles(richTextBox_History, defaultMapColour, commander);
+            visitedSystems = netlog.ParseFiles(richTextBox_History, defaultMapColour);
         }
 
         private void AddHistoryRow(bool insert, SystemPosition item, SystemPosition item2)
@@ -573,6 +573,7 @@ namespace EDDiscovery
             {
                 var itm = (EDCommander)comboBoxCommander.SelectedItem;
                 activecommander = itm.Nr;
+                netlog.ActiveCommander = itm.Nr;
                 if (visitedSystems != null)
                     visitedSystems.Clear();
                 RefreshHistory();


### PR DESCRIPTION
This should prevent a recurrence of #164 - the commander wasn't being stored in the database.

Some sort of fixer tool would need to be used to associate netlogs with the correct commander(s).