### PR TITLE
Fix DatasetBuilder test initialization

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -2024,7 +2024,7 @@ namespace EDDiscovery2
     public class SystemClassStarNames    // holds star data.. used as its kept up to date with visited systems and has extra info
     {
         public SystemClassStarNames() { }
-        public SystemClassStarNames(SystemClass other)
+        public SystemClassStarNames(ISystem other)
         {
             name = other.name;
             x = other.x; y = other.y; z = other.z;
@@ -2056,7 +2056,7 @@ namespace EDDiscovery2
         public TexturedQuadData painttexture { get; set; }
         public PointData paintstar { get; set; }                // instead of doing a array paint.
         public bool candisposepainttexture { get; set; }
-        public SystemClass sysclass;                            // set if created from it
+        public ISystem sysclass;                            // set if created from it
     };
 
 }

--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -184,8 +184,8 @@ namespace EDDiscovery2._3DMap.Tests
             _subject.BuildSelected();
             var datasets = _subject.AddPOIsToDataset();
 
-            Assert.AreEqual("Center", datasets[0].Name);
-            Assert.AreEqual("Interest", datasets[2].Name);
+            Assert.AreEqual("Selected", datasets[0].Name);
+            Assert.AreEqual("Center", datasets[1].Name);
         }
     }
 }

--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -96,7 +96,7 @@ namespace EDDiscovery2._3DMap.Tests
             _subject = new DatasetBuilder
             {
                 CenterSystem = new DB.InMemory.SystemClass(),
-                StarList = SpawnStars()
+                StarList = SpawnStars().Select(s => new SystemClassStarNames(s)).ToList()
             };
         }
 


### PR DESCRIPTION
Fixes an error in the DatasetBuilder initialization during testing that caused the tests to fail to compile.  Also fixes the `When_building_with_no_stars` test to match the new dataset ordering.