### PR TITLE
Minor code readability fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages
 /Installer/EDDiscovery
 */*Secrets.config
 /EDDiscovery.v12.suo
+*.ncrunch*

--- a/EDDiscovery/Controls/DataGridViewExtensions.cs
+++ b/EDDiscovery/Controls/DataGridViewExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace EDDiscovery.Controls
+{
+    public static class DataGridViewExtensions
+    {
+        public static void MakeDoubleBuffered(this DataGridView datagridView)
+        {
+            // this improves dataGridView's scrolling performance
+            typeof(DataGridView).InvokeMember(
+                "DoubleBuffered",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.SetProperty,
+                null,
+                datagridView,
+                new object[] {true}
+                );
+        }
+    }
+}

--- a/EDDiscovery/DistanceParser.cs
+++ b/EDDiscovery/DistanceParser.cs
@@ -1,0 +1,43 @@
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace EDDiscovery
+{
+    public static class DistanceParser
+    {
+        /// <summary>
+        /// Parse a distance as a positive double, in the formats "xx", "xx.yy", "xx,yy" or "xxxx,yy".
+        /// </summary>
+        /// <param name="value">Decimal string to be parsed.</param>
+        /// <param name="maximum">Upper limit or null if not required.</param>
+        /// <returns>Parsed value or null on conversion failure.</returns>
+        public static double? DistanceAsDouble(string value, double? maximum = null)
+        {
+            if (value.Length == 0)
+            {
+                return null;
+            }
+
+            if (!new Regex(@"^\d+([.,]\d{1,2})?$").IsMatch(value))
+            {
+                return null;
+            }
+
+            double valueDouble;
+
+            // Allow regions with , as decimal separator to also use . as decimal separator and vice versa
+            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            if (!double.TryParse(decimalSeparator == "," ? value.Replace(".", ",") : value.Replace(",", "."), out valueDouble))
+            {
+                return null;
+            }
+
+            if (maximum.HasValue && valueDouble > maximum)
+            {
+                return null;
+            }
+
+            return valueDouble;
+        }
+    }
+}

--- a/EDDiscovery/DistanceParser.cs
+++ b/EDDiscovery/DistanceParser.cs
@@ -5,6 +5,8 @@ namespace EDDiscovery
 {
     public static class DistanceParser
     {
+        private static readonly Regex RegexDistance = new Regex(@"^\d+([.,]\d{1,2})?$", RegexOptions.Compiled | RegexOptions.Singleline);
+
         /// <summary>
         /// Parse a distance as a positive double, in the formats "xx", "xx.yy", "xx,yy" or "xxxx,yy".
         /// </summary>
@@ -18,19 +20,14 @@ namespace EDDiscovery
                 return null;
             }
 
-            if (!new Regex(@"^\d+([.,]\d{1,2})?$").IsMatch(value))
+            if (!RegexDistance.IsMatch(value))
             {
                 return null;
             }
 
-            double valueDouble;
-
-            // Allow regions with , as decimal separator to also use . as decimal separator and vice versa
-            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-            if (!double.TryParse(decimalSeparator == "," ? value.Replace(".", ",") : value.Replace(",", "."), out valueDouble))
-            {
-                return null;
-            }
+            // Replace comma decimal point separator with dot, as it is the invariant culture separator that we
+            // will be using to parse the distance. TryParse is not need, the regex ensures it always parses
+            var valueDouble = double.Parse(value.Replace(",", "."), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture);
 
             if (maximum.HasValue && valueDouble > maximum)
             {

--- a/EDDiscovery/DistanceParser.cs
+++ b/EDDiscovery/DistanceParser.cs
@@ -8,12 +8,13 @@ namespace EDDiscovery
         private static readonly Regex RegexDistance = new Regex(@"^\d+([.,]\d{1,2})?$", RegexOptions.Compiled | RegexOptions.Singleline);
 
         /// <summary>
-        /// Parse a distance as a positive double, in the formats "xx", "xx.yy", "xx,yy" or "xxxx,yy".
+        /// Parse a jump distance as a positive double, in the formats "xx", "xx.yy", "xx,yy" or "xxxx,yy".
         /// </summary>
         /// <param name="value">Decimal string to be parsed.</param>
-        /// <param name="maximum">Upper limit or null if not required.</param>
-        /// <returns>Parsed value or null on conversion failure.</returns>
-        public static double? DistanceAsDouble(string value, double? maximum = null)
+        /// <param name="maximum">Upper limit or null if not required. If this is set and the parsed value is greater, 
+        /// the result will be null</param>
+        /// <returns>Parsed value or null on conversion failure or null if value is greater than maximum value.</returns>
+        public static double? ParseJumpDistance(string value, double? maximum = null)
         {
             if (value.Length == 0)
             {
@@ -35,6 +36,24 @@ namespace EDDiscovery
             }
 
             return valueDouble;
+        }
+
+        public static double? ParseInterstellarDistance(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
+            double result;
+            if (double.TryParse(input.Replace(",", "."), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out result))
+            {
+                return result;
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -171,6 +171,7 @@
     <Compile Include="3DMap\DatasetBuilder.cs" />
     <Compile Include="3DMap\MapManager.cs" />
     <Compile Include="3DMap\KeyboardActions.cs" />
+    <Compile Include="Controls\DataGridViewExtensions.cs" />
     <Compile Include="DistanceParser.cs" />
     <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Controls\ButtonExt.cs">

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -371,6 +371,7 @@
     <Compile Include="TravelHistoryControl.Designer.cs">
       <DependentUpon>TravelHistoryControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="TravelHistoryFilter.cs" />
     <Compile Include="Trilateration\ReferencesSector.cs" />
     <Compile Include="Trilateration\ReferenceSystem.cs" />
     <Compile Include="Trilateration\SuggestedReferences.cs" />

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -171,6 +171,7 @@
     <Compile Include="3DMap\DatasetBuilder.cs" />
     <Compile Include="3DMap\MapManager.cs" />
     <Compile Include="3DMap\KeyboardActions.cs" />
+    <Compile Include="DistanceParser.cs" />
     <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Controls\ButtonExt.cs">
       <SubType>Component</SubType>

--- a/EDDiscovery/TravelHistoryControl.Designer.cs
+++ b/EDDiscovery/TravelHistoryControl.Designer.cs
@@ -685,7 +685,6 @@
             this.dataGridViewNearest.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.dataGridViewNearest.Size = new System.Drawing.Size(277, 287);
             this.dataGridViewNearest.TabIndex = 23;
-            this.dataGridViewNearest.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView2_CellContentClick);
             // 
             // Col1
             // 
@@ -962,9 +961,8 @@
             this.dataGridViewTravel.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.dataGridViewTravel.Size = new System.Drawing.Size(571, 516);
             this.dataGridViewTravel.TabIndex = 3;
-            this.dataGridViewTravel.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellClick);
-            this.dataGridViewTravel.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewTravel_CellContentClick);
-            this.dataGridViewTravel.CellContentDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridView1_CellContentDoubleClick);
+            this.dataGridViewTravel.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewTravel_CellClick);
+            this.dataGridViewTravel.CellContentDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewTravel_CellContentDoubleClick);
             this.dataGridViewTravel.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dgv_ColumnHeaderMouseClick);
             this.dataGridViewTravel.RowPostPaint += new System.Windows.Forms.DataGridViewRowPostPaintEventHandler(this.dataGridView1_RowPostPaint);
             // 
@@ -1047,7 +1045,6 @@
             this.textBoxFilter.Name = "textBoxFilter";
             this.textBoxFilter.Size = new System.Drawing.Size(148, 20);
             this.textBoxFilter.TabIndex = 1;
-            this.textBoxFilter.TextChanged += new System.EventHandler(this.textBoxFilter_TextChanged);
             this.textBoxFilter.KeyUp += new System.Windows.Forms.KeyEventHandler(this.textBoxFilter_KeyUp);
             // 
             // comboBoxHistoryWindow

--- a/EDDiscovery/TravelHistoryControl.Designer.cs
+++ b/EDDiscovery/TravelHistoryControl.Designer.cs
@@ -136,7 +136,6 @@
             this.viewOnEDSMToolStripMenuItem});
             this.historyContextMenu.Name = "historyContextMenu";
             this.historyContextMenu.Size = new System.Drawing.Size(233, 114);
-            this.historyContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.historyContextMenu_Opening);
             // 
             // starMapColourToolStripMenuItem
             // 

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -1,24 +1,15 @@
 ﻿using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Data;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using System.IO;
-using System.Collections;
-using System.Data.SQLite;
 using EDDiscovery.DB;
 using System.Diagnostics;
 using EDDiscovery2;
 using EDDiscovery2.DB;
-using System.Globalization;
-using System.Text.RegularExpressions;
-using EDDiscovery2.Trilateration;
 using EDDiscovery2.EDSM;
-using EDDiscovery2.HTTP;
 using System.Threading.Tasks;
 
 namespace EDDiscovery
@@ -28,7 +19,6 @@ namespace EDDiscovery
         private static EDDiscoveryForm _discoveryForm;
         public int defaultMapColour;
         public EDSMSync sync;
-        string datapath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Frontier_Development_s", "Products"); // \\FORC-FDEV-D-1001\\Logs\\";
 
         internal List<SystemPosition> visitedSystems;
         internal bool EDSMSyncTo = true;
@@ -59,7 +49,7 @@ namespace EDDiscovery
             EDSMSyncFrom = db.GetSettingBool("EDSMSyncFrom", true);
             checkBoxEDSMSyncTo.Checked = EDSMSyncTo;
             checkBoxEDSMSyncFrom.Checked = EDSMSyncFrom;
-            comboBoxHistoryWindow.Items.AddRange(new string[] { "6 Hours", "12 Hours", "24 Hours", "3 days", "Week", "2 Weeks", "Month", "Last 20", "All" });
+            comboBoxHistoryWindow.Items.AddRange(new[] { "6 Hours", "12 Hours", "24 Hours", "3 days", "Week", "2 Weeks", "Month", "Last 20", "All" });
             comboBoxHistoryWindow.SelectedIndex = db.GetSettingInt("EDUIHistory", 4);
             LoadCommandersListBox();
         }
@@ -120,34 +110,34 @@ namespace EDDiscovery
             switch (comboBoxHistoryWindow.SelectedIndex)
             {
                 case 0:
-                    maxDataAge = new TimeSpan(6, 0, 0); // 6 hours
+                    maxDataAge = TimeSpan.FromHours(6);
                     break;
                 case 1:
-                    maxDataAge = new TimeSpan(12, 0, 0); // 12 hours
+                    maxDataAge = TimeSpan.FromHours(12);
                     break;
                 case 2:
-                    maxDataAge = new TimeSpan(24, 0, 0); // 24 hours
+                    maxDataAge = TimeSpan.FromDays(1);
                     break;
                 case 3:
-                    maxDataAge = new TimeSpan(3 * 24, 0, 0); // 3 days
+                    maxDataAge = TimeSpan.FromDays(3);
                     break;
                 case 4:
-                    maxDataAge = new TimeSpan(7 * 24, 0, 0); // 1 week
+                    maxDataAge = TimeSpan.FromDays(7);
                     break;
                 case 5:
-                    maxDataAge = new TimeSpan(14 * 24, 0, 0); // 2 weeks
+                    maxDataAge = TimeSpan.FromDays(14);
                     break;
                 case 6:
-                    maxDataAge = new TimeSpan(30, 0, 0, 0); // 30 days (month)
+                    maxDataAge = TimeSpan.FromDays(30);
                     break;
                 case 7:
                     atMost = 20; // Last 20
                     break;
                 case 8:
-                    maxDataAge = new TimeSpan(100000, 24, 0, 0); // all
+                    maxDataAge = TimeSpan.FromDays(100000);
                     break;
                 default:
-                    maxDataAge = new TimeSpan(7 * 24, 0, 0); // 1 week (default)
+                    maxDataAge = TimeSpan.FromDays(7);
                     break;
             }
 
@@ -412,7 +402,7 @@ namespace EDDiscovery
         private void ShowClosestSystems(string name)
         {
             sysDist = new List<SystemDist>();
-            SystemClass LastSystem = null;
+            SystemClass lastSystem = null;
             float dx, dy, dz;
             double dist;
 
@@ -428,32 +418,32 @@ namespace EDDiscovery
                     {
                         SystemPosition item = result[ii];
 
-                        LastSystem = SystemData.GetSystem(item.Name);
+                        lastSystem = SystemData.GetSystem(item.Name);
                         name = item.Name;
-                        if (LastSystem != null)
+                        if (lastSystem != null)
                             break;
                     }
 
                 }
                 else
                 {
-                    LastSystem = SystemData.GetSystem(name);
+                    lastSystem = SystemData.GetSystem(name);
                 }
 
                 if (name !=null)
-                    labelclosests.Text = "Closest systems from " + name.ToString();
+                    labelclosests.Text = "Closest systems from " + name;
 
                 dataGridViewNearest.Rows.Clear();
 
-                if (LastSystem == null)
+                if (lastSystem == null)
                     return;
 
                 foreach (SystemClass pos in SystemData.SystemList)
                 {
 
-                    dx = (float)(pos.x - LastSystem.x);
-                    dy = (float)(pos.y - LastSystem.y);
-                    dz = (float)(pos.z - LastSystem.z);
+                    dx = (float)(pos.x - lastSystem.x);
+                    dy = (float)(pos.y - lastSystem.y);
+                    dz = (float)(pos.z - lastSystem.z);
                     dist = dx * dx + dy * dy + dz * dz;
 
                     //distance = (float)((system.x - arcsystem.x) * (system.x - arcsystem.x) + (system.y - arcsystem.y) * (system.y - arcsystem.y) + (system.z - arcsystem.z) * (system.z - arcsystem.z));
@@ -623,7 +613,7 @@ namespace EDDiscovery
 
         private void buttonUpdate_Click(object sender, EventArgs e)
         {
-            var dist = DistanceAsDouble(textBoxDistance.Text.Trim());
+            var dist = DistanceParser.DistanceAsDouble(textBoxDistance.Text.Trim());
 
             if (!dist.HasValue)
                 MessageBox.Show("Distance in wrong format!");
@@ -685,7 +675,6 @@ namespace EDDiscovery
                 if (currentSysPos != null && !txt.Equals(currentSysPos.curSystem.Note))
                 {
                     SystemNoteClass sn;
-                    List<SystemClass> systems = new List<SystemClass>();
 
                     if (SQLiteDBClass.globalSystemNotes.ContainsKey(currentSysPos.curSystem.SearchName))
                     {
@@ -817,8 +806,8 @@ namespace EDDiscovery
 
                     int count = GetVisitsCount(name);
 
-                    LogText("  : Vist nr " + count.ToString()  + Environment.NewLine);
-                    System.Diagnostics.Trace.WriteLine("Arrived to system: " + name + " " + count.ToString() + ":th visit.");
+                    LogText("  : Vist nr " + count  + Environment.NewLine);
+                    System.Diagnostics.Trace.WriteLine("Arrived to system: " + name + " " + count + ":th visit.");
 
                     var result = visitedSystems.OrderByDescending(a => a.time).ToList<SystemPosition>();
 
@@ -861,7 +850,7 @@ namespace EDDiscovery
 
                         if (currentSystem == null || previousSystem == null || !currentSystem.HasCoordinate || !previousSystem.HasCoordinate)
                         {
-                            var presetDistance = DistanceAsDouble(textBoxDistanceToNextSystem.Text.Trim(), 45);
+                            var presetDistance = DistanceParser.DistanceAsDouble(textBoxDistanceToNextSystem.Text.Trim(), 45);
                             if (presetDistance.HasValue)
                             {
                                 var distance = new DistanceClass
@@ -977,46 +966,12 @@ namespace EDDiscovery
                 return;
             }
 
-            if (!DistanceAsDouble(value, 45).HasValue) // max jump range is ~42Ly
+            if (!DistanceParser.DistanceAsDouble(value, 45).HasValue) // max jump range is ~42Ly
             {
                 e.Cancel = true;
             }
         }
 
-        /// <summary>
-        /// Parse a distance as a positive double, in the formats "xx", "xx.yy", "xx,yy" or "xxxx,yy".
-        /// </summary>
-        /// <param name="value">Decimal string to be parsed.</param>
-        /// <param name="maximum">Upper limit or null if not required.</param>
-        /// <returns>Parsed value or null on conversion failure.</returns>
-        private static double? DistanceAsDouble(string value, double? maximum = null)
-        {
-            if (value.Length == 0)
-            {
-                return null;
-            }
-
-            if (!new Regex(@"^\d+([.,]\d{1,2})?$").IsMatch(value))
-            {
-                return null;
-            }
-
-            double valueDouble;
-
-            // Allow regions with , as decimal separator to  also use . as decimal separator and vice versa
-            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-            if (!double.TryParse(decimalSeparator == "," ? value.Replace(".", ",") : value.Replace(",", "."), out valueDouble))
-            {
-                return null;
-            }
-
-            if (maximum.HasValue && valueDouble > maximum)
-            {
-                return null;
-            }
-
-            return valueDouble;
-        }
 
         private void textBoxFilter_KeyUp(object sender, KeyEventArgs e)
         {
@@ -1201,7 +1156,7 @@ namespace EDDiscovery
             TextBox tb = sender as TextBox;
             if (tb != null && tb.Text != null)
             {
-                System.Windows.Forms.Clipboard.SetText(tb.Text);
+                Clipboard.SetText(tb.Text);
             }
         }
 
@@ -1308,11 +1263,6 @@ namespace EDDiscovery
             }
 
             this.Cursor = Cursors.Default;
-        }
-
-        private void historyContextMenu_Opening(object sender, CancelEventArgs e)
-        {
-
         }
 
         private void viewOnEDSMToolStripMenuItem_Click(object sender, EventArgs e)

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -588,7 +588,7 @@ namespace EDDiscovery
 
         private void buttonUpdate_Click(object sender, EventArgs e)
         {
-            var dist = DistanceParser.DistanceAsDouble(textBoxDistance.Text.Trim());
+            var dist = DistanceParser.ParseJumpDistance(textBoxDistance.Text.Trim());
 
             if (!dist.HasValue)
                 MessageBox.Show("Distance in wrong format!");
@@ -825,7 +825,7 @@ namespace EDDiscovery
 
                         if (currentSystem == null || previousSystem == null || !currentSystem.HasCoordinate || !previousSystem.HasCoordinate)
                         {
-                            var presetDistance = DistanceParser.DistanceAsDouble(textBoxDistanceToNextSystem.Text.Trim(), MaximumJumpRange);
+                            var presetDistance = DistanceParser.ParseJumpDistance(textBoxDistanceToNextSystem.Text.Trim(), MaximumJumpRange);
                             if (presetDistance.HasValue)
                             {
                                 var distance = new DistanceClass
@@ -940,7 +940,7 @@ namespace EDDiscovery
                 return;
             }
 
-            if (!DistanceParser.DistanceAsDouble(value, MaximumJumpRange).HasValue)
+            if (!DistanceParser.ParseJumpDistance(value, MaximumJumpRange).HasValue)
             {
                 e.Cancel = true;
             }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -16,6 +16,7 @@ namespace EDDiscovery
 {
     public partial class TravelHistoryControl : UserControl
     {
+        private const int MaximumJumpRange = 45;
         private static EDDiscoveryForm _discoveryForm;
         public int defaultMapColour;
         public EDSMSync sync;
@@ -850,7 +851,7 @@ namespace EDDiscovery
 
                         if (currentSystem == null || previousSystem == null || !currentSystem.HasCoordinate || !previousSystem.HasCoordinate)
                         {
-                            var presetDistance = DistanceParser.DistanceAsDouble(textBoxDistanceToNextSystem.Text.Trim(), 45);
+                            var presetDistance = DistanceParser.DistanceAsDouble(textBoxDistanceToNextSystem.Text.Trim(), MaximumJumpRange);
                             if (presetDistance.HasValue)
                             {
                                 var distance = new DistanceClass
@@ -966,7 +967,7 @@ namespace EDDiscovery
                 return;
             }
 
-            if (!DistanceParser.DistanceAsDouble(value, 45).HasValue) // max jump range is ~42Ly
+            if (!DistanceParser.DistanceAsDouble(value, MaximumJumpRange).HasValue) // max jump range is ~42Ly
             {
                 e.Cancel = true;
             }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -17,8 +17,20 @@ namespace EDDiscovery
     public partial class TravelHistoryControl : UserControl
     {
         private const int MaximumJumpRange = 45; // max jump range is ~42Ly
-        private const int NoteColumnIndex = 3;
-        private const int DistanceColumnIndex = 2;
+
+        public class TravelHistoryColumns
+        {
+            public const int Time = 0;
+            public const int SystemName = 1;
+            public const int Distance = 2;
+            public const int Note = 3;
+            public const int Map = 4;
+        }
+
+        public class ClosestSystemsColumns
+        {
+            public const int SystemName = 0;
+        }
 
         private const int DefaultTravelHistoryFilterIndex = 4;
         private const string SingleCoordinateFormat = "#.#####";
@@ -177,7 +189,7 @@ namespace EDDiscovery
 
             if (dataGridViewTravel.Rows.Count > 0)
             {
-                ShowSystemInformation((SystemPosition)(dataGridViewTravel.Rows[0].Cells[1].Tag));
+                ShowSystemInformation((SystemPosition)(dataGridViewTravel.Rows[0].Cells[TravelHistoryColumns.SystemName].Tag));
             }
 //            System.Diagnostics.Trace.WriteLine("SW3: " + (sw1.ElapsedMilliseconds / 1000.0).ToString("0.000"));
             sw1.Stop();
@@ -269,13 +281,13 @@ namespace EDDiscovery
                 rownr = dataGridViewTravel.Rows.Count - 1;
             }
 
-            var cell = dataGridViewTravel.Rows[rownr].Cells[1];
+            var cell = dataGridViewTravel.Rows[rownr].Cells[TravelHistoryColumns.SystemName];
 
             cell.Tag = item;
 
             dataGridViewTravel.Rows[rownr].DefaultCellStyle.ForeColor = (sys1.HasCoordinate) ? _discoveryForm.theme.VisitedSystemColor : _discoveryForm.theme.NonVisitedSystemColor;
 
-            cell = dataGridViewTravel.Rows[rownr].Cells[4];
+            cell = dataGridViewTravel.Rows[rownr].Cells[TravelHistoryColumns.Map];
             cell.Style.ForeColor = (item.vs == null) ? Color.FromArgb(defaultMapColour) : Color.FromArgb(item.vs.MapColour);
         }
 
@@ -511,11 +523,11 @@ namespace EDDiscovery
             DataGridViewSorter.DataGridSort(dataGridViewTravel, e.ColumnIndex);
         }
 
-        private void dataGridView1_CellContentDoubleClick(object sender, DataGridViewCellEventArgs e)
+        private void dataGridViewTravel_CellContentDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
             if (e.RowIndex >= 0)
             {
-                ShowSystemInformation((SystemPosition)(dataGridViewTravel.Rows[e.RowIndex].Cells[1].Tag));
+                ShowSystemInformation((SystemPosition)(dataGridViewTravel.Rows[e.RowIndex].Cells[TravelHistoryColumns.SystemName].Tag));
             }
 
         }
@@ -539,7 +551,7 @@ namespace EDDiscovery
             {
                 do
                 {
-                    selectedSys = (SystemPosition)dataGridViewTravel.Rows[selectedLine].Cells[1].Tag;
+                    selectedSys = (SystemPosition)dataGridViewTravel.Rows[selectedLine].Cells[TravelHistoryColumns.SystemName].Tag;
                     selectedLine += 1;
                 } while (!selectedSys.curSystem.HasCoordinate && selectedLine < dataGridViewTravel.Rows.Count);
             }
@@ -553,19 +565,19 @@ namespace EDDiscovery
                         _discoveryForm.settings.MapZoom);
         }
 
-        private void dataGridView1_CellClick(object sender, DataGridViewCellEventArgs e)
+        private void dataGridViewTravel_CellClick(object sender, DataGridViewCellEventArgs e)
         {
             if (e.RowIndex >= 0)
             {
-                ShowSystemInformation((SystemPosition)(dataGridViewTravel.Rows[e.RowIndex].Cells[1].Tag));
+                ShowSystemInformation((SystemPosition)(dataGridViewTravel.Rows[e.RowIndex].Cells[TravelHistoryColumns.SystemName].Tag));
 
-                if (e.ColumnIndex == NoteColumnIndex)
+                if (e.ColumnIndex == TravelHistoryColumns.Note)
                 {
                     richTextBoxNote.TextBox.Select(richTextBoxNote.Text.Length, 0);     // move caret to end and focus.
                     richTextBoxNote.TextBox.ScrollToCaret();
                     richTextBoxNote.TextBox.Focus();
                 }
-                else  if (e.ColumnIndex == DistanceColumnIndex && textBoxDistance.Enabled == true )       // distance column and on..
+                else  if (e.ColumnIndex == TravelHistoryColumns.Distance && textBoxDistance.Enabled == true )       // distance column and on..
                 {
                     textBoxDistance.Select(textBoxDistance.Text.Length, 0);     // move caret to end (in case something is there) and focus
                     textBoxDistance.Focus();
@@ -595,7 +607,7 @@ namespace EDDiscovery
                 SQLiteDBClass.AddDistanceToCache(distance);
 
                 if (dataGridViewTravel.SelectedCells.Count > 0)          // if we have selected (we should!)
-                    dataGridViewTravel.Rows[dataGridViewTravel.SelectedCells[0].OwningRow.Index].Cells[DistanceColumnIndex].Value = textBoxDistance.Text.Trim();
+                    dataGridViewTravel.Rows[dataGridViewTravel.SelectedCells[0].OwningRow.Index].Cells[TravelHistoryColumns.Distance].Value = textBoxDistance.Text.Trim();
 
             }
         }
@@ -609,7 +621,7 @@ namespace EDDiscovery
         private void richTextBoxNote_TextChanged(object sender, EventArgs e)
         {
             if (dataGridViewTravel.SelectedCells.Count > 0)          // if we have selected (we should!)
-                dataGridViewTravel.Rows[dataGridViewTravel.SelectedCells[0].OwningRow.Index].Cells[NoteColumnIndex].Value = richTextBoxNote.Text;     // keep the grid up to date to make it seem more interactive
+                dataGridViewTravel.Rows[dataGridViewTravel.SelectedCells[0].OwningRow.Index].Cells[TravelHistoryColumns.Note].Value = richTextBoxNote.Text;     // keep the grid up to date to make it seem more interactive
         }
 
         private void StoreSystemNote()
@@ -661,7 +673,7 @@ namespace EDDiscovery
                     currentSysPos.curSystem.Note = txt;
 
                     if (dataGridViewTravel.SelectedCells.Count > 0)          // if we have selected (we should!)
-                        dataGridViewTravel.Rows[dataGridViewTravel.SelectedCells[0].OwningRow.Index].Cells[NoteColumnIndex].Value = txt;
+                        dataGridViewTravel.Rows[dataGridViewTravel.SelectedCells[0].OwningRow.Index].Cells[TravelHistoryColumns.Note].Value = txt;
 
                     if (edsm.commanderName == null || edsm.apiKey == null)
                         return;
@@ -905,15 +917,14 @@ namespace EDDiscovery
             }
         }
 
-		public ISystem CurrentSystem
+        public ISystem CurrentSystem
         {
             get
             {
                 if (dataGridViewTravel == null || dataGridViewTravel.CurrentRow == null) return null;
-                return ((SystemPosition)dataGridViewTravel.CurrentRow.Cells[1].Tag).curSystem;
+                return ((SystemPosition)dataGridViewTravel.CurrentRow.Cells[TravelHistoryColumns.SystemName].Tag).curSystem;
             }
         }
-
 
         public string GetCommanderName()
         {
@@ -974,11 +985,6 @@ namespace EDDiscovery
             dataGridViewTravel.ResumeLayout();
         }
 
-        private void textBoxFilter_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void starMapColourToolStripMenuItem_Click(object sender, EventArgs e)
         {
             IEnumerable<DataGridViewRow> selectedRows = dataGridViewTravel.SelectedCells.Cast<DataGridViewCell>()
@@ -987,7 +993,7 @@ namespace EDDiscovery
             ColorDialog mapColorDialog = new ColorDialog();
             mapColorDialog.AllowFullOpen = true;
             mapColorDialog.FullOpen = true;
-            mapColorDialog.Color = selectedRows.First().Cells[4].Style.ForeColor;
+            mapColorDialog.Color = selectedRows.First().Cells[TravelHistoryColumns.Map].Style.ForeColor;
 
             if (mapColorDialog.ShowDialog(this) == DialogResult.OK)
             {
@@ -995,11 +1001,11 @@ namespace EDDiscovery
                 string sysName = "";
                 foreach(DataGridViewRow r in selectedRows)
                 {
-                    r.Cells[4].Style.ForeColor = mapColorDialog.Color;
-                    sysName = r.Cells[1].Value.ToString();
+                    r.Cells[TravelHistoryColumns.Map].Style.ForeColor = mapColorDialog.Color;
+                    sysName = r.Cells[TravelHistoryColumns.SystemName].Value.ToString();
 
                     SystemPosition sp = null;
-                    sp = (SystemPosition)r.Cells[1].Tag;
+                    sp = (SystemPosition)r.Cells[TravelHistoryColumns.SystemName].Tag;
                     if (sp == null)
                         sp = visitedSystems.First(s => s.Name.ToUpperInvariant() == sysName.ToUpperInvariant());
                     if (sp.vs != null)
@@ -1015,104 +1021,83 @@ namespace EDDiscovery
         private void hideSystemToolStripMenuItem_Click(object sender, EventArgs e)
         {
             IEnumerable<DataGridViewRow> selectedRows = dataGridViewTravel.SelectedCells.Cast<DataGridViewCell>()
-                                                                  .Select(cell => cell.OwningRow)
-                                                                  .Distinct();
+                .Select(cell => cell.OwningRow)
+                .Distinct();
 
-
-
-
+            this.Cursor = Cursors.WaitCursor;
+            string sysName = "";
+            foreach (DataGridViewRow r in selectedRows)
             {
-                this.Cursor = Cursors.WaitCursor;
-                string sysName = "";
-                foreach (DataGridViewRow r in selectedRows)
+                SystemPosition sp = null;
+
+                sp = (SystemPosition) r.Cells[TravelHistoryColumns.SystemName].Tag;
+
+                if (sp != null && sp.vs != null)
                 {
-                    sysName = r.Cells[1].Value.ToString();
-                    SystemPosition sp=null;
-
-                    sp = (SystemPosition)r.Cells[1].Tag;
-
-
-
-                    if (sp!= null && sp.vs != null)
-                    {
-                        sp.vs.Commander = -1;
-                        sp.Update();
-                    }
+                    sp.vs.Commander = -1;
+                    sp.Update();
                 }
-                // Remove rows
-                if (selectedRows.Count<DataGridViewRow>() == dataGridViewTravel.Rows.Count)
-                {
-                    dataGridViewTravel.Rows.Clear();
-                }
-                else
-                {
-                    foreach (DataGridViewRow row in selectedRows.ToList<DataGridViewRow>())
-                    {
-                        dataGridViewTravel.Rows.Remove(row);
-                    }
-                }
-                this.Cursor = Cursors.Default;
             }
+            // Remove rows
+            if (selectedRows.Count<DataGridViewRow>() == dataGridViewTravel.Rows.Count)
+            {
+                dataGridViewTravel.Rows.Clear();
+            }
+            else
+            {
+                foreach (DataGridViewRow row in selectedRows.ToList<DataGridViewRow>())
+                {
+                    dataGridViewTravel.Rows.Remove(row);
+                }
+            }
+            this.Cursor = Cursors.Default;
         }
 
         private void moveToAnotherCommanderToolStripMenuItem_Click(object sender, EventArgs e)
         {
             IEnumerable<DataGridViewRow> selectedRows = dataGridViewTravel.SelectedCells.Cast<DataGridViewCell>()
-                                                                        .Select(cell => cell.OwningRow)
-                                                                        .Distinct();
-
-
+                .Select(cell => cell.OwningRow)
+                .Distinct();
 
             List<SystemPosition> listsyspos = new List<SystemPosition>();
 
+            this.Cursor = Cursors.WaitCursor;
+            string sysName = "";
+            foreach (DataGridViewRow r in selectedRows)
             {
-                this.Cursor = Cursors.WaitCursor;
-                string sysName = "";
-                foreach (DataGridViewRow r in selectedRows)
+                SystemPosition sp = null;
+
+                sp = (SystemPosition) r.Cells[TravelHistoryColumns.SystemName].Tag;
+                if (sp != null && sp.vs != null)
                 {
-                    sysName = r.Cells[1].Value.ToString();
-                    SystemPosition sp = null;
+                    listsyspos.Add(sp);
+                }
+            }
 
-                    sp = (SystemPosition)r.Cells[1].Tag;
-                    if (sp != null && sp.vs != null)
-                    {
-                        listsyspos.Add(sp);
+            MoveToCommander movefrm = new MoveToCommander();
 
-                    }
+            movefrm.Init(listsyspos.Count > 1);
+
+            DialogResult red = movefrm.ShowDialog();
+            if (red == DialogResult.OK)
+            {
+                foreach (SystemPosition sp in listsyspos)
+                {
+                    sp.vs.Commander = movefrm.selectedCommander.Nr;
+                    sp.Update();
                 }
 
-                MoveToCommander movefrm = new MoveToCommander();
-
-                movefrm.Init(listsyspos.Count>1);
-
-                DialogResult red = movefrm.ShowDialog();
-                if (red == DialogResult.OK)
+                foreach (DataGridViewRow row in selectedRows)
                 {
-
-                        foreach (SystemPosition sp in listsyspos)
-                        {
-                            sp.vs.Commander = movefrm.selectedCommander.Nr;
-                            sp.Update();
-                   
-                        }
-
-                        foreach (DataGridViewRow row in selectedRows)
-                        {
-                            dataGridViewTravel.Rows.Remove(row);
-                        }
-                        this.Cursor = Cursors.Default;
-
-
-
+                    dataGridViewTravel.Rows.Remove(row);
                 }
-
-
-
-
                 this.Cursor = Cursors.Default;
             }
+
+
+            this.Cursor = Cursors.Default;
         }
-        
+
         private void textBoxPrevSystem_Enter(object sender, EventArgs e)
         {
             /* Automatically copy the contents to the clipboard whenever this control is activated */
@@ -1131,11 +1116,6 @@ namespace EDDiscovery
         private void checkBoxEDSMSyncFrom_CheckedChanged(object sender, EventArgs e)
         {
             EDSMSyncFrom = checkBoxEDSMSyncFrom.Checked;
-        }
-
-        private void dataGridView2_CellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
-
         }
 
         private void button2DMap_Click(object sender, EventArgs e)
@@ -1158,7 +1138,7 @@ namespace EDDiscovery
             string sysName = "";
             foreach (DataGridViewRow r in selectedRows)
             {
-                sysName = r.Cells[0].Value.ToString();
+                sysName = r.Cells[ClosestSystemsColumns.SystemName].Value.ToString();
 
                 tctrl.AddSystemToDataGridViewDistances(sysName);
             }
@@ -1179,8 +1159,7 @@ namespace EDDiscovery
             string sysName = "";
             foreach (DataGridViewRow r in selectedRows)
             {
-                sysName = r.Cells[1].Value.ToString();
-
+                sysName = r.Cells[TravelHistoryColumns.SystemName].Value.ToString();
                 tctrl.AddWantedSystem(sysName);
             }
 
@@ -1200,7 +1179,7 @@ namespace EDDiscovery
             string sysName = "";
             foreach (DataGridViewRow r in selectedRows)
             {
-                sysName = r.Cells[1].Value.ToString();
+                sysName = r.Cells[TravelHistoryColumns.SystemName].Value.ToString();
                 tctrl.AddSystemToDataGridViewDistances(sysName);
                 tctrl.AddWantedSystem(sysName);
             }
@@ -1221,7 +1200,7 @@ namespace EDDiscovery
             string sysName = "";
             foreach (DataGridViewRow r in selectedRows)
             {
-                sysName = r.Cells[1].Value.ToString();
+                sysName = r.Cells[TravelHistoryColumns.SystemName].Value.ToString();
                 tctrl.AddSystemToDataGridViewDistances(sysName);
             }
 
@@ -1235,7 +1214,7 @@ namespace EDDiscovery
                                                                         .Distinct()
                                                                         .OrderBy(cell => cell.Index);
             this.Cursor = Cursors.WaitCursor;
-            string sysName = selectedRows.First<DataGridViewRow>().Cells[1].Value.ToString();
+            string sysName = selectedRows.First<DataGridViewRow>().Cells[TravelHistoryColumns.SystemName].Value.ToString();
             EDSMClass edsm = new EDSMClass();
             if (!edsm.ShowSystemInEDSM(sysName)) LogTextHighlight("System could not be found - has not been synched or EDSM is unavailable" + Environment.NewLine);
 
@@ -1250,7 +1229,7 @@ namespace EDDiscovery
                                                                         .OrderBy(cell => cell.Index);
 
             this.Cursor = Cursors.WaitCursor;
-            string sysName = selectedRows.First<DataGridViewRow>().Cells[0].Value.ToString();
+            string sysName = selectedRows.First<DataGridViewRow>().Cells[ClosestSystemsColumns.SystemName].Value.ToString();
             EDSMClass edsm = new EDSMClass();
             if (!edsm.ShowSystemInEDSM(sysName)) LogTextHighlight("System could not be found - has not been synched or EDSM is unavailable" + Environment.NewLine);
 
@@ -1267,11 +1246,6 @@ namespace EDDiscovery
                 //if (currentSysPos.curSystem.id_eddb > 0)
                 //Process.Start("http://ross.eddb.io/system/update/" + currentSysPos.curSystem.id_eddb.ToString());
             }
-        }
-
-        private void dataGridViewTravel_CellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
-
         }
     }
 

--- a/EDDiscovery/TravelHistoryFilter.cs
+++ b/EDDiscovery/TravelHistoryFilter.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EDDiscovery
+{
+    public class TravelHistoryFilter
+    {
+        public TimeSpan? MaximumDataAge { get; }
+        public int? MaximumNumberOfItems { get; }
+        public string Label { get; }
+
+        public static TravelHistoryFilter NoFilter { get; } = new TravelHistoryFilter();
+
+        private TravelHistoryFilter(TimeSpan maximumDataAge, string label)
+        {
+            MaximumDataAge = maximumDataAge;
+            Label = label;
+        }
+
+        private TravelHistoryFilter(int maximumNumberOfItems, string label)
+        {
+            MaximumNumberOfItems = maximumNumberOfItems;
+            Label = label;
+        }
+
+        private TravelHistoryFilter()
+        {
+            Label = "All";
+        }
+
+        public static TravelHistoryFilter FromHours(int hours)
+        {
+            return new TravelHistoryFilter(TimeSpan.FromHours(hours), $"{hours} hours");
+        }
+
+        public static TravelHistoryFilter FromDays(int days)
+        {
+            return new TravelHistoryFilter(TimeSpan.FromDays(days), $"{days} days");
+        }
+
+        public static TravelHistoryFilter FromWeeks(int weeks)
+        {
+            return new TravelHistoryFilter(TimeSpan.FromDays(7 * weeks), weeks == 1 ? "week" : $"{weeks} weeks");
+        }
+
+        public static TravelHistoryFilter LastMonth()
+        {
+            return new TravelHistoryFilter(TimeSpan.FromDays(30), "month");
+        }
+
+        public static TravelHistoryFilter Last(int number)
+        {
+            return new TravelHistoryFilter(number, $"last {number}");
+        }
+
+        public List<SystemPosition> Filter(List<SystemPosition> input)
+        {
+            if (MaximumNumberOfItems.HasValue)
+            {
+                return input.OrderByDescending(s => s.time).Take(MaximumNumberOfItems.Value).ToList();
+            }
+            else if(MaximumDataAge.HasValue)
+            {
+                var oldestData = DateTime.Now.Subtract(MaximumDataAge.Value);
+                return (from systems in input where systems.time > oldestData orderby systems.time descending select systems).ToList();
+            }
+            else
+            {
+                return input;
+            }
+        }
+
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+}

--- a/EDDiscovery/TravelHistoryFilter.cs
+++ b/EDDiscovery/TravelHistoryFilter.cs
@@ -70,10 +70,5 @@ namespace EDDiscovery
                 return input;
             }
         }
-
-        public override string ToString()
-        {
-            return Label;
-        }
     }
 }

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -165,19 +165,14 @@ namespace EDDiscovery
                 if (e.ColumnIndex == 1)
                 {
                     var value = e.FormattedValue.ToString().Trim();
-                    if (Application.CurrentCulture.NumberFormat.CurrencyDecimalSeparator.Equals(","))  // To make it easier for  regions that uses , as deciaml separator. .   allow them to use . also
-                        value = value.Replace(".", ",");
-
                     if (value == "")
                     {
                         dataGridViewDistances.Rows[e.RowIndex].ErrorText = null;
                         return;
                     }
 
-                    //var regex = new Regex(@"^((\d{1,2}[,.]\d{3})|(\d{1,5}))([,.]\d{1,2})?$");
-                    //e.Cancel = !regex.Match(e.FormattedValue.ToString()).Success;
-                    double dummy;
-                    if (double.TryParse(value, out dummy))
+                    var parsed = DistanceParser.ParseInterstellarDistance(value);
+                    if (parsed.HasValue)
                     {
                         dataGridViewDistances.Rows[e.RowIndex].ErrorText = null;
                     }
@@ -209,7 +204,7 @@ namespace EDDiscovery
             {
                 if (!edsm.IsKnownSystem(systemName))
                 {
-                    LogTextHighlight("Only systems with coordinates or already known to EDSM can be added" + Environment.NewLine);                    
+                    LogTextHighlight("Only systems with coordinates or already known to EDSM can be added" + Environment.NewLine);
                 }
                 else
                 {
@@ -288,13 +283,10 @@ namespace EDDiscovery
                 if (dataGridViewDistances[1, e.RowIndex].Value != null && !string.IsNullOrEmpty(dataGridViewDistances[1, e.RowIndex].Value.ToString().Trim()))
                 {
                     var value = dataGridViewDistances[1, e.RowIndex].Value.ToString().Trim();
-                    if (Application.CurrentCulture.NumberFormat.CurrencyDecimalSeparator.Equals(","))  // To make it easier for  regions that uses , as deciaml separator. .   allow them to use . also
-                        value = value.Replace(".", ",");
-
-                    double dist;
-                    if (double.TryParse(value, out dist))
+                    var parsedDistance = DistanceParser.ParseInterstellarDistance(value);
+                    if (parsedDistance.HasValue)
                     {
-                        dataGridViewDistances[1, e.RowIndex].Value = dist.ToString("F2");
+                        dataGridViewDistances[1, e.RowIndex].Value = parsedDistance.Value.ToString("F2");
                         // trigger trilateration calculation
                         RunTrilateration();
                     }
@@ -345,12 +337,10 @@ namespace EDDiscovery
                     if (system != null && system.HasCoordinate)
                     {
                         var value = distanceCell.Value.ToString().Trim();
-                        if (Application.CurrentCulture.NumberFormat.CurrencyDecimalSeparator.Equals(","))  // To make it easier for  regions that uses , as deciaml separator. .   allow them to use . also
-                            value = value.Replace(".", ",");
-                        double distance;
-                        if (double.TryParse(value, out distance))
+                        var parsedDistance = DistanceParser.ParseInterstellarDistance(value);
+                        if (parsedDistance.HasValue)
                         {
-                            var entry = new Trilateration.Entry(system.x, system.y, system.z, distance);
+                            var entry = new Trilateration.Entry(system.x, system.y, system.z, parsedDistance.Value);
 
                             systemsEntries.Add(system, entry);
                         }
@@ -866,16 +856,14 @@ namespace EDDiscovery
                         var system = systemCell.Value.ToString();
 
                         var value = distanceCell.Value.ToString().Trim();
-                        if (Application.CurrentCulture.NumberFormat.CurrencyDecimalSeparator.Equals(","))  // To make it easier for  regions that uses , as deciaml separator. .   allow them to use . also
-                            value = value.Replace(".", ",");
+                        var parsedDistance = DistanceParser.ParseInterstellarDistance(value);
 
-                        double distance;
-                        if (double.TryParse(value, out distance))
+                        if (parsedDistance.HasValue)
                         {
                             // can over-ride drop down now if it's a real system so you could add duplicates if you wanted (even once I've figured out issue #81 which makes it easy if not likely...)
                             if (!distances.Keys.Contains(system))
                             {
-                                distances.Add(system, distance);
+                                distances.Add(system, parsedDistance.Value);
                             }
                         }
                     }

--- a/EDDiscoveryTests/DistanceParserTests.cs
+++ b/EDDiscoveryTests/DistanceParserTests.cs
@@ -1,8 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using EDDiscovery;
 using NFluent;
 
@@ -38,7 +34,25 @@ namespace EDDiscoveryTests
         [TestMethod]
         public void Distance_greater_than_the_maximum_allowed_value_is_not_parsed()
         {
-            Check.That(DistanceParser.DistanceAsDouble("10", 9)).IsNull();
+            Check.That(DistanceParser.DistanceAsDouble("15", 14)).IsNull();
+        }
+
+        [TestMethod]
+        public void Distance_equal_to_the_maximum_allowed_value_is_parsed_correctly()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("15", 15)).IsEqualTo(15);
+        }
+
+        [TestMethod]
+        public void Negative_distance_is_not_parsed()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("-15")).IsNull();
+        }
+
+        [TestMethod]
+        public void Distance_with_more_than_2_decimals_is_not_parsed()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("15.000")).IsNull();
         }
 
         [TestMethod]

--- a/EDDiscoveryTests/DistanceParserTests.cs
+++ b/EDDiscoveryTests/DistanceParserTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EDDiscovery;
+using NFluent;
+
+namespace EDDiscoveryTests
+{
+    [TestClass]
+    public class DistanceParserTests
+    {
+        [TestMethod]
+        public void Empty_value_is_not_parsed()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("")).IsNull();
+        }
+
+        [TestMethod]
+        public void Distance_without_decimals_is_parsed_correctly()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("15")).IsEqualTo(15);
+        }
+
+        [TestMethod]
+        public void Distance_with_point_as_decimal_separator_is_parsed_correctly()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("15.5")).IsEqualTo(15.5);
+        }
+
+        [TestMethod]
+        public void Distance_with_comma_as_decimal_separator_is_parsed_correctly()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("15,5")).IsEqualTo(15.5);
+        }
+
+        [TestMethod]
+        public void Distance_greater_than_the_maximum_allowed_value_is_not_parsed()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("10", 9)).IsNull();
+        }
+
+        [TestMethod]
+        public void Distance_that_does_not_match_any_expected_format_is_not_parsed()
+        {
+            Check.That(DistanceParser.DistanceAsDouble("not a distance")).IsNull();
+        }
+    }
+}

--- a/EDDiscoveryTests/DistanceParserTests.cs
+++ b/EDDiscoveryTests/DistanceParserTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EDDiscovery;
 using NFluent;
 
@@ -7,58 +9,162 @@ namespace EDDiscoveryTests
     [TestClass]
     public class DistanceParserTests
     {
-        [TestMethod]
-        public void Empty_value_is_not_parsed()
+        private static readonly CultureInfo frenchCulture = CultureInfo.GetCultureInfo("fr-FR");
+        private static readonly CultureInfo americanCulture = CultureInfo.GetCultureInfo("en-US");
+
+        public static void TestWithCulture(CultureInfo culture, Action test)
         {
-            Check.That(DistanceParser.DistanceAsDouble("")).IsNull();
+            var originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            try
+            {
+                test();
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         [TestMethod]
-        public void Distance_without_decimals_is_parsed_correctly()
+        public void Empty_jump_distance_is_not_parsed()
         {
-            Check.That(DistanceParser.DistanceAsDouble("15")).IsEqualTo(15);
+            Check.That(DistanceParser.ParseJumpDistance("")).IsNull();
         }
 
         [TestMethod]
-        public void Distance_with_point_as_decimal_separator_is_parsed_correctly()
+        public void Jump_distance_without_decimals_is_parsed_correctly()
         {
-            Check.That(DistanceParser.DistanceAsDouble("15.5")).IsEqualTo(15.5);
+            Check.That(DistanceParser.ParseJumpDistance("15")).IsEqualTo(15);
+        }
+
+        public void Jump_distance_with_point_as_decimal_separator_is_parsed_correctly()
+        {
+            Check.That(DistanceParser.ParseJumpDistance("15.5")).IsEqualTo(15.5);
         }
 
         [TestMethod]
-        public void Distance_with_comma_as_decimal_separator_is_parsed_correctly()
+        public void Jump_distance_with_point_as_decimal_separator_is_parsed_correctly_with_french_culture()
         {
-            Check.That(DistanceParser.DistanceAsDouble("15,5")).IsEqualTo(15.5);
+            TestWithCulture(frenchCulture, Jump_distance_with_point_as_decimal_separator_is_parsed_correctly);
         }
 
         [TestMethod]
-        public void Distance_greater_than_the_maximum_allowed_value_is_not_parsed()
+        public void Jump_distance_with_point_as_decimal_separator_is_parsed_correctly_with_american_culture()
         {
-            Check.That(DistanceParser.DistanceAsDouble("15", 14)).IsNull();
+            TestWithCulture(americanCulture, Jump_distance_with_point_as_decimal_separator_is_parsed_correctly);
+        }
+
+        public void Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly()
+        {
+            Check.That(DistanceParser.ParseJumpDistance("15,5")).IsEqualTo(15.5);
         }
 
         [TestMethod]
-        public void Distance_equal_to_the_maximum_allowed_value_is_parsed_correctly()
+        public void Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly_with_french_culture()
         {
-            Check.That(DistanceParser.DistanceAsDouble("15", 15)).IsEqualTo(15);
+            TestWithCulture(frenchCulture, Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly);
         }
 
         [TestMethod]
-        public void Negative_distance_is_not_parsed()
+        public void Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly_with_american_culture()
         {
-            Check.That(DistanceParser.DistanceAsDouble("-15")).IsNull();
+            TestWithCulture(americanCulture, Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly);
         }
 
         [TestMethod]
-        public void Distance_with_more_than_2_decimals_is_not_parsed()
+        public void Jump_distance_greater_than_the_maximum_allowed_value_is_not_parsed()
         {
-            Check.That(DistanceParser.DistanceAsDouble("15.000")).IsNull();
+            Check.That(DistanceParser.ParseJumpDistance("15", 14)).IsNull();
         }
 
         [TestMethod]
-        public void Distance_that_does_not_match_any_expected_format_is_not_parsed()
+        public void Jump_distance_equal_to_the_maximum_allowed_value_is_parsed_correctly()
         {
-            Check.That(DistanceParser.DistanceAsDouble("not a distance")).IsNull();
+            Check.That(DistanceParser.ParseJumpDistance("15", 15)).IsEqualTo(15);
+        }
+
+        [TestMethod]
+        public void Negative_jump_distance_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseJumpDistance("-15")).IsNull();
+        }
+
+        [TestMethod]
+        public void Jump_distance_with_more_than_2_decimals_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseJumpDistance("15.000")).IsNull();
+        }
+
+        [TestMethod]
+        public void Jump_distance_that_does_not_match_any_expected_format_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseJumpDistance("not a distance")).IsNull();
+        }
+
+        [TestMethod]
+        public void Interstellar_distance_without_any_decimal_separator_can_be_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance("12345")).IsEqualTo(12345);
+        }
+
+        public void Interstellar_distance_with_dot_decimal_separator_can_be_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance("12345.6789")).IsEqualTo(12345.6789);
+        }
+
+        [TestMethod]
+        public void Interstellar_distance_with_dot_decimal_separator_can_be_parsed_with_french_culture()
+        {
+            TestWithCulture(frenchCulture, Interstellar_distance_with_dot_decimal_separator_can_be_parsed);
+        }
+
+        [TestMethod]
+        public void Interstellar_distance_with_dot_decimal_separator_can_be_parsed_with_american_culture()
+        {
+            TestWithCulture(americanCulture, Interstellar_distance_with_dot_decimal_separator_can_be_parsed);
+        }
+
+        [TestMethod]
+        public void Negative_interstellar_distance_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance("-12345")).IsEqualTo(null);
+        }
+
+        public void Interstellar_distance_with_comma_decimal_separator_can_be_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance("12345,6789")).IsEqualTo(12345.6789);
+        }
+
+        [TestMethod]
+        public void Interstellar_distance_with_comma_decimal_separator_can_be_parsed_with_french_culture()
+        {
+            TestWithCulture(frenchCulture, Interstellar_distance_with_comma_decimal_separator_can_be_parsed);
+        }
+
+        [TestMethod]
+        public void Interstellar_distance_with_comma_decimal_separator_can_be_parsed_with_american_culture()
+        {
+            TestWithCulture(americanCulture, Interstellar_distance_with_comma_decimal_separator_can_be_parsed);
+        }
+
+
+        [TestMethod]
+        public void Invalid_interstellar_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance("not a distance")).IsNull();
+        }
+
+        [TestMethod]
+        public void Empty_interstellar_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance("")).IsNull();
+        }
+
+        [TestMethod]
+        public void Null_interstellar_is_not_parsed()
+        {
+            Check.That(DistanceParser.ParseInterstellarDistance(null)).IsNull();
         }
     }
 }

--- a/EDDiscoveryTests/EDDiscoveryTests.csproj
+++ b/EDDiscoveryTests/EDDiscoveryTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="3DMap\DatasetBuilderTests.cs" />
     <Compile Include="DistanceParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TravelHistoryFilterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EDDiscovery\EDDiscovery.csproj">

--- a/EDDiscoveryTests/EDDiscoveryTests.csproj
+++ b/EDDiscoveryTests/EDDiscoveryTests.csproj
@@ -75,6 +75,10 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
+      <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4" />
     <Reference Include="System" />
     <Reference Include="System.Data.SQLite, Version=1.0.99.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
@@ -101,6 +105,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="3DMap\DatasetBuilderTests.cs" />
+    <Compile Include="DistanceParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using EDDiscovery;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NFluent;
+
+namespace EDDiscoveryTests
+{
+    [TestClass]
+    public class TravelHistoryFilterTests
+    {
+        [TestMethod]
+        public void No_filter_does_not_filter_anything()
+        {
+            var veryOldData = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(500000))};
+            var input = new List<SystemPosition> { veryOldData };
+
+            Check.That(TravelHistoryFilter.NoFilter.Filter(input)).ContainsExactly(veryOldData);
+        }
+
+        [TestMethod]
+        public void Data_age_filter_removes_data_older_than_the_limit_and_keeps_data_more_recent_than_the_limit()
+        {
+            var now = new SystemPosition { time = DateTime.Now };
+            var fourDaysAgo = new SystemPosition {time = DateTime.Now.Subtract(TimeSpan.FromDays(4))};
+            var input = new List<SystemPosition> { fourDaysAgo, now };
+
+            Check.That(new TravelHistoryFilter(TimeSpan.FromDays(2)).Filter(input)).ContainsExactly(now);
+        }
+
+        [TestMethod]
+        public void Last_2_items_filter_returns_the_2_most_recent_items_sorted_by_most_recent_and_removes_the_older_items()
+        {
+            var twentyDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(20)) };
+            var tenDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(10)) };
+            var thirtyDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(30)) };
+            var input = new List<SystemPosition> { twentyDaysAgo, tenDaysAgo, thirtyDaysAgo };
+
+            Check.That(new TravelHistoryFilter(2).Filter(input)).ContainsExactly(tenDaysAgo, twentyDaysAgo);
+        }
+    }
+}

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -25,7 +25,7 @@ namespace EDDiscoveryTests
             var fourDaysAgo = new SystemPosition {time = DateTime.Now.Subtract(TimeSpan.FromDays(4))};
             var input = new List<SystemPosition> { fourDaysAgo, now };
 
-            Check.That(new TravelHistoryFilter(TimeSpan.FromDays(2)).Filter(input)).ContainsExactly(now);
+            Check.That(TravelHistoryFilter.FromDays(2).Filter(input)).ContainsExactly(now);
         }
 
         [TestMethod]
@@ -36,7 +36,49 @@ namespace EDDiscoveryTests
             var thirtyDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(30)) };
             var input = new List<SystemPosition> { twentyDaysAgo, tenDaysAgo, thirtyDaysAgo };
 
-            Check.That(new TravelHistoryFilter(2).Filter(input)).ContainsExactly(tenDaysAgo, twentyDaysAgo);
+            Check.That(TravelHistoryFilter.Last(2).Filter(input)).ContainsExactly(tenDaysAgo, twentyDaysAgo);
+        }
+
+        [TestMethod]
+        public void No_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.NoFilter.Label).IsEqualTo("All");
+        }
+
+        [TestMethod]
+        public void last_20_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.Last(20).Label).IsEqualTo("last 20");
+        }
+
+        [TestMethod]
+        public void Last_6_hours_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.FromHours(6).Label).IsEqualTo("6 hours");
+        }
+
+        [TestMethod]
+        public void Last_days_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.FromDays(3).Label).IsEqualTo("3 days");
+        }
+
+        [TestMethod]
+        public void Last_week_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.FromWeeks(1).Label).IsEqualTo("week");
+        }
+
+        [TestMethod]
+        public void Last_3_weeks_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.FromWeeks(3).Label).IsEqualTo("3 weeks");
+        }
+
+        [TestMethod]
+        public void Last_month_filter_has_correct_label()
+        {
+            Check.That(TravelHistoryFilter.LastMonth().Label).IsEqualTo("month");
         }
     }
 }

--- a/EDDiscoveryTests/packages.config
+++ b/EDDiscoveryTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NFluent" version="1.3.1.0" targetFramework="net40" />
   <package id="OpenTK" version="1.1.1589.5942" targetFramework="net40" />
   <package id="System.Data.SQLite.Core" version="1.0.99.0" targetFramework="net40" />
   <package id="System.Data.SQLite.Linq" version="1.0.99.0" targetFramework="net40" />


### PR DESCRIPTION
Hey guys,

I'm getting acquainted with the codebase so I took the opportunity to extract a few things and add some unit tests for them, introduce constants to get rid of magic numbers, remove unused event handlers etc.

I also added a dependency on NFluent to the unit tests project. It's a cool library that provides more expressive assertions and nicer assertion failure messages.

I realize reading the diff that I've used C# 6 features like auto-property initializers and string interpolation out of habit. Let me know if you prefer not to do that.