### PR TITLE
Sync comments from EDSM

### DIFF
--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -263,6 +263,35 @@ namespace EDDiscovery2.EDSM
             return listDistances;
         }
 
+        public int GetComments(DateTime starttime, out List<SystemNoteClass> notes)
+        {
+            notes = new List<SystemNoteClass>();
+
+            var json = GetComments(starttime);
+            if (json == null)
+            {
+                return 0;
+            }
+
+            JObject msg = JObject.Parse(json);
+            int msgnr = msg["msgnum"].Value<int>();
+
+            JArray comments = (JArray)msg["comments"];
+            if (comments != null)
+            {
+                foreach (JObject jo in comments)
+                {
+                    SystemNoteClass note = new SystemNoteClass();
+                    note.Name = jo["system"].Value<string>();
+                    note.Note = jo["comment"].Value<string>();
+                    note.Time = DateTime.ParseExact(jo["lastUpdate"].Value<string>(), "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal).ToLocalTime();
+                    notes.Add(note);
+                }
+            }
+
+            return msgnr;
+        }
+
         public string GetComments(DateTime starttime)
         {
             SQLiteDBClass db = new SQLiteDBClass();

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -72,7 +72,9 @@ namespace EDDiscovery2.EDSM
 
                 //string comments =  edsm.GetComments(new DateTime(2015, 1, 1));
                 List<SystemPosition> log;
+                List<SystemNoteClass> notes;
                 int ret = edsm.GetLogs(new DateTime(2011, 1, 1), out log);
+                int nret = edsm.GetComments(new DateTime(2011, 1, 1), out notes);
 
                 if (log == null)
                     log = new List<SystemPosition>();
@@ -150,6 +152,26 @@ namespace EDDiscovery2.EDSM
                             System.Diagnostics.Trace.WriteLine("New from EDSM");
                             newsystem = true;
 
+                        }
+                    }
+
+                    // Sync comments from EDSM
+                    foreach (var note in notes)
+                    {
+                        string searchname = note.Name.ToLower();
+                        if (SQLiteDBClass.globalSystemNotes.ContainsKey(searchname))
+                        {
+                            SystemNoteClass dbnote = SQLiteDBClass.globalSystemNotes[searchname];
+                            if (note.Time > dbnote.Time)
+                            {
+                                dbnote.Time = note.Time;
+                                dbnote.Note = note.Note;
+                                dbnote.Update();
+                            }
+                        }
+                        else
+                        {
+                            note.Add();
                         }
                     }
                 }


### PR DESCRIPTION
Sync comments from EDSM under the active commander.  Note that this currently uses the most recent comment, regardless of which commander the comment was filed under.  Requested in #156 and #199