### PR TITLE
Upgrade to EDMatieralier API v4 (take 2)

### DIFF
--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -171,6 +171,7 @@
     <Compile Include="3DMap\DatasetBuilder.cs" />
     <Compile Include="3DMap\MapManager.cs" />
     <Compile Include="3DMap\KeyboardActions.cs" />
+    <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Controls\ButtonExt.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -281,6 +281,7 @@
     <Compile Include="PlanetSystems\AddMaterialNodeControl.Designer.cs">
       <DependentUpon>AddMaterialNodeControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="PlanetSystems\EDBasecamp.cs" />
     <Compile Include="PlanetSystems\EDSurvey.cs" />
     <Compile Include="PlanetSystems\EDWorldSurvey.cs" />
     <Compile Include="PlanetSystems\Repositories\Basecamp.cs" />

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -216,16 +216,16 @@ namespace EDDiscovery
 
                 CheckForNewInstaller();
 
-#if DEBUG
-//Robby : not sure about this, should we be moaning about this, what if people don't want to use EDmaterializer.
+                // Note: This is not for the end user, it's actually an alarm for us so we 
+                // know the file is missing from the installer. Without this credentials file 
+                // Prospecting data writes are broken.
                 var appSettings = ConfigurationManager.AppSettings;
                 if (appSettings["EDMaterializerUsername"] == null || appSettings["EDMaterializerPassword"] == null)
                 {
-                    // Note: It's ok if this happens in DEBUG build Because we now hard code the
+                    // Note: It's ok if this happens in DEBUG build Because we now hard coding the
                     // credentials in that particular case.
                     LogLineHighlight("WARNING: EDMaterializer credentials are missing!");
                 }
-#endif
                 LogLineSuccess("Loading completed, Total number of systems " + SystemData.SystemList.Count().ToString());
             }
             catch (Exception ex)

--- a/EDDiscovery/HTTP/EDMaterializerCom.cs
+++ b/EDDiscovery/HTTP/EDMaterializerCom.cs
@@ -16,6 +16,12 @@ namespace EDDiscovery2.HTTP
         private NameValueCollection _authTokens = null;
         private readonly string _authPath = "auth";
 
+        public EDMaterizliaerCom()
+        {
+            // JSON API Mimetype: http://jsonapi.org/
+            MimeType = "application/vnd.api+json; charset=utf-8";
+        }
+
         protected ResponseData RequestSecureGet(string action)
         {
             return ManagedRequest(null, action, RequestGetWrapper);

--- a/EDDiscovery/HTTP/HttpCom.cs
+++ b/EDDiscovery/HTTP/HttpCom.cs
@@ -11,6 +11,8 @@ namespace EDDiscovery2.HTTP
     {
         protected string _serverAddress;
 
+        public String MimeType { get; set; } = "application/json; charset=utf-8";
+
         protected ResponseData RequestPost(string json, string action, NameValueCollection headers = null)
         {
             try
@@ -32,7 +34,7 @@ namespace EDDiscovery2.HTTP
 
                     byte[] byteArray = Encoding.UTF8.GetBytes(postData);
                     // Set the ContentType property of the WebRequest.
-                    request.ContentType = "application/json; charset=utf-8";
+                    request.ContentType = MimeType;
                     //request.Headers.Add("Accept-Encoding", "gzip,deflate");
                     // Set the ContentLength property of the WebRequest.
                     request.ContentLength = byteArray.Length;
@@ -112,7 +114,7 @@ namespace EDDiscovery2.HTTP
 
                     byte[] byteArray = Encoding.UTF8.GetBytes(postData);
                     // Set the ContentType property of the WebRequest.
-                    request.ContentType = "application/json; charset=utf-8";
+                    request.ContentType = MimeType;
                     //request.Headers.Add("Accept-Encoding", "gzip,deflate");
                     // Set the ContentLength property of the WebRequest.
                     request.ContentLength = byteArray.Length;
@@ -187,7 +189,7 @@ namespace EDDiscovery2.HTTP
                     request.Method = "GET";
 
                     // Set the ContentType property of the WebRequest.
-                    request.ContentType = "application/json; charset=utf-8";
+                    request.ContentType = MimeType;
                     request.Headers.Add("Accept-Encoding", "gzip,deflate");
                     if (headers != null)
                     {
@@ -261,7 +263,7 @@ namespace EDDiscovery2.HTTP
                     request.Method = "DELETE";
 
                     // Set the ContentType property of the WebRequest.
-                    request.ContentType = "application/json; charset=utf-8";
+                    request.ContentType = MimeType;
                     request.Headers.Add("Accept-Encoding", "gzip,deflate");
                     if (headers != null)
                     {

--- a/EDDiscovery/HTTP/ResponseData.cs
+++ b/EDDiscovery/HTTP/ResponseData.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Specialized;
 using System.Net;
 
@@ -33,23 +34,30 @@ namespace EDDiscovery2.HTTP
             string message = "";
             try
             {
-                JObject jbody = JObject.Parse(Body);
-                JArray jerrors = (JArray)jbody["errors"];
-                if (jerrors != null)
+                if (Body.Length > 0)
                 {
-                    foreach (JObject jerror in jerrors)
+                    JObject jbody = JObject.Parse(Body);
+                    JArray jerrors = (JArray)jbody["errors"];
+                    if (jerrors != null)
                     {
-                        if (message.Length > 0)
+                        foreach (JObject jerror in jerrors)
                         {
-                            message += "\n";
+                            if (message.Length > 0)
+                            {
+                                message += "\n";
+                            }
+                            message += $"{jerror["title"]} - {jerror["detail"]}";
                         }
-                        message += $"{jerror["title"]} - {jerror["detail"]}";
                     }
                 }
+                else
+                {
+                    message = $"Server Error\nHTTP response: {StatusCode.ToString()}\n\nCheck the logs for more details";
+                }
             }
-            catch
+            catch(Exception e)
             {
-                message = "Unknown JSON API error";
+                message = $"Unknown JSON API error\n\nDetails: {e}\n\nCheck the logs for more details";
             }
             return message;
         }

--- a/EDDiscovery/HTTP/ResponseData.cs
+++ b/EDDiscovery/HTTP/ResponseData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Specialized;
 using System.Net;
 
 namespace EDDiscovery2.HTTP
@@ -23,6 +24,35 @@ namespace EDDiscovery2.HTTP
                                           // converstation with the server
         public string Body;
         public NameValueCollection Headers;
+
+        // Uses knowledge of the error object structure in JSON API to
+        // output all the errors for human consumption. 
+        // Reference http://jsonapi.org/format/#error-objects
+        public string JsonApiErrorMessage()
+        {
+            string message = "";
+            try
+            {
+                JObject jbody = JObject.Parse(Body);
+                JArray jerrors = (JArray)jbody["errors"];
+                if (jerrors != null)
+                {
+                    foreach (JObject jerror in jerrors)
+                    {
+                        if (message.Length > 0)
+                        {
+                            message += "\n";
+                        }
+                        message += $"{jerror["title"]} - {jerror["detail"]}";
+                    }
+                }
+            }
+            catch
+            {
+                message = "Unknown JSON API error";
+            }
+            return message;
+        }
     }
 
 }

--- a/EDDiscovery/ObjectExtensions.cs
+++ b/EDDiscovery/ObjectExtensions.cs
@@ -1,0 +1,7 @@
+﻿public static class ObjectExtensions
+{
+    public static string ToNullSafeString(this object obj)
+        {
+        return (obj ?? string.Empty).ToString();
+    }
+}

--- a/EDDiscovery/PlanetSystems/EDBasecamp.cs
+++ b/EDDiscovery/PlanetSystems/EDBasecamp.cs
@@ -1,8 +1,13 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 
 namespace EDDiscovery2.PlanetSystems
 {
 
+    // Relationships:
+    //   A Basecamp belongs to a single World
+    //   A Basecamp can have Surveys
     public class EDBasecamp : EDObject
     {
         public int worldId; // A basecamp has to have a worldid
@@ -14,6 +19,7 @@ namespace EDDiscovery2.PlanetSystems
         public int terrainHue3;
         public float landingZoneLat;
         public float landingZoneLon;
+        public List<int> surveyIds;
 
         public EDBasecamp()
         {
@@ -41,7 +47,36 @@ namespace EDDiscovery2.PlanetSystems
             var relationships = jo["relationships"];
             var world = relationships["world"];
             worldId = world["id"].Value<int>();
+
+            // TODO: Make this lookup Lazy Loading to reduce on server
+            // traffic and keep it fresh
+            surveyIds = new List<int>();
+            foreach (var survey in relationships["surveys"]["data"] as JArray)
+            {
+                surveyIds.Add(GetInt(survey["id"]));
+            }
             return true;
+        }
+
+
+        // Obtain a world object using the world-id
+        public EDWorld GetWorld()
+        {
+            if (worldId > 0)
+            {
+                Repositories.World worldRepo = new Repositories.World();
+                return worldRepo.GetForId(worldId);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public List<EDSurvey> GetSurveys()
+        {
+            Repositories.Survey surveyRepo = new Repositories.Survey();
+            return surveyRepo.GetForIds(surveyIds);
         }
 
     }

--- a/EDDiscovery/PlanetSystems/EDBasecamp.cs
+++ b/EDDiscovery/PlanetSystems/EDBasecamp.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace EDDiscovery2.PlanetSystems
+{
+
+    public class EDBasecamp : EDObject
+    {
+        public int worldId; // A basecamp has to have a worldid
+        public string name;
+        public string description;
+        public string landingZoneTerrain;
+        public int terrainHue1; // rgb color ints
+        public int terrainHue2;
+        public int terrainHue3;
+        public float landingZoneLat;
+        public float landingZoneLon;
+
+        public EDBasecamp()
+        {
+        }
+
+        public bool ParseJson(JObject jo)
+        {
+            //Reminder - JSONAPI attributes and relationships structure
+
+            id = jo["id"].Value<int>();
+
+            var attributes = jo["attributes"];
+            name = attributes["name"].Value<string>();
+            description = attributes["description"].Value<string>();
+            landingZoneTerrain = attributes["landing-zone-terrain"].Value<string>();
+            terrainHue1 = attributes["terrain-hue-1"].Value<int>();
+            terrainHue2 = attributes["terrain-hue-2"].Value<int>();
+            terrainHue3 = attributes["terrain-hue-3"].Value<int>(); ;
+            landingZoneLat = attributes["landing-zone-lat"].Value<float>();
+            landingZoneLon = attributes["landing-zone-lon"].Value<float>();
+            notes = attributes["notes"].Value<string>();
+            imageUrl = attributes["image-url"].Value<string>();
+
+            var relationships = jo["relationships"];
+            var world = relationships["world"];
+            worldId = world["id"].Value<int>();
+            return true;
+        }
+
+    }
+}
+    

--- a/EDDiscovery/PlanetSystems/EDBasecamp.cs
+++ b/EDDiscovery/PlanetSystems/EDBasecamp.cs
@@ -26,6 +26,7 @@ namespace EDDiscovery2.PlanetSystems
             id = jo["id"].Value<int>();
 
             var attributes = jo["attributes"];
+            updater = attributes["updater"].Value<string>();
             name = attributes["name"].Value<string>();
             description = attributes["description"].Value<string>();
             landingZoneTerrain = attributes["landing-zone-terrain"].Value<string>();

--- a/EDDiscovery/PlanetSystems/EDObject.cs
+++ b/EDDiscovery/PlanetSystems/EDObject.cs
@@ -170,8 +170,9 @@ public enum AtmosphereEnum
 
         public DateTime updated_at;
         public DateTime created_at;
+        public string creator; // Read only
 
-        public string image_url;
+        public string imageUrl;
 
         static protected List<ObjectsType> objectsTypes = ObjectsType.GetAllTypes();
         static private Dictionary<string, ObjectTypesEnum> objectAliases = ObjectsType.GetAllTypesAlias();

--- a/EDDiscovery/PlanetSystems/EDStar.cs
+++ b/EDDiscovery/PlanetSystems/EDStar.cs
@@ -37,7 +37,7 @@ namespace EDDiscovery2.PlanetSystems
             notes = GetString(attributes["notes"]);
             subclass = GetString(attributes["spectral-subclass"]);
             luminosity = GetString(attributes["luminosity"]);
-            image_url = GetString(attributes["image-url"]);
+            imageUrl = GetString(attributes["image-url"]);
 
             return true;
         }

--- a/EDDiscovery/PlanetSystems/EDSurvey.cs
+++ b/EDDiscovery/PlanetSystems/EDSurvey.cs
@@ -38,20 +38,26 @@ namespace EDDiscovery2.PlanetSystems
 
         public bool ParseJson(JObject jo)
         {
+            //Reminder - JSONAPI attributes and relationships structure
 
             id = jo["id"].Value<int>();
+
             var attributes = jo["attributes"];
-            worldId = attributes["world-id"].Value<int>();
             commander = attributes["commander"].Value<string>();
             resource = attributes["resource"].Value<string>();
             notes = attributes["notes"].Value<string>();
             imageUrl = attributes["image-url"].Value<string>();
+
+            var relationships = jo["relationships"];
+            var world = relationships["world"];
+            worldId = world["id"].Value<int>();
+
             // surveyedBy is an array of strings. Leaving it for now;
             // surveyedAt is a date. Leaving it for now;
 
             //TODO: Not quite sure how to work with materials object in their current state, 
             //      but something like this should do it - Greg
-            
+
             //foreach (var mat in mlist)
             //{
             //    materials[mat.material] = attributes[mat.Name.ToLower()].Value<int>();

--- a/EDDiscovery/PlanetSystems/EDSurvey.cs
+++ b/EDDiscovery/PlanetSystems/EDSurvey.cs
@@ -6,7 +6,9 @@ using System.Text;
 
 namespace EDDiscovery2.PlanetSystems
 {
-
+    // Relationships:
+    //   A Survey belongs to a single World
+    //   A Survey can optionally have a basecamp
     public class EDSurvey : EDObject
     {
         public int worldId;
@@ -64,6 +66,36 @@ namespace EDDiscovery2.PlanetSystems
             //}
             return true;
         }
+
+
+        // Obtain a world object using the world-id
+        public EDWorld GetWorld()
+        {
+            if (worldId > 0)
+            {
+                Repositories.World worldRepo = new Repositories.World();
+                return worldRepo.GetForId(worldId);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        // Go to the associated basecamp if there is one
+        public EDBasecamp GetBasecamp()
+        {
+            if (basecampId > 0)
+            {
+                Repositories.Basecamp basecampRepo = new Repositories.Basecamp();
+                return basecampRepo.GetForId(basecampId);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
 
     }
 }

--- a/EDDiscovery/PlanetSystems/EDWorld.cs
+++ b/EDDiscovery/PlanetSystems/EDWorld.cs
@@ -135,7 +135,7 @@ namespace EDDiscovery2.PlanetSystems
             terraformable = GetString(attributes["terraformable"]);
             notes = GetString(attributes["notes"]);
             atmosphere = (AtmosphereEnum)AtmosphereStr2Enum(attributes["atmosphere-type"].Value<string>());
-            image_url = GetString(attributes["image-url"]);
+            imageUrl = GetString(attributes["image-url"]);
 
             var relationships = (JObject) jo["relationships"];
             var data = relationships["world-survey"]["data"] as JObject;

--- a/EDDiscovery/PlanetSystems/EDWorld.cs
+++ b/EDDiscovery/PlanetSystems/EDWorld.cs
@@ -7,6 +7,9 @@ using System.Text;
 namespace EDDiscovery2.PlanetSystems
 {
 
+    // Relationships:
+    //   A World can have a single World Survey
+    //   A World can have multiple Surveys
     public class EDWorld : EDObject
     {
         public string terraformable;
@@ -142,12 +145,13 @@ namespace EDDiscovery2.PlanetSystems
             if (data != null)
                 worldSurveyId = GetInt(data["id"]);
 
+            // TODO: Make this lookup Lazy Loading to reduce on server
+            // traffic and keep it fresh
             surveyIds = new List<int>();
             foreach(var survey in relationships["surveys"]["data"] as JArray)
             {
                 surveyIds.Add(GetInt(survey["id"]));
             }
-
             return true;
         }
 
@@ -223,8 +227,15 @@ namespace EDDiscovery2.PlanetSystems
         // Obtain a World Survey from a World object here!
         public EDWorldSurvey GetWorldSurvey()
         {
-            Repositories.WorldSurvey worldSurveyRepo = new Repositories.WorldSurvey();
-            return worldSurveyRepo.GetForId(worldSurveyId);
+            if (worldSurveyId > 0)
+            {
+                Repositories.WorldSurvey worldSurveyRepo = new Repositories.WorldSurvey();
+                return worldSurveyRepo.GetForId(worldSurveyId);
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public List<EDSurvey> GetSurveys()

--- a/EDDiscovery/PlanetSystems/EDWorldSurvey.cs
+++ b/EDDiscovery/PlanetSystems/EDWorldSurvey.cs
@@ -6,7 +6,8 @@ using System.Text;
 
 namespace EDDiscovery2.PlanetSystems
 {
-
+    // Relationships:
+    //   A WorldSurvey belongs to a single World
     public class EDWorldSurvey : EDObject
     {
         public int worldId;
@@ -64,6 +65,20 @@ namespace EDDiscovery2.PlanetSystems
             }
 
             return MaterialEnum.Unknown;
+        }
+
+        // Obtain a world object using the world-id
+        public EDWorld GetWorld()
+        {
+            if (worldId > 0)
+            {
+                Repositories.World worldRepo = new Repositories.World();
+                return worldRepo.GetForId(worldId);
+            }
+            else
+            {
+                return null;
+            }
         }
 
     }

--- a/EDDiscovery/PlanetSystems/EDWorldSurvey.cs
+++ b/EDDiscovery/PlanetSystems/EDWorldSurvey.cs
@@ -17,19 +17,21 @@ namespace EDDiscovery2.PlanetSystems
 
         public bool ParseJson(JObject jo)
         {
+            //Reminder - JSONAPI attributes and relationships structure
 
             id = jo["id"].Value<int>();
             var attributes = jo["attributes"];
-            worldId = attributes["world-id"].Value<int>();
-
-
             //TODO: Not quite sure how to work with materials object in their current state, 
             //      but something like this should do it - Greg
-            
+
             //foreach (var mat in mlist)
             //{
             //    materials[mat.material] = attributes[mat.Name.ToLower()].Value<bool>();
             //}
+
+            var relationships = jo["relationships"];
+            var world = relationships["world"];
+            worldId = world["id"].Value<int>();
             return true;
         }
 

--- a/EDDiscovery/PlanetSystems/PlanetsForm.cs
+++ b/EDDiscovery/PlanetSystems/PlanetsForm.cs
@@ -10,6 +10,8 @@ using System.Windows.Forms;
 using EDDiscovery2.DB;
 using System.Globalization;
 using EDDiscovery2.PlanetSystems;
+using EDDiscovery2.HTTP;
+using Newtonsoft.Json.Linq;
 
 namespace EDDiscovery2.PlanetSystems
 {
@@ -270,12 +272,14 @@ namespace EDDiscovery2.PlanetSystems
             if (currentObj is EDWorld)
             {
                 Repositories.World world = new Repositories.World();
-                world.Store((EDWorld)currentObj);
+                ResponseData response = world.Store((EDWorld)currentObj);
+                OutputErrors(response);
             }
             if (currentObj is EDStar)
             {
                 Repositories.Star star = new Repositories.Star();
-                star.Store((EDStar)currentObj);
+                ResponseData response = star.Store((EDStar)currentObj);
+                OutputErrors(response);
             }
         }
 
@@ -502,6 +506,16 @@ namespace EDDiscovery2.PlanetSystems
             if (mass == 0 || radius == 0)
                 return 0;
             return mass * 5.9722E+24 * 6.67E-11 / ((radius * 1000)* (radius * 1000)) / 9.80665;
+        }
+
+        private void OutputErrors(ResponseData response)
+        {
+            if ((int)response.StatusCode >= 400)
+            {
+                var errorMsg = response.JsonApiErrorMessage();
+                MessageBox.Show(errorMsg, "Unable to save", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
         }
 
     }

--- a/EDDiscovery/PlanetSystems/Repositories/Basecamp.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Basecamp.cs
@@ -1,11 +1,166 @@
-﻿using System;
+﻿using EDDiscovery;
+using EDDiscovery2.HTTP;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Net;
 
 namespace EDDiscovery2.PlanetSystems.Repositories
 {
     public class Basecamp : EdMaterializer
     {
+        public List<EDBasecamp> GetForIds(List<int> ids)
+        {
+            var basecamps = new List<EDBasecamp>();
+            if (ids != null)
+            {
+                foreach (var id in ids)
+                {
+                    var basecamp = GetForId(id);
+                    if (basecamp != null)
+                        basecamps.Add(basecamp);
+                }
+            }
+            return basecamps;
+        }
+
+        public EDBasecamp GetForId(int id)
+        {
+            if (id > 0)
+            {
+                var request = RequestGet($"{ApiNamespace}/basecamps/{id}");
+                if (request.StatusCode == HttpStatusCode.OK)
+                {
+                    var jo = JObject.Parse(request.Body);
+                    var data = jo["data"];
+                    EDBasecamp obj = new EDBasecamp();
+
+                    return (obj.ParseJson((JObject)data)) ? obj : null;
+                }
+            }
+
+            return null;
+        }
+
+        public EDBasecamp GetFirst(string scope)
+        {
+            var items = GetAll(scope);
+            return (items.Count > 0) ? items[0] : null;
+        }
+
+        public List<EDBasecamp> GetAll(string scope)
+        {
+            List<EDBasecamp> listObjects = new List<EDBasecamp>();
+            string query = ApiNamespace + "/basecamps";
+
+            if (!String.IsNullOrEmpty(scope))
+                query = query + "?" + scope;
+
+            var response = RequestGet(query);
+            var json = response.Body;
+
+            JArray jArray = null;
+            JObject jObject = null;
+            if (json != null && json.Length > 5)
+                jObject = (JObject)JObject.Parse(json);
+
+            if (jObject == null)
+                return listObjects;
+
+            jArray = (JArray)jObject["data"];
+
+            foreach (JObject jo in jArray)
+            {
+                EDBasecamp obj = new EDBasecamp();
+
+                if (obj.ParseJson((JObject)jo))
+                    listObjects.Add(obj);
+            }
+
+            return listObjects;
+        }
+
+        // NOTE: With Stars and Worlds we get away with attempting to POST and resorting to a PATCH
+        // if a record is already present. This won't work for Basecamps because there is no uniqueness rule.
+        // A user might create several basecamp records for a world each with differet Resource types.
+        // Also they may make extra sets for each Basecamp if they're using Basecamps.
+        // If in doubt search for a record first and create a new one if there isn't one in existence.
+        public ResponseData Store(EDBasecamp edobj)
+        {
+            dynamic jo = new JObject();
+
+
+            ResponseData response;
+            if (edobj.id == 0)
+            {
+                string json = Payload(edobj);
+
+                JObject joPost = JObject.Parse(json);
+
+                response = RequestSecurePost(joPost.ToString(), $"{ApiNamespace}/basecamps");
+                if (response.StatusCode == HttpStatusCode.Created)
+                {
+                    JObject jo2 = (JObject)JObject.Parse(response.Body);
+                    JObject obj = (JObject)jo2["data"];
+                    edobj.id = obj["id"].Value<int>();
+                }
+            }
+            else
+            {
+                string json = Payload(edobj, edobj.id);
+                JObject joPatch = JObject.Parse(json);
+
+                response = RequestSecurePatch(joPatch.ToString(), $"{ApiNamespace}/basecamps/" + edobj.id.ToString());
+            }
+            return response;
+        }
+
+        public ResponseData Delete(int id)
+        {
+            var response = RequestSecureDelete($"{ApiNamespace}/basecamps/" + id.ToString());
+
+            return response;
+        }
+
+        public ResponseData Delete(EDBasecamp obj)
+        {
+            if (obj.id > 0)
+                return Delete(obj.id);
+            else
+                return new ResponseData(HttpStatusCode.NotFound);
+        }
+
+        // Payload can be for Insert or Update. The difference is whether there is an id or not
+        private string Payload(EDBasecamp edobj, int id = 0)
+        {
+            string json = @"{
+                'data': {" +
+                    (id > 0 ? JsonAttributeString("id", id.ToString()) : "") + @"
+                    'type': 'basecamps',
+                    'attributes': {" +
+                        JsonAttributeString("updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
+                        JsonAttributeString("name", edobj.name) +
+                        JsonAttributeString("description", edobj.description) +
+                        JsonAttributeString("landingZoneTerrain", edobj.landingZoneTerrain) +
+                        JsonAttributeString("terrainHue1", edobj.terrainHue1.ToNullSafeString()) +
+                        JsonAttributeString("terrainHue2", edobj.terrainHue2.ToNullSafeString()) +
+                        JsonAttributeString("terrainHue3", edobj.terrainHue3.ToNullSafeString()) +
+                        JsonAttributeString("landingZoneLat", edobj.landingZoneLat.ToNullSafeString()) +
+                        JsonAttributeString("landingZoneLon", edobj.landingZoneLon.ToNullSafeString()) +
+                        JsonAttributeString("notes", edobj.notes) +
+                        JsonAttributeString("images-url", edobj.imageUrl) + @"
+                    },
+                    'relationships' {
+                        'world' {" +
+                            JsonAttributeString("id", edobj.worldId.ToNullSafeString()) + @"
+                            'type': 'worlds'
+                        }
+                    }
+                }
+            }";
+            return json;
+        }
+
     }
+
 }

--- a/EDDiscovery/PlanetSystems/Repositories/Basecamp.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Basecamp.cs
@@ -93,9 +93,7 @@ namespace EDDiscovery2.PlanetSystems.Repositories
             ResponseData response;
             if (edobj.id == 0)
             {
-                string json = Payload(edobj);
-
-                JObject joPost = JObject.Parse(json);
+                JObject joPost = Payload(edobj);
 
                 response = RequestSecurePost(joPost.ToString(), $"{ApiNamespace}/basecamps");
                 if (response.StatusCode == HttpStatusCode.Created)
@@ -107,8 +105,7 @@ namespace EDDiscovery2.PlanetSystems.Repositories
             }
             else
             {
-                string json = Payload(edobj, edobj.id);
-                JObject joPatch = JObject.Parse(json);
+                JObject joPatch = Payload(edobj, edobj.id);
 
                 response = RequestSecurePatch(joPatch.ToString(), $"{ApiNamespace}/basecamps/" + edobj.id.ToString());
             }
@@ -131,34 +128,39 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         }
 
         // Payload can be for Insert or Update. The difference is whether there is an id or not
-        private string Payload(EDBasecamp edobj, int id = 0)
+        private JObject Payload(EDBasecamp edobj, int id = 0)
         {
-            string json = @"{
-                'data': {" +
-                    (id > 0 ? JsonAttributeString("id", id.ToString()) : "") + @"
-                    'type': 'basecamps',
-                    'attributes': {" +
-                        JsonAttributeString("updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
-                        JsonAttributeString("name", edobj.name) +
-                        JsonAttributeString("description", edobj.description) +
-                        JsonAttributeString("landingZoneTerrain", edobj.landingZoneTerrain) +
-                        JsonAttributeString("terrainHue1", edobj.terrainHue1.ToNullSafeString()) +
-                        JsonAttributeString("terrainHue2", edobj.terrainHue2.ToNullSafeString()) +
-                        JsonAttributeString("terrainHue3", edobj.terrainHue3.ToNullSafeString()) +
-                        JsonAttributeString("landingZoneLat", edobj.landingZoneLat.ToNullSafeString()) +
-                        JsonAttributeString("landingZoneLon", edobj.landingZoneLon.ToNullSafeString()) +
-                        JsonAttributeString("notes", edobj.notes) +
-                        JsonAttributeString("images-url", edobj.imageUrl) + @"
-                    },
-                    'relationships' {
-                        'world' {" +
-                            JsonAttributeString("id", edobj.worldId.ToNullSafeString()) + @"
-                            'type': 'worlds'
-                        }
-                    }
-                }
-            }";
-            return json;
+            var joPayload = new JObject {
+                { "data", new JObject {
+                    { "type", "basecamps" },
+                    { "attributes", new JObject {
+                        { "updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name },
+                        { "name", edobj.name },
+                        { "description", edobj.description },
+                        { "landing-zone-terrain", edobj.landingZoneTerrain },
+                        { "terrain-hue-1", edobj.terrainHue1 },
+                        { "terrain-hue-2", edobj.terrainHue2 },
+                        { "terrain-hue-3", edobj.terrainHue3 },
+                        { "landing-zone-lat", edobj.landingZoneLat },
+                        { "landing-zone-lon", edobj.landingZoneLon },
+                        { "notes", edobj.notes },
+                        { "images-url", edobj.imageUrl },
+                    } },
+                    { "relationships", new JObject {
+                        { "worlds", new JObject {
+                            { "id",  edobj.worldId },
+                            { "type", "worlds" },
+                        } },
+                    } },
+                } }
+            };
+            if (id > 0)
+            {
+                var jData = joPayload["data"];
+                jData["id"] = id;
+            }
+
+            return joPayload;
         }
 
     }

--- a/EDDiscovery/PlanetSystems/Repositories/EdMaterializer.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/EdMaterializer.cs
@@ -16,12 +16,21 @@ namespace EDDiscovery2.PlanetSystems.Repositories
 #if DEBUG
             // Dev server. Mess with data as much as you like here
             _serverAddress = "https://ed-materializer.herokuapp.com/";
+
+            // Want some to visuals on that thing you're working on?
+            // Frontend app is at:
+            // http://qa.edmaterializer.com
+
+            // You'll need to register a commander account. Don't use the EDDiscovery credentials
 #else
             // Production
             _serverAddress = "http://api.edmaterializer.com/";
+
+            // Frontend app is at:
+            // http://edmaterializer.com
 #endif
         }
 
-        public String ApiNamespace { get; } = "api/v3";
+        public String ApiNamespace { get; } = "api/v4";
     }
 }

--- a/EDDiscovery/PlanetSystems/Repositories/EdMaterializer.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/EdMaterializer.cs
@@ -32,11 +32,5 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         }
 
         public String ApiNamespace { get; } = "api/v4";
-
-        // Little helper for building up json payloads;
-        protected string JsonAttributeString(string key, string value)
-        {
-            return $"'{key}': '{value}',";
-        }
     }
 }

--- a/EDDiscovery/PlanetSystems/Repositories/EdMaterializer.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/EdMaterializer.cs
@@ -32,5 +32,11 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         }
 
         public String ApiNamespace { get; } = "api/v4";
+
+        // Little helper for building up json payloads;
+        protected string JsonAttributeString(string key, string value)
+        {
+            return $"'{key}': '{value}',";
+        }
     }
 }

--- a/EDDiscovery/PlanetSystems/Repositories/Star.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Star.cs
@@ -68,23 +68,23 @@ namespace EDDiscovery2.PlanetSystems.Repositories
 
             string json = @"{
                 'data': {
-                      'type': 'stars',
-                      'attributes': {" +
-            $"            'system-name':       '{edobj.system}'," +
-            $"            'updater':           '{EDDiscoveryForm.EDDConfig.CurrentCommander.Name}'," +
-            $"            'star':              '{edobj.objectName}'," +
-            $"            'spectral-class':    '{edobj.Description}'," +
-            $"            'spectral-subclass': '{edobj.subclass}'," +
-            $"            'solar-mass':        '{edobj.mass}'," +
-            $"            'solar-radius':      '{edobj.radius}'," +
-            $"            'surface-temp':      '{edobj.surfaceTemp}'," +
-            $"            'star-age':          '{edobj.star_age}'," +
-            $"            'orbit-period':      '{edobj.orbitPeriod}'," +
-            $"            'arrival-point':     '{edobj.arrivalPoint}'," +
-            $"            'luminosity':        '{edobj.luminosity}'," +
-            $"            'notes':             '{edobj.notes}'," +
-            $"            'image-url':         '{edobj.image_url}'," +
-            @"         }
+                    'type': 'stars',
+                    'attributes': {" +
+                        JsonAttributeString("system-name",       edobj.system) +
+                        JsonAttributeString("updater",           EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
+                        JsonAttributeString("star",              edobj.objectName) +
+                        JsonAttributeString("spectral-class",    edobj.Description) +
+                        JsonAttributeString("spectral-subclass", edobj.subclass) +
+                        JsonAttributeString("solar-mass",        edobj.mass.ToString()) +
+                        JsonAttributeString("solar-radius",      edobj.radius.ToString()) +
+                        JsonAttributeString("surface-temp",      edobj.surfaceTemp.ToString()) +
+                        JsonAttributeString("star-age",          edobj.star_age.ToString()) +
+                        JsonAttributeString("orbit-period",      edobj.orbitPeriod.ToString()) +
+                        JsonAttributeString("arrival-point",     edobj.arrivalPoint.ToString()) +
+                        JsonAttributeString("luminosity",        edobj.luminosity) +
+                        JsonAttributeString("notes",             edobj.notes) +
+                        JsonAttributeString("image-url",         edobj.image_url) + @"
+                    }
                 }
             }";
             JObject joPost = JObject.Parse(json);

--- a/EDDiscovery/PlanetSystems/Repositories/Star.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Star.cs
@@ -66,27 +66,33 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         {
             dynamic jo = new JObject();
 
-            jo.system = edobj.system;
-            jo.updater = EDDiscoveryForm.EDDConfig.CurrentCommander.Name;
-            jo.star = edobj.objectName;
-            jo.spectral_class = edobj.Description;
-            jo.spectral_subclass = edobj.subclass;
-            jo.solar_mass = edobj.mass;
-            jo.solar_radius = edobj.radius;
-            jo.surface_temp = edobj.surfaceTemp;
-            jo.star_age = edobj.star_age;
-            jo.orbit_period = edobj.orbitPeriod;
-            jo.arrival_point = edobj.arrivalPoint;
-            jo.luminosity = edobj.luminosity;
-            jo.notes = edobj.notes;
-            jo.image_url = edobj.image_url;
-
-            JObject joPost = new JObject(new JProperty("star", jo));
-
+            string json = @"{
+                'data': {
+                      'type': 'stars',
+                      'attributes': {" +
+            $"            'system-name':       '{edobj.system}'," +
+            $"            'updater':           '{EDDiscoveryForm.EDDConfig.CurrentCommander.Name}'," +
+            $"            'star':              '{edobj.objectName}'," +
+            $"            'spectral-class':    '{edobj.Description}'," +
+            $"            'spectral-subclass': '{edobj.subclass}'," +
+            $"            'solar-mass':        '{edobj.mass}'," +
+            $"            'solar-radius':      '{edobj.radius}'," +
+            $"            'surface-temp':      '{edobj.surfaceTemp}'," +
+            $"            'star-age':          '{edobj.star_age}'," +
+            $"            'orbit-period':      '{edobj.orbitPeriod}'," +
+            $"            'arrival-point':     '{edobj.arrivalPoint}'," +
+            $"            'luminosity':        '{edobj.luminosity}'," +
+            $"            'notes':             '{edobj.notes}'," +
+            $"            'image-url':         '{edobj.image_url}'," +
+            @"         }
+                }
+            }";
+            JObject joPost = JObject.Parse(json);
+ 
             ResponseData response;
             if (edobj.id == 0)
             {
-                response = RequestSecurePost(joPost.ToString(), $"{ApiNamespace}/stars");
+                response = RequestSecurePost(joPost.ToString(), $"{ ApiNamespace}/stars");
                 if (response.StatusCode == HttpStatusCode.Created)
                 {
                     JObject jo2 = (JObject)JObject.Parse(response.Body);
@@ -104,6 +110,8 @@ namespace EDDiscovery2.PlanetSystems.Repositories
                         if (items.Count > 0)
                         {
                             edobj.id = items[0]["id"].Value<int>();
+                            JObject jData = (JObject)joPost["data"];
+                            jData["id"] = edobj.id;
                             response2 = RequestSecurePatch(joPost.ToString(), $"{ApiNamespace}/stars/" + edobj.id.ToString());
                             response = response2;
                         }

--- a/EDDiscovery/PlanetSystems/Repositories/Star.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Star.cs
@@ -66,29 +66,28 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         {
             dynamic jo = new JObject();
 
-            string json = @"{
-                'data': {
-                    'type': 'stars',
-                    'attributes': {" +
-                        JsonAttributeString("system-name",       edobj.system) +
-                        JsonAttributeString("updater",           EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
-                        JsonAttributeString("star",              edobj.objectName) +
-                        JsonAttributeString("spectral-class",    edobj.Description) +
-                        JsonAttributeString("spectral-subclass", edobj.subclass) +
-                        JsonAttributeString("solar-mass",        edobj.mass.ToNullSafeString()) +
-                        JsonAttributeString("solar-radius",      edobj.radius.ToNullSafeString()) +
-                        JsonAttributeString("surface-temp",      edobj.surfaceTemp.ToNullSafeString()) +
-                        JsonAttributeString("star-age",          edobj.star_age.ToNullSafeString()) +
-                        JsonAttributeString("orbit-period",      edobj.orbitPeriod.ToNullSafeString()) +
-                        JsonAttributeString("arrival-point",     edobj.arrivalPoint.ToNullSafeString()) +
-                        JsonAttributeString("luminosity",        edobj.luminosity) +
-                        JsonAttributeString("notes",             edobj.notes) +
-                        JsonAttributeString("image-url",         edobj.imageUrl) + @"
-                    }
-                }
-            }";
-            JObject joPost = JObject.Parse(json);
- 
+            var joPost = new JObject {
+                { "data", new JObject {
+                    { "type", "stars" },
+                    { "attributes", new JObject {
+                        { "system-name", edobj.system },
+                        { "updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name },
+                        { "star", edobj.objectName },
+                        { "spectral-class", edobj.Description },
+                        { "spectral-subclass", edobj.subclass },
+                        { "solar-mass", edobj.mass },
+                        { "solar-radius", edobj.radius },
+                        { "surface-temp", edobj.surfaceTemp },
+                        { "star-age", edobj.star_age },
+                        { "orbit-period", edobj.orbitPeriod },
+                        { "arrival-point", edobj.arrivalPoint },
+                        { "luminosity", edobj.luminosity },
+                        { "notes", edobj.notes },
+                        { "image-url", edobj.imageUrl }
+                    } }
+                } }
+            };
+  
             ResponseData response;
             if (edobj.id == 0)
             {

--- a/EDDiscovery/PlanetSystems/Repositories/Star.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Star.cs
@@ -75,12 +75,12 @@ namespace EDDiscovery2.PlanetSystems.Repositories
                         JsonAttributeString("star",              edobj.objectName) +
                         JsonAttributeString("spectral-class",    edobj.Description) +
                         JsonAttributeString("spectral-subclass", edobj.subclass) +
-                        JsonAttributeString("solar-mass",        edobj.mass.ToString()) +
-                        JsonAttributeString("solar-radius",      edobj.radius.ToString()) +
-                        JsonAttributeString("surface-temp",      edobj.surfaceTemp.ToString()) +
-                        JsonAttributeString("star-age",          edobj.star_age.ToString()) +
-                        JsonAttributeString("orbit-period",      edobj.orbitPeriod.ToString()) +
-                        JsonAttributeString("arrival-point",     edobj.arrivalPoint.ToString()) +
+                        JsonAttributeString("solar-mass",        edobj.mass.ToNullSafeString()) +
+                        JsonAttributeString("solar-radius",      edobj.radius.ToNullSafeString()) +
+                        JsonAttributeString("surface-temp",      edobj.surfaceTemp.ToNullSafeString()) +
+                        JsonAttributeString("star-age",          edobj.star_age.ToNullSafeString()) +
+                        JsonAttributeString("orbit-period",      edobj.orbitPeriod.ToNullSafeString()) +
+                        JsonAttributeString("arrival-point",     edobj.arrivalPoint.ToNullSafeString()) +
                         JsonAttributeString("luminosity",        edobj.luminosity) +
                         JsonAttributeString("notes",             edobj.notes) +
                         JsonAttributeString("image-url",         edobj.image_url) + @"
@@ -92,7 +92,7 @@ namespace EDDiscovery2.PlanetSystems.Repositories
             ResponseData response;
             if (edobj.id == 0)
             {
-                response = RequestSecurePost(joPost.ToString(), $"{ ApiNamespace}/stars");
+                response = RequestSecurePost(joPost.ToString(), $"{ApiNamespace}/stars");
                 if (response.StatusCode == HttpStatusCode.Created)
                 {
                     JObject jo2 = (JObject)JObject.Parse(response.Body);

--- a/EDDiscovery/PlanetSystems/Repositories/Star.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Star.cs
@@ -83,7 +83,7 @@ namespace EDDiscovery2.PlanetSystems.Repositories
                         JsonAttributeString("arrival-point",     edobj.arrivalPoint.ToNullSafeString()) +
                         JsonAttributeString("luminosity",        edobj.luminosity) +
                         JsonAttributeString("notes",             edobj.notes) +
-                        JsonAttributeString("image-url",         edobj.image_url) + @"
+                        JsonAttributeString("image-url",         edobj.imageUrl) + @"
                     }
                 }
             }";

--- a/EDDiscovery/PlanetSystems/Repositories/Survey.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Survey.cs
@@ -88,21 +88,59 @@ namespace EDDiscovery2.PlanetSystems.Repositories
             return listObjects;
         }
 
-        // NOTE: I haven't included code for what happens if you try to
-        // insert but a record is in the way because this shouldn't really happen
-        // with surveys. If a commander accidentally creates a duplicate it's going
-        // to actually give them that duplicate. So to avoid this scenario make sure
-        // you searched for the survey first.
+        // NOTE: With Stars and Worlds we get away with attempting to POST and resorting to a PATCH
+        // if a record is already present. This won't work for Surveys because there is no uniqueness rule.
+        // A user might create several survey records for a world each with differet Resource types.
+        // Also they may make extra sets for each Basecamp if they're using Basecamps.
+        // If in doubt search for a record first and create a new one if there isn't one in existence.
         public ResponseData Store(EDSurvey edobj)
         {
             dynamic jo = new JObject();
 
-            jo.commander = EDDiscoveryForm.EDDConfig.CurrentCommander.Name;
-            jo.world_id = edobj.worldId;
-            jo.resource = edobj.resource;
-            jo.notes = edobj.notes;
-            jo.image_url = edobj.image_url;
 
+            ResponseData response;
+            if (edobj.id == 0)
+            {
+                string json = Payload(edobj);
+
+                JObject joPost = JObject.Parse(json);
+
+                response = RequestSecurePost(joPost.ToString(), $"{ApiNamespace}/surveys");
+                if (response.StatusCode == HttpStatusCode.Created)
+                {
+                    JObject jo2 = (JObject)JObject.Parse(response.Body);
+                    JObject obj = (JObject)jo2["data"];
+                    edobj.id = obj["id"].Value<int>();
+                }
+            }
+            else
+            {
+                string json = Payload(edobj, edobj.id);
+                JObject joPatch = JObject.Parse(json);
+
+                response = RequestSecurePatch(joPatch.ToString(), $"{ApiNamespace}/surveys/" + edobj.id.ToString());
+            }
+            return response;
+        }
+
+        public ResponseData Delete(int id)
+        {
+            var response = RequestSecureDelete($"{ApiNamespace}/surveys/" + id.ToString());
+
+            return response;
+        }
+
+        public ResponseData Delete(EDSurvey obj)
+        {
+            if (obj.id > 0)
+                return Delete(obj.id);
+            else
+                return new ResponseData(HttpStatusCode.NotFound);
+        }
+
+        // Payload can be for Insert or Update. The difference is whether there is an id or not
+        private string Payload(EDSurvey edobj, int id=0)
+        {
             // TODO: Add materials. They will be integers for this. Use Resource of "BINARY"
             // and 1s and 0s for a simple survey.
 
@@ -132,40 +170,23 @@ namespace EDDiscovery2.PlanetSystems.Repositories
             //jo.tellurium = edobj.materials[MaterialEnum.Tellurium];
             //jo.yttrium = edobj.materials[MaterialEnum.Yttrium];
 
-
-            JObject joPost = new JObject(new JProperty("survey", jo));
-
-            ResponseData response;
-            if (edobj.id == 0)
-            {
-                response = RequestSecurePost(joPost.ToString(), $"{ApiNamespace}/surveys");
-                if (response.StatusCode == HttpStatusCode.Created)
-                {
-                    JObject jo2 = (JObject)JObject.Parse(response.Body);
-                    JObject obj = (JObject)jo2["data"];
-                    edobj.id = obj["id"].Value<int>();
+            string json = @"{
+                'data': {" +
+                    (id > 0 ? JsonAttributeString("id", id.ToString()) : "") + @"
+                    'type': 'surveys',
+                    'attributes': {" +
+                        JsonAttributeString("commander", EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
+                        JsonAttributeString("resource", edobj.resource) +
+                        JsonAttributeString("notes", edobj.notes) +
+                        JsonAttributeString("images-url", edobj.image_url) + @"
+                    }
+                    'relationships' {" +
+                        JsonAttributeString("id", edobj.worldId.ToNullSafeString()) + @"
+                        'type': 'worlds'
+                    }
                 }
-            }
-            else
-            {
-                response = RequestSecurePatch(joPost.ToString(), $"{ApiNamespace}/surveys/" + edobj.id.ToString());
-            }
-            return response;
-        }
-
-        public ResponseData Delete(int id)
-        {
-            var response = RequestSecureDelete($"{ApiNamespace}/surveys/" + id.ToString());
-
-            return response;
-        }
-
-        public ResponseData Delete(EDSurvey obj)
-        {
-            if (obj.id > 0)
-                return Delete(obj.id);
-            else
-                return new ResponseData(HttpStatusCode.NotFound);
+            }";
+            return json;
         }
 
     }

--- a/EDDiscovery/PlanetSystems/Repositories/Survey.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/Survey.cs
@@ -178,11 +178,13 @@ namespace EDDiscovery2.PlanetSystems.Repositories
                         JsonAttributeString("commander", EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
                         JsonAttributeString("resource", edobj.resource) +
                         JsonAttributeString("notes", edobj.notes) +
-                        JsonAttributeString("images-url", edobj.image_url) + @"
-                    }
-                    'relationships' {" +
-                        JsonAttributeString("id", edobj.worldId.ToNullSafeString()) + @"
-                        'type': 'worlds'
+                        JsonAttributeString("images-url", edobj.imageUrl) + @"
+                    },
+                    'relationships' {
+                        'world' {" +
+                            JsonAttributeString("id", edobj.worldId.ToNullSafeString()) + @"
+                            'type': 'worlds'
+                        }
                     }
                 }
             }";

--- a/EDDiscovery/PlanetSystems/Repositories/World.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/World.cs
@@ -94,7 +94,7 @@ namespace EDDiscovery2.PlanetSystems.Repositories
                         JsonAttributeString("terraformable", edobj.terraformable) +
                         JsonAttributeString("atmosphere-type", edobj.atmosphere.ToNullSafeString()) +
                         JsonAttributeString("notes", edobj.notes) +
-                        JsonAttributeString("images-url", edobj.image_url) + @"
+                        JsonAttributeString("images-url", edobj.imageUrl) + @"
                     }
                 }
             }";

--- a/EDDiscovery/PlanetSystems/Repositories/World.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/World.cs
@@ -67,35 +67,38 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         public ResponseData Store(EDWorld edobj)
         {
             dynamic jo = new JObject();
-
-            jo.system = edobj.system;
-            jo.updater = EDDiscoveryForm.EDDConfig.CurrentCommander.Name;
-            jo.world = edobj.objectName;
-            jo.world_type = edobj.Description;
-
-            jo.mass = edobj.mass;
-            jo.radius = edobj.radius;
-            jo.gravity = edobj.gravity;
-            jo.surface_temp = edobj.surfaceTemp;
-            jo.surface_pressure = edobj.surfacePressure;
-            jo.orbit_period = edobj.orbitPeriod;
-            jo.rotation_period = edobj.rotationPeriod;
-            jo.semi_major_axis = edobj.semiMajorAxis;
-            jo.terrain_difficulty = edobj.terrain_difficulty;
-
-            jo.vulcanism_type = edobj.vulcanism.ToString();
-            jo.rock_pct = edobj.rockPct;
-            jo.metal_pct = edobj.metalPct;
-            jo.ice_pct = edobj.metalPct;
-            jo.reserve = edobj.Reserve;
-            jo.arrival_point = edobj.arrivalPoint;
-            jo.terraformable = edobj.terraformable;
-            jo.atmosphere_type = edobj.atmosphere.ToString();
-
-            jo.notes = edobj.notes;
-            jo.images_url = edobj.image_url;
-
-            JObject joPost = new JObject(new JProperty("world", jo));
+           
+            string json = @"{
+                'data': {
+                    'type': 'worlds',
+                    'attributes': {" +
+                        JsonAttributeString("system-name", edobj.system) +
+                        JsonAttributeString("updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
+                        JsonAttributeString("world", edobj.objectName) +
+                        JsonAttributeString("world-type", edobj.Description) +
+                        JsonAttributeString("mass", edobj.mass.ToNullSafeString()) +
+                        JsonAttributeString("radius", edobj.radius.ToNullSafeString()) +
+                        JsonAttributeString("gravity", edobj.gravity.ToNullSafeString()) +
+                        JsonAttributeString("surface-temp", edobj.surfaceTemp.ToNullSafeString()) +
+                        JsonAttributeString("surface-pressure", edobj.surfacePressure.ToNullSafeString()) +
+                        JsonAttributeString("orbit-period", edobj.orbitPeriod.ToNullSafeString()) +
+                        JsonAttributeString("rotation-period", edobj.rotationPeriod.ToNullSafeString()) +
+                        JsonAttributeString("semi-major-axis", edobj.semiMajorAxis.ToNullSafeString()) +
+                        JsonAttributeString("terrain-difficulty", edobj.terrain_difficulty.ToNullSafeString()) +
+                        JsonAttributeString("vulcanism-type", edobj.vulcanism.ToNullSafeString()) +
+                        JsonAttributeString("rock-pct", edobj.rockPct.ToNullSafeString()) +
+                        JsonAttributeString("metal-pct", edobj.metalPct.ToNullSafeString()) +
+                        JsonAttributeString("ice-pct", edobj.icePct.ToNullSafeString()) +
+                        JsonAttributeString("reserve", edobj.Reserve.ToNullSafeString()) +
+                        JsonAttributeString("arrival-point", edobj.arrivalPoint.ToNullSafeString()) +
+                        JsonAttributeString("terraformable", edobj.terraformable) +
+                        JsonAttributeString("atmosphere-type", edobj.atmosphere.ToNullSafeString()) +
+                        JsonAttributeString("notes", edobj.notes) +
+                        JsonAttributeString("images-url", edobj.image_url) + @"
+                    }
+                }
+            }";
+            JObject joPost = JObject.Parse(json);
 
             ResponseData response;
             if (edobj.id == 0)
@@ -118,6 +121,8 @@ namespace EDDiscovery2.PlanetSystems.Repositories
                         if (items.Count > 0)
                         {
                             edobj.id = items[0]["id"].Value<int>();
+                            JObject jData = (JObject)joPost["data"];
+                            jData["id"] = edobj.id;
                             response2 = RequestSecurePatch(joPost.ToString(), $"{ApiNamespace}/worlds/" + edobj.id.ToString());
                             response = response2;
                         }

--- a/EDDiscovery/PlanetSystems/Repositories/World.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/World.cs
@@ -32,6 +32,25 @@ namespace EDDiscovery2.PlanetSystems.Repositories
             return (items.Count > 0) ? items[0] : null;           
         }
 
+        public EDWorld GetForId(int id)
+        {
+            if (id > 0)
+            {
+                var request = RequestGet($"{ApiNamespace}/worlds/{id}");
+                if (request.StatusCode == HttpStatusCode.OK)
+                {
+                    var jo = JObject.Parse(request.Body);
+                    var data = jo["data"];
+                    EDWorld obj = new EDWorld();
+
+                    return (obj.ParseJson((JObject)data)) ? obj : null;
+                }
+            }
+
+            return null;
+        }
+
+
         public List<EDWorld> GetAll(string scope)
         {
             List<EDWorld> listObjects = new List<EDWorld>();

--- a/EDDiscovery/PlanetSystems/Repositories/World.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/World.cs
@@ -86,38 +86,37 @@ namespace EDDiscovery2.PlanetSystems.Repositories
         public ResponseData Store(EDWorld edobj)
         {
             dynamic jo = new JObject();
-           
-            string json = @"{
-                'data': {
-                    'type': 'worlds',
-                    'attributes': {" +
-                        JsonAttributeString("system-name", edobj.system) +
-                        JsonAttributeString("updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name) +
-                        JsonAttributeString("world", edobj.objectName) +
-                        JsonAttributeString("world-type", edobj.Description) +
-                        JsonAttributeString("mass", edobj.mass.ToNullSafeString()) +
-                        JsonAttributeString("radius", edobj.radius.ToNullSafeString()) +
-                        JsonAttributeString("gravity", edobj.gravity.ToNullSafeString()) +
-                        JsonAttributeString("surface-temp", edobj.surfaceTemp.ToNullSafeString()) +
-                        JsonAttributeString("surface-pressure", edobj.surfacePressure.ToNullSafeString()) +
-                        JsonAttributeString("orbit-period", edobj.orbitPeriod.ToNullSafeString()) +
-                        JsonAttributeString("rotation-period", edobj.rotationPeriod.ToNullSafeString()) +
-                        JsonAttributeString("semi-major-axis", edobj.semiMajorAxis.ToNullSafeString()) +
-                        JsonAttributeString("terrain-difficulty", edobj.terrain_difficulty.ToNullSafeString()) +
-                        JsonAttributeString("vulcanism-type", edobj.vulcanism.ToNullSafeString()) +
-                        JsonAttributeString("rock-pct", edobj.rockPct.ToNullSafeString()) +
-                        JsonAttributeString("metal-pct", edobj.metalPct.ToNullSafeString()) +
-                        JsonAttributeString("ice-pct", edobj.icePct.ToNullSafeString()) +
-                        JsonAttributeString("reserve", edobj.Reserve.ToNullSafeString()) +
-                        JsonAttributeString("arrival-point", edobj.arrivalPoint.ToNullSafeString()) +
-                        JsonAttributeString("terraformable", edobj.terraformable) +
-                        JsonAttributeString("atmosphere-type", edobj.atmosphere.ToNullSafeString()) +
-                        JsonAttributeString("notes", edobj.notes) +
-                        JsonAttributeString("images-url", edobj.imageUrl) + @"
-                    }
-                }
-            }";
-            JObject joPost = JObject.Parse(json);
+
+            var joPost = new JObject {
+                { "data", new JObject {
+                    { "type", "worlds" },
+                    { "attributes", new JObject {
+                        { "system-name", edobj.system },
+                        { "updater", EDDiscoveryForm.EDDConfig.CurrentCommander.Name },
+                        { "world-type", edobj.Description },
+                        { "mass", edobj.mass },
+                        { "radius", edobj.radius },
+                        { "gravity", edobj.gravity },
+                        { "surface-temp", edobj.surfaceTemp },
+                        { "surface-pressure", edobj.surfacePressure },
+                        { "orbit-period", edobj.orbitPeriod },
+                        { "rotation-period", edobj.rotationPeriod },
+                        { "semi-major-axis", edobj.semiMajorAxis },
+                        { "terrain-difficulty", edobj.terrain_difficulty },
+                        { "vulcanism-type", edobj.vulcanism.ToNullSafeString() },
+                        { "rock-pct", edobj.rockPct },
+                        { "metal-pct", edobj.metalPct },
+                        { "ice-pct", edobj.icePct },
+                        { "reserve", edobj.Reserve },
+                        { "arrival-point", edobj.arrivalPoint },
+                        { "terraformable", edobj.terraformable },
+                        { "atmosphere-type", edobj.atmosphere.ToNullSafeString() },
+                        { "notes", edobj.notes },
+                        { "images-url", edobj.imageUrl },
+                    } }
+                } }
+            };
+
 
             ResponseData response;
             if (edobj.id == 0)

--- a/EDDiscovery/PlanetSystems/Repositories/WorldSurvey.cs
+++ b/EDDiscovery/PlanetSystems/Repositories/WorldSurvey.cs
@@ -9,6 +9,9 @@ using System.Web;
 
 namespace EDDiscovery2.PlanetSystems.Repositories
 {
+    // Note: A WorldSurvey is now a "view" of the sum of surveys for a given world. So
+    // It's read only. It can be used for creating quick reports on a planet's status or
+    // in search features where you juts want to know which Worlds have jumponium ingredients.
     public class WorldSurvey : EdMaterializer
     {
         // Use this to get the WorldSurvey given a world-survey id.
@@ -68,11 +71,5 @@ namespace EDDiscovery2.PlanetSystems.Repositories
 
             return listObjects;
         }
-
-        // NO STORE METHOD BY DESIGN
-        // World Surveys are now Read Only.
-        //
-        // The World Survey is calculated through updating of surveys. Note that the world_survey
-        // record is summing of all commanders surveys for a world.
     }
 }


### PR DESCRIPTION
Upgraded the EdMaterializer interface from v3 to v4 which uses JSON API payloads for POSTs and PATCHs.
Also:
* Implemented a method for populated message boxes when a JSON API request fails. So if a Save fails the user is now told why.
* Finished implementing EDBasecamp Model/ Basecamp repository
* Finished supplying methods for accessing associated models from any given model. For example from a survey, basecamp or world survey you get request the world that the model belongs to. From a world you can access list all assoicated surveys. From a basecamp you can list all basecamp surveys.

And...
* Followed @klightspeed's suggestion on a better Payload construction. Thanks for that! :)