### PR TITLE
Improvements to DB access

### DIFF
--- a/EDDiscovery/DB/BookmarkClass.cs
+++ b/EDDiscovery/DB/BookmarkClass.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 
@@ -50,19 +50,19 @@ namespace EDDiscovery2.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into Bookmarks (StarName, x, y, z, Time, Heading, Note) values (@sname, @xp, @yp, @zp, @time, @head, @note)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into Bookmarks (StarName, x, y, z, Time, Heading, Note) values (@sname, @xp, @yp, @zp, @time, @head, @note)"))
             {
-                cmd.Parameters.AddWithValue("@sname", StarName);
-                cmd.Parameters.AddWithValue("@xp", x);
-                cmd.Parameters.AddWithValue("@yp", y);
-                cmd.Parameters.AddWithValue("@zp", z);
-                cmd.Parameters.AddWithValue("@time", Time);
-                cmd.Parameters.AddWithValue("@head", Heading);
-                cmd.Parameters.AddWithValue("@note", Note);
+                cmd.AddParameterWithValue("@sname", StarName);
+                cmd.AddParameterWithValue("@xp", x);
+                cmd.AddParameterWithValue("@yp", y);
+                cmd.AddParameterWithValue("@zp", z);
+                cmd.AddParameterWithValue("@time", Time);
+                cmd.AddParameterWithValue("@head", Heading);
+                cmd.AddParameterWithValue("@note", Note);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from Bookmarks"))
+                using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from Bookmarks"))
                 {
                     id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                 }
@@ -82,16 +82,16 @@ namespace EDDiscovery2.DB
 
         private bool Update(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update Bookmarks set StarName=@sname, x = @xp, y = @yp, z = @zp, Time=@time, Heading = @head, Note=@note  where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Update Bookmarks set StarName=@sname, x = @xp, y = @yp, z = @zp, Time=@time, Heading = @head, Note=@note  where ID=@id"))
             {
-                cmd.Parameters.AddWithValue("@ID", id);
-                cmd.Parameters.AddWithValue("@sname", StarName);
-                cmd.Parameters.AddWithValue("@xp", x);
-                cmd.Parameters.AddWithValue("@yp", y);
-                cmd.Parameters.AddWithValue("@zp", z);
-                cmd.Parameters.AddWithValue("@time", Time);
-                cmd.Parameters.AddWithValue("@head", Heading);
-                cmd.Parameters.AddWithValue("@note", Note);
+                cmd.AddParameterWithValue("@ID", id);
+                cmd.AddParameterWithValue("@sname", StarName);
+                cmd.AddParameterWithValue("@xp", x);
+                cmd.AddParameterWithValue("@yp", y);
+                cmd.AddParameterWithValue("@zp", z);
+                cmd.AddParameterWithValue("@time", Time);
+                cmd.AddParameterWithValue("@head", Heading);
+                cmd.AddParameterWithValue("@note", Note);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
@@ -112,9 +112,9 @@ namespace EDDiscovery2.DB
 
         private bool Delete(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("DELETE FROM Bookmarks WHERE id = @id"))
+            using (DbCommand cmd = cn.CreateCommand("DELETE FROM Bookmarks WHERE id = @id"))
             {
-                cmd.Parameters.AddWithValue("@id", id);
+                cmd.AddParameterWithValue("@id", id);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
                 bookmarks.RemoveAll(x => x.id == id);     // remove from list any containing id.
@@ -130,7 +130,7 @@ namespace EDDiscovery2.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select * from Bookmarks"))
+                    using (DbCommand cmd = cn.CreateCommand("select * from Bookmarks"))
                     {
                         DataSet ds = null;
 

--- a/EDDiscovery/DB/DistanceClass.cs
+++ b/EDDiscovery/DB/DistanceClass.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -55,7 +55,7 @@ namespace EDDiscovery.DB
             Status = (DistancsEnum)(long)dr["status"];
         }
 
-        public DistanceClass(SQLiteDataReader dr)
+        public DistanceClass(DbDataReader dr)
         {
             id = (long)dr["id"];
             if (System.DBNull.Value != dr["id_edsm"])
@@ -98,9 +98,9 @@ namespace EDDiscovery.DB
         {
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("Delete from Distances where Status=@Status"))
+                using (DbCommand cmd = cn.CreateCommand("Delete from Distances where Status=@Status"))
                 {
-                    cmd.Parameters.AddWithValue("@Status", (int)distsource);
+                    cmd.AddParameterWithValue("@Status", (int)distsource);
                     SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 }
             }
@@ -117,7 +117,7 @@ namespace EDDiscovery.DB
 
                 if (ret == true)
                 {
-                    using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from Distances"))
+                    using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from Distances"))
                     {
                         id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                     }
@@ -129,20 +129,20 @@ namespace EDDiscovery.DB
             }
         }
 
-        private bool Store(SQLiteConnectionED cn, SQLiteTransaction tn = null)
+        private bool Store(SQLiteConnectionED cn, DbTransaction tn = null)
         {
             if (CommanderCreate == null)
                 CommanderCreate = "";
 
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into Distances (NameA, NameB, Dist, CommanderCreate, CreateTime, Status, id_edsm) values (@NameA, @NameB, @Dist, @CommanderCreate, @CreateTime, @Status, @id_edsm)",tn))
+            using (DbCommand cmd = cn.CreateCommand("Insert into Distances (NameA, NameB, Dist, CommanderCreate, CreateTime, Status, id_edsm) values (@NameA, @NameB, @Dist, @CommanderCreate, @CreateTime, @Status, @id_edsm)",tn))
             {
-                cmd.Parameters.AddWithValue("@NameA", NameA);
-                cmd.Parameters.AddWithValue("@NameB", NameB);
-                cmd.Parameters.AddWithValue("@Dist", Dist);
-                cmd.Parameters.AddWithValue("@CommanderCreate", CommanderCreate);
-                cmd.Parameters.AddWithValue("@CreateTime", CreateTime);
-                cmd.Parameters.AddWithValue("@Status", Status);
-                cmd.Parameters.AddWithValue("@id_edsm", id_edsm);
+                cmd.AddParameterWithValue("@NameA", NameA);
+                cmd.AddParameterWithValue("@NameB", NameB);
+                cmd.AddParameterWithValue("@Dist", Dist);
+                cmd.AddParameterWithValue("@CommanderCreate", CommanderCreate);
+                cmd.AddParameterWithValue("@CreateTime", CreateTime);
+                cmd.AddParameterWithValue("@Status", Status);
+                cmd.AddParameterWithValue("@id_edsm", id_edsm);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
             }
@@ -159,18 +159,18 @@ namespace EDDiscovery.DB
             }
         }
 
-        private bool Update(SQLiteConnectionED cn, SQLiteTransaction tn = null)
+        private bool Update(SQLiteConnectionED cn, DbTransaction tn = null)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update Distances  set NameA=@NameA, NameB=@NameB, Dist=@Dist, commandercreate=@commandercreate, CreateTime=@CreateTime, status=@status, id_edsm=@id_edsm  where ID=@id",tn))
+            using (DbCommand cmd = cn.CreateCommand("Update Distances  set NameA=@NameA, NameB=@NameB, Dist=@Dist, commandercreate=@commandercreate, CreateTime=@CreateTime, status=@status, id_edsm=@id_edsm  where ID=@id",tn))
             {
-                cmd.Parameters.AddWithValue("@ID", id);
-                cmd.Parameters.AddWithValue("@NameA", NameA);
-                cmd.Parameters.AddWithValue("@NameB", NameB);
-                cmd.Parameters.AddWithValue("@Dist", Dist);
-                cmd.Parameters.AddWithValue("@CommanderCreate", CommanderCreate);
-                cmd.Parameters.AddWithValue("@CreateTime", CreateTime);
-                cmd.Parameters.AddWithValue("@Status", Status);
-                cmd.Parameters.AddWithValue("@id_edsm", id_edsm);
+                cmd.AddParameterWithValue("@ID", id);
+                cmd.AddParameterWithValue("@NameA", NameA);
+                cmd.AddParameterWithValue("@NameB", NameB);
+                cmd.AddParameterWithValue("@Dist", Dist);
+                cmd.AddParameterWithValue("@CommanderCreate", CommanderCreate);
+                cmd.AddParameterWithValue("@CreateTime", CreateTime);
+                cmd.AddParameterWithValue("@Status", Status);
+                cmd.AddParameterWithValue("@id_edsm", id_edsm);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 return true;
@@ -187,9 +187,9 @@ namespace EDDiscovery.DB
 
         private bool Delete(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Delete From  Distances where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Delete From  Distances where ID=@id"))
             {
-                cmd.Parameters.AddWithValue("@ID", id);
+                cmd.AddParameterWithValue("@ID", id);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 return true;
@@ -205,10 +205,10 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("SELECT * FROM Distances WHERE (NameA = @NameA and NameB = @NameB) OR (NameA = @NameB and NameB = @NameA) limit 1"))
+                    using (DbCommand cmd = cn.CreateCommand("SELECT * FROM Distances WHERE (NameA = @NameA and NameB = @NameB) OR (NameA = @NameB and NameB = @NameA) limit 1"))
                     {
-                        cmd.Parameters.AddWithValue("@NameA", s1.name);
-                        cmd.Parameters.AddWithValue("@NameB", s2.name);
+                        cmd.AddParameterWithValue("@NameA", s1.name);
+                        cmd.AddParameterWithValue("@NameB", s2.name);
                         DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
 
                         if (ds.Tables.Count > 0 && ds.Tables[0].Rows.Count > 0)     // if found.
@@ -239,7 +239,7 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select * from Distances WHERE status='" + status.ToString() + "'"))
+                    using (DbCommand cmd = cn.CreateCommand("select * from Distances WHERE status='" + status.ToString() + "'"))
                     {
                         DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
 
@@ -269,7 +269,7 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    SQLiteCommand cmd = cn.CreateCommand("SELECT * FROM Distances WHERE(NameA = @NameA and NameB = @NameB) OR(NameA = @NameB and NameB = @NameA) limit 1");
+                    DbCommand cmd = cn.CreateCommand("SELECT * FROM Distances WHERE(NameA = @NameA and NameB = @NameB) OR(NameA = @NameB and NameB = @NameA) limit 1");
 
                     for (int i = 1; i < visitedSystems.Count; i++)                 // now we filled in current system, fill in previous system (except for last)
                     {
@@ -282,10 +282,10 @@ namespace EDDiscovery.DB
                         if ( dist < 0 && usedb )     // failed, and use the db is allowed..
                         {
                             cmd.Parameters.Clear();
-                            cmd.Parameters.AddWithValue("@NameA", cur.Name);
-                            cmd.Parameters.AddWithValue("@NameB", prev.Name);
+                            cmd.AddParameterWithValue("@NameA", cur.Name);
+                            cmd.AddParameterWithValue("@NameB", prev.Name);
 
-                            using (SQLiteDataReader reader = cmd.ExecuteReader())
+                            using (DbDataReader reader = cmd.ExecuteReader())
                             {
                                 if (reader.Read())
                                 {
@@ -293,8 +293,6 @@ namespace EDDiscovery.DB
                                     dist = dst.Dist;
                                 }
                             }
-
-                            cmd.Reset();
                         }
 
                         if (dist > 0)
@@ -333,7 +331,7 @@ namespace EDDiscovery.DB
             {
                 int c = 0;
 
-                SQLiteCommand cmd = cn.CreateCommand("select * from Distances where id_edsm=@id limit 1");   // 1 return matching
+                DbCommand cmd = cn.CreateCommand("select * from Distances where id_edsm=@id limit 1");   // 1 return matching
 
                 int lasttc = Environment.TickCount;
 
@@ -355,9 +353,9 @@ namespace EDDiscovery.DB
                         }
 
                         cmd.Parameters.Clear();
-                        cmd.Parameters.AddWithValue("id", dc.id_edsm);
+                        cmd.AddParameterWithValue("id", dc.id_edsm);
 
-                        using (SQLiteDataReader reader1 = cmd.ExecuteReader())              // see if ESDM ID is there..
+                        using (DbDataReader reader1 = cmd.ExecuteReader())              // see if ESDM ID is there..
                         {
                             if (reader1.Read())                                          // its there..
                             {
@@ -378,8 +376,6 @@ namespace EDDiscovery.DB
                                 newpairs.Add(dc);
                             }
                         }
-
-                        cmd.Reset();
                     }
                 }
 
@@ -390,7 +386,7 @@ namespace EDDiscovery.DB
             {
                 if (toupdate.Count > 0)
                 {
-                    using (SQLiteTransaction transaction = cn2.BeginTransaction())
+                    using (DbTransaction transaction = cn2.BeginTransaction())
                     {
                         foreach (DistanceClass dc in toupdate)
                             dc.Update(cn2, transaction);
@@ -405,7 +401,7 @@ namespace EDDiscovery.DB
 
                     while (count < newpairs.Count())
                     {
-                        using (SQLiteTransaction transaction = cn2.BeginTransaction())
+                        using (DbTransaction transaction = cn2.BeginTransaction())
                         {
                             while (count < newpairs.Count())
                             {
@@ -424,7 +420,7 @@ namespace EDDiscovery.DB
                 if (removenonedsmids)                            // done on a full sync..
                 {
                     Console.WriteLine("Delete old ones");
-                    using (SQLiteCommand cmddel = cn2.CreateCommand("Delete from Distances where id_edsm is null"))
+                    using (DbCommand cmddel = cn2.CreateCommand("Delete from Distances where id_edsm is null"))
                     {
                         SQLiteDBClass.SQLNonQueryText(cn2, cmddel);
                     }

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Data.SQLite;
 using System.Diagnostics;
 using System.Globalization;
@@ -10,11 +11,59 @@ using System.Windows.Forms;
 
 namespace EDDiscovery.DB
 {
+    public static class SQLiteDBExtensions
+    {
+        public static void AddParameterWithValue(this DbCommand cmd, string name, object val)
+        {
+            var par = cmd.CreateParameter();
+            par.ParameterName = name;
+            par.Value = val;
+            cmd.Parameters.Add(par);
+        }
+
+        public static void AddParameter(this DbCommand cmd, string name, DbType type)
+        {
+            var par = cmd.CreateParameter();
+            par.ParameterName = name;
+            par.DbType = type;
+            cmd.Parameters.Add(par);
+        }
+
+        public static void SetParameterValue(this DbCommand cmd, string name, object val)
+        {
+            cmd.Parameters[name].Value = val;
+        }
+
+        public static DbDataAdapter CreateDataAdapter(this DbCommand cmd)
+        {
+            DbDataAdapter da = SQLiteDBClass.DbFactory.CreateDataAdapter();
+            da.SelectCommand = cmd;
+            return da;
+        }
+
+        public static DbCommand CreateCommand(this DbConnection conn, string query)
+        {
+            DbCommand cmd = conn.CreateCommand();
+            cmd.CommandType = CommandType.Text;
+            cmd.CommandTimeout = 30;
+            cmd.CommandText = query;
+            return cmd;
+        }
+
+        public static DbCommand CreateCommand(this DbConnection conn, string query, DbTransaction transaction)
+        {
+            DbCommand cmd = conn.CreateCommand(query);
+            cmd.Transaction = transaction;
+            return cmd;
+        }
+    }
+
+
     public class SQLiteConnectionED : IDisposable              // USE this for connections.. 
     {
         //static Object monitor = new Object();                 // monitor disabled for now - it prevent SQLite DB locked errors but 
                                                                 // causes the program to become unresponsive during big DB updates
-        private SQLiteConnection _cn;
+        private DbConnection _cn;
 
         public SQLiteConnectionED()
         {
@@ -24,14 +73,12 @@ namespace EDDiscovery.DB
             _cn.Open();
         }
 
-        public SQLiteCommand CreateCommand(string cmd, SQLiteTransaction tn = null)
+        public DbCommand CreateCommand(string cmd, DbTransaction tn = null)
         {
-            SQLiteCommand sqcmd = new SQLiteCommand(cmd, _cn, tn);
-            sqcmd.CommandTimeout = 30;
-            return sqcmd;
+            return _cn.CreateCommand(cmd, tn);
         }
 
-        public SQLiteTransaction BeginTransaction()
+        public DbTransaction BeginTransaction()
         {
             return _cn.BeginTransaction();
         }
@@ -53,15 +100,31 @@ namespace EDDiscovery.DB
 
     public class SQLiteDBClass
     {
-        public static SQLiteConnection CreateCN()
+        private static DbProviderFactory _factory;
+        public static DbProviderFactory DbFactory
+        {
+            get
+            {
+                if (_factory == null)
+                {
+                    _factory = new SQLiteFactory();
+                }
+                return _factory;
+            }
+        }
+
+        public static DbConnection CreateCN()
         {
             lock (lockDBInit)                                           // one at a time chaps
             {
                 if (_db == null)                                        // first one to ask for a connection sets the db up
+                {
                     _db = new SQLiteDBClass();
+                    _db.InitializeDatabase();
+                }
             }
 
-            SQLiteConnection cn = new SQLiteConnection(_db.constring);
+            DbConnection cn = DbFactory.CreateConnection();
             return cn;
         }
 
@@ -72,6 +135,10 @@ namespace EDDiscovery.DB
 
         private SQLiteDBClass()         // non static class functions in here are only used by the construction
         {                               // so this is private to make sure you don't try and initialise a DB anywhere..
+        }
+
+        private void InitializeDatabase()
+        {
             string dbfile = GetSQLiteDBFile();
             constring = "Data Source=" + dbfile + ";Pooling=true;";
             try
@@ -97,7 +164,7 @@ namespace EDDiscovery.DB
 
         private void ExecuteQuery(string query)
         {
-            using (SQLiteCommand command = m_SQLiteConnectionED.CreateCommand(query))
+            using (DbCommand command = m_SQLiteConnectionED.CreateCommand(query))
                 command.ExecuteNonQuery();
         }
 
@@ -365,12 +432,12 @@ namespace EDDiscovery.DB
         ///----------------------------
         /// STATIC code helpers for other DB classes
 
-        public static DataSet SQLQueryText(SQLiteConnectionED cn, SQLiteCommand cmd)  
+        public static DataSet SQLQueryText(SQLiteConnectionED cn, DbCommand cmd)  
         {
             try
             {
                 DataSet ds = new DataSet();
-                SQLiteDataAdapter da = new SQLiteDataAdapter(cmd);
+                DbDataAdapter da = cmd.CreateDataAdapter();
                 da.Fill(ds);
                 return ds;
             }
@@ -381,7 +448,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        static public int SQLNonQueryText(SQLiteConnectionED cn, SQLiteCommand cmd)   
+        static public int SQLNonQueryText(SQLiteConnectionED cn, DbCommand cmd)   
         {
             int rows = 0;
 
@@ -397,7 +464,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        static public object SQLScalar(SQLiteConnectionED cn, SQLiteCommand cmd)      
+        static public object SQLScalar(SQLiteConnectionED cn, DbCommand cmd)      
         {
             object ret = null;
 
@@ -428,9 +495,9 @@ namespace EDDiscovery.DB
         {
             try
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("select ID from Register WHERE ID=@key"))
+                using (DbCommand cmd = cn.CreateCommand("select ID from Register WHERE ID=@key"))
                 {
-                    cmd.Parameters.AddWithValue("@key", sKey);
+                    cmd.AddParameterWithValue("@key", sKey);
 
                     DataSet ds = SQLQueryText(cn, cmd);
 
@@ -456,9 +523,9 @@ namespace EDDiscovery.DB
         { 
             try
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("SELECT ValueInt from Register WHERE ID = @ID"))
+                using (DbCommand cmd = cn.CreateCommand("SELECT ValueInt from Register WHERE ID = @ID"))
                 {
-                    cmd.Parameters.AddWithValue("@ID", key);
+                    cmd.AddParameterWithValue("@ID", key);
 
                     object ob = SQLScalar(cn, cmd);
 
@@ -491,10 +558,10 @@ namespace EDDiscovery.DB
             {
                 if (keyExists(key,cn))
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Update Register set ValueInt = @ValueInt Where ID=@ID"))
+                    using (DbCommand cmd = cn.CreateCommand("Update Register set ValueInt = @ValueInt Where ID=@ID"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@ValueInt", intvalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@ValueInt", intvalue);
 
                         SQLNonQueryText(cn, cmd);
 
@@ -503,10 +570,10 @@ namespace EDDiscovery.DB
                 }
                 else
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueInt) values (@ID, @valint)"))
+                    using (DbCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueInt) values (@ID, @valint)"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@valint", intvalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@valint", intvalue);
 
                         SQLNonQueryText(cn, cmd);
                         return true;
@@ -531,9 +598,9 @@ namespace EDDiscovery.DB
         {
             try
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("SELECT ValueDouble from Register WHERE ID = @ID"))
+                using (DbCommand cmd = cn.CreateCommand("SELECT ValueDouble from Register WHERE ID = @ID"))
                 {
-                    cmd.Parameters.AddWithValue("@ID", key);
+                    cmd.AddParameterWithValue("@ID", key);
 
                     object ob = SQLScalar(cn, cmd);
 
@@ -566,10 +633,10 @@ namespace EDDiscovery.DB
             {
                 if (keyExists(key,cn))
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Update Register set ValueDouble = @ValueDouble Where ID=@ID"))
+                    using (DbCommand cmd = cn.CreateCommand("Update Register set ValueDouble = @ValueDouble Where ID=@ID"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@ValueDouble", doublevalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@ValueDouble", doublevalue);
 
                         SQLNonQueryText(cn, cmd);
 
@@ -578,10 +645,10 @@ namespace EDDiscovery.DB
                 }
                 else
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueDouble) values (@ID, @valdbl)"))
+                    using (DbCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueDouble) values (@ID, @valdbl)"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@valdbl", doublevalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@valdbl", doublevalue);
 
                         SQLNonQueryText(cn, cmd);
                         return true;
@@ -606,9 +673,9 @@ namespace EDDiscovery.DB
         {
             try
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("SELECT ValueInt from Register WHERE ID = @ID"))
+                using (DbCommand cmd = cn.CreateCommand("SELECT ValueInt from Register WHERE ID = @ID"))
                 {
-                    cmd.Parameters.AddWithValue("@ID", key);
+                    cmd.AddParameterWithValue("@ID", key);
 
                     object ob = SQLScalar(cn, cmd);
 
@@ -650,10 +717,10 @@ namespace EDDiscovery.DB
 
                 if (keyExists(key,cn))
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Update Register set ValueInt = @ValueInt Where ID=@ID"))
+                    using (DbCommand cmd = cn.CreateCommand("Update Register set ValueInt = @ValueInt Where ID=@ID"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@ValueInt", intvalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@ValueInt", intvalue);
 
                         SQLNonQueryText(cn, cmd);
 
@@ -662,10 +729,10 @@ namespace EDDiscovery.DB
                 }
                 else
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueInt) values (@ID, @valint)"))
+                    using (DbCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueInt) values (@ID, @valint)"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@valint", intvalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@valint", intvalue);
 
                         SQLNonQueryText(cn, cmd);
                         return true;
@@ -690,9 +757,9 @@ namespace EDDiscovery.DB
         {
             try
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("SELECT ValueString from Register WHERE ID = @ID"))
+                using (DbCommand cmd = cn.CreateCommand("SELECT ValueString from Register WHERE ID = @ID"))
                 {
-                    cmd.Parameters.AddWithValue("@ID", key);
+                    cmd.AddParameterWithValue("@ID", key);
                     object ob = SQLScalar(cn, cmd);
 
                     if (ob == null)
@@ -727,10 +794,10 @@ namespace EDDiscovery.DB
             {
                 if (keyExists(key,cn))
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Update Register set ValueString = @ValueString Where ID=@ID"))
+                    using (DbCommand cmd = cn.CreateCommand("Update Register set ValueString = @ValueString Where ID=@ID"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@ValueString", strvalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@ValueString", strvalue);
 
                         SQLNonQueryText(cn, cmd);
 
@@ -739,10 +806,10 @@ namespace EDDiscovery.DB
                 }
                 else
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueString) values (@ID, @valint)"))
+                    using (DbCommand cmd = cn.CreateCommand("Insert into Register (ID, ValueString) values (@ID, @valint)"))
                     {
-                        cmd.Parameters.AddWithValue("@ID", key);
-                        cmd.Parameters.AddWithValue("@valint", strvalue);
+                        cmd.AddParameterWithValue("@ID", key);
+                        cmd.AddParameterWithValue("@valint", strvalue);
 
                         SQLNonQueryText(cn, cmd);
                         return true;

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -125,6 +125,7 @@ namespace EDDiscovery.DB
             }
 
             DbConnection cn = DbFactory.CreateConnection();
+            cn.ConnectionString = _db.constring;
             return cn;
         }
 

--- a/EDDiscovery/DB/SavedRouteClass.cs
+++ b/EDDiscovery/DB/SavedRouteClass.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
-using System.Data.SQLite;
+using System.Data.Common;
 
 namespace EDDiscovery.DB
 {
@@ -81,23 +81,23 @@ namespace EDDiscovery.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into routes_expeditions (name, start, end) values (@name, @start, @end)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into routes_expeditions (name, start, end) values (@name, @start, @end)"))
             {
-                cmd.Parameters.AddWithValue("@name", Name);
-                cmd.Parameters.AddWithValue("@start", StartDate);
-                cmd.Parameters.AddWithValue("@end", EndDate);
+                cmd.AddParameterWithValue("@name", Name);
+                cmd.AddParameterWithValue("@start", StartDate);
+                cmd.AddParameterWithValue("@end", EndDate);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from routes_expeditions"))
+                using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from routes_expeditions"))
                 {
                     Id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                 }
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("INSERT INTO route_systems (routeid, systemname) VALUES (@routeid, @name)"))
+                using (DbCommand cmd2 = cn.CreateCommand("INSERT INTO route_systems (routeid, systemname) VALUES (@routeid, @name)"))
                 {
-                    cmd2.Parameters.Add("@routeid", DbType.String);
-                    cmd2.Parameters.Add("@name", DbType.String);
+                    cmd2.AddParameter("@routeid", DbType.String);
+                    cmd2.AddParameter("@name", DbType.String);
 
                     foreach (var sysname in Systems)
                     {
@@ -122,24 +122,24 @@ namespace EDDiscovery.DB
 
         private bool Update(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("UPDATE routes_expeditions SET name=@name, start=@start, end=@end WHERE id=@id"))
+            using (DbCommand cmd = cn.CreateCommand("UPDATE routes_expeditions SET name=@name, start=@start, end=@end WHERE id=@id"))
             {
-                cmd.Parameters.AddWithValue("@id", Id);
-                cmd.Parameters.AddWithValue("@name", Name);
-                cmd.Parameters.AddWithValue("@start", StartDate);
-                cmd.Parameters.AddWithValue("@end", EndDate);
+                cmd.AddParameterWithValue("@id", Id);
+                cmd.AddParameterWithValue("@name", Name);
+                cmd.AddParameterWithValue("@start", StartDate);
+                cmd.AddParameterWithValue("@end", EndDate);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("DELETE FROM route_systems WHERE routeid=@routeid"))
+                using (DbCommand cmd2 = cn.CreateCommand("DELETE FROM route_systems WHERE routeid=@routeid"))
                 {
-                    cmd2.Parameters.AddWithValue("@routeid", Id);
+                    cmd2.AddParameterWithValue("@routeid", Id);
                     SQLiteDBClass.SQLNonQueryText(cn, cmd2);
                 }
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("INSERT INTO route_systems (routeid, systemname) VALUES (@routeid, @name)"))
+                using (DbCommand cmd2 = cn.CreateCommand("INSERT INTO route_systems (routeid, systemname) VALUES (@routeid, @name)"))
                 {
-                    cmd2.Parameters.Add("@routeid", DbType.String);
-                    cmd2.Parameters.Add("@name", DbType.String);
+                    cmd2.AddParameter("@routeid", DbType.String);
+                    cmd2.AddParameter("@name", DbType.String);
 
                     foreach (var sysname in Systems)
                     {
@@ -162,13 +162,13 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd1 = cn.CreateCommand("select * from routes_expeditions"))
+                    using (DbCommand cmd1 = cn.CreateCommand("select * from routes_expeditions"))
                     {
                         DataSet ds1 = SQLiteDBClass.SQLQueryText(cn, cmd1);
 
                         if (ds1.Tables.Count > 0 && ds1.Tables[0].Rows.Count > 0)
                         {
-                            using (SQLiteCommand cmd2 = cn.CreateCommand("select * from route_systems"))
+                            using (DbCommand cmd2 = cn.CreateCommand("select * from route_systems"))
                             {
                                 DataSet ds2 = SQLiteDBClass.SQLQueryText(cn, cmd2);
 

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -257,7 +257,7 @@ namespace EDDiscovery.DB
             needs_permit = o == DBNull.Value ? 0 : (int)((long)o);
         }
 
-        public SystemClass(SQLiteDataReader dr)         // read from a SQLite reader after a query
+        public SystemClass(DbDataReader dr)         // read from a SQLite reader after a query
         {
             Object o;
 
@@ -333,9 +333,9 @@ namespace EDDiscovery.DB
         {
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("Delete from Systems where Status=@Status"))
+                using (DbCommand cmd = cn.CreateCommand("Delete from Systems where Status=@Status"))
                 {
-                    cmd.Parameters.AddWithValue("@Status", (int)source);
+                    cmd.AddParameterWithValue("@Status", (int)source);
                     SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 }
             }
@@ -376,54 +376,54 @@ namespace EDDiscovery.DB
         }
 
 
-        public bool Store(SQLiteConnectionED cn, SQLiteTransaction transaction)
+        public bool Store(SQLiteConnectionED cn, DbTransaction transaction)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note, id_eddb, population, faction, government_id, allegiance_id, primary_economy_id, security, eddb_updated_at, state, needs_permit, versiondate, id_edsm) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note, @id_eddb, @population, @faction, @government_id, @allegiance_id, @primary_economy_id,  @security, @eddb_updated_at, @state, @needs_permit, datetime('now'),@id_edsm)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note, id_eddb, population, faction, government_id, allegiance_id, primary_economy_id, security, eddb_updated_at, state, needs_permit, versiondate, id_edsm) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note, @id_eddb, @population, @faction, @government_id, @allegiance_id, @primary_economy_id,  @security, @eddb_updated_at, @state, @needs_permit, datetime('now'),@id_edsm)"))
             {
                 if (SystemNote == null)
                     SystemNote = "";
 
                 if (id_eddb != 0)
                 {
-                    cmd.Parameters.AddWithValue("@name", name);
-                    cmd.Parameters.AddWithValue("@x", x);
-                    cmd.Parameters.AddWithValue("@y", y);
-                    cmd.Parameters.AddWithValue("@z", z);
-                    cmd.Parameters.AddWithValue("@cr", cr);
-                    cmd.Parameters.AddWithValue("@CommanderCreate", CommanderCreate);
-                    cmd.Parameters.AddWithValue("@Createdate", CreateDate);
-                    cmd.Parameters.AddWithValue("@CommanderUpdate", CommanderCreate);
-                    cmd.Parameters.AddWithValue("@updatedate", CreateDate);
-                    cmd.Parameters.AddWithValue("@Status", (int)status);
+                    cmd.AddParameterWithValue("@name", name);
+                    cmd.AddParameterWithValue("@x", x);
+                    cmd.AddParameterWithValue("@y", y);
+                    cmd.AddParameterWithValue("@z", z);
+                    cmd.AddParameterWithValue("@cr", cr);
+                    cmd.AddParameterWithValue("@CommanderCreate", CommanderCreate);
+                    cmd.AddParameterWithValue("@Createdate", CreateDate);
+                    cmd.AddParameterWithValue("@CommanderUpdate", CommanderCreate);
+                    cmd.AddParameterWithValue("@updatedate", CreateDate);
+                    cmd.AddParameterWithValue("@Status", (int)status);
 
-                    cmd.Parameters.AddWithValue("@id_eddb", id_eddb);
-                    cmd.Parameters.AddWithValue("@population", population);
-                    cmd.Parameters.AddWithValue("@faction", faction);
-                    cmd.Parameters.AddWithValue("@government_id", government);
-                    cmd.Parameters.AddWithValue("@allegiance_id", allegiance);
-                    cmd.Parameters.AddWithValue("@primary_economy_id", primary_economy);
-                    cmd.Parameters.AddWithValue("@security", security);
-                    cmd.Parameters.AddWithValue("@eddb_updated_at", eddb_updated_at);
-                    cmd.Parameters.AddWithValue("@state", state);
-                    cmd.Parameters.AddWithValue("@needs_permit", needs_permit);
-                    cmd.Parameters.AddWithValue("@Note", SystemNote);
-                    cmd.Parameters.AddWithValue("@id_edsm", id_edsm);
+                    cmd.AddParameterWithValue("@id_eddb", id_eddb);
+                    cmd.AddParameterWithValue("@population", population);
+                    cmd.AddParameterWithValue("@faction", faction);
+                    cmd.AddParameterWithValue("@government_id", government);
+                    cmd.AddParameterWithValue("@allegiance_id", allegiance);
+                    cmd.AddParameterWithValue("@primary_economy_id", primary_economy);
+                    cmd.AddParameterWithValue("@security", security);
+                    cmd.AddParameterWithValue("@eddb_updated_at", eddb_updated_at);
+                    cmd.AddParameterWithValue("@state", state);
+                    cmd.AddParameterWithValue("@needs_permit", needs_permit);
+                    cmd.AddParameterWithValue("@Note", SystemNote);
+                    cmd.AddParameterWithValue("@id_edsm", id_edsm);
                 }
                 else
                 {       // override the cmd.
                     cmd.CommandText = "Insert into Systems (name, x, y, z, cr, commandercreate, createdate, commanderupdate, updatedate, status, note, versiondate,id_edsm) values (@name, @x, @y, @z, @cr, @commandercreate, @createdate, @commanderupdate, @updatedate, @status, @Note, datetime('now'),@id_edsm)";
-                    cmd.Parameters.AddWithValue("@name", name);
-                    cmd.Parameters.AddWithValue("@x", x);
-                    cmd.Parameters.AddWithValue("@y", y);
-                    cmd.Parameters.AddWithValue("@z", z);
-                    cmd.Parameters.AddWithValue("@cr", cr);
-                    cmd.Parameters.AddWithValue("@CommanderCreate", CommanderCreate);
-                    cmd.Parameters.AddWithValue("@Createdate", CreateDate);
-                    cmd.Parameters.AddWithValue("@CommanderUpdate", CommanderCreate);
-                    cmd.Parameters.AddWithValue("@updatedate", CreateDate);
-                    cmd.Parameters.AddWithValue("@Status", (int)status);
-                    cmd.Parameters.AddWithValue("@Note", SystemNote);
-                    cmd.Parameters.AddWithValue("@id_edsm", id_edsm);
+                    cmd.AddParameterWithValue("@name", name);
+                    cmd.AddParameterWithValue("@x", x);
+                    cmd.AddParameterWithValue("@y", y);
+                    cmd.AddParameterWithValue("@z", z);
+                    cmd.AddParameterWithValue("@cr", cr);
+                    cmd.AddParameterWithValue("@CommanderCreate", CommanderCreate);
+                    cmd.AddParameterWithValue("@Createdate", CreateDate);
+                    cmd.AddParameterWithValue("@CommanderUpdate", CommanderCreate);
+                    cmd.AddParameterWithValue("@updatedate", CreateDate);
+                    cmd.AddParameterWithValue("@Status", (int)status);
+                    cmd.AddParameterWithValue("@Note", SystemNote);
+                    cmd.AddParameterWithValue("@id_edsm", id_edsm);
                 }
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
@@ -431,52 +431,52 @@ namespace EDDiscovery.DB
             }
         }
 
-        public bool Update(SQLiteConnectionED cn, long id, SQLiteTransaction transaction)
+        public bool Update(SQLiteConnectionED cn, long id, DbTransaction transaction)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update Systems set name=@name, x=@x, y=@y, z=@z, cr=@cr, commandercreate=@commandercreate, createdate=@createdate, commanderupdate=@commanderupdate, updatedate=@updatedate, status=@status, note=@Note, id_eddb=@id_eddb, population=@population, faction=@faction, government_id=@government_id, allegiance_id=@allegiance_id, primary_economy_id=@primary_economy_id,  security=@security, eddb_updated_at=@eddb_updated_at, state=@state, needs_permit=@needs_permit, versiondate=datetime('now'), id_edsm=@id_edsm where ID=@id",  transaction))
+            using (DbCommand cmd = cn.CreateCommand("Update Systems set name=@name, x=@x, y=@y, z=@z, cr=@cr, commandercreate=@commandercreate, createdate=@createdate, commanderupdate=@commanderupdate, updatedate=@updatedate, status=@status, note=@Note, id_eddb=@id_eddb, population=@population, faction=@faction, government_id=@government_id, allegiance_id=@allegiance_id, primary_economy_id=@primary_economy_id,  security=@security, eddb_updated_at=@eddb_updated_at, state=@state, needs_permit=@needs_permit, versiondate=datetime('now'), id_edsm=@id_edsm where ID=@id",  transaction))
             {
-                cmd.Parameters.AddWithValue("@id", id);
-                cmd.Parameters.AddWithValue("@name", name);
-                cmd.Parameters.AddWithValue("@x", x);
-                cmd.Parameters.AddWithValue("@y", y);
-                cmd.Parameters.AddWithValue("@z", z);
-                cmd.Parameters.AddWithValue("@cr", cr);
-                cmd.Parameters.AddWithValue("@CommanderCreate", CommanderCreate);
-                cmd.Parameters.AddWithValue("@Createdate", CreateDate);
-                cmd.Parameters.AddWithValue("@CommanderUpdate", CommanderCreate);
-                cmd.Parameters.AddWithValue("@updatedate", CreateDate);
-                cmd.Parameters.AddWithValue("@Status", (int)status);
+                cmd.AddParameterWithValue("@id", id);
+                cmd.AddParameterWithValue("@name", name);
+                cmd.AddParameterWithValue("@x", x);
+                cmd.AddParameterWithValue("@y", y);
+                cmd.AddParameterWithValue("@z", z);
+                cmd.AddParameterWithValue("@cr", cr);
+                cmd.AddParameterWithValue("@CommanderCreate", CommanderCreate);
+                cmd.AddParameterWithValue("@Createdate", CreateDate);
+                cmd.AddParameterWithValue("@CommanderUpdate", CommanderCreate);
+                cmd.AddParameterWithValue("@updatedate", CreateDate);
+                cmd.AddParameterWithValue("@Status", (int)status);
                 if (SystemNote == null)
                     SystemNote = "";
-                cmd.Parameters.AddWithValue("@Note", SystemNote);
+                cmd.AddParameterWithValue("@Note", SystemNote);
 
-                cmd.Parameters.AddWithValue("@id_eddb", id_eddb);
-                cmd.Parameters.AddWithValue("@population", population);
-                cmd.Parameters.AddWithValue("@faction", faction);
-                cmd.Parameters.AddWithValue("@government_id", government);
-                cmd.Parameters.AddWithValue("@allegiance_id", allegiance);
-                cmd.Parameters.AddWithValue("@primary_economy_id", primary_economy);
-                cmd.Parameters.AddWithValue("@security", security);
-                cmd.Parameters.AddWithValue("@eddb_updated_at", eddb_updated_at);
-                cmd.Parameters.AddWithValue("@state", state);
-                cmd.Parameters.AddWithValue("@needs_permit", needs_permit);
+                cmd.AddParameterWithValue("@id_eddb", id_eddb);
+                cmd.AddParameterWithValue("@population", population);
+                cmd.AddParameterWithValue("@faction", faction);
+                cmd.AddParameterWithValue("@government_id", government);
+                cmd.AddParameterWithValue("@allegiance_id", allegiance);
+                cmd.AddParameterWithValue("@primary_economy_id", primary_economy);
+                cmd.AddParameterWithValue("@security", security);
+                cmd.AddParameterWithValue("@eddb_updated_at", eddb_updated_at);
+                cmd.AddParameterWithValue("@state", state);
+                cmd.AddParameterWithValue("@needs_permit", needs_permit);
 
-                cmd.Parameters.AddWithValue("@id_edsm", id_edsm);
+                cmd.AddParameterWithValue("@id_edsm", id_edsm);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 return true;
             }
         }
 
-        public bool UpdateEDSM(SQLiteConnectionED cn, long id, SQLiteTransaction transaction)     // only altering fields EDSM sets..
+        public bool UpdateEDSM(SQLiteConnectionED cn, long id, DbTransaction transaction)     // only altering fields EDSM sets..
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update Systems set name=@name, x=@x, y=@y, z=@z, versiondate=datetime('now') where ID=@id",  transaction))
+            using (DbCommand cmd = cn.CreateCommand("Update Systems set name=@name, x=@x, y=@y, z=@z, versiondate=datetime('now') where ID=@id",  transaction))
             {
-                cmd.Parameters.AddWithValue("@id", id);
-                cmd.Parameters.AddWithValue("@name", name);
-                cmd.Parameters.AddWithValue("@x", x);
-                cmd.Parameters.AddWithValue("@y", y);
-                cmd.Parameters.AddWithValue("@z", z);
+                cmd.AddParameterWithValue("@id", id);
+                cmd.AddParameterWithValue("@name", name);
+                cmd.AddParameterWithValue("@x", x);
+                cmd.AddParameterWithValue("@y", y);
+                cmd.AddParameterWithValue("@z", z);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 return true;
             }
@@ -484,11 +484,11 @@ namespace EDDiscovery.DB
 
         public enum SystemIDType { id, id_edsm, id_eddb };       // which ID to match?
 
-        public static bool Delete(long id, SQLiteConnectionED cn = null, SQLiteTransaction transaction = null, SystemIDType idtype = SystemIDType.id)
+        public static bool Delete(long id, SQLiteConnectionED cn = null, DbTransaction transaction = null, SystemIDType idtype = SystemIDType.id)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Delete from Systems where " + idtype.ToString() + "=@id",  transaction))
+            using (DbCommand cmd = cn.CreateCommand("Delete from Systems where " + idtype.ToString() + "=@id",  transaction))
             {
-                cmd.Parameters.AddWithValue("@id", id);
+                cmd.AddParameterWithValue("@id", id);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
             }
 
@@ -517,9 +517,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select id,name,x,y,z,population from Systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select id,name,x,y,z,population from Systems"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read())
                             {
@@ -553,9 +553,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select name from Systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select name from Systems"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read())
                             {
@@ -581,9 +581,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select x,y,z from Systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select x,y,z from Systems"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read())
                             {
@@ -609,9 +609,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select * from Systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select * from Systems"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read())
                             {
@@ -637,9 +637,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select name from Systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select name from Systems"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read())
                             {
@@ -674,10 +674,10 @@ namespace EDDiscovery.DB
                     closeit = true;
                 }
 
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from Systems where name = @name limit 1"))   // 1 return matching name
+                using (DbCommand cmd = cn.CreateCommand("select * from Systems where name = @name limit 1"))   // 1 return matching name
                 {
-                    cmd.Parameters.AddWithValue("name", name);
-                    using (SQLiteDataReader reader = cmd.ExecuteReader())
+                    cmd.AddParameterWithValue("name", name);
+                    using (DbDataReader reader = cmd.ExecuteReader())
                     {
                         if (reader.Read())
                             sys = new SystemClass(reader);
@@ -711,10 +711,10 @@ namespace EDDiscovery.DB
                     closeit = true;
                 }
 
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from Systems where " + idtype.ToString() + "=@id limit 1"))   // 1 return matching name
+                using (DbCommand cmd = cn.CreateCommand("select * from Systems where " + idtype.ToString() + "=@id limit 1"))   // 1 return matching name
                 {
-                    cmd.Parameters.AddWithValue("id", id);
-                    using (SQLiteDataReader reader = cmd.ExecuteReader())
+                    cmd.AddParameterWithValue("id", id);
+                    using (DbDataReader reader = cmd.ExecuteReader())
                     {
                         if (reader.Read())
                             sys = new SystemClass(reader);
@@ -743,9 +743,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select Count(*) from Systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select Count(*) from Systems"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             if (reader.Read())
                                 value = (long)reader["Count(*)"];
@@ -770,9 +770,9 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select versiondate from Systems Order By versiondate DESC limit 1"))
+                    using (DbCommand cmd = cn.CreateCommand("select versiondate from Systems Order By versiondate DESC limit 1"))
                     {
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             if (reader.Read() && System.DBNull.Value != reader["versiondate"])
                                 lasttime = (DateTime)reader["versiondate"];
@@ -791,9 +791,9 @@ namespace EDDiscovery.DB
 
         public static void TouchSystem(SQLiteConnectionED cn, string systemName)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("update systems set versiondate=datetime('now') where name=@systemName"))
+            using (DbCommand cmd = cn.CreateCommand("update systems set versiondate=datetime('now') where name=@systemName"))
             {
-                cmd.Parameters.AddWithValue("systemName", systemName);
+                cmd.AddParameterWithValue("systemName", systemName);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
             }
         }
@@ -804,14 +804,14 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select name,x,y,z from Systems Order By (x-@xv)*(x-@xv)+(y-@yv)*(y-@yv)+(z-@zv)*(z-@zv) Limit @max"))
+                    using (DbCommand cmd = cn.CreateCommand("select name,x,y,z from Systems Order By (x-@xv)*(x-@xv)+(y-@yv)*(y-@yv)+(z-@zv)*(z-@zv) Limit @max"))
                     {
-                        cmd.Parameters.AddWithValue("xv", x);
-                        cmd.Parameters.AddWithValue("yv", y);
-                        cmd.Parameters.AddWithValue("zv", z);
-                        cmd.Parameters.AddWithValue("max", maxitems+1);     // 1 more, because if we are on a star, that will be returned
+                        cmd.AddParameterWithValue("xv", x);
+                        cmd.AddParameterWithValue("yv", y);
+                        cmd.AddParameterWithValue("zv", z);
+                        cmd.AddParameterWithValue("max", maxitems+1);     // 1 more, because if we are on a star, that will be returned
 
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read() && distlist.Count < maxitems)           // already sorted, and already limited to max items
                             {
@@ -866,21 +866,21 @@ namespace EDDiscovery.DB
                                       "where (x-@xw)*(x-@xw)+(y-@yw)*(y-@yw)+(z-@zw)*(z-@zw)<=@maxfromwanted AND " +
                                       "(x-@xc)*(x-@xc)+(y-@yc)*(y-@yc)+(z-@zc)*(z-@zc)<=@maxfromcurrent";
                     
-                    using (SQLiteCommand cmd = cn.CreateCommand(sqlquery))
+                    using (DbCommand cmd = cn.CreateCommand(sqlquery))
                     {
-                        cmd.Parameters.AddWithValue("xw", wantedpos.X);
-                        cmd.Parameters.AddWithValue("yw", wantedpos.Y);
-                        cmd.Parameters.AddWithValue("zw", wantedpos.Z);
-                        cmd.Parameters.AddWithValue("maxfromwanted", maxfromwanted * maxfromwanted);     //squared
+                        cmd.AddParameterWithValue("xw", wantedpos.X);
+                        cmd.AddParameterWithValue("yw", wantedpos.Y);
+                        cmd.AddParameterWithValue("zw", wantedpos.Z);
+                        cmd.AddParameterWithValue("maxfromwanted", maxfromwanted * maxfromwanted);     //squared
 
-                        cmd.Parameters.AddWithValue("xc", curpos.X);
-                        cmd.Parameters.AddWithValue("yc", curpos.Y);
-                        cmd.Parameters.AddWithValue("zc", curpos.Z);
-                        cmd.Parameters.AddWithValue("maxfromcurrent", maxfromcurpos * maxfromcurpos);     //squared
+                        cmd.AddParameterWithValue("xc", curpos.X);
+                        cmd.AddParameterWithValue("yc", curpos.Y);
+                        cmd.AddParameterWithValue("zc", curpos.Z);
+                        cmd.AddParameterWithValue("maxfromcurrent", maxfromcurpos * maxfromcurpos);     //squared
 
                         double bestmindistance = double.MaxValue;
 
-                        using (SQLiteDataReader reader = cmd.ExecuteReader())
+                        using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             while (reader.Read())
                             {
@@ -952,22 +952,20 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    SQLiteCommand cmd = cn.CreateCommand("select * from Systems where name = @name limit 1");
+                    DbCommand cmd = cn.CreateCommand("select * from Systems where name = @name limit 1");
 
                     foreach (VisitedSystemsClass vsc in visitedSystems)
                     {
                         if (vsc.curSystem == null)                                              // if not set before, look it up
                         {
                             cmd.Parameters.Clear();
-                            cmd.Parameters.AddWithValue("name", vsc.Name);
+                            cmd.AddParameterWithValue("name", vsc.Name);
 
-                            using (SQLiteDataReader reader = cmd.ExecuteReader())
+                            using (DbDataReader reader = cmd.ExecuteReader())
                             {
                                 if (reader.Read())
                                     vsc.curSystem = new SystemClass(reader);
                             }
-
-                            cmd.Reset();
                         }
                     }
                 }
@@ -1005,7 +1003,7 @@ namespace EDDiscovery.DB
             {
                 int c = 0;
 
-                SQLiteCommand cmd = cn.CreateCommand("select * from Systems where id_edsm = @id_edsm limit 1");   // 1 return matching EDSM ID
+                DbCommand cmd = cn.CreateCommand("select * from Systems where id_edsm = @id_edsm limit 1");   // 1 return matching EDSM ID
                 
                 int lasttc = Environment.TickCount;
 
@@ -1036,9 +1034,9 @@ namespace EDDiscovery.DB
                             else
                             {
                                 cmd.Parameters.Clear();
-                                cmd.Parameters.AddWithValue("id_edsm", system.id_edsm);
+                                cmd.AddParameterWithValue("id_edsm", system.id_edsm);
 
-                                using (SQLiteDataReader reader1 = cmd.ExecuteReader())              // see if ESDM ID is there..
+                                using (DbDataReader reader1 = cmd.ExecuteReader())              // see if ESDM ID is there..
                                 {
                                     if (reader1.Read())                                          // its there..
                                     {
@@ -1062,8 +1060,6 @@ namespace EDDiscovery.DB
                                     }
                                 }
                             }
-
-                            cmd.Reset();
                         }
                     }
                 }
@@ -1075,7 +1071,7 @@ namespace EDDiscovery.DB
             {
                 if (toupdate.Count > 0)
                 {
-                    using (SQLiteTransaction transaction = cn2.BeginTransaction())
+                    using (DbTransaction transaction = cn2.BeginTransaction())
                     {
                         foreach (SystemClass sys in toupdate)
                             sys.UpdateEDSM(cn2, sys.id, transaction);        // do an EDSM update of only name/x/y/z, not expected to be many at a time
@@ -1090,7 +1086,7 @@ namespace EDDiscovery.DB
 
                     while (count < newsystems.Count())
                     {
-                        using (SQLiteTransaction transaction = cn2.BeginTransaction())
+                        using (DbTransaction transaction = cn2.BeginTransaction())
                         {
                             while (count < newsystems.Count())
                             {
@@ -1109,7 +1105,7 @@ namespace EDDiscovery.DB
                 if (removenonedsmids)                            // done on a full sync..
                 {
                     Console.WriteLine("Delete old ones");
-                    using (SQLiteCommand cmddel = cn2.CreateCommand("Delete from Systems where id_edsm is null"))
+                    using (DbCommand cmddel = cn2.CreateCommand("Delete from Systems where id_edsm is null"))
                     {
                         SQLiteDBClass.SQLNonQueryText(cn2, cmddel);
                     }
@@ -1159,8 +1155,8 @@ namespace EDDiscovery.DB
 
             using (SQLiteConnectionED cn = new SQLiteConnectionED())  // open the db
             {
-                SQLiteCommand cmd1 = cn.CreateCommand("select * from Systems where id_eddb = @id limit 1");   // 1 return matching ID
-                SQLiteCommand cmd2 = cn.CreateCommand("select * from Systems where name = @name and ABS(x-@x)<1 and ABS(y-@y)<1 and ABS(z-@z)<1 limit 1");   // 1 return matching name
+                DbCommand cmd1 = cn.CreateCommand("select * from Systems where id_eddb = @id limit 1");   // 1 return matching ID
+                DbCommand cmd2 = cn.CreateCommand("select * from Systems where name = @name and ABS(x-@x)<1 and ABS(y-@y)<1 and ABS(z-@z)<1 limit 1");   // 1 return matching name
 
                 int c = 0;
                 int lasttc = Environment.TickCount;
@@ -1175,31 +1171,30 @@ namespace EDDiscovery.DB
                         SystemClass dbsys = null;
 
                         cmd1.Parameters.Clear();
-                        cmd1.Parameters.AddWithValue("id", system.id_eddb);
+                        cmd1.AddParameterWithValue("id", system.id_eddb);
 
-                        using (SQLiteDataReader reader1 = cmd1.ExecuteReader())             // try its ID first
+                        using (DbDataReader reader1 = cmd1.ExecuteReader())             // try its ID first
                         {
                             if (reader1.Read())                                          // its there..
                             {
                                 dbsys = new SystemClass(reader1);
-                                cmd1.Reset();
                             }
-                            else
-                            {
-                                cmd1.Reset();
-                                cmd2.Parameters.Clear();                                // else just pick the best name
-                                cmd2.Parameters.AddWithValue("name", system.name);
-                                cmd2.Parameters.AddWithValue("x", system.x);
-                                cmd2.Parameters.AddWithValue("y", system.y);
-                                cmd2.Parameters.AddWithValue("z", system.z);
+                        }
 
-                                SQLiteDataReader reader2 = cmd2.ExecuteReader();        // case insensitive
+                        if (dbsys == null)
+                        {
+                            cmd2.Parameters.Clear();                                // else just pick the best name
+                            cmd2.AddParameterWithValue("name", system.name);
+                            cmd2.AddParameterWithValue("x", system.x);
+                            cmd2.AddParameterWithValue("y", system.y);
+                            cmd2.AddParameterWithValue("z", system.z);
+
+                            using (DbDataReader reader2 = cmd2.ExecuteReader())        // case insensitive
+                            {
                                 if (reader2.Read())                                     // its there..
                                 {
                                     dbsys = new SystemClass(reader2);
                                 }
-
-                                cmd2.Reset();
                             }
                         }
 
@@ -1239,7 +1234,7 @@ namespace EDDiscovery.DB
 
                     while (count < toupdate.Count())
                     {
-                        using (SQLiteTransaction transaction = cn2.BeginTransaction())
+                        using (DbTransaction transaction = cn2.BeginTransaction())
                         {
                             while (count < toupdate.Count())
                             {

--- a/EDDiscovery/DB/SystemNoteClass.cs
+++ b/EDDiscovery/DB/SystemNoteClass.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 
@@ -40,15 +40,15 @@ namespace EDDiscovery2.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into SystemNote (Name, Time, Note) values (@name, @time, @note)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into SystemNote (Name, Time, Note) values (@name, @time, @note)"))
             {
-                cmd.Parameters.AddWithValue("@name", Name);
-                cmd.Parameters.AddWithValue("@time", Time);
-                cmd.Parameters.AddWithValue("@note", Note);
+                cmd.AddParameterWithValue("@name", Name);
+                cmd.AddParameterWithValue("@time", Time);
+                cmd.AddParameterWithValue("@note", Note);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from SystemNote"))
+                using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from SystemNote"))
                 {
                     id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                 }
@@ -68,12 +68,12 @@ namespace EDDiscovery2.DB
 
         private bool Update(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update SystemNote set Name=@Name, Time=@Time, Note=@Note  where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Update SystemNote set Name=@Name, Time=@Time, Note=@Note  where ID=@id"))
             {
-                cmd.Parameters.AddWithValue("@ID", id);
-                cmd.Parameters.AddWithValue("@Name", Name);
-                cmd.Parameters.AddWithValue("@Note", Note);
-                cmd.Parameters.AddWithValue("@Time", Time);
+                cmd.AddParameterWithValue("@ID", id);
+                cmd.AddParameterWithValue("@Name", Name);
+                cmd.AddParameterWithValue("@Note", Note);
+                cmd.AddParameterWithValue("@Time", Time);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
                 globalSystemNotes[Name.ToLower()] = this;
@@ -90,7 +90,7 @@ namespace EDDiscovery2.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select * from SystemNote"))
+                    using (DbCommand cmd = cn.CreateCommand("select * from SystemNote"))
                     {
                         DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
                         if (ds.Tables.Count == 0 || ds.Tables[0].Rows.Count == 0)

--- a/EDDiscovery/DB/TravelLogUnit.cs
+++ b/EDDiscovery/DB/TravelLogUnit.cs
@@ -3,7 +3,7 @@ using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 
@@ -59,16 +59,16 @@ namespace EDDiscovery2.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into TravelLogUnit (Name, type, size, Path) values (@name, @type, @size, @Path)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into TravelLogUnit (Name, type, size, Path) values (@name, @type, @size, @Path)"))
             {
-                cmd.Parameters.AddWithValue("@name", Name);
-                cmd.Parameters.AddWithValue("@type", type);
-                cmd.Parameters.AddWithValue("@size", Size);
-                cmd.Parameters.AddWithValue("@Path", Path);
+                cmd.AddParameterWithValue("@name", Name);
+                cmd.AddParameterWithValue("@type", type);
+                cmd.AddParameterWithValue("@size", Size);
+                cmd.AddParameterWithValue("@Path", Path);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from TravelLogUnit"))
+                using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from TravelLogUnit"))
                 {
                     id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                 }
@@ -87,13 +87,13 @@ namespace EDDiscovery2.DB
 
         private bool Update(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update TravelLogUnit set Name=@Name, Type=@type, size=@size, Path=@Path  where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Update TravelLogUnit set Name=@Name, Type=@type, size=@size, Path=@Path  where ID=@id"))
             {
-                cmd.Parameters.AddWithValue("@ID", id);
-                cmd.Parameters.AddWithValue("@Name", Name);
-                cmd.Parameters.AddWithValue("@Type", type);
-                cmd.Parameters.AddWithValue("@size", Size);
-                cmd.Parameters.AddWithValue("@Path", Path);
+                cmd.AddParameterWithValue("@ID", id);
+                cmd.AddParameterWithValue("@Name", Name);
+                cmd.AddParameterWithValue("@Type", type);
+                cmd.AddParameterWithValue("@size", Size);
+                cmd.AddParameterWithValue("@Path", Path);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
@@ -107,7 +107,7 @@ namespace EDDiscovery2.DB
 
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from TravelLogUnit"))
+                using (DbCommand cmd = cn.CreateCommand("select * from TravelLogUnit"))
                 {
                     DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
                     if (ds.Tables.Count == 0 || ds.Tables[0].Rows.Count == 0)

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -67,22 +67,22 @@ namespace EDDiscovery2.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into VisitedSystems (Name, Time, Unit, Commander, Source, edsm_sync, map_colour, X, Y, Z) values (@name, @time, @unit, @commander, @source, @edsm_sync, @map_colour, @x, @y, @z)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into VisitedSystems (Name, Time, Unit, Commander, Source, edsm_sync, map_colour, X, Y, Z) values (@name, @time, @unit, @commander, @source, @edsm_sync, @map_colour, @x, @y, @z)"))
             {
-                cmd.Parameters.AddWithValue("@name", Name);
-                cmd.Parameters.AddWithValue("@time", Time);
-                cmd.Parameters.AddWithValue("@unit", Unit);
-                cmd.Parameters.AddWithValue("@commander", Commander);
-                cmd.Parameters.AddWithValue("@source", Source);
-                cmd.Parameters.AddWithValue("@edsm_sync", EDSM_sync);
-                cmd.Parameters.AddWithValue("@map_colour", MapColour);
-                cmd.Parameters.AddWithValue("@x", X);
-                cmd.Parameters.AddWithValue("@y", Y);
-                cmd.Parameters.AddWithValue("@z", Z);
+                cmd.AddParameterWithValue("@name", Name);
+                cmd.AddParameterWithValue("@time", Time);
+                cmd.AddParameterWithValue("@unit", Unit);
+                cmd.AddParameterWithValue("@commander", Commander);
+                cmd.AddParameterWithValue("@source", Source);
+                cmd.AddParameterWithValue("@edsm_sync", EDSM_sync);
+                cmd.AddParameterWithValue("@map_colour", MapColour);
+                cmd.AddParameterWithValue("@x", X);
+                cmd.AddParameterWithValue("@y", Y);
+                cmd.AddParameterWithValue("@z", Z);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from VisitedSystems"))
+                using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from VisitedSystems"))
                 {
                     id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                 }
@@ -100,19 +100,19 @@ namespace EDDiscovery2.DB
 
         private bool Update(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Update VisitedSystems set Name=@Name, Time=@Time, Unit=@Unit, Commander=@commander, Source=@Source, edsm_sync=@edsm_sync, map_colour=@map_colour, X=@x, Y=@y, Z=@z  where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Update VisitedSystems set Name=@Name, Time=@Time, Unit=@Unit, Commander=@commander, Source=@Source, edsm_sync=@edsm_sync, map_colour=@map_colour, X=@x, Y=@y, Z=@z  where ID=@id"))
             {
-                cmd.Parameters.AddWithValue("@ID", id);
-                cmd.Parameters.AddWithValue("@Name", Name);
-                cmd.Parameters.AddWithValue("@Time", Time);
-                cmd.Parameters.AddWithValue("@unit", Unit);
-                cmd.Parameters.AddWithValue("@commander", Commander);
-                cmd.Parameters.AddWithValue("@source", Source);
-                cmd.Parameters.AddWithValue("@edsm_sync", EDSM_sync);
-                cmd.Parameters.AddWithValue("@map_colour", MapColour);
-                cmd.Parameters.AddWithValue("@x", X);
-                cmd.Parameters.AddWithValue("@y", Y);
-                cmd.Parameters.AddWithValue("@z", Z);
+                cmd.AddParameterWithValue("@ID", id);
+                cmd.AddParameterWithValue("@Name", Name);
+                cmd.AddParameterWithValue("@Time", Time);
+                cmd.AddParameterWithValue("@unit", Unit);
+                cmd.AddParameterWithValue("@commander", Commander);
+                cmd.AddParameterWithValue("@source", Source);
+                cmd.AddParameterWithValue("@edsm_sync", EDSM_sync);
+                cmd.AddParameterWithValue("@map_colour", MapColour);
+                cmd.AddParameterWithValue("@x", X);
+                cmd.AddParameterWithValue("@y", Y);
+                cmd.AddParameterWithValue("@z", Z);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
                 return true;
@@ -251,7 +251,7 @@ namespace EDDiscovery2.DB
 
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from VisitedSystems Order by Time "))
+                using (DbCommand cmd = cn.CreateCommand("select * from VisitedSystems Order by Time "))
                 {
                     DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
 
@@ -276,9 +276,9 @@ namespace EDDiscovery2.DB
 
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from VisitedSystems where commander=@commander Order by Time "))
+                using (DbCommand cmd = cn.CreateCommand("select * from VisitedSystems where commander=@commander Order by Time "))
                 {
-                    cmd.Parameters.AddWithValue("@commander", commander);
+                    cmd.AddParameterWithValue("@commander", commander);
 
                     DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
                     if (ds.Tables.Count == 0 || ds.Tables[0].Rows.Count == 0)
@@ -301,7 +301,7 @@ namespace EDDiscovery2.DB
 
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from VisitedSystems Order by Time DESC Limit 1"))
+                using (DbCommand cmd = cn.CreateCommand("select * from VisitedSystems Order by Time DESC Limit 1"))
                 {
                     DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
                     if (ds.Tables.Count == 0 || ds.Tables[0].Rows.Count == 0)
@@ -319,10 +319,10 @@ namespace EDDiscovery2.DB
         {
             using (SQLiteConnectionED cn = new SQLiteConnectionED())
             {
-                using (SQLiteCommand cmd = cn.CreateCommand("select * from VisitedSystems where name=@name and Time=@time  Order by Time DESC Limit 1"))
+                using (DbCommand cmd = cn.CreateCommand("select * from VisitedSystems where name=@name and Time=@time  Order by Time DESC Limit 1"))
                 {
-                    cmd.Parameters.AddWithValue("@name", name);
-                    cmd.Parameters.AddWithValue("@time", time);
+                    cmd.AddParameterWithValue("@name", name);
+                    cmd.AddParameterWithValue("@time", time);
                     DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
                     return !(ds.Tables.Count == 0 || ds.Tables[0].Rows.Count == 0);
                 }

--- a/EDDiscovery/DB/WantedSystemClass.cs
+++ b/EDDiscovery/DB/WantedSystemClass.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SQLite;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -41,12 +41,12 @@ namespace EDDiscovery.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("Insert into wanted_systems (systemname) values (@systemname)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into wanted_systems (systemname) values (@systemname)"))
             {
-                cmd.Parameters.AddWithValue("@systemname", system);
+                cmd.AddParameterWithValue("@systemname", system);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
-                using (SQLiteCommand cmd2 = cn.CreateCommand("Select Max(id) as id from wanted_systems"))
+                using (DbCommand cmd2 = cn.CreateCommand("Select Max(id) as id from wanted_systems"))
                 {
                     id = (long)SQLiteDBClass.SQLScalar(cn, cmd2);
                 }
@@ -64,9 +64,9 @@ namespace EDDiscovery.DB
 
         private bool Delete(SQLiteConnectionED cn)
         {
-            using (SQLiteCommand cmd = cn.CreateCommand("DELETE FROM wanted_systems WHERE id = @id"))
+            using (DbCommand cmd = cn.CreateCommand("DELETE FROM wanted_systems WHERE id = @id"))
             {
-                cmd.Parameters.AddWithValue("@id", id);
+                cmd.AddParameterWithValue("@id", id);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
@@ -80,7 +80,7 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (SQLiteCommand cmd = cn.CreateCommand("select * from wanted_systems"))
+                    using (DbCommand cmd = cn.CreateCommand("select * from wanted_systems"))
                     {
                         DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
                         if (ds.Tables.Count == 0 || ds.Tables[0].Rows.Count == 0)


### PR DESCRIPTION
Use the `DbConnection` etc. base classes instead of the `SQLiteConnection` etc. implementation specific classes.

Also fix a missing using block, and wrap blocks where we can't use `using{}` (e.g. where the method only owns the connection if it creates it) with `try {} finally {}`