### PR TITLE
Move tests to NUnit

### DIFF
--- a/EDDiscoveryTests/DistanceParserTests.cs
+++ b/EDDiscoveryTests/DistanceParserTests.cs
@@ -1,11 +1,25 @@
 ﻿using System;
 using System.Globalization;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EDDiscovery;
 using NFluent;
 
 namespace EDDiscoveryTests
 {
+#if false
+    // Visual Studio Test Framework
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    partial class TestFixtureAttribute : Attribute { }
+    partial class TestAttribute : Attribute { }
+#else
+    // NUnit Test Framework
+    using NUnit.Framework;
+
+    partial class TestClassAttribute : Attribute { }
+    partial class TestMethodAttribute : Attribute { }
+#endif
+
+    [TestFixture]
     [TestClass]
     public class DistanceParserTests
     {
@@ -27,12 +41,14 @@ namespace EDDiscoveryTests
         }
 
         [TestMethod]
+        [Test]
         public void Empty_jump_distance_is_not_parsed()
         {
             Check.That(DistanceParser.ParseJumpDistance("")).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_without_decimals_is_parsed_correctly()
         {
             Check.That(DistanceParser.ParseJumpDistance("15")).IsEqualTo(15);
@@ -44,12 +60,14 @@ namespace EDDiscoveryTests
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_with_point_as_decimal_separator_is_parsed_correctly_with_french_culture()
         {
             TestWithCulture(frenchCulture, Jump_distance_with_point_as_decimal_separator_is_parsed_correctly);
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_with_point_as_decimal_separator_is_parsed_correctly_with_american_culture()
         {
             TestWithCulture(americanCulture, Jump_distance_with_point_as_decimal_separator_is_parsed_correctly);
@@ -61,48 +79,56 @@ namespace EDDiscoveryTests
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly_with_french_culture()
         {
             TestWithCulture(frenchCulture, Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly);
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly_with_american_culture()
         {
             TestWithCulture(americanCulture, Jump_distance_with_comma_as_decimal_separator_is_parsed_correctly);
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_greater_than_the_maximum_allowed_value_is_not_parsed()
         {
             Check.That(DistanceParser.ParseJumpDistance("15", 14)).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_equal_to_the_maximum_allowed_value_is_parsed_correctly()
         {
             Check.That(DistanceParser.ParseJumpDistance("15", 15)).IsEqualTo(15);
         }
 
         [TestMethod]
+        [Test]
         public void Negative_jump_distance_is_not_parsed()
         {
             Check.That(DistanceParser.ParseJumpDistance("-15")).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_with_more_than_2_decimals_is_not_parsed()
         {
             Check.That(DistanceParser.ParseJumpDistance("15.000")).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Jump_distance_that_does_not_match_any_expected_format_is_not_parsed()
         {
             Check.That(DistanceParser.ParseJumpDistance("not a distance")).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Interstellar_distance_without_any_decimal_separator_can_be_parsed()
         {
             Check.That(DistanceParser.ParseInterstellarDistance("12345")).IsEqualTo(12345);
@@ -114,18 +140,21 @@ namespace EDDiscoveryTests
         }
 
         [TestMethod]
+        [Test]
         public void Interstellar_distance_with_dot_decimal_separator_can_be_parsed_with_french_culture()
         {
             TestWithCulture(frenchCulture, Interstellar_distance_with_dot_decimal_separator_can_be_parsed);
         }
 
         [TestMethod]
+        [Test]
         public void Interstellar_distance_with_dot_decimal_separator_can_be_parsed_with_american_culture()
         {
             TestWithCulture(americanCulture, Interstellar_distance_with_dot_decimal_separator_can_be_parsed);
         }
 
         [TestMethod]
+        [Test]
         public void Negative_interstellar_distance_is_not_parsed()
         {
             Check.That(DistanceParser.ParseInterstellarDistance("-12345")).IsEqualTo(null);
@@ -137,12 +166,14 @@ namespace EDDiscoveryTests
         }
 
         [TestMethod]
+        [Test]
         public void Interstellar_distance_with_comma_decimal_separator_can_be_parsed_with_french_culture()
         {
             TestWithCulture(frenchCulture, Interstellar_distance_with_comma_decimal_separator_can_be_parsed);
         }
 
         [TestMethod]
+        [Test]
         public void Interstellar_distance_with_comma_decimal_separator_can_be_parsed_with_american_culture()
         {
             TestWithCulture(americanCulture, Interstellar_distance_with_comma_decimal_separator_can_be_parsed);
@@ -150,18 +181,21 @@ namespace EDDiscoveryTests
 
 
         [TestMethod]
+        [Test]
         public void Invalid_interstellar_is_not_parsed()
         {
             Check.That(DistanceParser.ParseInterstellarDistance("not a distance")).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Empty_interstellar_is_not_parsed()
         {
             Check.That(DistanceParser.ParseInterstellarDistance("")).IsNull();
         }
 
         [TestMethod]
+        [Test]
         public void Null_interstellar_is_not_parsed()
         {
             Check.That(DistanceParser.ParseInterstellarDistance(null)).IsNull();

--- a/EDDiscoveryTests/EDDiscoveryTests.csproj
+++ b/EDDiscoveryTests/EDDiscoveryTests.csproj
@@ -75,11 +75,33 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.0.10\lib\Mono.Cecil.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4" />
+    <Reference Include="nunit.engine, Version=3.0.5813.39036, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.0.10\lib\nunit.engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.0.10\lib\nunit.engine.api.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit3.TestAdapter, Version=3.0.10.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.0.10\lib\NUnit3.TestAdapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="OpenTK">
+      <HintPath>..\packages\OpenTK.1.1.1589.5942\lib\NET40\OpenTK.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.SQLite, Version=1.0.99.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.99.0\lib\net40\System.Data.SQLite.dll</HintPath>

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -1,80 +1,105 @@
 ﻿using System;
 using System.Collections.Generic;
 using EDDiscovery;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NFluent;
+using EDDiscovery2.DB;
 
 namespace EDDiscoveryTests
 {
+#if false
+    // Visual Studio Test Framework
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    partial class TestFixtureAttribute : Attribute { }
+    partial class TestAttribute : Attribute { }
+#else
+    // NUnit Test Framework
+    using NUnit.Framework;
+
+    partial class TestClassAttribute : Attribute { }
+    partial class TestMethodAttribute : Attribute { }
+#endif
+
+    [TestFixture]
     [TestClass]
     public class TravelHistoryFilterTests
     {
+        [Test]
         [TestMethod]
         public void No_filter_does_not_filter_anything()
         {
-            var veryOldData = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(500000))};
-            var input = new List<SystemPosition> { veryOldData };
+            var veryOldData = new VisitedSystemsClass { Time = DateTime.Now.Subtract(TimeSpan.FromDays(500000))};
+            var input = new List<VisitedSystemsClass> { veryOldData };
 
             Check.That(TravelHistoryFilter.NoFilter.Filter(input)).ContainsExactly(veryOldData);
         }
 
+        [Test]
         [TestMethod]
         public void Data_age_filter_removes_data_older_than_the_limit_and_keeps_data_more_recent_than_the_limit()
         {
-            var now = new SystemPosition { time = DateTime.Now };
-            var fourDaysAgo = new SystemPosition {time = DateTime.Now.Subtract(TimeSpan.FromDays(4))};
-            var input = new List<SystemPosition> { fourDaysAgo, now };
+            var now = new VisitedSystemsClass { Time = DateTime.Now };
+            var fourDaysAgo = new VisitedSystemsClass { Time = DateTime.Now.Subtract(TimeSpan.FromDays(4))};
+            var input = new List<VisitedSystemsClass> { fourDaysAgo, now };
 
             Check.That(TravelHistoryFilter.FromDays(2).Filter(input)).ContainsExactly(now);
         }
 
+        [Test]
         [TestMethod]
         public void Last_2_items_filter_returns_the_2_most_recent_items_sorted_by_most_recent_and_removes_the_older_items()
         {
-            var twentyDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(20)) };
-            var tenDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(10)) };
-            var thirtyDaysAgo = new SystemPosition { time = DateTime.Now.Subtract(TimeSpan.FromDays(30)) };
-            var input = new List<SystemPosition> { twentyDaysAgo, tenDaysAgo, thirtyDaysAgo };
+            var twentyDaysAgo = new VisitedSystemsClass { Time = DateTime.Now.Subtract(TimeSpan.FromDays(20)) };
+            var tenDaysAgo = new VisitedSystemsClass { Time = DateTime.Now.Subtract(TimeSpan.FromDays(10)) };
+            var thirtyDaysAgo = new VisitedSystemsClass { Time = DateTime.Now.Subtract(TimeSpan.FromDays(30)) };
+            var input = new List<VisitedSystemsClass> { twentyDaysAgo, tenDaysAgo, thirtyDaysAgo };
 
             Check.That(TravelHistoryFilter.Last(2).Filter(input)).ContainsExactly(tenDaysAgo, twentyDaysAgo);
         }
 
+        [Test]
         [TestMethod]
         public void No_filter_has_correct_label()
         {
             Check.That(TravelHistoryFilter.NoFilter.Label).IsEqualTo("All");
         }
 
+        [Test]
         [TestMethod]
         public void last_20_filter_has_correct_label()
         {
             Check.That(TravelHistoryFilter.Last(20).Label).IsEqualTo("last 20");
         }
 
+        [Test]
         [TestMethod]
         public void Last_6_hours_filter_has_correct_label()
         {
             Check.That(TravelHistoryFilter.FromHours(6).Label).IsEqualTo("6 hours");
         }
 
+        [Test]
         [TestMethod]
         public void Last_days_filter_has_correct_label()
         {
             Check.That(TravelHistoryFilter.FromDays(3).Label).IsEqualTo("3 days");
         }
 
+        [Test]
         [TestMethod]
         public void Last_week_filter_has_correct_label()
         {
             Check.That(TravelHistoryFilter.FromWeeks(1).Label).IsEqualTo("week");
         }
 
+        [Test]
         [TestMethod]
         public void Last_3_weeks_filter_has_correct_label()
         {
             Check.That(TravelHistoryFilter.FromWeeks(3).Label).IsEqualTo("3 weeks");
         }
 
+        [Test]
         [TestMethod]
         public void Last_month_filter_has_correct_label()
         {

--- a/EDDiscoveryTests/packages.config
+++ b/EDDiscoveryTests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NFluent" version="1.3.1.0" targetFramework="net40" />
+  <package id="NUnit" version="3.2.1" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.0.10" targetFramework="net40" />
   <package id="OpenTK" version="1.1.1589.5942" targetFramework="net40" />
   <package id="System.Data.SQLite.Core" version="1.0.99.0" targetFramework="net40" />
   <package id="System.Data.SQLite.Linq" version="1.0.99.0" targetFramework="net40" />


### PR DESCRIPTION
This, along with an appropriate `.travis.yml` and `appveyor.yml` will allow build tests on both Windows and Mono.  It also fixes some tests to match the changes that have been made in 3.2.

Do we want to re-add unit-tests to the solution, and add `.travis.yml` and `appveyor.yml` settings files?

Travis CI: [![travis](https://travis-ci.org/klightspeed/EDDiscovery.svg?branch=master)](https://travis-ci.org/klightspeed/EDDiscovery)
Appveyor: [![appveyor](https://ci.appveyor.com/api/projects/status/3ydfl4j37e6o7iwr?svg=true)](https://ci.appveyor.com/project/klightspeed/eddiscovery)