### PR TITLE
Fix an error that snuck in with 52cbcc3

### DIFF
--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -85,14 +85,9 @@ namespace EDDiscovery.DB
                     if (!File.Exists(dbfile))
                     {
                         CreateDB(dbfile);
-
-                        if (!File.Exists(dbfile))
-                        {
-                            CreateDB(dbfile);
-                        }
-                        else
-                            UpgradeDB();
                     }
+                    else
+                        UpgradeDB();
                 }
             }
         }


### PR DESCRIPTION
Fix an error where DB upgrade / creation would only occur
if the database file had never been created

Fixes: 52cbcc3 Only initialize the database once