### PR TITLE
Add splitter containers to allow resizing trilateration controls

### DIFF
--- a/EDDiscovery/Controls/SplitContainerCustom.cs
+++ b/EDDiscovery/Controls/SplitContainerCustom.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class SplitContainerCustom : System.Windows.Forms.SplitContainer
+    {
+        public bool LayoutChanging { get; private set; } = false;
+        protected override void OnLayout(LayoutEventArgs e)
+        {
+            LayoutChanging = true;
+            base.OnLayout(e);
+            LayoutChanging = false;
+        }
+    }
+}

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -171,6 +171,9 @@
     <Compile Include="3DMap\DatasetBuilder.cs" />
     <Compile Include="3DMap\MapManager.cs" />
     <Compile Include="3DMap\KeyboardActions.cs" />
+    <Compile Include="Controls\SplitContainerCustom.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Controls\ButtonExt.cs">
       <SubType>Component</SubType>

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -44,8 +44,29 @@ namespace EDDiscovery
             this.labelCoordinateZ = new System.Windows.Forms.Label();
             this.panelImplementation = new System.Windows.Forms.Panel();
             this.labelAlgorithm = new System.Windows.Forms.Label();
+            this.radioButtonAlgorithmJs = new ExtendedControls.RadioButtonCustom();
+            this.radioButtonAlgorithmCsharp = new ExtendedControls.RadioButtonCustom();
             this.toolTipAlgorithm = new System.Windows.Forms.ToolTip(this.components);
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.splitContainer1 = new ExtendedControls.SplitContainerCustom();
+            this.splitContainerTop = new ExtendedControls.SplitContainerCustom();
+            this.dataViewScrollerPanelDistances = new ExtendedControls.DataViewScrollerPanel();
+            this.vScrollBarCustom3 = new ExtendedControls.VScrollBarCustom();
+            this.dataGridViewDistances = new System.Windows.Forms.DataGridView();
+            this.ColumnSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnCalculated = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataViewScrollerPanelSuggestedReferences = new ExtendedControls.DataViewScrollerPanel();
+            this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
+            this.dataGridViewSuggestedSystems = new System.Windows.Forms.DataGridView();
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.splitContainerBottom = new ExtendedControls.SplitContainerCustom();
+            this.richTextBox_History = new ExtendedControls.RichTextBoxScroll();
+            this.dataViewScrollerPanelWantedSystems = new ExtendedControls.DataViewScrollerPanel();
+            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
+            this.dataGridViewClosestSystems = new System.Windows.Forms.DataGridView();
+            this.Source = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumnClosestSystemsSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.wantedContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.removeFromWantedSystemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewOnEDSMToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
@@ -58,45 +79,34 @@ namespace EDDiscovery
             this.toolStripButtonMap = new System.Windows.Forms.ToolStripButton();
             this.panel_controls = new System.Windows.Forms.Panel();
             this.labelstpos = new System.Windows.Forms.Label();
-            this.dataViewScrollerPanel1 = new ExtendedControls.DataViewScrollerPanel();
-            this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
-            this.dataGridViewSuggestedSystems = new System.Windows.Forms.DataGridView();
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataViewScrollerPanel3 = new ExtendedControls.DataViewScrollerPanel();
-            this.vScrollBarCustom3 = new ExtendedControls.VScrollBarCustom();
-            this.dataGridViewDistances = new System.Windows.Forms.DataGridView();
-            this.ColumnSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnCalculated = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
-            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
-            this.dataGridViewClosestSystems = new System.Windows.Forms.DataGridView();
-            this.Source = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumnClosestSystemsSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.richTextBox_History = new ExtendedControls.RichTextBoxScroll();
             this.textBox_status = new ExtendedControls.TextBoxBorder();
             this.textBoxSystemName = new ExtendedControls.TextBoxBorder();
             this.textBoxCoordinateX = new ExtendedControls.TextBoxBorder();
             this.textBoxCoordinateY = new ExtendedControls.TextBoxBorder();
             this.textBoxCoordinateZ = new ExtendedControls.TextBoxBorder();
-            this.radioButtonAlgorithmJs = new ExtendedControls.RadioButtonCustom();
-            this.radioButtonAlgorithmCsharp = new ExtendedControls.RadioButtonCustom();
             this.trilatContextMenu.SuspendLayout();
             this.panelImplementation.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerTop)).BeginInit();
+            this.splitContainerTop.Panel1.SuspendLayout();
+            this.splitContainerTop.Panel2.SuspendLayout();
+            this.splitContainerTop.SuspendLayout();
+            this.dataViewScrollerPanelDistances.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewDistances)).BeginInit();
+            this.dataViewScrollerPanelSuggestedReferences.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSuggestedSystems)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerBottom)).BeginInit();
+            this.splitContainerBottom.Panel1.SuspendLayout();
+            this.splitContainerBottom.Panel2.SuspendLayout();
+            this.splitContainerBottom.SuspendLayout();
+            this.dataViewScrollerPanelWantedSystems.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewClosestSystems)).BeginInit();
             this.wantedContextMenu.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.panel_controls.SuspendLayout();
-            this.dataViewScrollerPanel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSuggestedSystems)).BeginInit();
-            this.dataViewScrollerPanel3.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewDistances)).BeginInit();
-            this.dataViewScrollerPanel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewClosestSystems)).BeginInit();
             this.SuspendLayout();
             // 
             // trilatContextMenu
@@ -187,6 +197,43 @@ namespace EDDiscovery
             this.labelAlgorithm.TabIndex = 2;
             this.labelAlgorithm.Text = "Algorithm:";
             // 
+            // radioButtonAlgorithmJs
+            // 
+            this.radioButtonAlgorithmJs.AutoSize = true;
+            this.radioButtonAlgorithmJs.FontNerfReduction = 0.5F;
+            this.radioButtonAlgorithmJs.Location = new System.Drawing.Point(3, 27);
+            this.radioButtonAlgorithmJs.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.radioButtonAlgorithmJs.Name = "radioButtonAlgorithmJs";
+            this.radioButtonAlgorithmJs.RadioButtonColor = System.Drawing.Color.Gray;
+            this.radioButtonAlgorithmJs.RadioButtonInnerColor = System.Drawing.Color.White;
+            this.radioButtonAlgorithmJs.SelectedColor = System.Drawing.Color.DarkBlue;
+            this.radioButtonAlgorithmJs.SelectedColorRing = System.Drawing.Color.Black;
+            this.radioButtonAlgorithmJs.Size = new System.Drawing.Size(37, 17);
+            this.radioButtonAlgorithmJs.TabIndex = 1;
+            this.radioButtonAlgorithmJs.Text = "JS";
+            this.toolTipAlgorithm.SetToolTip(this.radioButtonAlgorithmJs, "Original algoritthm from ed-systems, written in Javascript (slower)");
+            this.radioButtonAlgorithmJs.UseVisualStyleBackColor = true;
+            this.radioButtonAlgorithmJs.CheckedChanged += new System.EventHandler(this.radioButtonAlgorithm_CheckedChanged);
+            // 
+            // radioButtonAlgorithmCsharp
+            // 
+            this.radioButtonAlgorithmCsharp.AutoSize = true;
+            this.radioButtonAlgorithmCsharp.Checked = true;
+            this.radioButtonAlgorithmCsharp.FontNerfReduction = 0.5F;
+            this.radioButtonAlgorithmCsharp.Location = new System.Drawing.Point(3, 44);
+            this.radioButtonAlgorithmCsharp.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.radioButtonAlgorithmCsharp.Name = "radioButtonAlgorithmCsharp";
+            this.radioButtonAlgorithmCsharp.RadioButtonColor = System.Drawing.Color.Gray;
+            this.radioButtonAlgorithmCsharp.RadioButtonInnerColor = System.Drawing.Color.White;
+            this.radioButtonAlgorithmCsharp.SelectedColor = System.Drawing.Color.DarkBlue;
+            this.radioButtonAlgorithmCsharp.SelectedColorRing = System.Drawing.Color.Black;
+            this.radioButtonAlgorithmCsharp.Size = new System.Drawing.Size(39, 17);
+            this.radioButtonAlgorithmCsharp.TabIndex = 0;
+            this.radioButtonAlgorithmCsharp.TabStop = true;
+            this.radioButtonAlgorithmCsharp.Text = "C#";
+            this.toolTipAlgorithm.SetToolTip(this.radioButtonAlgorithmCsharp, "Algorithm from ed-systems rewritten to C# (fast, experimental)");
+            this.radioButtonAlgorithmCsharp.UseVisualStyleBackColor = true;
+            // 
             // splitContainer1
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -196,16 +243,325 @@ namespace EDDiscovery
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.dataViewScrollerPanel1);
-            this.splitContainer1.Panel1.Controls.Add(this.dataViewScrollerPanel3);
+            this.splitContainer1.Panel1.Controls.Add(this.splitContainerTop);
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.dataViewScrollerPanel2);
-            this.splitContainer1.Panel2.Controls.Add(this.richTextBox_History);
+            this.splitContainer1.Panel2.Controls.Add(this.splitContainerBottom);
             this.splitContainer1.Size = new System.Drawing.Size(924, 582);
             this.splitContainer1.SplitterDistance = 247;
             this.splitContainer1.TabIndex = 20;
+            // 
+            // splitContainerTop
+            // 
+            this.splitContainerTop.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerTop.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerTop.Name = "splitContainerTop";
+            // 
+            // splitContainerTop.Panel1
+            // 
+            this.splitContainerTop.Panel1.Controls.Add(this.dataViewScrollerPanelDistances);
+            // 
+            // splitContainerTop.Panel2
+            // 
+            this.splitContainerTop.Panel2.Controls.Add(this.dataViewScrollerPanelSuggestedReferences);
+            this.splitContainerTop.Size = new System.Drawing.Size(924, 247);
+            this.splitContainerTop.SplitterDistance = 540;
+            this.splitContainerTop.TabIndex = 3;
+            this.splitContainerTop.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainerTop_SplitterMoved);
+            // 
+            // dataViewScrollerPanelDistances
+            // 
+            this.dataViewScrollerPanelDistances.Controls.Add(this.vScrollBarCustom3);
+            this.dataViewScrollerPanelDistances.Controls.Add(this.dataGridViewDistances);
+            this.dataViewScrollerPanelDistances.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataViewScrollerPanelDistances.InternalMargin = new System.Windows.Forms.Padding(0);
+            this.dataViewScrollerPanelDistances.Location = new System.Drawing.Point(0, 0);
+            this.dataViewScrollerPanelDistances.Name = "dataViewScrollerPanelDistances";
+            this.dataViewScrollerPanelDistances.ScrollBarWidth = 20;
+            this.dataViewScrollerPanelDistances.Size = new System.Drawing.Size(540, 247);
+            this.dataViewScrollerPanelDistances.TabIndex = 22;
+            this.dataViewScrollerPanelDistances.VerticalScrollBarDockRight = true;
+            // 
+            // vScrollBarCustom3
+            // 
+            this.vScrollBarCustom3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.vScrollBarCustom3.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustom3.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustom3.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustom3.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustom3.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustom3.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustom3.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustom3.HideScrollBar = true;
+            this.vScrollBarCustom3.LargeChange = 1;
+            this.vScrollBarCustom3.Location = new System.Drawing.Point(520, 21);
+            this.vScrollBarCustom3.Maximum = 0;
+            this.vScrollBarCustom3.Minimum = 0;
+            this.vScrollBarCustom3.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustom3.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustom3.Name = "vScrollBarCustom3";
+            this.vScrollBarCustom3.Size = new System.Drawing.Size(20, 226);
+            this.vScrollBarCustom3.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustom3.SmallChange = 1;
+            this.vScrollBarCustom3.TabIndex = 1;
+            this.vScrollBarCustom3.Text = "vScrollBarCustom3";
+            this.vScrollBarCustom3.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustom3.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustom3.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustom3.ThumbDrawAngle = 0F;
+            this.vScrollBarCustom3.Value = 0;
+            this.vScrollBarCustom3.ValueLimited = 0;
+            // 
+            // dataGridViewDistances
+            // 
+            this.dataGridViewDistances.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridViewDistances.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewDistances.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.ColumnSystem,
+            this.ColumnDistance,
+            this.ColumnCalculated,
+            this.ColumnStatus});
+            this.dataGridViewDistances.ContextMenuStrip = this.trilatContextMenu;
+            this.dataGridViewDistances.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewDistances.Name = "dataGridViewDistances";
+            this.dataGridViewDistances.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewDistances.Size = new System.Drawing.Size(520, 247);
+            this.dataGridViewDistances.TabIndex = 0;
+            this.dataGridViewDistances.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellClick);
+            this.dataGridViewDistances.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellEndEdit);
+            this.dataGridViewDistances.CellLeave += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellLeave);
+            this.dataGridViewDistances.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewDistances_CellValidating);
+            this.dataGridViewDistances.CurrentCellChanged += new System.EventHandler(this.dataGridViewDistances_CurrentCellChanged);
+            this.dataGridViewDistances.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewDistances_EditingControlShowing);
+            this.dataGridViewDistances.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridViewDistances_KeyDown);
+            // 
+            // ColumnSystem
+            // 
+            this.ColumnSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ColumnSystem.FillWeight = 250F;
+            this.ColumnSystem.HeaderText = "System";
+            this.ColumnSystem.MinimumWidth = 75;
+            this.ColumnSystem.Name = "ColumnSystem";
+            // 
+            // ColumnDistance
+            // 
+            this.ColumnDistance.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ColumnDistance.HeaderText = "Distance";
+            this.ColumnDistance.MinimumWidth = 75;
+            this.ColumnDistance.Name = "ColumnDistance";
+            // 
+            // ColumnCalculated
+            // 
+            this.ColumnCalculated.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ColumnCalculated.HeaderText = "Calculated";
+            this.ColumnCalculated.MinimumWidth = 75;
+            this.ColumnCalculated.Name = "ColumnCalculated";
+            this.ColumnCalculated.ReadOnly = true;
+            // 
+            // ColumnStatus
+            // 
+            this.ColumnStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ColumnStatus.HeaderText = "Status";
+            this.ColumnStatus.MinimumWidth = 75;
+            this.ColumnStatus.Name = "ColumnStatus";
+            this.ColumnStatus.ReadOnly = true;
+            // 
+            // dataViewScrollerPanelSuggestedReferences
+            // 
+            this.dataViewScrollerPanelSuggestedReferences.Controls.Add(this.vScrollBarCustom1);
+            this.dataViewScrollerPanelSuggestedReferences.Controls.Add(this.dataGridViewSuggestedSystems);
+            this.dataViewScrollerPanelSuggestedReferences.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataViewScrollerPanelSuggestedReferences.InternalMargin = new System.Windows.Forms.Padding(0);
+            this.dataViewScrollerPanelSuggestedReferences.Location = new System.Drawing.Point(0, 0);
+            this.dataViewScrollerPanelSuggestedReferences.Name = "dataViewScrollerPanelSuggestedReferences";
+            this.dataViewScrollerPanelSuggestedReferences.ScrollBarWidth = 20;
+            this.dataViewScrollerPanelSuggestedReferences.Size = new System.Drawing.Size(380, 247);
+            this.dataViewScrollerPanelSuggestedReferences.TabIndex = 19;
+            this.dataViewScrollerPanelSuggestedReferences.VerticalScrollBarDockRight = true;
+            // 
+            // vScrollBarCustom1
+            // 
+            this.vScrollBarCustom1.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustom1.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustom1.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustom1.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustom1.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustom1.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustom1.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustom1.HideScrollBar = true;
+            this.vScrollBarCustom1.LargeChange = 0;
+            this.vScrollBarCustom1.Location = new System.Drawing.Point(360, 21);
+            this.vScrollBarCustom1.Maximum = -1;
+            this.vScrollBarCustom1.Minimum = 0;
+            this.vScrollBarCustom1.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustom1.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustom1.Name = "vScrollBarCustom1";
+            this.vScrollBarCustom1.Size = new System.Drawing.Size(20, 226);
+            this.vScrollBarCustom1.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustom1.SmallChange = 1;
+            this.vScrollBarCustom1.TabIndex = 19;
+            this.vScrollBarCustom1.Text = "vScrollBarCustom1";
+            this.vScrollBarCustom1.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustom1.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustom1.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustom1.ThumbDrawAngle = 0F;
+            this.vScrollBarCustom1.Value = -1;
+            this.vScrollBarCustom1.ValueLimited = -1;
+            // 
+            // dataGridViewSuggestedSystems
+            // 
+            this.dataGridViewSuggestedSystems.AllowUserToAddRows = false;
+            this.dataGridViewSuggestedSystems.AllowUserToDeleteRows = false;
+            this.dataGridViewSuggestedSystems.AllowUserToResizeRows = false;
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridViewSuggestedSystems.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            this.dataGridViewSuggestedSystems.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewSuggestedSystems.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem});
+            this.dataGridViewSuggestedSystems.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
+            this.dataGridViewSuggestedSystems.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewSuggestedSystems.Name = "dataGridViewSuggestedSystems";
+            this.dataGridViewSuggestedSystems.ReadOnly = true;
+            this.dataGridViewSuggestedSystems.RowHeadersVisible = false;
+            this.dataGridViewSuggestedSystems.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewSuggestedSystems.Size = new System.Drawing.Size(360, 247);
+            this.dataGridViewSuggestedSystems.TabIndex = 18;
+            this.dataGridViewSuggestedSystems.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewSuggestedSystems_CellClick);
+            // 
+            // dataGridViewTextBoxColumnSuggestedSystemsSystem
+            // 
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.HeaderText = "Suggested Reference Systems";
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.MinimumWidth = 100;
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.Name = "dataGridViewTextBoxColumnSuggestedSystemsSystem";
+            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.ReadOnly = true;
+            // 
+            // splitContainerBottom
+            // 
+            this.splitContainerBottom.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerBottom.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerBottom.Name = "splitContainerBottom";
+            // 
+            // splitContainerBottom.Panel1
+            // 
+            this.splitContainerBottom.Panel1.Controls.Add(this.richTextBox_History);
+            // 
+            // splitContainerBottom.Panel2
+            // 
+            this.splitContainerBottom.Panel2.Controls.Add(this.dataViewScrollerPanelWantedSystems);
+            this.splitContainerBottom.Size = new System.Drawing.Size(924, 331);
+            this.splitContainerBottom.SplitterDistance = 537;
+            this.splitContainerBottom.SplitterWidth = 6;
+            this.splitContainerBottom.TabIndex = 2;
+            this.splitContainerBottom.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainerBottom_SplitterMoved);
+            // 
+            // richTextBox_History
+            // 
+            this.richTextBox_History.BorderColor = System.Drawing.Color.Transparent;
+            this.richTextBox_History.BorderColorScaling = 0.5F;
+            this.richTextBox_History.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.richTextBox_History.HideScrollBar = true;
+            this.richTextBox_History.Location = new System.Drawing.Point(0, 0);
+            this.richTextBox_History.Name = "richTextBox_History";
+            this.richTextBox_History.ScrollBarWidth = 20;
+            this.richTextBox_History.ShowLineCount = false;
+            this.richTextBox_History.Size = new System.Drawing.Size(537, 331);
+            this.richTextBox_History.TabIndex = 6;
+            // 
+            // dataViewScrollerPanelWantedSystems
+            // 
+            this.dataViewScrollerPanelWantedSystems.Controls.Add(this.vScrollBarCustom2);
+            this.dataViewScrollerPanelWantedSystems.Controls.Add(this.dataGridViewClosestSystems);
+            this.dataViewScrollerPanelWantedSystems.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataViewScrollerPanelWantedSystems.InternalMargin = new System.Windows.Forms.Padding(0);
+            this.dataViewScrollerPanelWantedSystems.Location = new System.Drawing.Point(0, 0);
+            this.dataViewScrollerPanelWantedSystems.Name = "dataViewScrollerPanelWantedSystems";
+            this.dataViewScrollerPanelWantedSystems.ScrollBarWidth = 20;
+            this.dataViewScrollerPanelWantedSystems.Size = new System.Drawing.Size(381, 331);
+            this.dataViewScrollerPanelWantedSystems.TabIndex = 14;
+            this.dataViewScrollerPanelWantedSystems.VerticalScrollBarDockRight = true;
+            // 
+            // vScrollBarCustom2
+            // 
+            this.vScrollBarCustom2.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustom2.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustom2.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustom2.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustom2.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustom2.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustom2.HideScrollBar = true;
+            this.vScrollBarCustom2.LargeChange = 0;
+            this.vScrollBarCustom2.Location = new System.Drawing.Point(361, 21);
+            this.vScrollBarCustom2.Maximum = -1;
+            this.vScrollBarCustom2.Minimum = 0;
+            this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustom2.Name = "vScrollBarCustom2";
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 310);
+            this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustom2.SmallChange = 1;
+            this.vScrollBarCustom2.TabIndex = 14;
+            this.vScrollBarCustom2.Text = "vScrollBarCustom2";
+            this.vScrollBarCustom2.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustom2.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustom2.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustom2.ThumbDrawAngle = 0F;
+            this.vScrollBarCustom2.Value = -1;
+            this.vScrollBarCustom2.ValueLimited = -1;
+            // 
+            // dataGridViewClosestSystems
+            // 
+            this.dataGridViewClosestSystems.AllowUserToAddRows = false;
+            this.dataGridViewClosestSystems.AllowUserToDeleteRows = false;
+            this.dataGridViewClosestSystems.AllowUserToResizeRows = false;
+            this.dataGridViewClosestSystems.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridViewClosestSystems.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            this.dataGridViewClosestSystems.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewClosestSystems.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.Source,
+            this.dataGridViewTextBoxColumnClosestSystemsSystem});
+            this.dataGridViewClosestSystems.ContextMenuStrip = this.wantedContextMenu;
+            this.dataGridViewClosestSystems.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
+            this.dataGridViewClosestSystems.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewClosestSystems.Name = "dataGridViewClosestSystems";
+            this.dataGridViewClosestSystems.ReadOnly = true;
+            this.dataGridViewClosestSystems.RowHeadersVisible = false;
+            this.dataGridViewClosestSystems.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewClosestSystems.Size = new System.Drawing.Size(361, 331);
+            this.dataGridViewClosestSystems.TabIndex = 13;
+            this.dataGridViewClosestSystems.CellMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewClosestSystems_CellMouseClick);
+            // 
+            // Source
+            // 
+            this.Source.HeaderText = "Source";
+            this.Source.Name = "Source";
+            this.Source.ReadOnly = true;
+            // 
+            // dataGridViewTextBoxColumnClosestSystemsSystem
+            // 
+            this.dataGridViewTextBoxColumnClosestSystemsSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.dataGridViewTextBoxColumnClosestSystemsSystem.HeaderText = "Wanted System";
+            this.dataGridViewTextBoxColumnClosestSystemsSystem.MinimumWidth = 100;
+            this.dataGridViewTextBoxColumnClosestSystemsSystem.Name = "dataGridViewTextBoxColumnClosestSystemsSystem";
+            this.dataGridViewTextBoxColumnClosestSystemsSystem.ReadOnly = true;
             // 
             // wantedContextMenu
             // 
@@ -322,285 +678,6 @@ namespace EDDiscovery
             this.panel_controls.Size = new System.Drawing.Size(924, 74);
             this.panel_controls.TabIndex = 24;
             // 
-            // labelstpos
-            // 
-            this.labelstpos.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.labelstpos.Location = new System.Drawing.Point(3, 3);
-            this.labelstpos.Name = "labelstpos";
-            this.labelstpos.Size = new System.Drawing.Size(90, 19);
-            this.labelstpos.TabIndex = 20;
-            this.labelstpos.Text = "Current Status:";
-            // 
-            // dataViewScrollerPanel1
-            // 
-            this.dataViewScrollerPanel1.Controls.Add(this.vScrollBarCustom1);
-            this.dataViewScrollerPanel1.Controls.Add(this.dataGridViewSuggestedSystems);
-            this.dataViewScrollerPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataViewScrollerPanel1.InternalMargin = new System.Windows.Forms.Padding(0);
-            this.dataViewScrollerPanel1.Location = new System.Drawing.Point(538, 0);
-            this.dataViewScrollerPanel1.Name = "dataViewScrollerPanel1";
-            this.dataViewScrollerPanel1.ScrollBarWidth = 20;
-            this.dataViewScrollerPanel1.Size = new System.Drawing.Size(386, 247);
-            this.dataViewScrollerPanel1.TabIndex = 19;
-            this.dataViewScrollerPanel1.VerticalScrollBarDockRight = true;
-            // 
-            // vScrollBarCustom1
-            // 
-            this.vScrollBarCustom1.ArrowBorderColor = System.Drawing.Color.LightBlue;
-            this.vScrollBarCustom1.ArrowButtonColor = System.Drawing.Color.LightGray;
-            this.vScrollBarCustom1.ArrowColorScaling = 0.5F;
-            this.vScrollBarCustom1.ArrowDownDrawAngle = 270F;
-            this.vScrollBarCustom1.ArrowUpDrawAngle = 90F;
-            this.vScrollBarCustom1.BorderColor = System.Drawing.Color.White;
-            this.vScrollBarCustom1.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.vScrollBarCustom1.HideScrollBar = true;
-            this.vScrollBarCustom1.LargeChange = 0;
-            this.vScrollBarCustom1.Location = new System.Drawing.Point(366, 21);
-            this.vScrollBarCustom1.Maximum = -1;
-            this.vScrollBarCustom1.Minimum = 0;
-            this.vScrollBarCustom1.MouseOverButtonColor = System.Drawing.Color.Green;
-            this.vScrollBarCustom1.MousePressedButtonColor = System.Drawing.Color.Red;
-            this.vScrollBarCustom1.Name = "vScrollBarCustom1";
-            this.vScrollBarCustom1.Size = new System.Drawing.Size(20, 226);
-            this.vScrollBarCustom1.SliderColor = System.Drawing.Color.DarkGray;
-            this.vScrollBarCustom1.SmallChange = 1;
-            this.vScrollBarCustom1.TabIndex = 19;
-            this.vScrollBarCustom1.Text = "vScrollBarCustom1";
-            this.vScrollBarCustom1.ThumbBorderColor = System.Drawing.Color.Yellow;
-            this.vScrollBarCustom1.ThumbButtonColor = System.Drawing.Color.DarkBlue;
-            this.vScrollBarCustom1.ThumbColorScaling = 0.5F;
-            this.vScrollBarCustom1.ThumbDrawAngle = 0F;
-            this.vScrollBarCustom1.Value = -1;
-            this.vScrollBarCustom1.ValueLimited = -1;
-            // 
-            // dataGridViewSuggestedSystems
-            // 
-            this.dataGridViewSuggestedSystems.AllowUserToAddRows = false;
-            this.dataGridViewSuggestedSystems.AllowUserToDeleteRows = false;
-            this.dataGridViewSuggestedSystems.AllowUserToResizeRows = false;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewSuggestedSystems.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.dataGridViewSuggestedSystems.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewSuggestedSystems.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem});
-            this.dataGridViewSuggestedSystems.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
-            this.dataGridViewSuggestedSystems.Location = new System.Drawing.Point(0, 0);
-            this.dataGridViewSuggestedSystems.Name = "dataGridViewSuggestedSystems";
-            this.dataGridViewSuggestedSystems.ReadOnly = true;
-            this.dataGridViewSuggestedSystems.RowHeadersVisible = false;
-            this.dataGridViewSuggestedSystems.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewSuggestedSystems.Size = new System.Drawing.Size(366, 247);
-            this.dataGridViewSuggestedSystems.TabIndex = 18;
-            this.dataGridViewSuggestedSystems.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewSuggestedSystems_CellClick);
-            // 
-            // dataGridViewTextBoxColumnSuggestedSystemsSystem
-            // 
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.HeaderText = "Suggested Reference Systems";
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.MinimumWidth = 100;
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.Name = "dataGridViewTextBoxColumnSuggestedSystemsSystem";
-            this.dataGridViewTextBoxColumnSuggestedSystemsSystem.ReadOnly = true;
-            // 
-            // dataViewScrollerPanel3
-            // 
-            this.dataViewScrollerPanel3.Controls.Add(this.vScrollBarCustom3);
-            this.dataViewScrollerPanel3.Controls.Add(this.dataGridViewDistances);
-            this.dataViewScrollerPanel3.Dock = System.Windows.Forms.DockStyle.Left;
-            this.dataViewScrollerPanel3.InternalMargin = new System.Windows.Forms.Padding(0);
-            this.dataViewScrollerPanel3.Location = new System.Drawing.Point(0, 0);
-            this.dataViewScrollerPanel3.Name = "dataViewScrollerPanel3";
-            this.dataViewScrollerPanel3.ScrollBarWidth = 20;
-            this.dataViewScrollerPanel3.Size = new System.Drawing.Size(538, 247);
-            this.dataViewScrollerPanel3.TabIndex = 22;
-            this.dataViewScrollerPanel3.VerticalScrollBarDockRight = true;
-            // 
-            // vScrollBarCustom3
-            // 
-            this.vScrollBarCustom3.ArrowBorderColor = System.Drawing.Color.LightBlue;
-            this.vScrollBarCustom3.ArrowButtonColor = System.Drawing.Color.LightGray;
-            this.vScrollBarCustom3.ArrowColorScaling = 0.5F;
-            this.vScrollBarCustom3.ArrowDownDrawAngle = 270F;
-            this.vScrollBarCustom3.ArrowUpDrawAngle = 90F;
-            this.vScrollBarCustom3.BorderColor = System.Drawing.Color.White;
-            this.vScrollBarCustom3.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.vScrollBarCustom3.HideScrollBar = true;
-            this.vScrollBarCustom3.LargeChange = 1;
-            this.vScrollBarCustom3.Location = new System.Drawing.Point(518, 21);
-            this.vScrollBarCustom3.Maximum = 0;
-            this.vScrollBarCustom3.Minimum = 0;
-            this.vScrollBarCustom3.MouseOverButtonColor = System.Drawing.Color.Green;
-            this.vScrollBarCustom3.MousePressedButtonColor = System.Drawing.Color.Red;
-            this.vScrollBarCustom3.Name = "vScrollBarCustom3";
-            this.vScrollBarCustom3.Size = new System.Drawing.Size(20, 226);
-            this.vScrollBarCustom3.SliderColor = System.Drawing.Color.DarkGray;
-            this.vScrollBarCustom3.SmallChange = 1;
-            this.vScrollBarCustom3.TabIndex = 1;
-            this.vScrollBarCustom3.Text = "vScrollBarCustom3";
-            this.vScrollBarCustom3.ThumbBorderColor = System.Drawing.Color.Yellow;
-            this.vScrollBarCustom3.ThumbButtonColor = System.Drawing.Color.DarkBlue;
-            this.vScrollBarCustom3.ThumbColorScaling = 0.5F;
-            this.vScrollBarCustom3.ThumbDrawAngle = 0F;
-            this.vScrollBarCustom3.Value = 0;
-            this.vScrollBarCustom3.ValueLimited = 0;
-            // 
-            // dataGridViewDistances
-            // 
-            this.dataGridViewDistances.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewDistances.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.ColumnSystem,
-            this.ColumnDistance,
-            this.ColumnCalculated,
-            this.ColumnStatus});
-            this.dataGridViewDistances.ContextMenuStrip = this.trilatContextMenu;
-            this.dataGridViewDistances.Dock = System.Windows.Forms.DockStyle.Left;
-            this.dataGridViewDistances.Location = new System.Drawing.Point(0, 0);
-            this.dataGridViewDistances.Name = "dataGridViewDistances";
-            this.dataGridViewDistances.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewDistances.Size = new System.Drawing.Size(518, 247);
-            this.dataGridViewDistances.TabIndex = 0;
-            this.dataGridViewDistances.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellClick);
-            this.dataGridViewDistances.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellEndEdit);
-            this.dataGridViewDistances.CellLeave += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellLeave);
-            this.dataGridViewDistances.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewDistances_CellValidating);
-            this.dataGridViewDistances.CurrentCellChanged += new System.EventHandler(this.dataGridViewDistances_CurrentCellChanged);
-            this.dataGridViewDistances.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewDistances_EditingControlShowing);
-            this.dataGridViewDistances.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridViewDistances_KeyDown);
-            // 
-            // ColumnSystem
-            // 
-            this.ColumnSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.ColumnSystem.FillWeight = 250F;
-            this.ColumnSystem.HeaderText = "System";
-            this.ColumnSystem.MinimumWidth = 75;
-            this.ColumnSystem.Name = "ColumnSystem";
-            // 
-            // ColumnDistance
-            // 
-            this.ColumnDistance.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.ColumnDistance.HeaderText = "Distance";
-            this.ColumnDistance.MinimumWidth = 75;
-            this.ColumnDistance.Name = "ColumnDistance";
-            // 
-            // ColumnCalculated
-            // 
-            this.ColumnCalculated.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.ColumnCalculated.HeaderText = "Calculated";
-            this.ColumnCalculated.MinimumWidth = 75;
-            this.ColumnCalculated.Name = "ColumnCalculated";
-            this.ColumnCalculated.ReadOnly = true;
-            // 
-            // ColumnStatus
-            // 
-            this.ColumnStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.ColumnStatus.HeaderText = "Status";
-            this.ColumnStatus.MinimumWidth = 75;
-            this.ColumnStatus.Name = "ColumnStatus";
-            this.ColumnStatus.ReadOnly = true;
-            // 
-            // dataViewScrollerPanel2
-            // 
-            this.dataViewScrollerPanel2.Controls.Add(this.vScrollBarCustom2);
-            this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewClosestSystems);
-            this.dataViewScrollerPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataViewScrollerPanel2.InternalMargin = new System.Windows.Forms.Padding(0);
-            this.dataViewScrollerPanel2.Location = new System.Drawing.Point(538, 0);
-            this.dataViewScrollerPanel2.Name = "dataViewScrollerPanel2";
-            this.dataViewScrollerPanel2.ScrollBarWidth = 20;
-            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(386, 331);
-            this.dataViewScrollerPanel2.TabIndex = 14;
-            this.dataViewScrollerPanel2.VerticalScrollBarDockRight = true;
-            // 
-            // vScrollBarCustom2
-            // 
-            this.vScrollBarCustom2.ArrowBorderColor = System.Drawing.Color.LightBlue;
-            this.vScrollBarCustom2.ArrowButtonColor = System.Drawing.Color.LightGray;
-            this.vScrollBarCustom2.ArrowColorScaling = 0.5F;
-            this.vScrollBarCustom2.ArrowDownDrawAngle = 270F;
-            this.vScrollBarCustom2.ArrowUpDrawAngle = 90F;
-            this.vScrollBarCustom2.BorderColor = System.Drawing.Color.White;
-            this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.vScrollBarCustom2.HideScrollBar = true;
-            this.vScrollBarCustom2.LargeChange = 0;
-            this.vScrollBarCustom2.Location = new System.Drawing.Point(366, 21);
-            this.vScrollBarCustom2.Maximum = -1;
-            this.vScrollBarCustom2.Minimum = 0;
-            this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
-            this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
-            this.vScrollBarCustom2.Name = "vScrollBarCustom2";
-            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 310);
-            this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
-            this.vScrollBarCustom2.SmallChange = 1;
-            this.vScrollBarCustom2.TabIndex = 14;
-            this.vScrollBarCustom2.Text = "vScrollBarCustom2";
-            this.vScrollBarCustom2.ThumbBorderColor = System.Drawing.Color.Yellow;
-            this.vScrollBarCustom2.ThumbButtonColor = System.Drawing.Color.DarkBlue;
-            this.vScrollBarCustom2.ThumbColorScaling = 0.5F;
-            this.vScrollBarCustom2.ThumbDrawAngle = 0F;
-            this.vScrollBarCustom2.Value = -1;
-            this.vScrollBarCustom2.ValueLimited = -1;
-            // 
-            // dataGridViewClosestSystems
-            // 
-            this.dataGridViewClosestSystems.AllowUserToAddRows = false;
-            this.dataGridViewClosestSystems.AllowUserToDeleteRows = false;
-            this.dataGridViewClosestSystems.AllowUserToResizeRows = false;
-            this.dataGridViewClosestSystems.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewClosestSystems.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
-            this.dataGridViewClosestSystems.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewClosestSystems.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Source,
-            this.dataGridViewTextBoxColumnClosestSystemsSystem});
-            this.dataGridViewClosestSystems.ContextMenuStrip = this.wantedContextMenu;
-            this.dataGridViewClosestSystems.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
-            this.dataGridViewClosestSystems.Location = new System.Drawing.Point(0, 0);
-            this.dataGridViewClosestSystems.Name = "dataGridViewClosestSystems";
-            this.dataGridViewClosestSystems.ReadOnly = true;
-            this.dataGridViewClosestSystems.RowHeadersVisible = false;
-            this.dataGridViewClosestSystems.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewClosestSystems.Size = new System.Drawing.Size(366, 331);
-            this.dataGridViewClosestSystems.TabIndex = 13;
-            this.dataGridViewClosestSystems.CellMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewClosestSystems_CellMouseClick);
-            // 
-            // Source
-            // 
-            this.Source.HeaderText = "Source";
-            this.Source.Name = "Source";
-            this.Source.ReadOnly = true;
-            // 
-            // dataGridViewTextBoxColumnClosestSystemsSystem
-            // 
-            this.dataGridViewTextBoxColumnClosestSystemsSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.dataGridViewTextBoxColumnClosestSystemsSystem.HeaderText = "Wanted System";
-            this.dataGridViewTextBoxColumnClosestSystemsSystem.MinimumWidth = 100;
-            this.dataGridViewTextBoxColumnClosestSystemsSystem.Name = "dataGridViewTextBoxColumnClosestSystemsSystem";
-            this.dataGridViewTextBoxColumnClosestSystemsSystem.ReadOnly = true;
-            // 
-            // richTextBox_History
-            // 
-            this.richTextBox_History.BorderColor = System.Drawing.Color.Transparent;
-            this.richTextBox_History.BorderColorScaling = 0.5F;
-            this.richTextBox_History.Dock = System.Windows.Forms.DockStyle.Left;
-            this.richTextBox_History.HideScrollBar = true;
-            this.richTextBox_History.Location = new System.Drawing.Point(0, 0);
-            this.richTextBox_History.Name = "richTextBox_History";
-            this.richTextBox_History.ScrollBarWidth = 20;
-            this.richTextBox_History.ShowLineCount = false;
-            this.richTextBox_History.Size = new System.Drawing.Size(538, 331);
-            this.richTextBox_History.TabIndex = 6;
-            // 
             // textBox_status
             // 
             this.textBox_status.BorderColor = System.Drawing.Color.Transparent;
@@ -611,6 +688,15 @@ namespace EDDiscovery
             this.textBox_status.ReadOnly = true;
             this.textBox_status.Size = new System.Drawing.Size(167, 13);
             this.textBox_status.TabIndex = 21;
+            // 
+            // labelstpos
+            // 
+            this.labelstpos.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.labelstpos.Location = new System.Drawing.Point(3, 3);
+            this.labelstpos.Name = "labelstpos";
+            this.labelstpos.Size = new System.Drawing.Size(90, 19);
+            this.labelstpos.TabIndex = 20;
+            this.labelstpos.Text = "Current Status:";
             // 
             // textBoxSystemName
             // 
@@ -659,43 +745,6 @@ namespace EDDiscovery
             this.textBoxCoordinateZ.Text = "?";
             this.textBoxCoordinateZ.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
-            // radioButtonAlgorithmJs
-            // 
-            this.radioButtonAlgorithmJs.AutoSize = true;
-            this.radioButtonAlgorithmJs.FontNerfReduction = 0.5F;
-            this.radioButtonAlgorithmJs.Location = new System.Drawing.Point(3, 27);
-            this.radioButtonAlgorithmJs.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.radioButtonAlgorithmJs.Name = "radioButtonAlgorithmJs";
-            this.radioButtonAlgorithmJs.RadioButtonColor = System.Drawing.Color.Gray;
-            this.radioButtonAlgorithmJs.RadioButtonInnerColor = System.Drawing.Color.White;
-            this.radioButtonAlgorithmJs.SelectedColor = System.Drawing.Color.DarkBlue;
-            this.radioButtonAlgorithmJs.SelectedColorRing = System.Drawing.Color.Black;
-            this.radioButtonAlgorithmJs.Size = new System.Drawing.Size(37, 17);
-            this.radioButtonAlgorithmJs.TabIndex = 1;
-            this.radioButtonAlgorithmJs.Text = "JS";
-            this.toolTipAlgorithm.SetToolTip(this.radioButtonAlgorithmJs, "Original algoritthm from ed-systems, written in Javascript (slower)");
-            this.radioButtonAlgorithmJs.UseVisualStyleBackColor = true;
-            this.radioButtonAlgorithmJs.CheckedChanged += new System.EventHandler(this.radioButtonAlgorithm_CheckedChanged);
-            // 
-            // radioButtonAlgorithmCsharp
-            // 
-            this.radioButtonAlgorithmCsharp.AutoSize = true;
-            this.radioButtonAlgorithmCsharp.Checked = true;
-            this.radioButtonAlgorithmCsharp.FontNerfReduction = 0.5F;
-            this.radioButtonAlgorithmCsharp.Location = new System.Drawing.Point(3, 44);
-            this.radioButtonAlgorithmCsharp.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.radioButtonAlgorithmCsharp.Name = "radioButtonAlgorithmCsharp";
-            this.radioButtonAlgorithmCsharp.RadioButtonColor = System.Drawing.Color.Gray;
-            this.radioButtonAlgorithmCsharp.RadioButtonInnerColor = System.Drawing.Color.White;
-            this.radioButtonAlgorithmCsharp.SelectedColor = System.Drawing.Color.DarkBlue;
-            this.radioButtonAlgorithmCsharp.SelectedColorRing = System.Drawing.Color.Black;
-            this.radioButtonAlgorithmCsharp.Size = new System.Drawing.Size(39, 17);
-            this.radioButtonAlgorithmCsharp.TabIndex = 0;
-            this.radioButtonAlgorithmCsharp.TabStop = true;
-            this.radioButtonAlgorithmCsharp.Text = "C#";
-            this.toolTipAlgorithm.SetToolTip(this.radioButtonAlgorithmCsharp, "Algorithm from ed-systems rewritten to C# (fast, experimental)");
-            this.radioButtonAlgorithmCsharp.UseVisualStyleBackColor = true;
-            // 
             // TrilaterationControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -712,17 +761,25 @@ namespace EDDiscovery
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            this.splitContainerTop.Panel1.ResumeLayout(false);
+            this.splitContainerTop.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerTop)).EndInit();
+            this.splitContainerTop.ResumeLayout(false);
+            this.dataViewScrollerPanelDistances.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewDistances)).EndInit();
+            this.dataViewScrollerPanelSuggestedReferences.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSuggestedSystems)).EndInit();
+            this.splitContainerBottom.Panel1.ResumeLayout(false);
+            this.splitContainerBottom.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerBottom)).EndInit();
+            this.splitContainerBottom.ResumeLayout(false);
+            this.dataViewScrollerPanelWantedSystems.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewClosestSystems)).EndInit();
             this.wantedContextMenu.ResumeLayout(false);
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();
             this.panel_controls.ResumeLayout(false);
             this.panel_controls.PerformLayout();
-            this.dataViewScrollerPanel1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSuggestedSystems)).EndInit();
-            this.dataViewScrollerPanel3.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewDistances)).EndInit();
-            this.dataViewScrollerPanel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewClosestSystems)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -743,7 +800,7 @@ namespace EDDiscovery
         private ExtendedControls.RadioButtonCustom radioButtonAlgorithmCsharp;
         private System.Windows.Forms.Label labelAlgorithm;
         private System.Windows.Forms.ToolTip toolTipAlgorithm;
-        private System.Windows.Forms.SplitContainer splitContainer1;
+        private ExtendedControls.SplitContainerCustom splitContainer1;
         private System.Windows.Forms.ToolStrip toolStrip1;
         private System.Windows.Forms.ToolStripButton toolStripButtonSubmitDistances;
         private System.Windows.Forms.DataGridView dataGridViewSuggestedSystems;
@@ -770,12 +827,14 @@ namespace EDDiscovery
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumnClosestSystemsSystem;
         private System.Windows.Forms.ToolStripMenuItem viewOnEDSMToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem viewOnEDSMToolStripMenuItem1;
-        private DataViewScrollerPanel dataViewScrollerPanel1;
+        private DataViewScrollerPanel dataViewScrollerPanelSuggestedReferences;
         private VScrollBarCustom vScrollBarCustom1;
-        private DataViewScrollerPanel dataViewScrollerPanel2;
+        private DataViewScrollerPanel dataViewScrollerPanelWantedSystems;
         private VScrollBarCustom vScrollBarCustom2;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumnSuggestedSystemsSystem;
-        private DataViewScrollerPanel dataViewScrollerPanel3;
+        private DataViewScrollerPanel dataViewScrollerPanelDistances;
         private VScrollBarCustom vScrollBarCustom3;
+        private ExtendedControls.SplitContainerCustom splitContainerTop;
+        private ExtendedControls.SplitContainerCustom splitContainerBottom;
     }
 }

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -26,6 +26,7 @@ namespace EDDiscovery
         private Thread EDSMSubmissionThread;
         private EDSMClass edsm;
         private List<WantedSystemClass> wanted;
+        private bool _resizing;
 
         /** This global should be set if the next CurrentCellChanged() event should skip to the next editable cell.
          * This should be the case whenver a keyboard event causes cells to change, but not on mouse-initiated events */
@@ -1307,6 +1308,18 @@ namespace EDDiscovery
             if (!edsm.ShowSystemInEDSM(sysName)) LogTextHighlight("System could not be found - has not been synched or EDSM is unavailable" + Environment.NewLine);
 
             this.Cursor = Cursors.Default;
+        }
+
+        private void splitContainerBottom_SplitterMoved(object sender, SplitterEventArgs e)
+        {
+            if (!splitContainer1.LayoutChanging && splitContainerTop.SplitterDistance != splitContainerBottom.SplitterDistance)
+                splitContainerTop.SplitterDistance = splitContainerBottom.SplitterDistance;
+        }
+
+        private void splitContainerTop_SplitterMoved(object sender, SplitterEventArgs e)
+        {
+            if (!splitContainer1.LayoutChanging && splitContainerBottom.SplitterDistance != splitContainerTop.SplitterDistance)
+                splitContainerBottom.SplitterDistance = splitContainerTop.SplitterDistance;
         }
     }
 }


### PR DESCRIPTION
Add the ability to resize the left and right sides of the trilateration control, as requested in #219 