### PR TITLE
Fetch system notes before systems

### DIFF
--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -377,6 +377,8 @@ namespace EDDiscovery.DB
 
         public bool GetAllSystems()
         {
+            // Get system notes first
+            GetAllSystemNotes();
             var sw = Stopwatch.StartNew();
             int numSystemsReturned = 0;
             try


### PR DESCRIPTION
This should resolve the system notes being missing from the travel history.