### PR TITLE
Fix check for old style controls

### DIFF
--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -602,7 +602,7 @@ namespace EDDiscovery2
 
             Type controltype = myControl.GetType();
             Type parentcontroltype = parent.GetType();
-            if (parentcontroltype.BaseType.Equals("Form") && (controltype.Name.Equals("Button") || controltype.Name.Equals("RadioButton") || controltype.Name.Equals("GroupBox") ||
+            if (!parentcontroltype.Namespace.Equals("ExtendedControls") && (controltype.Name.Equals("Button") || controltype.Name.Equals("RadioButton") || controltype.Name.Equals("GroupBox") ||
                 controltype.Name.Equals("CheckBox") || controltype.Name.Equals("TextBox") ||
                 controltype.Name.Equals("ComboBox") || (controltype.Name.Equals("RichTextBox") ) )
                 )


### PR DESCRIPTION
Should be checking for them and only allowing them if they are children
of ExtendedControls