### PR TITLE
Perf enhancements when loading systems

### DIFF
--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -1,6 +1,4 @@
-﻿using EDDiscovery2;
-using EDDiscovery2.DB;
-using Newtonsoft.Json.Linq;
+﻿using EDDiscovery2.DB;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -8,7 +6,6 @@ using System.Data.SQLite;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace EDDiscovery.DB
@@ -162,11 +159,48 @@ namespace EDDiscovery.DB
                 MessageBox.Show(ex.StackTrace);
                 return false;
             }
-
         }
 
+        public void PerformUpgrade(int newVersion, bool catchErrors, bool backupDbFile, string[] queries, Action doAfterQueries = null)
+        {
+            if (backupDbFile)
+            {
+                string dbfile = GetSQLiteDBFile();
 
-        private bool UpgradeDB2()
+                try
+                {
+                    File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", $"EDDiscovery{newVersion - 1}.sqlite"));
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
+                    System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
+                }
+            }
+
+            try
+            {
+                foreach (var query in queries)
+                {
+                    ExecuteQuery(query);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (!catchErrors)
+                    throw;
+
+                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
+                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
+                MessageBox.Show($"UpgradeDB{newVersion} error: " + ex.Message);
+            }
+
+            doAfterQueries?.Invoke();
+
+            PutSettingInt("DBVer", newVersion);
+        }
+
+        private void UpgradeDB2()
         {
             string query = "CREATE TABLE Systems (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , name TEXT NOT NULL COLLATE NOCASE , x FLOAT, y FLOAT, z FLOAT, cr INTEGER, commandercreate TEXT, createdate DATETIME, commanderupdate TEXT, updatedate DATETIME, status INTEGER, population INTEGER )";
             string query2 = "CREATE  INDEX main.SystemsIndex ON Systems (name ASC)";
@@ -177,122 +211,45 @@ namespace EDDiscovery.DB
             string query7 = "CREATE TABLE Stations (station_id INTEGER PRIMARY KEY  NOT NULL ,system_id INTEGER REFERENCES Systems(id), name TEXT NOT NULL ,blackmarket BOOL DEFAULT (null) ,max_landing_pad_size INTEGER,distance_to_star INTEGER,type TEXT,faction TEXT,shipyard BOOL,outfitting BOOL, commodities_market BOOL)";
             string query8 = "CREATE  INDEX stationIndex ON Stations (system_id ASC)";
 
-            ExecuteQuery(query);
-            ExecuteQuery(query2);
-            ExecuteQuery(query3);
-            ExecuteQuery(query4);
-            ExecuteQuery(query5);
-            ExecuteQuery(query6);
-            ExecuteQuery(query7);
-            ExecuteQuery(query8);
-
-            PutSettingInt("DBVer", 2);
-
-            return true;
+            PerformUpgrade(2, false, false, new[] {query, query2, query3, query4, query5, query6, query7, query8});
         }
 
-
-        
-
-        private bool UpgradeDB3()
+        private void UpgradeDB3()
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN Note TEXT";
-
-            ExecuteQuery(query1);
-            PutSettingInt("DBVer", 3);
-
-            return true;
+            PerformUpgrade(3, false, false, new[] { query1 });
         }
 
-        private bool UpgradeDB4()
+        private void UpgradeDB4()
         {
             string query1 = "ALTER TABLE SystemNote ADD COLUMN Note TEXT";
-            string dbfile = GetSQLiteDBFile();
-
-            try
+            PerformUpgrade(4, true, true, new[] { query1 }, () =>
             {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery3.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB4 error: " + ex.Message);
-            }
-
-            GetAllSystems();
-
-
-            foreach (SystemClass sys in globalSystems)
-            {
-                if (!string.IsNullOrEmpty(sys.Note))
+                GetAllSystems();
+                foreach (SystemClass sys in globalSystems)
                 {
-                    SystemNoteClass note = new SystemNoteClass();
+                    if (!string.IsNullOrEmpty(sys.Note))
+                    {
+                        SystemNoteClass note = new SystemNoteClass();
 
-                    note.Name = sys.name;
-                    note.Note = sys.Note;
-                    note.Time = DateTime.Now;
-                    note.Add();
+                        note.Name = sys.name;
+                        note.Note = sys.Note;
+                        note.Time = DateTime.Now;
+                        note.Add();
+                    }
                 }
-            }
-
-            
-            PutSettingInt("DBVer", 4);
-
-            return true;
+            });
         }
 
-
-        private bool UpgradeDB5()
+        private void UpgradeDB5()
         {
             string query1 = "ALTER TABLE VisitedSystems ADD COLUMN Unit TEXT";
             string query3 = "ALTER TABLE VisitedSystems ADD COLUMN Commander Integer";
             string query4 = "CREATE INDEX VisitedSystemIndex ON VisitedSystems (Name ASC, Time ASC)";
-            string dbfile = GetSQLiteDBFile();
-
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery4.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-                //ExecuteQuery(query2);
-                ExecuteQuery(query3);
-                ExecuteQuery(query4);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB4 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 5);
-
-            return true;
+            PerformUpgrade(5, true, true, new[] {query1, query3, query4});
         }
 
-
-        private bool UpgradeDB6()
+        private void UpgradeDB6()
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN id_eddb Integer";
             string query2 = "ALTER TABLE Systems ADD COLUMN faction TEXT";
@@ -304,14 +261,11 @@ namespace EDDiscovery.DB
             string query8 = "ALTER TABLE Systems ADD COLUMN eddb_updated_at Integer";
             string query9 = "ALTER TABLE Systems ADD COLUMN state Integer";
             string query10 = "ALTER TABLE Systems ADD COLUMN needs_permit Integer";
-
             string query11 = "DROP TABLE Stations";
             string query12 = "CREATE TABLE Stations (id INTEGER PRIMARY KEY  NOT NULL ,system_id INTEGER, name TEXT NOT NULL ,  " +
                 " max_landing_pad_size INTEGER, distance_to_star INTEGER, faction Text, government_id INTEGER, allegiance_id Integer,  state_id INTEGER, type_id Integer, " +
                 "has_commodities BOOL DEFAULT (null), has_refuel BOOL DEFAULT (null), has_repair BOOL DEFAULT (null), has_rearm BOOL DEFAULT (null), " +
                 "has_outfitting BOOL DEFAULT (null),  has_shipyard BOOL DEFAULT (null), has_blackmarket BOOL DEFAULT (null),   eddb_updated_at Integer  )";
-
-
 
             string query13 = "CREATE TABLE station_commodities (station_id INTEGER PRIMARY KEY NOT NULL, commodity_id INTEGER, type INTEGER)";
             string query14 = "CREATE INDEX station_commodities_index ON station_commodities (station_id ASC, commodity_id ASC, type ASC)";
@@ -319,308 +273,69 @@ namespace EDDiscovery.DB
             string query16 = "CREATE INDEX StationsIndex_system_ID  ON Stations (system_id ASC)";
             string query17 = "CREATE INDEX StationsIndex_system_Name  ON Stations (Name ASC)";
 
-            string dbfile = GetSQLiteDBFile();
-
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery5.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-                ExecuteQuery(query2);
-                //ExecuteQuery(query3);
-                ExecuteQuery(query4);
-                ExecuteQuery(query5);
-                ExecuteQuery(query6);
-                ExecuteQuery(query7);
-                ExecuteQuery(query8);
-                ExecuteQuery(query9);
-                ExecuteQuery(query10);
-                ExecuteQuery(query11);
-                ExecuteQuery(query12);
-                ExecuteQuery(query13);
-                ExecuteQuery(query14);
-                ExecuteQuery(query15);
-                ExecuteQuery(query16);
-                ExecuteQuery(query17);
-
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB6 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 6);
-
-            return true;
+            PerformUpgrade(6, true, true, new[] {
+                query1, query2, query4, query5, query6, query7, query8, query9, query10,
+                query11, query12, query13, query14, query15, query16, query17 });
         }
 
 
-        private bool UpgradeDB7()
+        private void UpgradeDB7()
         {
-            
             string query1 = "DROP TABLE VisitedSystems";
             string query2 = "CREATE TABLE VisitedSystems(id INTEGER PRIMARY KEY  NOT NULL, Name TEXT NOT NULL, Time DATETIME NOT NULL, Unit Text, Commander Integer, Source Integer, edsm_sync BOOL DEFAULT (null))";
             string query3 = "CREATE TABLE TravelLogUnit(id INTEGER PRIMARY KEY  NOT NULL, type INTEGER NOT NULL, name TEXT NOT NULL, size INTEGER, path TEXT)";
-
-
-            string dbfile = GetSQLiteDBFile();
-
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery6.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-                ExecuteQuery(query2);
-                ExecuteQuery(query3);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB7 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 7);
-
-            return true;
+            PerformUpgrade(7, true, true, new[] { query1, query2, query3 });
         }
 
-
-        private bool UpgradeDB8()
+        private void UpgradeDB8()
         {
-            //Default is Color.Red.ToARGB()
             string query1 = "ALTER TABLE VisitedSystems ADD COLUMN Map_colour INTEGER DEFAULT (-65536)";
-            string dbfile = GetSQLiteDBFile();
-            
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery7.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB8 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 8);
-
-            return true;
+            PerformUpgrade(8, true, true, new[] { query1 });
         }
 
-
-        private bool UpgradeDB9()
+        private void UpgradeDB9()
         {
-            //Default is Color.Red.ToARGB()
             string query1 = "CREATE TABLE Objects (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , SystemName TEXT NOT NULL , ObjectName TEXT NOT NULL , ObjectType INTEGER NOT NULL , ArrivalPoint Float, Gravity FLOAT, Atmosphere Integer, Vulcanism Integer, Terrain INTEGER, Carbon BOOL, Iron BOOL, Nickel BOOL, Phosphorus BOOL, Sulphur BOOL, Arsenic BOOL, Chromium BOOL, Germanium BOOL, Manganese BOOL, Selenium BOOL NOT NULL , Vanadium BOOL, Zinc BOOL, Zirconium BOOL, Cadmium BOOL, Mercury BOOL, Molybdenum BOOL, Niobium BOOL, Tin BOOL, Tungsten BOOL, Antimony BOOL, Polonium BOOL, Ruthenium BOOL, Technetium BOOL, Tellurium BOOL, Yttrium BOOL, Commander  Text, UpdateTime DATETIME, Status INTEGER )";
-            string dbfile = GetSQLiteDBFile();
-
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery8.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB9 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 9);
-
-            return true;
+            PerformUpgrade(9, true, true, new[] { query1 });
         }
 
-
-        private bool UpgradeDB10()
+        private void UpgradeDB10()
         {
             string query1 = "CREATE TABLE wanted_systems (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, systemname TEXT UNIQUE NOT NULL)";
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery9.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-            try
-            {
-                ExecuteQuery(query1);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB10 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 10);
-
-            return true;
+            PerformUpgrade(10, true, true, new[] { query1 });
         }
 
-
-        private bool UpgradeDB11()
+        private void UpgradeDB11()
         {
             //Default is Color.Red.ToARGB()
             string query1 = "ALTER TABLE Systems ADD COLUMN FirstDiscovery BOOL";
             string query2 = "ALTER TABLE Objects ADD COLUMN Landed BOOL";
             string query3 = "ALTER TABLE Objects ADD COLUMN terraform Integer";
             string query4 = "ALTER TABLE VisitedSystems ADD COLUMN Status BOOL";
-            string dbfile = GetSQLiteDBFile();
-
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery10.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-
-            try
-            {
-                ExecuteQuery(query1);
-                ExecuteQuery(query2);
-                ExecuteQuery(query3);
-                ExecuteQuery(query4);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB11 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 11);
-
-            return true;
+            PerformUpgrade(11, true, true, new[] { query1, query2, query3, query4 });
         }
 
-        private bool UpgradeDB12()
+        private void UpgradeDB12()
         {
             string query1 = "CREATE TABLE routes_expeditions (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT UNIQUE NOT NULL, start DATETIME, end DATETIME)";
             string query2 = "CREATE TABLE route_systems (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, routeid INTEGER NOT NULL, systemname TEXT NOT NULL)";
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery11.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
-
-            try
-            {
-                ExecuteQuery(query1);
-                ExecuteQuery(query2);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB12 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 12);
-
-            return true;
+            PerformUpgrade(12, true, true, new[] { query1, query2 });
         }
 
-        private bool UpgradeDB13()
+        private void UpgradeDB13()
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN VersionDate DATETIME";
-            string query2 = "UPDATE TABLE Systems SET VersionDate = @now";
+            string query2 = "UPDATE Systems SET VersionDate = datetime('now')";
             string query3 = "CREATE INDEX IDX_Systems_VersionDate ON Systems (VersionDate ASC)";
-            try
-            {
-                File.Copy(dbfile, dbfile.Replace("EDDiscovery.sqlite", "EDDiscovery12.sqlite"));
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-            }
 
-            try
-            {
-                ExecuteQuery(query1);
-                ExecuteQuery(query2, new SQLiteParameter { ParameterName = "now", Value = DateTime.Now, DbType = DbType.DateTime });
-                ExecuteQuery(query3);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine("Exception: " + ex.Message);
-                System.Diagnostics.Trace.WriteLine("Trace: " + ex.StackTrace);
-                MessageBox.Show("UpgradeDB13 error: " + ex.Message);
-            }
-
-            PutSettingInt("DBVer", 13);
-
-            return true;
+            PerformUpgrade(13, true, true, new[] { query1, query2, query3 });
         }
 
-        private void ExecuteQuery(string query, params SQLiteParameter[] parameters)
+        private void ExecuteQuery(string query)
         {
             if (Connect2DB())
             {
                 SQLiteCommand command = new SQLiteCommand(query, m_dbConnection);
-                foreach (var p in parameters)
-                {
-                    p.Command = command;
-                }
-
-                if (parameters.Any())
-                {
-                    command.Parameters.AddRange(parameters);
-                }
                 command.ExecuteNonQuery();
             }
             CloseDB();

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -425,19 +425,15 @@ namespace EDDiscovery.DB
             }
         }
 
-        public static void TouchSystem(string systemName)
+        public static void TouchSystem(SQLiteConnection connection, string systemName)
         {
-            using (SQLiteConnection cn = new SQLiteConnection(ConnectionString))
+            using (SQLiteCommand cmd = connection.CreateCommand())
             {
-                using (SQLiteCommand cmd = new SQLiteCommand())
-                {
-                    cmd.Connection = cn;
-                    cmd.CommandType = CommandType.Text;
-                    cmd.CommandTimeout = 30;
-                    cmd.CommandText = "update systems set versiondate=datetime('now') where name=@systemName";
-                    cmd.Parameters.AddWithValue("systemName", systemName);
-                    SqlNonQuery(cn, cmd);
-                }
+                cmd.CommandType = CommandType.Text;
+                cmd.CommandTimeout = 30;
+                cmd.CommandText = "update systems set versiondate=datetime('now') where name=@systemName";
+                cmd.Parameters.AddWithValue("systemName", systemName);
+                SqlNonQueryText(connection, cmd);
             }
         }
 

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -358,7 +358,6 @@ namespace EDDiscovery.DB
         {
             var sw = Stopwatch.StartNew();
             int numSystemsReturned = 0;
-            int numMoreRecentSystems = 0;
             try
             {
                 using (SQLiteConnection cn = new SQLiteConnection(ConnectionString))
@@ -407,10 +406,7 @@ namespace EDDiscovery.DB
 
                             // If the row that was modified more recently than versionDate, this is the new versionDate
                             // Next time we get the systems, we will only get the updates since that date and time.
-                            if (UpdateVersionDate(dr))
-                            {
-                                numMoreRecentSystems++;
-                            }
+                            UpdateVersionDate(dr);
                         }
 
                         globalSystems = dictSystems.Values.ToList<SystemClass>();
@@ -425,20 +421,18 @@ namespace EDDiscovery.DB
             }
             finally
             {
-                System.Diagnostics.Trace.WriteLine(string.Format("GetAllSystems completed in {0}. Retrieved {1} systems from DB. Including {2} systems with updated information.", sw.Elapsed, numSystemsReturned, numMoreRecentSystems));
+                System.Diagnostics.Trace.WriteLine(string.Format("GetAllSystems completed in {0}. Retrieved {1} systems from DB. Version date is now {2}", sw.Elapsed, numSystemsReturned, versionDate));
             }
         }
 
-        private static bool UpdateVersionDate(DataRow dr)
+        private static void UpdateVersionDate(DataRow dr)
         {
             object vdRaw = dr["versiondate"];
             var vd = vdRaw != DBNull.Value ? (DateTime?) vdRaw : null;
             if ((vd.HasValue && !versionDate.HasValue) || (vd > versionDate))
             {
                 versionDate = vd;
-                return true;
             }
-            return false;
         }
 
         public bool GetAllDistances(bool loadAlldata)

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -425,6 +425,22 @@ namespace EDDiscovery.DB
             }
         }
 
+        public static void TouchSystem(string systemName)
+        {
+            using (SQLiteConnection cn = new SQLiteConnection(ConnectionString))
+            {
+                using (SQLiteCommand cmd = new SQLiteCommand())
+                {
+                    cmd.Connection = cn;
+                    cmd.CommandType = CommandType.Text;
+                    cmd.CommandTimeout = 30;
+                    cmd.CommandText = "update systems set versiondate=datetime('now') where name=@systemName";
+                    cmd.Parameters.AddWithValue("systemName", systemName);
+                    SqlNonQuery(cn, cmd);
+                }
+            }
+        }
+
         private static void UpdateVersionDate(DataRow dr)
         {
             object vdRaw = dr["versiondate"];
@@ -762,7 +778,7 @@ namespace EDDiscovery.DB
             System.Diagnostics.Trace.WriteLine(text);
         }
 
-        public DataSet SqlQueryText(SQLiteConnection cn, SQLiteCommand cmd)
+        public static DataSet SqlQueryText(SQLiteConnection cn, SQLiteCommand cmd)
         {
 
             //LogLine("SqlQueryText: " + cmd.CommandText);
@@ -813,7 +829,7 @@ namespace EDDiscovery.DB
         }
 
 
-        public int SqlNonQuery(SQLiteConnection cn, SQLiteCommand cmd)
+        public static int SqlNonQuery(SQLiteConnection cn, SQLiteCommand cmd)
         {
             int rows = 0;
 

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1,5 +1,4 @@
 ﻿using EDDiscovery2;
-using EDDiscovery2.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -7,8 +6,6 @@ using System.Data;
 using System.Data.SQLite;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 
 namespace EDDiscovery.DB
 {
@@ -472,7 +469,7 @@ namespace EDDiscovery.DB
                     cmd.Transaction = transaction;
                     cmd.CommandType = CommandType.Text;
                     cmd.CommandTimeout = 30;
-                    cmd.CommandText = "Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note, id_eddb, population, faction, government_id, allegiance_id, primary_economy_id,  security, eddb_updated_at, state, needs_permit) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note, @id_eddb, @population, @faction, @government_id, @allegiance_id, @primary_economy_id,  @security, @eddb_updated_at, @state, @needs_permit)";
+                    cmd.CommandText = "Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note, id_eddb, population, faction, government_id, allegiance_id, primary_economy_id, security, eddb_updated_at, state, needs_permit, versiondate) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note, @id_eddb, @population, @faction, @government_id, @allegiance_id, @primary_economy_id,  @security, @eddb_updated_at, @state, @needs_permit, datetime('now'))";
                     cmd.Parameters.AddWithValue("@name", name);
                     cmd.Parameters.AddWithValue("@x", x);
                     cmd.Parameters.AddWithValue("@y", y);
@@ -510,7 +507,7 @@ namespace EDDiscovery.DB
                     cmd.Connection = cn;
                     cmd.CommandType = CommandType.Text;
                     cmd.CommandTimeout = 30;
-                    cmd.CommandText = "Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note)";
+                    cmd.CommandText = "Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note, versiondate) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note, datetime('now'))";
                     cmd.Parameters.AddWithValue("@name", name);
                     cmd.Parameters.AddWithValue("@x", x);
                     cmd.Parameters.AddWithValue("@y", y);
@@ -542,7 +539,7 @@ namespace EDDiscovery.DB
             {
                 cmd.CommandType = CommandType.Text;
                 cmd.CommandTimeout = 30;
-                cmd.CommandText = "Update Systems set name=@name, x=@x, y=@y, z=@z, cr=@cr, commandercreate=@commandercreate, createdate=@createdate, commanderupdate=@commanderupdate, updatedate=@updatedate, status=@status, note=@Note, id_eddb=@id_eddb, population=@population, faction=@faction, government_id=@government_id, allegiance_id=@allegiance_id, primary_economy_id=@primary_economy_id,  security=@security, eddb_updated_at=@eddb_updated_at, state=@state, needs_permit=@needs_permit  where ID=@id";
+                cmd.CommandText = "Update Systems set name=@name, x=@x, y=@y, z=@z, cr=@cr, commandercreate=@commandercreate, createdate=@createdate, commanderupdate=@commanderupdate, updatedate=@updatedate, status=@status, note=@Note, id_eddb=@id_eddb, population=@population, faction=@faction, government_id=@government_id, allegiance_id=@allegiance_id, primary_economy_id=@primary_economy_id,  security=@security, eddb_updated_at=@eddb_updated_at, state=@state, needs_permit=@needs_permit, versiondate=datetime('now') where ID=@id";
 
                 cmd.Parameters.AddWithValue("@id", id); 
                 cmd.Parameters.AddWithValue("@name", name);
@@ -582,7 +579,7 @@ namespace EDDiscovery.DB
             {
                 cmd.CommandType = CommandType.Text;
                 cmd.CommandTimeout = 30;
-                cmd.CommandText = "Update Systems set name=@name, x=@x, y=@y, z=@z, commandercreate=@commandercreate, createdate=@createdate, commanderupdate=@commanderupdate, updatedate=@updatedate, status=@status   where ID=@id";
+                cmd.CommandText = "Update Systems set name=@name, x=@x, y=@y, z=@z, commandercreate=@commandercreate, createdate=@createdate, commanderupdate=@commanderupdate, updatedate=@updatedate, status=@status, versiondate=datetime('now') where ID=@id";
 
                 cmd.Parameters.AddWithValue("@id", id);
                 cmd.Parameters.AddWithValue("@name", name);

--- a/EDDiscovery/DB/SystemNoteClass.cs
+++ b/EDDiscovery/DB/SystemNoteClass.cs
@@ -50,7 +50,7 @@ namespace EDDiscovery2.DB
                 cmd.Parameters.AddWithValue("@note", Note);
 
                 SQLiteDBClass.SqlNonQueryText(cn, cmd);
-                SQLiteDBClass.TouchSystem(Name);
+                SQLiteDBClass.TouchSystem(cn, Name);
 
                 using (SQLiteCommand cmd2 = new SQLiteCommand())
                 {
@@ -90,7 +90,7 @@ namespace EDDiscovery2.DB
                 cmd.Parameters.AddWithValue("@Time", Time);
 
                 SQLiteDBClass.SqlNonQueryText(cn, cmd);
-                SQLiteDBClass.TouchSystem(Name);
+                SQLiteDBClass.TouchSystem(cn, Name);
                 SQLiteDBClass.globalSystemNotes[Name.ToLower()] = this;
 
                 return true;

--- a/EDDiscovery/DB/SystemNoteClass.cs
+++ b/EDDiscovery/DB/SystemNoteClass.cs
@@ -50,6 +50,7 @@ namespace EDDiscovery2.DB
                 cmd.Parameters.AddWithValue("@note", Note);
 
                 SQLiteDBClass.SqlNonQueryText(cn, cmd);
+                SQLiteDBClass.TouchSystem(Name);
 
                 using (SQLiteCommand cmd2 = new SQLiteCommand())
                 {
@@ -89,6 +90,7 @@ namespace EDDiscovery2.DB
                 cmd.Parameters.AddWithValue("@Time", Time);
 
                 SQLiteDBClass.SqlNonQueryText(cn, cmd);
+                SQLiteDBClass.TouchSystem(Name);
                 SQLiteDBClass.globalSystemNotes[Name.ToLower()] = this;
 
                 return true;

--- a/EDDiscovery/SystemData.cs
+++ b/EDDiscovery/SystemData.cs
@@ -1,10 +1,6 @@
 ﻿using EDDiscovery.DB;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace EDDiscovery
 {
@@ -18,17 +14,8 @@ namespace EDDiscovery
     }
 
 
-
     public class SystemData
     {
-       
-
-        public SystemData()
-        {
-            //ReadData();V:\RobertW\EDDiscovery\EDDiscovery\systems.json
-        }
-
-    
 
         static public List<SystemClass> SystemList
         {
@@ -37,8 +24,6 @@ namespace EDDiscovery
                 return SQLiteDBClass.globalSystems;
             }
         }
-
-      
 
         static public SystemClass GetSystem(string name)
         {
@@ -54,49 +39,12 @@ namespace EDDiscovery
                 return null;
         }
 
-
-        static public SystemClass GetSystemOld(string name)
-        {
-            if (name == null)
-                return null;
-
-            string lname = name.ToLower();
-
-            
-            var obj = from p in SystemList where p.SearchName == lname select p;
-
-            if (obj.Count() < 1)
-                return null;
-
-            return (SystemClass)obj.First();
-
-            //return SQLiteDBClass.dictSystems[lname];
-        }
-
-
         public static double Distance(SystemClass s1, SystemClass s2)
         {
             if (s1 == null || s2== null)
                 return -1;
 
-            //return Math.Sqrt(Math.Pow(s1.x - s2.x, 2) + Math.Pow(s1.y - s2.y, 2) + Math.Pow(s1.z - s2.z, 2));
             return Math.Sqrt((s1.x - s2.x) * (s1.x - s2.x) + (s1.y - s2.y) * (s1.y - s2.y) + (s1.z - s2.z) * (s1.z - s2.z));
         }
-
-        public static double DistanceX2(SystemClass s1, SystemClass s2)
-        {
-            if (s1 == null || s2 == null)
-                return -1;
-
-            //return Math.Sqrt(Math.Pow(s1.x - s2.x, 2) + Math.Pow(s1.y - s2.y, 2) + Math.Pow(s1.z - s2.z, 2));
-            return ((s1.x - s2.x) * (s1.x - s2.x) + (s1.y - s2.y) * (s1.y - s2.y) + (s1.z - s2.z) * (s1.z - s2.z));
-        }
-
-        public static double Distance(string s1, string s2)
-        {
-            return Distance(GetSystem(s1), GetSystem(s2));
-        }
-
-
     }
 }


### PR DESCRIPTION
This is why I've started looking into the code in the first place. I've noticed that some operations were taking a very long time, up to 5/6 seconds on my machine. After profiling the app I pinpointed it to the GetAllSystems method that was loading the whole systems table from SQLite every time it was called.

So this introduces a new column called versiondate that contains the last time a given row was updated or inserted. GetAllSystems now uses this to only load more recent data than the last time it was called.

Potentially, this could introduce minor issues if the local time of the machine changes while EDD is running (i.e. DST or windows time synchronization) but the performance boost is really huge.

I also refactored the database schema upgrade code a bit since there was a lot of repeated code.