### PR TITLE
Fix unlocated systems appearing at Null Island

### DIFF
--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -209,6 +209,9 @@ namespace EDDiscovery2.DB
 
                         //sp.Nr = int.Parse(match.Groups["Body"].Value);
                         sp.Name = match.Groups["SystemName"].Value;
+                        sp.X = Double.NaN;
+                        sp.Y = Double.NaN;
+                        sp.Z = Double.NaN;
                     }
                     else
                     {


### PR DESCRIPTION
The X, Y and Z coordinates were not being set in VisitedSystemClass when reading pre-2.1 logs, thus they defaulted to {0,0,0}