### PR TITLE
Adjust screen position to ensure window is always on screen

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -285,6 +285,14 @@ namespace EDDiscovery
                 var left = SQLiteDBClass.GetSettingInt("FormLeft", 0);
                 var height = SQLiteDBClass.GetSettingInt("FormHeight", 800);
                 var width = SQLiteDBClass.GetSettingInt("FormWidth", 800);
+
+                // Adjust so window fits on screen; just in case user unplugged a monitor or something
+                var screen = Screen.FromControl(this).Bounds;
+                if( height > screen.Height ) height = screen.Height;
+                if( top + height > screen.Height) top = screen.Height - height;
+                if( width > screen.Width ) width = screen.Width;
+                if( left + width > screen.Width ) left = screen.Width - width;
+
                 this.Top = top;
                 this.Left = left;
                 this.Height = height;


### PR DESCRIPTION
Ensures the main form is always displayed on the screen.
Useful if copying a database from a desktop to a laptop, or unplugging monitors, etc.  Easier than remembering a command-line.