### PR TITLE
Change SQLite availabilty test; allow no theme

### DIFF
--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -649,10 +649,8 @@ namespace EDDiscovery.DB
         {
             try
             {
-                using (var conn = new SQLiteConnection(ConnectionString))
-                {
-                    conn.Open();
-                }
+                // This will throw an exception if the SQLite.Interop.dll can't be loaded.
+                System.Diagnostics.Trace.WriteLine($"SQLite version {SQLiteConnection.SQLiteVersion}");
                 return true;
             }
             catch

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -32,7 +32,8 @@ namespace EDDiscovery2
         {
             { "Netlogdir", () => System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Frontier_Developments", "Products") },
             { "NetlogDirAutoMode", () => true },
-            { "DefaultMap", () => System.Drawing.Color.Red.ToArgb() }
+            { "DefaultMap", () => System.Drawing.Color.Red.ToArgb() },
+            { "UseTheme", () => true }
         };
 
         private Dictionary<string, Action> onchange = new Dictionary<string, Action>
@@ -125,6 +126,7 @@ namespace EDDiscovery2
         public string NetLogDir { get { return GetSettingString("Netlogdir"); } set { PutSettingString("Netlogdir", value); } }
         public bool NetLogDirAutoMode { get { return GetSettingBool("NetlogDirAutoMode"); } set { PutSettingBool("NetlogDirAutoMode", value); } }
         public int DefaultMapColour { get { return GetSettingInt("DefaultMap"); } set { PutSettingInt("DefaultMap", value); } }
+        public bool UseTheme { get { return GetSettingBool("UseTheme"); } set { PutSettingBool("UseTheme", value); } }
 
         public event Action NetLogDirChanged { add { onchange["Netlogdir"] += value; } remove { onchange["Netlogdir"] -= value; } }
         public event Action NetLogDirAutoModeChanged { add { onchange["NetlogDirAutoMode"] += value; } remove { onchange["NetlogDirAutoMode"] -= value; } }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -101,7 +101,6 @@ namespace EDDiscovery
             }
             _edsmSync = new EDSMSync(this);
 
-            ToolStripManager.Renderer = theme.toolstripRenderer;
             theme.LoadThemes();                                         // default themes and ones on disk loaded
             theme.RestoreSettings();                                    // theme, remember your saved settings
 
@@ -327,6 +326,11 @@ namespace EDDiscovery
 
         public void ApplyTheme(bool refreshhistory)
         {
+            if (settings.ThemeName != "None")
+                ToolStripManager.Renderer = theme.toolstripRenderer;
+            else
+                ToolStripManager.Renderer = new ToolStripProfessionalRenderer();
+
             this.FormBorderStyle = theme.WindowsFrame ? FormBorderStyle.Sizable : FormBorderStyle.None;
             panel_grip.Visible = !theme.WindowsFrame;
             panel_close.Visible = !theme.WindowsFrame;
@@ -335,7 +339,8 @@ namespace EDDiscovery
             label_version.Text = "Version " + Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
             this.Text = "EDDiscovery " + label_version.Text;            // note in no border mode, this is not visible on the title bar but it is in the taskbar..
 
-            theme.ApplyColors(this);
+            if (settings.ThemeName != "None")
+                theme.ApplyColors(this);
 
             if (refreshhistory)
                 travelHistoryControl1.RefreshHistory();             // so we repaint this with correct colours.

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery2
         public string MapHomeSystem { get { return textBoxHomeSystem.Text; } }
         public float MapZoom { get { return float.Parse(textBoxDefaultZoom.Text); } }
         public bool MapCentreOnSelection { get { return radioButtonHistorySelection.Checked; } }
+        public string ThemeName { get { return comboBoxTheme.Items[comboBoxTheme.SelectedIndex]; } }
 
         public Settings()
         {
@@ -39,16 +40,25 @@ namespace EDDiscovery2
 
         void SetEntryThemeComboBox()
         {
-            int i = _discoveryForm.theme.GetIndexOfCurrentTheme();
-            if (i == -1)
-                comboBoxTheme.SelectedItem = "Custom";
+            if (EDDConfig.Instance.UseTheme)
+            {
+                int i = _discoveryForm.theme.GetIndexOfCurrentTheme();
+                if (i == -1)
+                    comboBoxTheme.SelectedItem = "Custom";
+                else
+                    comboBoxTheme.SelectedIndex = i + 1;
+            }
             else
-                comboBoxTheme.SelectedIndex = i;
+            {
+                comboBoxTheme.SelectedItem = "None";
+            }
         }
 
         private void ResetThemeList()
         {
-            comboBoxTheme.Items = _discoveryForm.theme.GetThemeList();
+            comboBoxTheme.Items.Clear();
+            comboBoxTheme.Items.Add("None");
+            comboBoxTheme.Items.AddRange(_discoveryForm.theme.GetThemeList());
             comboBoxTheme.Items.Add("Custom");
         }
 
@@ -206,27 +216,38 @@ namespace EDDiscovery2
 
         private void comboBoxTheme_SelectedIndexChanged(object sender, EventArgs e) // theme selected..
         {
-            string themename = comboBoxTheme.Items[comboBoxTheme.SelectedIndex].ToString();
+            string themename = this.ThemeName;
 
-            string fontwanted = null;                                               // don't check custom, only a stored theme..
-            if (!themename.Equals("Custom") && !_discoveryForm.theme.IsFontAvailableInTheme(themename, out fontwanted))
+            if (ThemeName == "None")
             {
-                DialogResult res = MessageBox.Show("The font used by this theme is not available on your system" + Environment.NewLine +
-                      "The font needed is \"" + fontwanted + "\"" + Environment.NewLine +
-                      "Install this font and you can use this scheme." + Environment.NewLine +
-                      "EuroCaps font is available www.edassets.org.",
-                      "Warning", MessageBoxButtons.OK);
-
-                _discoveryForm.theme.SetCustom();                              // go to custom theme whatever
-                SetEntryThemeComboBox();
-                return;
+                EDDConfig.Instance.UseTheme = false;
+                _discoveryForm.theme.SetThemeByName("Windows Default");
+                _discoveryForm.ApplyTheme(true);
+                MessageBox.Show("You will need to restart the application for this setting to take effect", "Restart to apply no theme", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
+            else
+            {
+                EDDConfig.Instance.UseTheme = true;
+                string fontwanted = null;                                               // don't check custom, only a stored theme..
+                if (!themename.Equals("Custom") && !_discoveryForm.theme.IsFontAvailableInTheme(themename, out fontwanted))
+                {
+                    DialogResult res = MessageBox.Show("The font used by this theme is not available on your system" + Environment.NewLine +
+                          "The font needed is \"" + fontwanted + "\"" + Environment.NewLine +
+                          "Install this font and you can use this scheme." + Environment.NewLine +
+                          "EuroCaps font is available www.edassets.org.",
+                          "Warning", MessageBoxButtons.OK);
 
-            if (!_discoveryForm.theme.SetThemeByName(themename))
-                _discoveryForm.theme.SetCustom();                                   // go to custom theme..
+                    _discoveryForm.theme.SetCustom();                              // go to custom theme whatever
+                    SetEntryThemeComboBox();
+                    return;
+                }
 
-            SetEntryThemeComboBox();
-            _discoveryForm.ApplyTheme(true);
+                if (!_discoveryForm.theme.SetThemeByName(themename))
+                    _discoveryForm.theme.SetCustom();                                   // go to custom theme..
+
+                SetEntryThemeComboBox();
+                _discoveryForm.ApplyTheme(true);
+            }
         }
 
         private void buttonSaveTheme_Click(object sender, EventArgs e)


### PR DESCRIPTION
* Use SQLiteConnection.SQLiteVersion instead of SQLiteConnection.Open() to test System.Data.SQLite availability
* Allow setting no theme in order to get around the pink menus and unrendered scrollbars in Mono