### PR TITLE
Moved the missing credentials warning close to where the problem matters

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -216,16 +216,6 @@ namespace EDDiscovery
 
                 CheckForNewInstaller();
 
-                // Note: This is not for the end user, it's actually an alarm for us so we 
-                // know the file is missing from the installer. Without this credentials file 
-                // Prospecting data writes are broken.
-                var appSettings = ConfigurationManager.AppSettings;
-                if (appSettings["EDMaterializerUsername"] == null || appSettings["EDMaterializerPassword"] == null)
-                {
-                    // Note: It's ok if this happens in DEBUG build Because we now hard coding the
-                    // credentials in that particular case.
-                    LogLineHighlight("WARNING: EDMaterializer credentials are missing!");
-                }
                 LogLineSuccess("Loading completed, Total number of systems " + SystemData.SystemList.Count().ToString());
             }
             catch (Exception ex)

--- a/EDDiscovery/HTTP/EDMaterializerCom.cs
+++ b/EDDiscovery/HTTP/EDMaterializerCom.cs
@@ -10,7 +10,7 @@ namespace EDDiscovery2.HTTP
     using Newtonsoft.Json.Linq;
     using System;
     using System.Web;
-
+    using System.Windows.Forms;
     public class EDMaterizliaerCom : HttpCom
     {
         private NameValueCollection _authTokens = null;
@@ -58,16 +58,38 @@ namespace EDDiscovery2.HTTP
             var username = appSettings["EDMaterializerUsername"];
             var password = appSettings["EDMaterializerPassword"];
 #endif
-            var json = $"{{\"email\": \"{username}\", \"password\": \"{password}\"}}";
-            var response = RequestPost(json, $"{_authPath}/sign_in");
-            if (response.StatusCode == HttpStatusCode.OK)
+            ResponseData response = new ResponseData(HttpStatusCode.BadRequest);
+            if (String.IsNullOrEmpty(username) || String.IsNullOrEmpty(password))
             {
-                var headers = response.Headers;
-                var tokens = new NameValueCollection();
-                tokens["access-token"] = headers["access-token"];
-                tokens["client"] = headers["client"];
-                tokens["uid"] = headers["uid"]; ;
-                _authTokens = tokens;
+                MessageBox.Show("Unabled to login to the EdMaterializer server, the credentials file is missing from the installation",
+                    "Unauthorized",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+            else
+            {
+                var joSignIn = new JObject {
+                    { "email", username },
+                    { "password", password }
+                };
+
+                response = RequestPost(joSignIn.ToString(), $"{_authPath}/sign_in");
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    var headers = response.Headers;
+                    var tokens = new NameValueCollection();
+                    tokens["access-token"] = headers["access-token"];
+                    tokens["client"] = headers["client"];
+                    tokens["uid"] = headers["uid"]; ;
+                    _authTokens = tokens;
+                }
+                else
+                {
+                    MessageBox.Show("Their was an error logging in to the EdMaterializer server.\nCheck the logs for details",
+                        "Unauthorized",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                }
             }
             return response;
         }


### PR DESCRIPTION
The warning for when the EDMaterializer credentials file is missing is confusing people so I've removed it and put something closer to the source of where it's a problem. 

Now when a user tries to change or insert a Star or Planet from the Prospecting window they'll get a pop up warning about it instead.