### PR TITLE
Improve 3D map performance; suspend updates when inactive

### DIFF
--- a/EDDiscovery/3DMap/Data3DSetClass.cs
+++ b/EDDiscovery/3DMap/Data3DSetClass.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using System.Drawing;
+using System.Collections;
 
 namespace EDDiscovery2._3DMap
 {
@@ -12,7 +14,7 @@ namespace EDDiscovery2._3DMap
         PrimitiveType Type { get; }
         float Size { get; set; }
         Color Color { get; set; }
-        void Draw();
+        void Draw(GLControl control);
     }
 
     public class PointData : IDrawingPrimative
@@ -30,15 +32,241 @@ namespace EDDiscovery2._3DMap
         public Color Color { get; set; }
         public float Size { get; set; }
 
-        public void Draw()
+        public void Draw(GLControl control)
         {
-            GL.PointSize(Size);
+            if (control.InvokeRequired)
+            {
+                control.Invoke(new Action<GLControl>(this.Draw), control);
+            }
+            else
+            {
+                GL.PointSize(Size);
 
-            GL.Begin(Type);
-            GL.Color3(Color);
-            GL.Vertex3(x, y, z);
-            GL.End();
+                GL.Begin(Type);
+                GL.Color3(Color);
+                GL.Vertex3(x, y, z);
+                GL.End();
+            }
         }
+    }
+
+    public class PointDataCollection : Data3DSetClass<PointData>, IList<PointData>, IDisposable
+    {
+        protected Vector3d[] Vertices;
+        protected int NumVertices;
+        protected int VtxVboID;
+        protected GLControl GLContext;
+
+        public PointDataCollection(string name, Color color, float pointsize)
+            : base(name, color, pointsize)
+        {
+            Primatives = this;
+        }
+
+        public void Dispose()
+        {
+            if (GLContext != null)
+            {
+                if (GLContext.InvokeRequired)
+                {
+                    GLContext.Invoke(new Action(this.Dispose));
+                }
+                else
+                {
+                    GL.DeleteBuffer(VtxVboID);
+                    GLContext = null;
+                }
+            }
+        }
+
+        public override void Add(PointData primative)
+        {
+            Dispose();
+
+            if (Vertices == null)
+            {
+                Vertices = new Vector3d[1024];
+            }
+            else if (NumVertices == Vertices.Length)
+            {
+                Array.Resize(ref Vertices, Vertices.Length * 2);
+            }
+
+            Vertices[NumVertices++] = new Vector3d(primative.x, primative.y, primative.z);
+        }
+
+        public override void DrawAll(GLControl control)
+        {
+            if (GLContext != null && GLContext != control)
+            {
+                Dispose();
+            }
+
+            if (control.InvokeRequired)
+            {
+                control.Invoke(new Action<GLControl>(this.DrawAll), control);
+            }
+            else
+            {
+                if (VtxVboID == 0)
+                {
+                    GL.GenBuffers(1, out VtxVboID);
+                    GL.BindBuffer(BufferTarget.ArrayBuffer, VtxVboID);
+                    GL.BufferData(BufferTarget.ArrayBuffer, new IntPtr(NumVertices * BlittableValueType.StrideOf(Vertices)), Vertices, BufferUsageHint.StaticDraw);
+                    GLContext = control;
+                }
+
+                int vbosize = NumVertices;
+                GL.EnableClientState(ArrayCap.VertexArray);
+                GL.BindBuffer(BufferTarget.ArrayBuffer, VtxVboID);
+                GL.VertexPointer(3, VertexPointerType.Double, 0, 0);
+                GL.PointSize(pointSize);
+                GL.Color3(color);
+                GL.DrawArrays(PrimitiveType.Points, 0, vbosize);
+                GL.DisableClientState(ArrayCap.VertexArray);
+            }
+        }
+
+        #region IList interface
+
+        public int Count
+        {
+            get
+            {
+                return NumVertices;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public int IndexOf(PointData p)
+        {
+            for (int i = 0; i < NumVertices; i++)
+            {
+                var v = Vertices[i];
+                if (v.X == p.x && v.Y == p.y && v.Z == p.z)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public void Insert(int index, PointData point)
+        {
+            if (index > NumVertices)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            Dispose();
+
+            this.Add(new PointData(0, 0, 0));
+            for (int i = NumVertices - 2; i >= index; i--)
+            {
+                Vertices[i + 1] = Vertices[i];
+            }
+            Vertices[index] = new Vector3d(point.x, point.y, point.z);
+        }
+
+        public void RemoveAt(int index)
+        {
+            if (index >= NumVertices)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            Dispose();
+
+            for (int i = index; i < NumVertices - 1; i++)
+            {
+                Vertices[i] = Vertices[i + 1];
+            }
+            NumVertices--;
+        }
+
+        public void Clear()
+        {
+            Dispose();
+            NumVertices = 0;
+        }
+
+        public bool Contains(PointData item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(PointData[] array, int arrayIndex)
+        {
+            for (int i = 0; i < NumVertices; i++)
+            {
+                array[i + arrayIndex] = new PointData(Vertices[i].X, Vertices[i].Y, Vertices[i].Z);
+            }
+        }
+
+        public bool Remove(PointData item)
+        {
+            int index = IndexOf(item);
+
+            if (index >= 0)
+            {
+                RemoveAt(index);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public IEnumerator<PointData> GetEnumerator()
+        {
+            for (int i = 0; i < NumVertices; i++)
+            {
+                var v = Vertices[i];
+                yield return new PointData(v.X, v.Y, v.Z) { Color = color, Size = pointSize };
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public PointData this[int index]
+        {
+            get
+            {
+                if (index >= NumVertices)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                var v = Vertices[index];
+                return new PointData(v.X, v.Y, v.Z) { Color = color, Size = pointSize };
+            }
+            set
+            {
+                if (index >= NumVertices)
+                {
+                    Insert(index, value);
+                }
+                else
+                {
+                    Dispose();
+                    Vertices[index] = new Vector3d(value.x, value.y, value.z);
+                }
+            }
+        }
+
+        #endregion
     }
 
     public class LineData : IDrawingPrimative
@@ -60,27 +288,260 @@ namespace EDDiscovery2._3DMap
         public Color Color { get; set; }
         public float Size { get; set; }
 
-        public void Draw()
+        public void Draw(GLControl control)
         {
-            GL.PointSize(Size);
+            if (control.InvokeRequired)
+            {
+                control.Invoke(new Action<GLControl>(this.Draw), control);
+            }
+            else
+            {
+                GL.PointSize(Size);
 
-            GL.Begin(Type);
-            GL.Color3(Color);
-            GL.Vertex3(x1, y1, z1);
-            GL.Vertex3(x2, y2, z2);
-            GL.End();
+                GL.Begin(Type);
+                GL.Color3(Color);
+                GL.Vertex3(x1, y1, z1);
+                GL.Vertex3(x2, y2, z2);
+                GL.End();
+            }
         }
     }
+
+    public class LineDataCollection : Data3DSetClass<LineData>, IList<LineData>, IDisposable
+    {
+        protected Vector3d[] Vertices;
+        protected int NumVertices;
+        protected int VtxVboID;
+        protected GLControl GLContext;
+
+        public LineDataCollection(string name, Color color, float pointsize)
+            : base(name, color, pointsize)
+        {
+            this.Primatives = this;
+        }
+
+        public void Dispose()
+        {
+            if (GLContext != null)
+            {
+                if (GLContext.InvokeRequired)
+                {
+                    GLContext.Invoke(new Action(this.Dispose));
+                }
+                else
+                {
+                    GL.DeleteBuffer(VtxVboID);
+                    GLContext = null;
+                }
+            }
+        }
+
+        public override void Add(LineData primative)
+        {
+            Dispose();
+
+            if (Vertices == null)
+            {
+                Vertices = new Vector3d[1024];
+            }
+            else if (NumVertices == Vertices.Length)
+            {
+                Array.Resize(ref Vertices, Vertices.Length * 2);
+            }
+
+            Vertices[NumVertices++] = new Vector3d(primative.x1, primative.y1, primative.z1);
+            Vertices[NumVertices++] = new Vector3d(primative.x2, primative.y2, primative.z2);
+        }
+
+        public override void DrawAll(GLControl control)
+        {
+            if (GLContext != null && GLContext != control)
+            {
+                Dispose();
+            }
+
+            if (control.InvokeRequired)
+            {
+                control.Invoke(new Action<GLControl>(this.DrawAll), control);
+            }
+            else
+            {
+                if (VtxVboID == 0)
+                {
+                    GL.GenBuffers(1, out VtxVboID);
+                    GL.BindBuffer(BufferTarget.ArrayBuffer, VtxVboID);
+                    GL.BufferData(BufferTarget.ArrayBuffer, new IntPtr(NumVertices * BlittableValueType.StrideOf(Vertices)), Vertices, BufferUsageHint.StaticDraw);
+                }
+
+                int vbosize = NumVertices;
+                GL.EnableClientState(ArrayCap.VertexArray);
+                GL.BindBuffer(BufferTarget.ArrayBuffer, VtxVboID);
+                GL.VertexPointer(3, VertexPointerType.Double, 0, 0);
+                GL.PointSize(pointSize);
+                GL.Color3(color);
+                GL.DrawArrays(PrimitiveType.Lines, 0, vbosize);
+                GL.DisableClientState(ArrayCap.VertexArray);
+            }
+        }
+
+
+        #region IList interface
+
+        public int Count
+        {
+            get
+            {
+                return NumVertices / 2;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public int IndexOf(LineData l)
+        {
+            for (int i = 0; i < NumVertices / 2; i++)
+            {
+                var v1 = Vertices[i * 2];
+                var v2 = Vertices[i * 2 + 1];
+
+                if (v1.X == l.x1 && v1.Y == l.y1 && v1.Z == l.z1 && v2.X == l.x2 && v2.Y == l.y2 && v2.Z == l.z2)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public void Insert(int index, LineData line)
+        {
+            if (index > NumVertices / 2)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            Dispose();
+
+            this.Add(new LineData(0, 0, 0, 0, 0, 0));
+            for (int i = NumVertices - 3; i >= index * 2; i--)
+            {
+                Vertices[i + 2] = Vertices[i];
+            }
+            Vertices[index * 2] = new Vector3d(line.x1, line.y1, line.z1);
+            Vertices[index * 2 + 1] = new Vector3d(line.x2, line.y2, line.z2);
+        }
+
+        public void RemoveAt(int index)
+        {
+            if (index >= NumVertices / 2)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            Dispose();
+
+            for (int i = index * 2; i < NumVertices - 2; i++)
+            {
+                Vertices[i] = Vertices[i + 2];
+            }
+            NumVertices -= 2;
+        }
+
+        public void Clear()
+        {
+            Dispose();
+            NumVertices = 0;
+        }
+
+        public bool Contains(LineData item)
+        {
+            return IndexOf(item) != -1;
+        }
+
+        public void CopyTo(LineData[] array, int arrayIndex)
+        {
+            for (int i = 0; i < NumVertices / 2; i++)
+            {
+                array[i + arrayIndex] = new LineData(Vertices[i * 2].X, Vertices[i * 2].Y, Vertices[i * 2].Z, Vertices[i * 2 + 1].X, Vertices[i * 2 + 1].Y, Vertices[i * 2 + 1].Z);
+            }
+        }
+
+        public bool Remove(LineData item)
+        {
+            int index = IndexOf(item);
+
+            if (index >= 0)
+            {
+                RemoveAt(index);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public IEnumerator<LineData> GetEnumerator()
+        {
+            for (int i = 0; i < NumVertices; i += 2)
+            {
+                yield return new LineData(Vertices[i].X, Vertices[i].Y, Vertices[i].Z, Vertices[i + 1].X, Vertices[i + 1].Y, Vertices[i + 1].Z);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public LineData this[int index]
+        {
+            get
+            {
+                if (index >= NumVertices / 2)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                var v1 = Vertices[index * 2];
+                var v2 = Vertices[index * 2 + 1];
+
+                return new LineData(v1.X, v1.Y, v1.Z, v2.X, v2.Y, v2.Z) { Color = color, Size = pointSize };
+            }
+            set
+            {
+                if (index >= NumVertices)
+                {
+                    Insert(index, value);
+                }
+                else
+                {
+                    Dispose();
+                    Vertices[index * 2] = new Vector3d(value.x1, value.y1, value.z1);
+                    Vertices[index * 2 + 1] = new Vector3d(value.x2, value.y2, value.z2);
+                }
+            }
+        }
+
+        #endregion
+    }
+
     public class Data3DSetClass<T> : IData3DSet where T : IDrawingPrimative
     {
         public string Name { get; set; }
-        public List<T> Primatives { get; private set; }
-        private readonly Color color;
-        private readonly float pointSize;
+        public IList<T> Primatives { get; protected set; }
+        protected readonly Color color;
+        protected readonly float pointSize;
 
         public bool Visible;
 
-        public Data3DSetClass(string name, Color color, float pointsize)
+        protected Data3DSetClass(string name, Color color, float pointsize)
         {
             Name = name;
             this.color = color;
@@ -89,21 +550,43 @@ namespace EDDiscovery2._3DMap
             Visible = true;
         }
 
-
-        public void Add(T primative)
+        public virtual void Add(T primative)
         {
             primative.Color = color;
             primative.Size = pointSize;
             Primatives.Add(primative);
         }
 
-        public void DrawAll()
+        public virtual void DrawAll(GLControl control)
         {
             if (!Visible) return;
 
-            foreach (var primative in Primatives)
+            if (control.InvokeRequired)
             {
-                primative.Draw();
+                control.Invoke(new Action<GLControl>(this.DrawAll), control);
+            }
+            else
+            {
+                foreach (var primative in Primatives)
+                {
+                    primative.Draw(control);
+                }
+            }
+        }
+
+        public static Data3DSetClass<T> Create(string name, Color color, float pointsize)
+        {
+            if (typeof(T) == typeof(PointData))
+            {
+                return new PointDataCollection(name, color, pointsize) as Data3DSetClass<T>;
+            }
+            else if (typeof(T) == typeof(LineData))
+            {
+                return new LineDataCollection(name, color, pointsize) as Data3DSetClass<T>;
+            }
+            else
+            {
+                return new Data3DSetClass<T>(name, color, pointsize);
             }
         }
     }
@@ -111,6 +594,6 @@ namespace EDDiscovery2._3DMap
     public interface IData3DSet
     {
         string Name { get; set; }
-        void DrawAll();
+        void DrawAll(GLControl control);
     }
 }

--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -58,7 +58,7 @@ namespace EDDiscovery2._3DMap
             if (GridLines)
             {
                 bool addstations = !Stations;
-                var datasetGrid = new Data3DSetClass<LineData>("grid", (Color)System.Drawing.ColorTranslator.FromHtml("#296A6C"), 0.6f);
+                var datasetGrid = Data3DSetClass<LineData>.Create("grid", (Color)System.Drawing.ColorTranslator.FromHtml("#296A6C"), 0.6f);
 
                 for (float x = MinGridPos.X; x <= MaxGridPos.X; x += unitSize)
                 {
@@ -78,7 +78,7 @@ namespace EDDiscovery2._3DMap
             if (AllSystems && StarList != null)
             {
                 bool addstations = !Stations;
-                var datasetS = new Data3DSetClass<PointData>("stars", Color.White, 1.0f);
+                var datasetS = Data3DSetClass<PointData>.Create("stars", Color.White, 1.0f);
 
                 foreach (ISystem si in StarList)
                 {
@@ -93,7 +93,7 @@ namespace EDDiscovery2._3DMap
         {
             if (Stations)
             {
-                var datasetS = new Data3DSetClass<PointData>("stations", Color.RoyalBlue, 1.0f);
+                var datasetS = Data3DSetClass<PointData>.Create("stations", Color.RoyalBlue, 1.0f);
 
                 foreach (ISystem si in StarList)
                 {
@@ -123,7 +123,7 @@ namespace EDDiscovery2._3DMap
                     {
                         if (DrawLines)
                         {
-                            var datasetl = new Data3DSetClass<LineData>("visitedstars" + colour.Key.ToString(), Color.FromArgb(colour.Key), 2.0f);
+                            var datasetl = Data3DSetClass<LineData>.Create("visitedstars" + colour.Key.ToString(), Color.FromArgb(colour.Key), 2.0f);
                             foreach (SystemPosition sp in colour)
                             {
                                 if (sp.curSystem != null && sp.curSystem.HasCoordinate && sp.lastKnownSystem != null && sp.lastKnownSystem.HasCoordinate)
@@ -137,7 +137,7 @@ namespace EDDiscovery2._3DMap
                         }
                         else
                         {
-                            var datasetvs = new Data3DSetClass<PointData>("visitedstars" + colour.Key.ToString(), Color.FromArgb(colour.Key), 2.0f);
+                            var datasetvs = Data3DSetClass<PointData>.Create("visitedstars" + colour.Key.ToString(), Color.FromArgb(colour.Key), 2.0f);
                             foreach (SystemPosition sp in colour)
                             {
                                 ISystem star = SystemData.GetSystem(sp.Name);
@@ -159,7 +159,7 @@ namespace EDDiscovery2._3DMap
         // dataset anymore. The origin will stay at Sol.
         public void AddCenterPointToDataset()
         {
-            var dataset = new Data3DSetClass<PointData>("Center", Color.Yellow, 5.0f);
+            var dataset = Data3DSetClass<PointData>.Create("Center", Color.Yellow, 5.0f);
 
             //GL.Enable(EnableCap.ProgramPointSize);
             dataset.Add(new PointData(CenterSystem.x, CenterSystem.y, CenterSystem.z));
@@ -170,7 +170,7 @@ namespace EDDiscovery2._3DMap
         {
             if (SelectedSystem != null)
             {
-                var dataset = new Data3DSetClass<PointData>("Selected", Color.Orange, 5.0f);
+                var dataset = Data3DSetClass<PointData>.Create("Selected", Color.Orange, 5.0f);
 
                 //GL.Enable(EnableCap.ProgramPointSize);
                 dataset.Add(new PointData(SelectedSystem.x, SelectedSystem.y, SelectedSystem.z));
@@ -180,7 +180,7 @@ namespace EDDiscovery2._3DMap
 
         public void AddPOIsToDataset()
         {
-            var dataset = new Data3DSetClass<PointData>("Interest", Color.Purple, 10.0f);
+            var dataset = Data3DSetClass<PointData>.Create("Interest", Color.Purple, 10.0f);
             AddSystem("sol", dataset);
             AddSystem("sagittarius a*", dataset);
             //AddSystem("polaris", dataset);
@@ -191,7 +191,7 @@ namespace EDDiscovery2._3DMap
         {
             if (ReferenceSystems != null && ReferenceSystems.Any())
             {
-                var referenceLines = new Data3DSetClass<LineData>("CurrentReference", Color.Green, 5.0f);
+                var referenceLines = Data3DSetClass<LineData>.Create("CurrentReference", Color.Green, 5.0f);
                 foreach (var refSystem in ReferenceSystems)
                 {
                     referenceLines.Add(new LineData(CenterSystem.x, CenterSystem.y, CenterSystem.z, refSystem.x, refSystem.y, refSystem.z));
@@ -199,7 +199,7 @@ namespace EDDiscovery2._3DMap
 
                 _datasets.Add(referenceLines);
 
-                var lineSet = new Data3DSetClass<LineData>("SuggestedReference", Color.DarkOrange, 5.0f);
+                var lineSet = Data3DSetClass<LineData>.Create("SuggestedReference", Color.DarkOrange, 5.0f);
 
 
                 Stopwatch sw = new Stopwatch();
@@ -226,7 +226,7 @@ namespace EDDiscovery2._3DMap
         {
             if (PlannedRoute != null && PlannedRoute.Any())
             {
-                var routeLines = new Data3DSetClass<LineData>("PlannedRoute", Color.DarkOrange, 25.0f);
+                var routeLines = Data3DSetClass<LineData>.Create("PlannedRoute", Color.DarkOrange, 25.0f);
                 ISystem prevSystem = PlannedRoute.First();
                 foreach (ISystem point in PlannedRoute.Skip(1))
                 {

--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -56,6 +56,7 @@ namespace EDDiscovery2
             this.labelClickedSystemCoords = new System.Windows.Forms.Label();
             this.dotSelectedSystemCoords = new System.Windows.Forms.PictureBox();
             this.dotSystemCoords = new System.Windows.Forms.PictureBox();
+            this.UpdateTimer = new System.Windows.Forms.Timer(this.components);
             this.toolStripShowAllStars.SuspendLayout();
             this.statusStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dotSelectedSystemCoords)).BeginInit();
@@ -72,10 +73,12 @@ namespace EDDiscovery2
             this.glControl.Name = "glControl";
             this.glControl.Size = new System.Drawing.Size(918, 485);
             this.glControl.TabIndex = 0;
-            this.glControl.VSync = false;
+            this.glControl.VSync = true;
             this.glControl.Load += new System.EventHandler(this.glControl_Load);
             this.glControl.Paint += new System.Windows.Forms.PaintEventHandler(this.glControl_Paint);
             this.glControl.DoubleClick += new System.EventHandler(this.glControl_DoubleClick);
+            this.glControl.KeyDown += new System.Windows.Forms.KeyEventHandler(this.glControl_KeyDown);
+            this.glControl.KeyUp += new System.Windows.Forms.KeyEventHandler(this.glControl_KeyUp);
             this.glControl.MouseDown += new System.Windows.Forms.MouseEventHandler(this.glControl_MouseDown);
             this.glControl.MouseMove += new System.Windows.Forms.MouseEventHandler(this.glControl_MouseMove);
             this.glControl.MouseUp += new System.Windows.Forms.MouseEventHandler(this.glControl_MouseUp);
@@ -275,6 +278,9 @@ namespace EDDiscovery2
             this.dotSystemCoords.Size = new System.Drawing.Size(12, 12);
             this.dotSystemCoords.TabIndex = 25;
             this.dotSystemCoords.TabStop = false;
+            // UpdateTimer
+            // 
+            this.UpdateTimer.Tick += new System.EventHandler(this.UpdateTimer_Tick);
             // 
             // FormMap
             // 
@@ -296,6 +302,8 @@ namespace EDDiscovery2
             this.Name = "FormMap";
             this.Text = "3D Star Map";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
+            this.Activated += new System.EventHandler(this.FormMap_Activated);
+            this.Deactivate += new System.EventHandler(this.FormMap_Deactivate);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMap_FormClosing);
             this.Load += new System.EventHandler(this.FormMap_Load);
             this.toolStripShowAllStars.ResumeLayout(false);
@@ -331,5 +339,6 @@ namespace EDDiscovery2
         private Label labelClickedSystemCoords;
         private PictureBox dotSystemCoords;
         private PictureBox dotSelectedSystemCoords;
+        private Timer UpdateTimer;
     }
     }

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -262,6 +262,17 @@ namespace EDDiscovery2
 
         private void GenerateDataSetStandard()
         {
+            if (_datasets != null)
+            {
+                foreach (var ds in _datasets)
+                {
+                    if (ds is IDisposable)
+                    {
+                        ((IDisposable)ds).Dispose();
+                    }
+                }
+            }
+
             InitStarLists();
 
             var builder = new DatasetBuilder()
@@ -306,13 +317,13 @@ namespace EDDiscovery2
 
             _datasets = new List<IData3DSet>();
 
-            datadict[(int)EDAllegiance.Alliance] = new Data3DSetClass<PointData>(EDAllegiance.Alliance.ToString(), Color.Green, 1.0f);
-            datadict[(int)EDAllegiance.Anarchy] = new Data3DSetClass<PointData>(EDAllegiance.Anarchy.ToString(), Color.Purple, 1.0f);
-            datadict[(int)EDAllegiance.Empire] = new Data3DSetClass<PointData>(EDAllegiance.Empire.ToString(), Color.Blue, 1.0f);
-            datadict[(int)EDAllegiance.Federation] = new Data3DSetClass<PointData>(EDAllegiance.Federation.ToString(), Color.Red, 1.0f);
-            datadict[(int)EDAllegiance.Independent] = new Data3DSetClass<PointData>(EDAllegiance.Independent.ToString(), Color.Yellow, 1.0f);
-            datadict[(int)EDAllegiance.None] = new Data3DSetClass<PointData>(EDAllegiance.None.ToString(), Color.LightGray, 1.0f);
-            datadict[(int)EDAllegiance.Unknown] = new Data3DSetClass<PointData>(EDAllegiance.Unknown.ToString(), Color.DarkGray, 1.0f);
+            datadict[(int)EDAllegiance.Alliance] = Data3DSetClass<PointData>.Create(EDAllegiance.Alliance.ToString(), Color.Green, 1.0f);
+            datadict[(int)EDAllegiance.Anarchy] = Data3DSetClass<PointData>.Create(EDAllegiance.Anarchy.ToString(), Color.Purple, 1.0f);
+            datadict[(int)EDAllegiance.Empire] = Data3DSetClass<PointData>.Create(EDAllegiance.Empire.ToString(), Color.Blue, 1.0f);
+            datadict[(int)EDAllegiance.Federation] = Data3DSetClass<PointData>.Create(EDAllegiance.Federation.ToString(), Color.Red, 1.0f);
+            datadict[(int)EDAllegiance.Independent] = Data3DSetClass<PointData>.Create(EDAllegiance.Independent.ToString(), Color.Yellow, 1.0f);
+            datadict[(int)EDAllegiance.None] = Data3DSetClass<PointData>.Create(EDAllegiance.None.ToString(), Color.LightGray, 1.0f);
+            datadict[(int)EDAllegiance.Unknown] = Data3DSetClass<PointData>.Create(EDAllegiance.Unknown.ToString(), Color.DarkGray, 1.0f);
 
             foreach (SystemClass si in _starList)
             {
@@ -342,21 +353,21 @@ namespace EDDiscovery2
 
             _datasets = new List<IData3DSet>();
 
-            datadict[(int)EDGovernment.Anarchy] = new Data3DSetClass<PointData>(EDGovernment.Anarchy.ToString(), Color.Yellow, 1.0f);
-            datadict[(int)EDGovernment.Colony] = new Data3DSetClass<PointData>(EDGovernment.Colony.ToString(), Color.YellowGreen, 1.0f);
-            datadict[(int)EDGovernment.Democracy] = new Data3DSetClass<PointData>(EDGovernment.Democracy.ToString(), Color.Green, 1.0f);
-            datadict[(int)EDGovernment.Imperial] = new Data3DSetClass<PointData>(EDGovernment.Imperial.ToString(), Color.DarkGreen, 1.0f);
-            datadict[(int)EDGovernment.Corporate] = new Data3DSetClass<PointData>(EDGovernment.Corporate.ToString(), Color.LawnGreen, 1.0f);
-            datadict[(int)EDGovernment.Communism] = new Data3DSetClass<PointData>(EDGovernment.Communism.ToString(), Color.DarkOliveGreen, 1.0f);
-            datadict[(int)EDGovernment.Feudal] = new Data3DSetClass<PointData>(EDGovernment.Feudal.ToString(), Color.LightBlue, 1.0f);
-            datadict[(int)EDGovernment.Dictatorship] = new Data3DSetClass<PointData>(EDGovernment.Dictatorship.ToString(), Color.Blue, 1.0f);
-            datadict[(int)EDGovernment.Theocracy] = new Data3DSetClass<PointData>(EDGovernment.Theocracy.ToString(), Color.DarkBlue, 1.0f);
-            datadict[(int)EDGovernment.Cooperative] = new Data3DSetClass<PointData>(EDGovernment.Cooperative.ToString(), Color.Purple, 1.0f);
-            datadict[(int)EDGovernment.Patronage] = new Data3DSetClass<PointData>(EDGovernment.Patronage.ToString(), Color.LightCyan, 1.0f);
-            datadict[(int)EDGovernment.Confederacy] = new Data3DSetClass<PointData>(EDGovernment.Confederacy.ToString(), Color.Red, 1.0f);
-            datadict[(int)EDGovernment.Prison_Colony] = new Data3DSetClass<PointData>(EDGovernment.Prison_Colony.ToString(), Color.Orange, 1.0f);
-            datadict[(int)EDGovernment.None] = new Data3DSetClass<PointData>(EDGovernment.None.ToString(), Color.Gray, 1.0f);
-            datadict[(int)EDGovernment.Unknown] = new Data3DSetClass<PointData>(EDGovernment.Unknown.ToString(), Color.DarkGray, 1.0f);
+            datadict[(int)EDGovernment.Anarchy] = Data3DSetClass<PointData>.Create(EDGovernment.Anarchy.ToString(), Color.Yellow, 1.0f);
+            datadict[(int)EDGovernment.Colony] = Data3DSetClass<PointData>.Create(EDGovernment.Colony.ToString(), Color.YellowGreen, 1.0f);
+            datadict[(int)EDGovernment.Democracy] = Data3DSetClass<PointData>.Create(EDGovernment.Democracy.ToString(), Color.Green, 1.0f);
+            datadict[(int)EDGovernment.Imperial] = Data3DSetClass<PointData>.Create(EDGovernment.Imperial.ToString(), Color.DarkGreen, 1.0f);
+            datadict[(int)EDGovernment.Corporate] = Data3DSetClass<PointData>.Create(EDGovernment.Corporate.ToString(), Color.LawnGreen, 1.0f);
+            datadict[(int)EDGovernment.Communism] = Data3DSetClass<PointData>.Create(EDGovernment.Communism.ToString(), Color.DarkOliveGreen, 1.0f);
+            datadict[(int)EDGovernment.Feudal] = Data3DSetClass<PointData>.Create(EDGovernment.Feudal.ToString(), Color.LightBlue, 1.0f);
+            datadict[(int)EDGovernment.Dictatorship] = Data3DSetClass<PointData>.Create(EDGovernment.Dictatorship.ToString(), Color.Blue, 1.0f);
+            datadict[(int)EDGovernment.Theocracy] = Data3DSetClass<PointData>.Create(EDGovernment.Theocracy.ToString(), Color.DarkBlue, 1.0f);
+            datadict[(int)EDGovernment.Cooperative] = Data3DSetClass<PointData>.Create(EDGovernment.Cooperative.ToString(), Color.Purple, 1.0f);
+            datadict[(int)EDGovernment.Patronage] = Data3DSetClass<PointData>.Create(EDGovernment.Patronage.ToString(), Color.LightCyan, 1.0f);
+            datadict[(int)EDGovernment.Confederacy] = Data3DSetClass<PointData>.Create(EDGovernment.Confederacy.ToString(), Color.Red, 1.0f);
+            datadict[(int)EDGovernment.Prison_Colony] = Data3DSetClass<PointData>.Create(EDGovernment.Prison_Colony.ToString(), Color.Orange, 1.0f);
+            datadict[(int)EDGovernment.None] = Data3DSetClass<PointData>.Create(EDGovernment.None.ToString(), Color.Gray, 1.0f);
+            datadict[(int)EDGovernment.Unknown] = Data3DSetClass<PointData>.Create(EDGovernment.Unknown.ToString(), Color.DarkGray, 1.0f);
 
             foreach (SystemClass si in _starList)
             {
@@ -389,7 +400,7 @@ namespace EDDiscovery2
         {
             foreach (var dataset in _datasets)
             {
-                dataset.DrawAll();
+                dataset.DrawAll(glControl);
             }
         }
 

--- a/EDDiscovery/3DMap/FormMap.resx
+++ b/EDDiscovery/3DMap/FormMap.resx
@@ -491,6 +491,9 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>295, 17</value>
   </metadata>
+  <metadata name="UpdateTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>392, 17</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAkAEBAAAAEAIABoBAAAlgAAABgYAAABACAAiAkAAP4EAAAgIAAAAQAgAKgQAACGDgAAMDAAAAEA


### PR DESCRIPTION
The first commit improves the performance of the 3D map significantly by using Vertex Buffer Objects.  This along with Vsync should give smooth movement using the keyboard.

The second commit reduces the amount of CPU and GPU time being used when no movement is occurring, and stops the map being updated when the map window is not active, as requested in #60.  This should also fix #161.