### PR TITLE
Mono UI fixes

### DIFF
--- a/EDDiscovery/Controls/CustomColourTable.cs
+++ b/EDDiscovery/Controls/CustomColourTable.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class CustomColourTable : ProfessionalColorTable
+    {
+        public CustomColourTable()
+        {
+            this.UseSystemColors = false;
+        }
+
+        public Color colMenuBackground = Color.FromArgb(255, 188, 199, 216);//ControlPaint.LightLight(ControlPaint.Light(Color.SlateBlue));
+        public Color colToolStripBorder = Color.FromArgb(255, 133, 145, 162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
+        public Color colToolStripBackGround = Color.LightGray;
+        public Color colToolStripSeparator = Color.FromArgb(255, 133, 145, 162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
+        public Color colMenuSelectedBack = Color.FromArgb(255, 201, 210, 225); //ControlPaint.LightLight(ControlPaint.LightLight(Color.LightSlateGray));
+        public Color colMenuSelectedText = Color.Black;
+        public Color dark = Color.FromArgb(255, 41, 57, 85);
+        public Color colMenuText = Color.White;
+        public Color colButtonSelectedBorder = Color.FromArgb(229, 195, 101);
+        public Color colButtonSelectBackLight = Color.FromArgb(255, 252, 242);
+        public Color colButtonSelectBackDark = Color.FromArgb(255, 236, 181);
+
+        public override Color ButtonCheckedGradientBegin { get { return colButtonSelectBackLight; } } // Top of button, checked
+        public override Color ButtonCheckedGradientEnd { get { return colButtonSelectBackDark; } } // Bottom of button, checked
+        public override Color ButtonCheckedGradientMiddle { get { return Color.Empty; } } // Unused
+
+        public override Color ButtonPressedGradientBegin { get { return colButtonSelectBackLight; } } // Top of button, checked and hovered
+        public override Color ButtonPressedGradientEnd { get { return colButtonSelectBackLight; } } // Bottom of button, checked and hovered
+        public override Color ButtonPressedGradientMiddle { get { return colButtonSelectBackLight; } } // Unused
+        public override Color ButtonPressedBorder { get { return colButtonSelectedBorder; } } // MS: Unused; Mono: Border of button, checked
+
+        public override Color ButtonSelectedGradientBegin { get { return Color.FromArgb(100, colButtonSelectedBorder); } } // MS: Top of button, unchecked and hovered; Mono: Top of button or menu item, unchecked and hovered
+        public override Color ButtonSelectedGradientEnd { get { return Color.FromArgb(100, colButtonSelectedBorder); } } // MS: Bottom of button, unchecked and hovered; Mono: Bottom of button or menu item, unchecked and hovered
+        public override Color ButtonSelectedGradientMiddle { get { return Color.FromArgb(100, colButtonSelectedBorder); } } // Unused
+        public override Color ButtonSelectedBorder { get { return dark; } } // MS: Border of button, checked or hovered; Mono: Border of button, hovered
+
+        public override Color CheckBackground { get { return colButtonSelectBackLight; } }
+        public override Color CheckPressedBackground { get { return colButtonSelectBackDark; } }
+        public override Color CheckSelectedBackground { get { return colButtonSelectBackDark; } }
+
+        public override Color ToolStripGradientBegin { get { return colToolStripBackGround; } } // MS: Top of toolstrip; Mono: Top of toolstrip or active top-level menu item, Left of dropdown margin
+        public override Color ToolStripGradientEnd { get { return colToolStripBackGround; } } // MS: Bottom of toolstrip; Mono: Bottom of toolstrip or active top-level menu item, Right of dropdown margin
+        public override Color ToolStripGradientMiddle { get { return colToolStripBackGround; } } // MS: Middle of toolstrip; Mono: Unused
+        public override Color ToolStripBorder { get { return colToolStripBorder; } } // Toolstrip border
+
+        public override Color MenuStripGradientBegin { get { return colMenuBackground; } } // Left of menu
+        public override Color MenuStripGradientEnd { get { return colMenuBackground; } } // Right of menu
+        public override Color MenuBorder { get { return Color.Empty; } } // Border of drop-down menu
+
+        public override Color ToolStripDropDownBackground { get { return colMenuBackground; } } // Background of menu or toolstrip dropdown
+
+        public override Color MenuItemSelectedGradientBegin { get { return Color.FromArgb(200, colMenuSelectedBack); } } // MS: Top of top-level menu item; Mono: Unused
+        public override Color MenuItemSelectedGradientEnd { get { return Color.FromArgb(200, colMenuSelectedBack); } } // MS: Bottom of top-level menu item; Mono: Unused
+        public override Color MenuItemBorder { get { return dark; } } // Border of menuitem, or of menu or toolstrip dropdown item
+
+        public override Color MenuItemPressedGradientBegin { get { return colMenuSelectedBack; } } // Top of active top-level menu item
+        public override Color MenuItemPressedGradientEnd { get { return colMenuSelectedBack; } } // Bottom of active top-level menu item
+
+        public override Color SeparatorDark { get { return colToolStripSeparator; } } // Left edge of vertical separator, colour of horizontal separator
+        public override Color SeparatorLight { get { return colToolStripSeparator; } } // Right edge of vertical separator
+
+        public override Color GripDark { get { return colToolStripSeparator; } } // Top-left dots of toolstrip grip
+        public override Color GripLight { get { return colMenuBackground; } } // Bottom-right dots of toolstrip grip
+
+        public override Color ImageMarginGradientBegin { get { return colButtonSelectBackLight; } } // MS: Left of dropdown margin; Mono: Unused
+        public override Color ImageMarginGradientEnd { get { return colButtonSelectBackLight; } } // MS: Right of dropdown margin; Mono: Unused
+        public override Color ImageMarginGradientMiddle { get { return colButtonSelectBackLight; } } // MS: Middle of dropdown margin; Mono: Unused
+
+        public override Color StatusStripGradientBegin { get { return colToolStripBackGround; } } // Unused
+        public override Color StatusStripGradientEnd { get { return colToolStripBackGround; } } // Unused
+
+        public override Color MenuItemSelected { get { return colMenuSelectedBack; } } // Background of hovered menu or toolstrip dropdown item
+
+        public override Color OverflowButtonGradientBegin { get { return colMenuSelectedBack; } } // Top of overflow button
+        public override Color OverflowButtonGradientEnd { get { return colMenuSelectedBack; } } // Bottom of overflow button
+        public override Color OverflowButtonGradientMiddle { get { return colMenuSelectedBack; } } // MS: Middle of overflow button; Mono: Unused
+    }
+}

--- a/EDDiscovery/Controls/StatusStripCustom.cs
+++ b/EDDiscovery/Controls/StatusStripCustom.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class StatusStripCustom : StatusStrip
+    {
+        public const int WM_NCHITTEST = 0x84;
+        public const int WM_NCLBUTTONDOWN = 0xA1;
+        public const int WM_NCLBUTTONUP = 0xA2;
+        public const int HT_CLIENT = 0x1;
+        public const int HT_BOTTOMRIGHT = 0x11;
+        public const int HT_TRANSPARENT = -1;
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+
+            if (m.Msg == WM_NCHITTEST && (int)m.Result == HT_BOTTOMRIGHT)
+            {
+                // Tell the system to test the parent
+                m.Result = (IntPtr)HT_TRANSPARENT;
+            }
+        }
+    }
+}

--- a/EDDiscovery/EDDToolStripRenderer.cs
+++ b/EDDiscovery/EDDToolStripRenderer.cs
@@ -241,12 +241,14 @@ namespace EDDiscovery2
                 e.Graphics.DrawImage(e.Item.Image, rc);
             }
         }
+#endif
 
         protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
         {
             if (!(e.ToolStrip is StatusStrip))
                 base.OnRenderStatusStripSizingGrip(e);
             
+            /*
             int kk = 5;
             Rectangle bnd = e.AffectedBounds;
 
@@ -261,9 +263,24 @@ namespace EDDiscovery2
                     kk--;
                 }
             }
+             */
             
+            using (Pen p1 = new Pen(ColorTable.GripDark))
+            {
+                int rightpx = e.AffectedBounds.Right - 1;
+                int bottompx = e.AffectedBounds.Bottom - 1;
+                int msize = 5;
+                int rightmarginpx = rightpx - msize;
+                int bottommarginpx = bottompx - msize;
+
+                for (int i = 0; i < 3; i++)
+                {
+                    e.Graphics.DrawLine(p1, new Point(rightmarginpx - i * msize, bottompx), new Point(rightpx, bottommarginpx - i * msize));
+                }
+            }
         }
 
+#if false
         protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
         {
             Rectangle rc = e.Item.ContentRectangle;

--- a/EDDiscovery/EDDToolStripRenderer.cs
+++ b/EDDiscovery/EDDToolStripRenderer.cs
@@ -9,20 +9,27 @@ namespace EDDiscovery2
 {
     public class EDDToolStripRenderer : ToolStripProfessionalRenderer//ToolStripSystemRenderer
     {
-        public Color colMenuBackground = Color.FromArgb(255, 188,199,216);//ControlPaint.LightLight(ControlPaint.Light(Color.SlateBlue));
-        public Color colToolStripBorder = Color.FromArgb(255, 133, 145, 162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
-        public Color colToolStripBackGround = Color.LightGray; 
-        public Color colToolStripSeparator = Color.FromArgb(255,133,145,162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
-        public Color colMenuSelectedBack = Color.FromArgb(255, 201,210,225); //ControlPaint.LightLight(ControlPaint.LightLight(Color.LightSlateGray));
-        public Color colMenuSelectedText = Color.Black;
-        public Color Dark = Color.FromArgb(255,41, 57, 85);
-        public Color colMenuText = Color.White;
+        protected ExtendedControls.CustomColourTable _colortable;
 
-        //Bitmap bmp = new Bitmap(1, 1);
-        public Color ButtonSelectedBorder = Color.FromArgb(229, 195, 101);
-        public Color ButtonSelectBackLight = Color.FromArgb(255, 252, 242);
-        public Color ButtonSelectBackDark = Color.FromArgb(255, 236, 181);
+        public Color colMenuBackground { get { return _colortable.colMenuBackground; } set { _colortable.colMenuBackground = value; } }
+        public Color colToolStripBorder { get { return _colortable.colToolStripBorder; } set { _colortable.colToolStripBorder = value; } }
+        public Color colToolStripBackGround { get { return _colortable.colToolStripBackGround; } set { _colortable.colToolStripBackGround = value; } }
+        public Color colToolStripSeparator { get { return _colortable.colToolStripSeparator; } set { _colortable.colToolStripSeparator = value; } }
+        public Color colMenuSelectedBack { get { return _colortable.colMenuSelectedBack; } set { _colortable.colMenuSelectedBack = value; } }
+        public Color colMenuSelectedText { get { return _colortable.colMenuSelectedText; } set { _colortable.colMenuSelectedText = value; } }
+        public Color Dark { get { return _colortable.dark; } set { _colortable.dark = value; } }
+        public Color colMenuText { get { return _colortable.colMenuText; } set { _colortable.colMenuText = value; } }
+        public Color ButtonSelectedBorder { get { return _colortable.colButtonSelectedBorder; } set { _colortable.colButtonSelectedBorder = value; } }
+        public Color ButtonSelectBackLight { get { return _colortable.colButtonSelectBackLight; } set { _colortable.colButtonSelectBackLight = value; } }
+        public Color ButtonSelectBackDark { get { return _colortable.colButtonSelectBackDark; } set { _colortable.colButtonSelectBackDark = value; } }
 
+        public EDDToolStripRenderer() : base(new ExtendedControls.CustomColourTable())
+        {
+            this._colortable = (ExtendedControls.CustomColourTable)ColorTable;
+            this.RoundedEdges = true;
+        }
+
+#if false
         protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
         {
             if (e.ToolStrip is MenuStrip)
@@ -51,7 +58,7 @@ namespace EDDiscovery2
                 //    e.Graphics.FillRectangle(new SolidBrush(Border), 1, 1, 24, e.AffectedBounds.Height - 1);
             }
         }
-
+#endif
 
 
         protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -88,6 +95,7 @@ namespace EDDiscovery2
             }
         }
 
+#if false
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
             if (e.Item.Enabled)
@@ -103,6 +111,7 @@ namespace EDDiscovery2
                 }
             }
         }
+#endif
 
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
@@ -123,6 +132,7 @@ namespace EDDiscovery2
             base.OnRenderItemText(e);
         }
 
+#if false
         protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
         {
             if (e.Vertical)
@@ -358,5 +368,6 @@ namespace EDDiscovery2
             else
                 base.OnRenderItemImage(e);
         }
+#endif
     }
 }

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Controls\CheckBoxCustom.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\CustomColourTable.cs" />
     <Compile Include="Controls\DataViewScrollerPanel.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -178,6 +178,9 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\CustomColourTable.cs" />
+    <Compile Include="Controls\StatusStripCustom.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\DataViewScrollerPanel.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -73,9 +73,9 @@
             this.savedRouteExpeditionControl1 = new EDDiscovery.SavedRouteExpeditionControl();
             this.label_version = new System.Windows.Forms.Label();
             this.panel_eddiscovery = new System.Windows.Forms.Panel();
-            this.panel_grip = new ExtendedControls.DrawnPanel();
             this.panel_minimize = new ExtendedControls.DrawnPanel();
             this.panel_close = new ExtendedControls.DrawnPanel();
+            this.statusStrip1 = new ExtendedControls.StatusStripCustom();
             this.menuStrip1.SuspendLayout();
             this.panelInfo.SuspendLayout();
             this.tabPageSettings.SuspendLayout();
@@ -394,6 +394,9 @@
             // 
             // tabControl1
             // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPageTravelHistory);
             this.tabControl1.Controls.Add(this.tabPageTriletaration);
             this.tabControl1.Controls.Add(this.tabPageScreenshots);
@@ -478,21 +481,6 @@
             this.panel_eddiscovery.TabIndex = 18;
             this.panel_eddiscovery.Click += new System.EventHandler(this.panel1_Click);
             // 
-            // panel_grip
-            // 
-            this.panel_grip.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.panel_grip.BackColor = System.Drawing.SystemColors.Control;
-            this.panel_grip.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.panel_grip.Image = ExtendedControls.DrawnPanel.ImageType.Gripper;
-            this.panel_grip.Location = new System.Drawing.Point(977, 727);
-            this.panel_grip.MarginSize = 5;
-            this.panel_grip.MouseOverColor = System.Drawing.Color.White;
-            this.panel_grip.MouseSelectedColor = System.Drawing.Color.Green;
-            this.panel_grip.Name = "panel_grip";
-            this.panel_grip.Size = new System.Drawing.Size(16, 16);
-            this.panel_grip.TabIndex = 16;
-            this.panel_grip.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel_grip_MouseDown);
-            // 
             // panel_minimize
             // 
             this.panel_minimize.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -523,6 +511,14 @@
             this.panel_close.TabIndex = 19;
             this.panel_close.Click += new System.EventHandler(this.panel_close_Click);
             // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Location = new System.Drawing.Point(0, 722);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(993, 22);
+            this.statusStrip1.TabIndex = 22;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
             // EDDiscoveryForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -532,11 +528,11 @@
             this.Controls.Add(this.panel_eddiscovery);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.panelInfo);
-            this.Controls.Add(this.panel_grip);
             this.Controls.Add(this.button_test);
             this.Controls.Add(this.panel_minimize);
             this.Controls.Add(this.panel_close);
             this.Controls.Add(this.menuStrip1);
+            this.Controls.Add(this.statusStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "EDDiscoveryForm";
@@ -594,7 +590,6 @@
         private System.Windows.Forms.ToolStripMenuItem eDDiscoveryChatDiscordToolStripMenuItem;
         private ExtendedControls.DrawnPanel panel_close;
         private ExtendedControls.DrawnPanel panel_minimize;
-        private ExtendedControls.DrawnPanel panel_grip;
         private System.Windows.Forms.TabPage tabPageSettings;
         public  EDDiscovery2.Settings settings;
         private System.Windows.Forms.TabPage tabPageRoute;
@@ -612,6 +607,7 @@
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.TabPage tabPageRoutesExpeditions;
         private SavedRouteExpeditionControl savedRouteExpeditionControl1;
+        private ExtendedControls.StatusStripCustom statusStrip1;
     }
 }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -31,9 +31,12 @@ namespace EDDiscovery
         #region Variables
 
         public const int WM_NCLBUTTONDOWN = 0xA1;
+        public const int HT_CLIENT = 0x1;
         public const int HT_CAPTION = 0x2;
+        public const int HT_BOTTOMRIGHT = 0x11;
         public const int WM_NCL_RESIZE = 0x112;
         public const int HT_RESIZE = 61448;
+        public const int WM_NCHITTEST = 0x84;
 
         private IntPtr SendMessage(int msg, IntPtr wparam, IntPtr lparam)
         {
@@ -119,6 +122,7 @@ namespace EDDiscovery
 
         private void EDDiscoveryForm_Layout(object sender, LayoutEventArgs e)       // Manually position, could not get gripper under tab control with it sizing for the life of me
         {
+            /*
             if (panel_grip.Visible)
             {
                 panel_grip.Location = new Point(this.ClientSize.Width - panel_grip.Size.Width, this.ClientSize.Height - panel_grip.Size.Height);
@@ -126,6 +130,7 @@ namespace EDDiscovery
             }
             else
                 tabControl1.Size = new Size(this.ClientSize.Width, this.ClientSize.Height - tabControl1.Location.Y);
+             */
         }
 
         private void ProcessCommandLineOptions()
@@ -331,8 +336,10 @@ namespace EDDiscovery
             else
                 ToolStripManager.Renderer = new ToolStripProfessionalRenderer();
 
+            this.statusStrip1.Renderer = ToolStripManager.Renderer;
+
             this.FormBorderStyle = theme.WindowsFrame ? FormBorderStyle.Sizable : FormBorderStyle.None;
-            panel_grip.Visible = !theme.WindowsFrame;
+            //panel_grip.Visible = !theme.WindowsFrame;
             panel_close.Visible = !theme.WindowsFrame;
             panel_minimize.Visible = !theme.WindowsFrame;
             label_version.Visible = !theme.WindowsFrame;
@@ -975,6 +982,7 @@ namespace EDDiscovery
             this.WindowState = FormWindowState.Minimized;
         }
 
+        /*
         private void panel_grip_MouseDown(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
@@ -984,6 +992,7 @@ namespace EDDiscovery
                 SendMessage(WM_NCL_RESIZE, (IntPtr)HT_RESIZE, IntPtr.Zero);
             }
         }
+         */
 
         private void changeMapColorToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -1026,6 +1035,34 @@ namespace EDDiscovery
             {
                 this.Capture = false;
                 SendMessage(WM_NCLBUTTONDOWN, (IntPtr)HT_CAPTION, IntPtr.Zero);
+            }
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_NCHITTEST)
+            {
+                base.WndProc(ref m);
+
+                if ((int)m.Result == HT_CLIENT)
+                {
+                    int x = unchecked((short)((uint)m.LParam & 0xFFFF));
+                    int y = unchecked((short)((uint)m.LParam >> 16));
+                    Point p = PointToClient(new Point(x, y));
+
+                    if (p.X > this.ClientSize.Width - statusStrip1.Height && p.Y > this.ClientSize.Height - statusStrip1.Height)
+                    {
+                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                    }
+                    else if (!theme.WindowsFrame)
+                    {
+                        m.Result = (IntPtr)HT_CAPTION;
+                    }
+                }
+            }
+            else
+            {
+                base.WndProc(ref m);
             }
         }
 

--- a/EDDiscovery/EDDiscoveryForm.resx
+++ b/EDDiscovery/EDDiscoveryForm.resx
@@ -7654,6 +7654,9 @@
         AABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>301, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>59</value>
   </metadata>


### PR DESCRIPTION
* Use a colour table for toolstrips etc.  This fixes the pink menus issue in Mono.
* Replace the DrawnPanel gripper with the gripper created by a status strip.  This allows the borderless window to be resized in both Mono and Windows.
* Use NCHITTEST to inform the window manager that the top area of the form should be treated as the title bar.
* Move the form ourselves if result of NCHITTEST is not honoured.  This allows the borderless window to be moved in both Mono and Windows.