### PR TITLE
Mw feature focus on new system

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -52,6 +52,7 @@ namespace EDDiscovery2
         readonly public string LogIndex;
         private bool _canSkipSlowUpdates = false;
         private bool _orderrowsinverted = false;
+        private bool _focusOnNewSystem = false; /**< Whether to automatically focus on a new system in the TravelHistory */
         public List<EDCommander> listCommanders;
         private int currentCmdrID=0;
         private Dictionary<string, object> settings = new Dictionary<string, object>();
@@ -170,6 +171,18 @@ namespace EDDiscovery2
             {
                 _orderrowsinverted = value;
                 _db.PutSettingBool("OrderRowsInverted", value);
+            }
+        }
+
+        public bool FocusOnNewSystem {
+            get
+            {
+                return _focusOnNewSystem;
+            }
+            set
+            {
+                _focusOnNewSystem = value;
+                _db.PutSettingBool("FocusOnNewSystem", value);
             }
         }
 

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -277,6 +277,7 @@ namespace EDDiscovery2
                 _EDSMLog = _db.GetSettingBool("EDSMLog", false);
                 _canSkipSlowUpdates = _db.GetSettingBool("CanSkipSlowUpdates", false);
                 _orderrowsinverted = _db.GetSettingBool("OrderRowsInverted", false);
+                _focusOnNewSystem = _db.GetSettingBool("FocusOnNewSystem", false);
                 LoadCommanders();
                 int activecommander = _db.GetSettingInt("ActiveCommander", 0);
                 var cmdr = listCommanders.Select((c, i) => new { index = i, cmdr = c }).SingleOrDefault(a => a.cmdr.Nr == activecommander);

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -44,7 +44,9 @@
             this.ColumnEDSMAPIKey = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnNetLogPath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.groupBox3 = new ExtendedControls.GroupBoxCustom();
+            this.checkBoxFocusNewSystem = new ExtendedControls.CheckBoxCustom();
             this.checkBox_Distances = new ExtendedControls.CheckBoxCustom();
+            this.checkBoxOrderRowsInverted = new ExtendedControls.CheckBoxCustom();
             this.checkBoxEDSMLog = new ExtendedControls.CheckBoxCustom();
             this.checkboxSkipSlowUpdates = new ExtendedControls.CheckBoxCustom();
             this.groupBox2 = new ExtendedControls.GroupBoxCustom();
@@ -62,7 +64,6 @@
             this.comboBoxTheme = new ExtendedControls.ComboBoxCustom();
             this.button_edittheme = new ExtendedControls.ButtonExt();
             this.buttonSaveTheme = new ExtendedControls.ButtonExt();
-            this.checkBoxOrderRowsInverted = new ExtendedControls.CheckBoxCustom();
             this.groupBox1.SuspendLayout();
             this.groupBox4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewCommanders)).BeginInit();
@@ -177,7 +178,7 @@
             this.buttonAddCommander.Location = new System.Drawing.Point(11, 16);
             this.buttonAddCommander.Name = "buttonAddCommander";
             this.buttonAddCommander.Size = new System.Drawing.Size(104, 23);
-            this.buttonAddCommander.TabIndex = 14;
+            this.buttonAddCommander.TabIndex = 0;
             this.buttonAddCommander.Text = "Add commander";
             this.buttonAddCommander.UseVisualStyleBackColor = true;
             this.buttonAddCommander.Click += new System.EventHandler(this.buttonAddCommander_Click);
@@ -188,7 +189,7 @@
             this.label2.Location = new System.Drawing.Point(125, 21);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(309, 13);
-            this.label2.TabIndex = 7;
+            this.label2.TabIndex = 1;
             this.label2.Text = "Get Api key from https://www.edsm.net in  \"My account\" menu.";
             // 
             // dataGridViewCommanders
@@ -205,7 +206,7 @@
             this.dataGridViewCommanders.Location = new System.Drawing.Point(11, 45);
             this.dataGridViewCommanders.Name = "dataGridViewCommanders";
             this.dataGridViewCommanders.Size = new System.Drawing.Size(792, 128);
-            this.dataGridViewCommanders.TabIndex = 13;
+            this.dataGridViewCommanders.TabIndex = 2;
             // 
             // ColumnNr
             // 
@@ -248,6 +249,7 @@
             this.groupBox3.BackColorScaling = 0.5F;
             this.groupBox3.BorderColor = System.Drawing.Color.LightGray;
             this.groupBox3.BorderColorScaling = 0.5F;
+            this.groupBox3.Controls.Add(this.checkBoxFocusNewSystem);
             this.groupBox3.Controls.Add(this.checkBox_Distances);
             this.groupBox3.Controls.Add(this.checkBoxOrderRowsInverted);
             this.groupBox3.Controls.Add(this.checkBoxEDSMLog);
@@ -255,12 +257,28 @@
             this.groupBox3.FillClientAreaWithAlternateColor = false;
             this.groupBox3.Location = new System.Drawing.Point(3, 280);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(426, 117);
+            this.groupBox3.Size = new System.Drawing.Size(426, 149);
             this.groupBox3.TabIndex = 16;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Options";
             this.groupBox3.TextPadding = 0;
             this.groupBox3.TextStartPosition = -1;
+            // 
+            // checkBoxFocusNewSystem
+            // 
+            this.checkBoxFocusNewSystem.AutoSize = true;
+            this.checkBoxFocusNewSystem.CheckBoxColor = System.Drawing.Color.Gray;
+            this.checkBoxFocusNewSystem.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxFocusNewSystem.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxFocusNewSystem.FontNerfReduction = 0.5F;
+            this.checkBoxFocusNewSystem.Location = new System.Drawing.Point(17, 87);
+            this.checkBoxFocusNewSystem.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxFocusNewSystem.Name = "checkBoxFocusNewSystem";
+            this.checkBoxFocusNewSystem.Size = new System.Drawing.Size(132, 17);
+            this.checkBoxFocusNewSystem.TabIndex = 3;
+            this.checkBoxFocusNewSystem.Text = "Focus on New System";
+            this.checkBoxFocusNewSystem.TickBoxReductionSize = 10;
+            this.checkBoxFocusNewSystem.UseVisualStyleBackColor = true;
             // 
             // checkBox_Distances
             // 
@@ -273,10 +291,26 @@
             this.checkBox_Distances.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBox_Distances.Name = "checkBox_Distances";
             this.checkBox_Distances.Size = new System.Drawing.Size(346, 17);
-            this.checkBox_Distances.TabIndex = 8;
+            this.checkBox_Distances.TabIndex = 0;
             this.checkBox_Distances.Text = "Get Distances from EDSM (Uses more memory normally not needed)";
             this.checkBox_Distances.TickBoxReductionSize = 10;
             this.checkBox_Distances.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxOrderRowsInverted
+            // 
+            this.checkBoxOrderRowsInverted.AutoSize = true;
+            this.checkBoxOrderRowsInverted.CheckBoxColor = System.Drawing.Color.Gray;
+            this.checkBoxOrderRowsInverted.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxOrderRowsInverted.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxOrderRowsInverted.FontNerfReduction = 0.5F;
+            this.checkBoxOrderRowsInverted.Location = new System.Drawing.Point(17, 64);
+            this.checkBoxOrderRowsInverted.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxOrderRowsInverted.Name = "checkBoxOrderRowsInverted";
+            this.checkBoxOrderRowsInverted.Size = new System.Drawing.Size(171, 17);
+            this.checkBoxOrderRowsInverted.TabIndex = 2;
+            this.checkBoxOrderRowsInverted.Text = "Order Rows By Visited Number";
+            this.checkBoxOrderRowsInverted.TickBoxReductionSize = 10;
+            this.checkBoxOrderRowsInverted.UseVisualStyleBackColor = true;
             // 
             // checkBoxEDSMLog
             // 
@@ -289,7 +323,7 @@
             this.checkBoxEDSMLog.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBoxEDSMLog.Name = "checkBoxEDSMLog";
             this.checkBoxEDSMLog.Size = new System.Drawing.Size(121, 17);
-            this.checkBoxEDSMLog.TabIndex = 9;
+            this.checkBoxEDSMLog.TabIndex = 1;
             this.checkBoxEDSMLog.Text = "Log EDSM requests";
             this.checkBoxEDSMLog.TickBoxReductionSize = 10;
             this.checkBoxEDSMLog.UseVisualStyleBackColor = true;
@@ -302,11 +336,11 @@
             this.checkboxSkipSlowUpdates.CheckBoxInnerColor = System.Drawing.Color.White;
             this.checkboxSkipSlowUpdates.CheckColor = System.Drawing.Color.DarkBlue;
             this.checkboxSkipSlowUpdates.FontNerfReduction = 0.5F;
-            this.checkboxSkipSlowUpdates.Location = new System.Drawing.Point(17, 87);
+            this.checkboxSkipSlowUpdates.Location = new System.Drawing.Point(17, 110);
             this.checkboxSkipSlowUpdates.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkboxSkipSlowUpdates.Name = "checkboxSkipSlowUpdates";
             this.checkboxSkipSlowUpdates.Size = new System.Drawing.Size(238, 17);
-            this.checkboxSkipSlowUpdates.TabIndex = 11;
+            this.checkboxSkipSlowUpdates.TabIndex = 4;
             this.checkboxSkipSlowUpdates.Text = "DEBUG ONLY: Skip slow updates on startup";
             this.checkboxSkipSlowUpdates.TickBoxReductionSize = 10;
             this.checkboxSkipSlowUpdates.UseVisualStyleBackColor = false;
@@ -449,9 +483,9 @@
             this.groupBoxTheme.Controls.Add(this.button_edittheme);
             this.groupBoxTheme.Controls.Add(this.buttonSaveTheme);
             this.groupBoxTheme.FillClientAreaWithAlternateColor = false;
-            this.groupBoxTheme.Location = new System.Drawing.Point(4, 403);
+            this.groupBoxTheme.Location = new System.Drawing.Point(3, 435);
             this.groupBoxTheme.Name = "groupBoxTheme";
-            this.groupBoxTheme.Size = new System.Drawing.Size(425, 120);
+            this.groupBoxTheme.Size = new System.Drawing.Size(426, 120);
             this.groupBoxTheme.TabIndex = 18;
             this.groupBoxTheme.TabStop = false;
             this.groupBoxTheme.Text = "Theme";
@@ -508,22 +542,6 @@
             this.buttonSaveTheme.Text = "Save Theme";
             this.buttonSaveTheme.UseVisualStyleBackColor = true;
             this.buttonSaveTheme.Click += new System.EventHandler(this.buttonSaveTheme_Click);
-            // 
-            // checkBoxOrderRowsInverted
-            // 
-            this.checkBoxOrderRowsInverted.AutoSize = true;
-            this.checkBoxOrderRowsInverted.CheckBoxColor = System.Drawing.Color.Gray;
-            this.checkBoxOrderRowsInverted.CheckBoxInnerColor = System.Drawing.Color.White;
-            this.checkBoxOrderRowsInverted.CheckColor = System.Drawing.Color.DarkBlue;
-            this.checkBoxOrderRowsInverted.FontNerfReduction = 0.5F;
-            this.checkBoxOrderRowsInverted.Location = new System.Drawing.Point(17, 64);
-            this.checkBoxOrderRowsInverted.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.checkBoxOrderRowsInverted.Name = "checkBoxOrderRowsInverted";
-            this.checkBoxOrderRowsInverted.Size = new System.Drawing.Size(171, 17);
-            this.checkBoxOrderRowsInverted.TabIndex = 9;
-            this.checkBoxOrderRowsInverted.Text = "Order Rows By Visited Number";
-            this.checkBoxOrderRowsInverted.TickBoxReductionSize = 10;
-            this.checkBoxOrderRowsInverted.UseVisualStyleBackColor = true;
             // 
             // Settings
             // 
@@ -585,5 +603,6 @@
         private ExtendedControls.ButtonExt button_edittheme;
         private ExtendedControls.GroupBoxCustom groupBoxTheme;
         private ExtendedControls.CheckBoxCustom checkBoxOrderRowsInverted;
+        private ExtendedControls.CheckBoxCustom checkBoxFocusNewSystem;
     }
 }

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -279,6 +279,7 @@
             this.checkBoxFocusNewSystem.Text = "Focus on New System";
             this.checkBoxFocusNewSystem.TickBoxReductionSize = 10;
             this.checkBoxFocusNewSystem.UseVisualStyleBackColor = true;
+            this.checkBoxFocusNewSystem.CheckedChanged += new System.EventHandler(this.checkBoxFocusNewSystem_CheckedChanged);
             // 
             // checkBox_Distances
             // 

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -75,6 +75,7 @@ namespace EDDiscovery2
             checkBoxEDSMLog.Checked = EDDiscoveryForm.EDDConfig.EDSMLog;
             checkboxSkipSlowUpdates.Checked = EDDiscoveryForm.EDDConfig.CanSkipSlowUpdates;
             checkBoxOrderRowsInverted.Checked = EDDiscoveryForm.EDDConfig.OrderRowsInverted;
+            checkBoxFocusNewSystem.Checked = EDDiscoveryForm.EDDConfig.FocusOnNewSystem;
 #if DEBUG
             checkboxSkipSlowUpdates.Visible = true;
 #endif
@@ -111,6 +112,7 @@ namespace EDDiscovery2
             EDDiscoveryForm.EDDConfig.EDSMLog = checkBoxEDSMLog.Checked;
             EDDiscoveryForm.EDDConfig.CanSkipSlowUpdates = checkboxSkipSlowUpdates.Checked;
             EDDiscoveryForm.EDDConfig.OrderRowsInverted = checkBoxOrderRowsInverted.Checked;
+            EDDiscoveryForm.EDDConfig.FocusOnNewSystem = checkBoxFocusNewSystem.Checked;
 
             List <EDCommander> edcommanders = (List<EDCommander>)dataGridViewCommanders.DataSource;
             EDDiscoveryForm.EDDConfig.StoreCommanders(edcommanders);

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -283,5 +283,10 @@ namespace EDDiscovery2
             comboBoxTheme.Enabled = true;          // no doing this while theme editor is open
             buttonSaveTheme.Enabled = true;
         }
+
+        private void checkBoxFocusNewSystem_CheckedChanged(object sender, EventArgs e)
+        {
+            EDDConfig.Instance.FocusOnNewSystem = checkBoxFocusNewSystem.Checked;
+        }
     }
 }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -874,9 +874,12 @@ namespace EDDiscovery
             });
 
             // Move focus to new row
-            dataGridViewTravel.ClearSelection();
-            dataGridViewTravel.Rows[0].Cells[0].Selected =true; // This won't raise the CellClick handler, which updates the rest of the form
-            dataGridViewTravel_CellClick(dataGridViewTravel, new DataGridViewCellEventArgs(0, 0));
+            if (EDDiscoveryForm.EDDConfig.FocusOnNewSystem)
+            {
+                dataGridViewTravel.ClearSelection();
+                dataGridViewTravel.Rows[0].Cells[0].Selected = true; // This won't raise the CellClick handler, which updates the rest of the form
+                dataGridViewTravel_CellClick(dataGridViewTravel, new DataGridViewCellEventArgs(0, 0));
+            }
         }
 
         private int GetVisitsCount(string name)

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -872,6 +872,11 @@ namespace EDDiscovery
             {
                 _discoveryForm.Map.UpdateVisited(visitedSystems);      // update in UI thread.
             });
+
+            // Move focus to new row
+            dataGridViewTravel.ClearSelection();
+            dataGridViewTravel.Rows[0].Cells[0].Selected =true; // This won't raise the CellClick handler, which updates the rest of the form
+            dataGridViewTravel_CellClick(dataGridViewTravel, new DataGridViewCellEventArgs(0, 0));
         }
 
         private int GetVisitsCount(string name)


### PR DESCRIPTION
Originally requested in #12, and something I quite like too.
This set of changes (disabled by default) automatically moves the focus to the new system.