### PR TITLE
Netlog watcher multicommander improvements

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -40,16 +40,16 @@ namespace EDDiscovery2
         {
             get
             {
-                if (currentCmdrID >= listCommanders.Count)
-                    currentCmdrID = listCommanders.Count - 1;
-                return currentCmdrID;
+                return CurrentCommander.Nr;
             }
 
             set
             {
-                currentCmdrID = value;
-                if (currentCmdrID >= listCommanders.Count)
-                    currentCmdrID = listCommanders.Count - 1;
+                var cmdr = listCommanders.Select((c, i) => new { index = i, cmdr = c }).SingleOrDefault(a => a.cmdr.Nr == value);
+                if (cmdr != null)
+                {
+                    currentCmdrID = cmdr.index;
+                }
             }
         }
 
@@ -64,7 +64,7 @@ namespace EDDiscovery2
                     currentCmdrID = listCommanders.Count - 1;
 
 
-                return listCommanders[CurrentCmdrID];
+                return listCommanders[currentCmdrID];
             }
         }
 

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -27,6 +27,12 @@ namespace EDDiscovery2
         private bool _canSkipSlowUpdates = false;
         public List<EDCommander> listCommanders;
         private int currentCmdrID=0;
+        private Dictionary<string, object> settings = new Dictionary<string, object>();
+        private Dictionary<string, Func<object>> defaults = new Dictionary<string, Func<object>>
+        {
+            { "Netlogdir", () => System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Frontier_Developments", "Products") },
+            { "NetlogDirAutoMode", () => true },
+        };
 
         SQLiteDBClass _db = new SQLiteDBClass();
 
@@ -109,7 +115,64 @@ namespace EDDiscovery2
             }
         }
 
+        public string NetLogDir { get { return GetSettingString("Netlogdir"); } set { PutSettingString("Netlogdir", value); } }
+        public bool NetLogDirAutoMode { get { return GetSettingBool("NetlogDirAutoMode"); } set { PutSettingBool("NetlogDirAutoMode", value); } }
 
+        private bool GetSettingBool(string key)
+        {
+            return GetSetting<bool>(key, _db.GetSettingBool);
+        }
+
+        private int GetSettingInt(string key)
+        {
+            return GetSetting<int>(key, _db.GetSettingInt);
+        }
+
+        private double GetSettingDouble(string key)
+        {
+            return GetSetting<double>(key, _db.GetSettingDouble);
+        }
+
+        private string GetSettingString(string key)
+        {
+            return GetSetting<string>(key, _db.GetSettingString);
+        }
+
+        private T GetSetting<T>(string key, Func<string,T,T> getter)
+        {
+            if (!settings.ContainsKey(key))
+            {
+                settings[key] = getter(key, (T)defaults[key]());
+            }
+
+            return (T)settings[key];
+        }
+
+        private bool PutSettingBool(string key, bool value)
+        {
+            return PutSetting<bool>(key, value, _db.PutSettingBool);
+        }
+
+        private bool PutSettingInt(string key, int value)
+        {
+            return PutSetting<int>(key, value, _db.PutSettingInt);
+        }
+
+        private bool PutSettingDouble(string key, double value)
+        {
+            return PutSetting<double>(key, value, _db.PutSettingDouble);
+        }
+
+        private bool PutSettingString(string key, string value)
+        {
+            return PutSetting<string>(key, value, _db.PutSettingString);
+        }
+
+        private bool PutSetting<T>(string key, T value, Func<string,T,bool> setter)
+        {
+            settings[key] = value;
+            return setter(key, value);
+        }
 
         public void Update()
         {
@@ -133,7 +196,6 @@ namespace EDDiscovery2
             }
 
         }
-
 
         private void LoadCommanders()
         {

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -32,6 +32,7 @@ namespace EDDiscovery2
         {
             { "Netlogdir", () => System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Frontier_Developments", "Products") },
             { "NetlogDirAutoMode", () => true },
+            { "DefaultMap", () => System.Drawing.Color.Red.ToArgb() }
         };
 
         SQLiteDBClass _db = new SQLiteDBClass();
@@ -117,6 +118,7 @@ namespace EDDiscovery2
 
         public string NetLogDir { get { return GetSettingString("Netlogdir"); } set { PutSettingString("Netlogdir", value); } }
         public bool NetLogDirAutoMode { get { return GetSettingBool("NetlogDirAutoMode"); } set { PutSettingBool("NetlogDirAutoMode", value); } }
+        public int DefaultMapColour { get { return GetSettingInt("DefaultMap"); } set { PutSettingInt("DefaultMap", value); } }
 
         private bool GetSettingBool(string key)
         {

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -130,12 +130,14 @@ namespace EDDiscovery2
            
 
             EDCommander cmdr = new EDCommander(0, _db.GetSettingString("EDCommanderName0", commanderName),  _db.GetSettingString("EDCommanderApiKey0", apikey));
+            cmdr.NetLogPath = _db.GetSettingString("EDCommanderNetLogPath0", null);
             listCommanders.Add(cmdr);
 
 
             for (int ii = 1; ii < 100; ii++)
             {
                 cmdr = new EDCommander(ii, _db.GetSettingString("EDCommanderName"+ii.ToString(), ""), _db.GetSettingString("EDCommanderApiKey" + ii.ToString(), ""));
+                cmdr.NetLogPath = _db.GetSettingString("EDCommanderNetLogPath" + ii.ToString(), null);
                 if (!cmdr.Name.Equals(""))
                     listCommanders.Add(cmdr);
             }

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -49,6 +49,7 @@ namespace EDDiscovery2
                 if (cmdr != null)
                 {
                     currentCmdrID = cmdr.index;
+                    _db.PutSettingInt("ActiveCommander", value);
                 }
             }
         }
@@ -105,6 +106,12 @@ namespace EDDiscovery2
                 _EDSMLog = _db.GetSettingBool("EDSMLog", false);
                 _canSkipSlowUpdates = _db.GetSettingBool("CanSkipSlowUpdates", false);
                 LoadCommanders();
+                int activecommander = _db.GetSettingInt("ActiveCommander", 0);
+                var cmdr = listCommanders.Select((c, i) => new { index = i, cmdr = c }).SingleOrDefault(a => a.cmdr.Nr == activecommander);
+                if (cmdr != null)
+                {
+                    currentCmdrID = cmdr.index;
+                }
             }
             catch (Exception ex)
             {

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -8,6 +8,19 @@ namespace EDDiscovery2
 {
     public class EDDConfig
     {
+        private static EDDConfig _instance;
+        public static EDDConfig Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new EDDConfig();
+                }
+                return _instance;
+            }
+        }
+
         private bool _useDistances;
         private bool _EDSMLog;
         readonly public string LogIndex;
@@ -17,7 +30,7 @@ namespace EDDiscovery2
 
         SQLiteDBClass _db = new SQLiteDBClass();
 
-        public EDDConfig()
+        private EDDConfig()
         {
             LogIndex = DateTime.Now.ToString("yyyyMMdd");
         }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -77,7 +77,7 @@ namespace EDDiscovery
             InitializeComponent();
             ProcessCommandLineOptions();
 
-            EDDConfig = new EDDConfig();
+            EDDConfig = EDDConfig.Instance;
 
             //_fileTgcSystems = Path.Combine(Tools.GetAppDataDirectory(), "tgcsystems.json");
             _fileEDSMDistances = Path.Combine(Tools.GetAppDataDirectory(), "EDSMDistances.json");

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -519,7 +519,7 @@ namespace EDDiscovery
                                             dbsys.Source = tlUnit.id;
                                             dbsys.EDSM_sync = false;
                                             dbsys.Unit = fi.Name;
-                                            dbsys.MapColour = db.GetSettingInt("DefaultMap", Color.Red.ToArgb());
+                                            dbsys.MapColour = EDDConfig.Instance.DefaultMapColour;
                                             dbsys.Unit = fi.Name;
                                             dbsys.Commander = 0;
 

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -43,15 +43,15 @@ namespace EDDiscovery
                 if (db == null)
                     db = new SQLiteDBClass();
 
-                string netlogdirstored = db.GetSettingString("Netlogdir", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Frontier_Developments\\Products");
+                string netlogdirstored = EDDConfig.Instance.NetLogDir;
                 string datapath = null;
-                if (db.GetSettingBool("NetlogDirAutoMode", true))
+                if (EDDConfig.Instance.NetLogDirAutoMode)
                 {
                     if (EliteDangerous.EDDirectory != null && EliteDangerous.EDDirectory.Length > 0)
                     {
                         datapath = Path.Combine(EliteDangerous.EDDirectory, "Logs");
                         if (!netlogdirstored.Equals(datapath))
-                            db.PutSettingString("Netlogdir", datapath);
+                            EDDConfig.Instance.NetLogDir = datapath;
                         return datapath;
                     }
 
@@ -90,8 +90,8 @@ namespace EDDiscovery
 
                     if (newfi != null)
                     {
-                        db.PutSettingString("Netlogdir" , newfi.DirectoryName);
-                        db.PutSettingBool("NetlogDirAutoMode" , false);
+                        EDDConfig.Instance.NetLogDir = newfi.DirectoryName;
+                        EDDConfig.Instance.NetLogDirAutoMode = false;
                         datapath = newfi.DirectoryName;
                     }
 
@@ -100,7 +100,11 @@ namespace EDDiscovery
                 }
                 else
                 {
-                    datapath = db.GetSettingString("Netlogdir", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Frontier_Developments\\Products");
+                    datapath = EDDConfig.Instance.NetLogDir;
+                    if (EDDConfig.Instance.CurrentCommander.NetLogPath != null)
+                    {
+                        datapath = EDDConfig.Instance.CurrentCommander.NetLogPath;
+                    }
                 }
 
                 return datapath;

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -32,7 +32,6 @@ namespace EDDiscovery
         bool Exit = false;
         bool NoEvents = false;
         public event NetLogEventHandler OnNewPosition;
-        public int ActiveCommander { get; set; }
 
         SQLiteDBClass db=null;
         public List<TravelLogUnit> tlUnits;
@@ -153,7 +152,7 @@ namespace EDDiscovery
 
             tlUnits =  TravelLogUnit.GetAll();
 
-            List<VisitedSystemsClass> vsSystemsList = VisitedSystemsClass.GetAll(ActiveCommander);
+            List<VisitedSystemsClass> vsSystemsList = VisitedSystemsClass.GetAll(EDDConfig.Instance.CurrentCmdrID);
 
             visitedSystems.Clear();
             // Add systems in local DB.
@@ -226,7 +225,7 @@ namespace EDDiscovery
                             dbsys.EDSM_sync = false;
                             dbsys.Unit = fi.Name;
                             dbsys.MapColour = defaultMapColour;
-                            dbsys.Commander = ActiveCommander;
+                            dbsys.Commander = EDDConfig.Instance.CurrentCmdrID;
 
                             if (!lu.Beta)  // dont store  history in DB for beta (YET)
                             {

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -111,6 +111,8 @@
             this.textBoxNetLogDir.Name = "textBoxNetLogDir";
             this.textBoxNetLogDir.Size = new System.Drawing.Size(623, 20);
             this.textBoxNetLogDir.TabIndex = 2;
+            this.textBoxNetLogDir.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxNetLogDir_Validating);
+            this.textBoxNetLogDir.Validated += new System.EventHandler(this.textBoxNetLogDir_Validated);
             // 
             // radioButton_Manual
             // 
@@ -145,6 +147,7 @@
             this.radioButton_Auto.TabStop = true;
             this.radioButton_Auto.Text = "Auto";
             this.radioButton_Auto.UseVisualStyleBackColor = true;
+            this.radioButton_Auto.CheckedChanged += new System.EventHandler(this.radioButton_Auto_CheckedChanged);
             // 
             // groupBox4
             // 

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -160,7 +160,7 @@ namespace EDDiscovery2
             {
                 _discoveryForm.TravelControl.defaultMapColour = mapColorDialog.Color.ToArgb();
                 var db = new SQLiteDBClass();
-                db.PutSettingInt("DefaultMap", _discoveryForm.TravelControl.defaultMapColour);
+                EDDConfig.Instance.DefaultMapColour = _discoveryForm.TravelControl.defaultMapColour;
                 panel_defaultmapcolor.BackColor = Color.FromArgb(_discoveryForm.TravelControl.defaultMapColour);
             }
         }

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -65,8 +65,10 @@ namespace EDDiscovery2
                 radioButton_Manual.Checked = true;
             }
 
-            string datapath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Frontier_Developments\\Products"); // \\FORC-FDEV-D-1001\\Logs\\";
             textBoxNetLogDir.Text = EDDConfig.Instance.NetLogDir;
+
+            EDDConfig.Instance.NetLogDirAutoModeChanged += EDDConfig_NetLogDirAutoModeChanged;
+            EDDConfig.Instance.NetLogDirChanged += EDDConfig_NetLogDirChanged;
 
             checkBox_Distances.Checked = EDDiscoveryForm.EDDConfig.UseDistances;
             checkBoxEDSMLog.Checked = EDDiscoveryForm.EDDConfig.EDSMLog;
@@ -129,6 +131,42 @@ namespace EDDiscovery2
             }
         }
 
+        private void textBoxNetLogDir_Validating(object sender, CancelEventArgs e)
+        {
+            var path = textBoxNetLogDir.Text;
+            if (!Directory.Exists(path))
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void textBoxNetLogDir_Validated(object sender, EventArgs e)
+        {
+            EDDConfig.Instance.NetLogDir = textBoxNetLogDir.Text;
+        }
+
+        private void radioButton_Auto_CheckedChanged(object sender, EventArgs e)
+        {
+            EDDConfig.Instance.NetLogDirAutoMode = radioButton_Auto.Checked;
+        }
+
+        private void EDDConfig_NetLogDirChanged()
+        {
+            if (EDDConfig.Instance.NetLogDir != textBoxNetLogDir.Text)
+            {
+                textBoxNetLogDir.Text = EDDConfig.Instance.NetLogDir;
+            }
+        }
+
+        private void EDDConfig_NetLogDirAutoModeChanged()
+        {
+            if (EDDConfig.Instance.NetLogDirAutoMode != radioButton_Auto.Checked)
+            {
+                radioButton_Auto.Checked = EDDConfig.Instance.NetLogDirAutoMode;
+                radioButton_Manual.Checked = !EDDConfig.Instance.NetLogDirAutoMode;
+            }
+        }
+
         private void button_Browse_Click(object sender, EventArgs e)
         {
             FolderBrowserDialog dirdlg = new FolderBrowserDialog();
@@ -138,6 +176,7 @@ namespace EDDiscovery2
             if (dlgResult == DialogResult.OK)
             {
                 textBoxNetLogDir.Text = dirdlg.SelectedPath;
+                EDDConfig.Instance.NetLogDir = textBoxNetLogDir.Text;
             }
         }
 

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -54,7 +54,7 @@ namespace EDDiscovery2
 
         public void InitSettingsTab()
         {
-            bool auto = _db.GetSettingBool("NetlogDirAutoMode", true);
+            bool auto = EDDConfig.Instance.NetLogDirAutoMode;
 
             if (auto)
             {
@@ -66,7 +66,7 @@ namespace EDDiscovery2
             }
 
             string datapath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Frontier_Developments\\Products"); // \\FORC-FDEV-D-1001\\Logs\\";
-            textBoxNetLogDir.Text = _db.GetSettingString("Netlogdir", datapath);
+            textBoxNetLogDir.Text = EDDConfig.Instance.NetLogDir;
 
             checkBox_Distances.Checked = EDDiscoveryForm.EDDConfig.UseDistances;
             checkBoxEDSMLog.Checked = EDDiscoveryForm.EDDConfig.EDSMLog;
@@ -97,8 +97,8 @@ namespace EDDiscovery2
 
         public void SaveSettings()
         {
-            _db.PutSettingBool("NetlogDirAutoMode", radioButton_Auto.Checked);
-            _db.PutSettingString("Netlogdir", textBoxNetLogDir.Text);
+            EDDConfig.Instance.NetLogDirAutoMode = radioButton_Auto.Checked;
+            EDDConfig.Instance.NetLogDir = textBoxNetLogDir.Text;
             _db.PutSettingString("DefaultMapCenter", textBoxHomeSystem.Text);
             _db.PutSettingDouble("DefaultMapZoom", Double.Parse(textBoxDefaultZoom.Text));
             _db.PutSettingBool("CentreMapOnSelection", radioButtonHistorySelection.Checked);

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -525,6 +525,7 @@ namespace EDDiscovery
                 var itm = (EDCommander)comboBoxCommander.SelectedItem;
                 activecommander = itm.Nr;
                 netlog.ActiveCommander = itm.Nr;
+                EDDiscoveryForm.EDDConfig.CurrentCmdrID = itm.Nr;
                 if (visitedSystems != null)
                     visitedSystems.Clear();
                 RefreshHistory();

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -524,7 +524,6 @@ namespace EDDiscovery
             {
                 var itm = (EDCommander)comboBoxCommander.SelectedItem;
                 activecommander = itm.Nr;
-                netlog.ActiveCommander = itm.Nr;
                 EDDiscoveryForm.EDDConfig.CurrentCmdrID = itm.Nr;
                 if (visitedSystems != null)
                     visitedSystems.Clear();

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -512,7 +512,10 @@ namespace EDDiscovery
             comboBoxCommander.DataSource = commanders;
             comboBoxCommander.ValueMember = "Nr";
             comboBoxCommander.DisplayMember = "Name";
-            comboBoxCommander.SelectedIndex = 1;
+
+            EDCommander currentcmdr = EDDiscoveryForm.EDDConfig.CurrentCommander;
+            comboBoxCommander.SelectedIndex = commanders.IndexOf(currentcmdr);
+            activecommander = currentcmdr.Nr;
 
             comboBoxCommander.Enabled = true;
 

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -227,7 +227,7 @@ namespace EDDiscovery
 
         private void GetVisitedSystems()
         {                                                       // for backwards compatibility, don't store RGB value.
-            visitedSystems = netlog.ParseFiles(richTextBox_History, defaultMapColour, activecommander);
+            visitedSystems = netlog.ParseFiles(richTextBox_History, defaultMapColour);
         }
 
         private void AddHistoryRow(bool insert, SystemPosition item, SystemPosition item2)

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -54,7 +54,7 @@ namespace EDDiscovery
             _discoveryForm = discoveryForm;
             sync = new EDSMSync(_discoveryForm);
             var db = new SQLiteDBClass();
-            defaultMapColour = db.GetSettingInt("DefaultMap", Color.Red.ToArgb());
+            defaultMapColour = EDDConfig.Instance.DefaultMapColour;
             EDSMSyncTo = db.GetSettingBool("EDSMSyncTo", true);
             EDSMSyncFrom = db.GetSettingBool("EDSMSyncFrom", true);
             checkBoxEDSMSyncTo.Checked = EDSMSyncTo;


### PR DESCRIPTION
This adds a few multi-commander improvements:
* `EDDConfig.CurrentCmdrID` is now the commander number and not the index of the commander in the `listCommanders`.
* Set the current commander on the `EDDConfig` object, so e.g. EDSM syncs go to the correct commander
* Allow the per-commander netlog path to override the global netlog path
* Store the active commander ID in the `ActiveCommander` setting in the database
* Use EDDConfig to access some settings from the database - specifically `Netlogdir`, `NetlogDirAutoMode` and `DefaultMap`
* Use locking to prevent conflicts between the netlog monitor, netlog main thread, and history refresh.
* Reloads the netlog watcher when the netlog directory changes
* Loads the last active commander on startup
