### PR TITLE
UI behaviour improvements for 3.3

### DIFF
--- a/EDDiscovery/Controls/ComboBoxCustom.cs
+++ b/EDDiscovery/Controls/ComboBoxCustom.cs
@@ -20,9 +20,7 @@ namespace ExtendedControls
         public event EventHandler SelectedIndexChanged;
 
         public int SelectedIndex { get { return _listcontrol.SelectedIndex; } set { _listcontrol.SelectedIndex = value; } }
-        public Color SelectionBackColor { get { return _listcontrol.SelectionBackColor; } set { _listcontrol.SelectionBackColor = value; } }
-        public override Color ForeColor { get { return base.ForeColor; } set { base.ForeColor = value; _listcontrol.ForeColor = value; } }
-        public override Color BackColor { get { return base.BackColor; } set { base.BackColor = value; _listcontrol.BackColor = value; } }
+        public Color SelectionBackColor { get { return _listcontrol.SelectionBackColor; } set { _listcontrol.SelectionBackColor = value; this.BackColor = value; } }
         public List<string> Items { get { return _listcontrol.Items; } set { _listcontrol.Items = value; } }
         public Color BorderColor { get { return _listcontrol.BorderColor; } set { _listcontrol.BorderColor = value; } }
         public Color ScrollBarColor { get { return _listcontrol.ScrollBarColor; } set { _listcontrol.ScrollBarColor = value; } }
@@ -42,6 +40,8 @@ namespace ExtendedControls
             this._listcontrol.Dock = DockStyle.Fill;
             this._listcontrol.Visible = true;
             this._listcontrol.SelectedIndexChanged += _listcontrol_SelectedIndexChanged;
+            this._listcontrol.Margin = new Padding(0);
+            this.Padding = new Padding(0);
             this.Controls.Add(this._listcontrol);
         }
 
@@ -428,6 +428,7 @@ namespace ExtendedControls
 
             _cbdropdown.SelectionBackColor = this.DropDownBackgroundColor;
             _cbdropdown.ForeColor = this.ForeColor;
+            _cbdropdown.BackColor = this.BorderColor;
             _cbdropdown.BorderColor = this.BorderColor;
             _cbdropdown.Items = this.Items.ToList();
             _cbdropdown.ItemHeight = this.ItemHeight;

--- a/EDDiscovery/Controls/ComboBoxCustom.cs
+++ b/EDDiscovery/Controls/ComboBoxCustom.cs
@@ -11,8 +11,219 @@ using System.Windows.Forms.VisualStyles;
 
 namespace ExtendedControls
 {
+    public class ComboBoxCustomDropdown : Form
+    {
+        private ListControlCustom _listcontrol;
+
+        public event EventHandler DropDown;
+        public event EventHandler DropDownClosed;
+        public event EventHandler SelectedIndexChanged;
+
+        public int SelectedIndex { get { return _listcontrol.SelectedIndex; } set { _listcontrol.SelectedIndex = value; } }
+        public Color SelectionBackColor { get { return _listcontrol.SelectionBackColor; } set { _listcontrol.SelectionBackColor = value; } }
+        public override Color ForeColor { get { return base.ForeColor; } set { base.ForeColor = value; _listcontrol.ForeColor = value; } }
+        public override Color BackColor { get { return base.BackColor; } set { base.BackColor = value; _listcontrol.BackColor = value; } }
+        public List<string> Items { get { return _listcontrol.Items; } set { _listcontrol.Items = value; } }
+        public Color BorderColor { get { return _listcontrol.BorderColor; } set { _listcontrol.BorderColor = value; } }
+        public Color ScrollBarColor { get { return _listcontrol.ScrollBarColor; } set { _listcontrol.ScrollBarColor = value; } }
+        public Color ScrollBarButtonColor { get { return _listcontrol.ScrollBarButtonColor; } set { _listcontrol.ScrollBarButtonColor = value; } }
+        public FlatStyle FlatStyle { get { return _listcontrol.FlatStyle; } set { _listcontrol.FlatStyle = value; } }
+        public new Font Font { get { return base.Font; } set { base.Font = value; _listcontrol.Font = value; } }
+
+        public int ItemHeight { get { return _listcontrol.ItemHeight; } set { _listcontrol.ItemHeight = value; } }
+
+
+        public ComboBoxCustomDropdown()
+        {
+            this.FormBorderStyle = FormBorderStyle.None;
+            this.ShowInTaskbar = false;
+            this._listcontrol = new ListControlCustom();
+            this._listcontrol.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            this._listcontrol.Dock = DockStyle.Fill;
+            this._listcontrol.Visible = true;
+            this._listcontrol.SelectedIndexChanged += _listcontrol_SelectedIndexChanged;
+            this.Controls.Add(this._listcontrol);
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+
+            DropDown(this, e);
+        }
+
+        private void _listcontrol_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            SelectedIndexChanged(this, e);
+            this.Close();
+        }
+
+        protected override void OnDeactivate(EventArgs e)
+        {
+            base.OnDeactivate(e);
+
+            this.Close();
+        }
+
+        protected override void OnFormClosed(FormClosedEventArgs e)
+        {
+            base.OnFormClosed(e);
+            DropDownClosed(this, e);
+        }
+    }
+
     public class ComboBoxCustom : Control
     {
+        public class ObjectCollection : IList<string>, ICollection<string>
+        {
+            private IList _explicitCollection;
+            private ComboBox _combobox;
+
+            private IList _collection
+            {
+                get
+                {
+                    if (_explicitCollection != null)
+                    {
+                        return _explicitCollection;
+                    }
+                    else if (_combobox.DisplayMember != null && _combobox.DataSource != null && _combobox.DataSource is ICollection)
+                    {
+                        return GetMembers((ICollection)_combobox.DataSource, _combobox.DisplayMember).ToList();
+                    }
+                    else
+                    {
+                        return _combobox.Items;
+                    }
+                }
+            }
+
+            protected IEnumerable<object> GetMembers(ICollection vals, string displaymember)
+            {
+                foreach (object val in vals)
+                {
+                    Type t = val.GetType();
+                    PropertyInfo pi = t.GetProperty(displaymember);
+                    object dm = pi.GetValue(val, new object[0]);
+                    yield return dm;
+                }
+            }
+
+
+            public ObjectCollection(ComboBox cb)
+            {
+                this._combobox = cb;
+            }
+
+            public ObjectCollection(IList<string> vals)
+            {
+                _explicitCollection = vals as IList;
+            }
+
+            public string this[int index]
+            {
+                get
+                {
+                    return _collection[index].ToNullSafeString();
+                }
+
+                set
+                {
+                    _collection[index] = value;
+                }
+            }
+
+            public int Count
+            {
+                get
+                {
+                    return _collection.Count;
+                }
+            }
+
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return _collection.IsReadOnly;
+                }
+            }
+
+            public void Add(string item)
+            {
+                _collection.Add(item);
+            }
+
+            public void AddRange(IEnumerable<string> items)
+            {
+                foreach (var val in items)
+                {
+                    _collection.Add(val);
+                }
+            }
+
+            public void Clear()
+            {
+                _collection.Clear();
+            }
+
+            public bool Contains(string item)
+            {
+                return _collection.Contains(item);
+            }
+
+            public void CopyTo(string[] array, int arrayIndex)
+            {
+                _collection.OfType<object>().Select(v => v.ToNullSafeString()).ToList().CopyTo(array, arrayIndex);
+            }
+
+            public IEnumerator<string> GetEnumerator()
+            {
+                return _collection.OfType<object>().Select(v => v.ToNullSafeString()).GetEnumerator();
+            }
+
+            public int IndexOf(string item)
+            {
+                return _collection.IndexOf(item);
+            }
+
+            public void Insert(int index, string item)
+            {
+                _collection.Insert(index, item);
+            }
+
+            public bool Remove(string item)
+            {
+                _collection.Remove(item);
+                return true;
+            }
+
+            public void RemoveAt(int index)
+            {
+                _collection.RemoveAt(index);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public static implicit operator ObjectCollection(List<string> vals)
+            {
+                return new ObjectCollection(vals);
+            }
+        }
+
+        protected ObjectCollection _items;
+
+        private ComboBox _cbsystem;
+        private Rectangle topBoxTextArea, arrowRectangleArea, topBoxOutline, topBoxTextTotalArea;
+        private Point arrowpt1, arrowpt2, arrowpt3;
+        private Point arrowpt1c, arrowpt2c, arrowpt3c;
+        private bool isActivated = false;
+        private bool mouseover = false;
+        private ComboBoxCustomDropdown _cbdropdown;
+
         // ForeColor = text, BackColor = control background
         public Color MouseOverBackgroundColor { get; set; } = Color.Silver;
         public Color BorderColor { get; set; } = Color.White;
@@ -20,59 +231,70 @@ namespace ExtendedControls
         public Color ScrollBarColor { get; set; } = Color.LightGray;
         public Color ScrollBarButtonColor { get; set; } = Color.LightGray;
 
-        public FlatStyle FlatStyle { get; set; } = FlatStyle.System;
-        public int DropDownHeight { get; set; } = 200;
         public int ArrowWidth { get; set; } = 1;
         public float ButtonColorScaling { get; set; } = 0.5F;           // Popup style only
-        public List<string> Items { get; set; }
         public int ScrollBarWidth { get; set; } = 16;
-        public int ItemHeight { get; set; } = 20;
+        public FlatStyle FlatStyle { get; set; } = FlatStyle.System;
+        public int DropDownWidth { get { return _cbsystem.DropDownWidth; } set { _cbsystem.DropDownWidth = value; } }
+        public int DropDownHeight { get { return _cbsystem.DropDownHeight; } set { _cbsystem.DropDownHeight = value; } }
+        public int ItemHeight { get { return _cbsystem.ItemHeight; } set { _cbsystem.ItemHeight = value; } }
 
-        public void Repaint() { firstpaint = true; Invalidate(); }     // MUST call after setting any of the above after first paint.
+        public int SelectedIndex { get { return _cbsystem.SelectedIndex; } set { _cbsystem.SelectedIndex = value; } }
 
-        public int SelectedIndex { get { return selected; } set { UpdateSelected(value); } }
+        public ObjectCollection Items { get { return _items; } set { _items.Clear(); _items.AddRange(value.ToArray()); } }
 
-        // attach a IList datasource with a property called DisplayMember
-        public object DataSource { get { return datasourceobject; } set { SetDS(value, datasourcedisplaymember); } }
-        public string DisplayMember { get { return datasourcedisplaymember; } set { SetDS(datasourceobject, value); } }
+        public override AnchorStyles Anchor { get { return base.Anchor; } set { base.Anchor = value; _cbsystem.Anchor = value; } }
+        public override DockStyle Dock { get { return base.Dock; } set { base.Dock = value; _cbsystem.Dock = value; } }
+        public override Font Font { get { return base.Font; } set { base.Font = value; _cbsystem.Font = value; } }
+        public override string Text { get { return base.Text; } set { base.Text = value; _cbsystem.Text = value; } }
 
-        // if Datasource, you get the object.  Else, you get/set it by Items string value.
-        public object SelectedItem { get { return GetSelectedObject(); } set { SetSelectedObject(value); } }
+        public object DataSource { get { return _cbsystem.DataSource; } set { _cbsystem.DataSource = value; } }
+        public string ValueMember { get { return _cbsystem.ValueMember; } set { _cbsystem.ValueMember = value; } }
+        public string DisplayMember { get { return _cbsystem.DisplayMember; } set { _cbsystem.DisplayMember = value; } }
+        public object SelectedItem { get { return _cbsystem.SelectedItem; } set { _cbsystem.SelectedItem = value; } }
+        public object SelectedValue { get { return _cbsystem.SelectedValue; } set { _cbsystem.SelectedValue = value; } }
 
-        // only required if SelectedValue required.
-        public string ValueMember { get { return datasourcevaluemember; } set { datasourcevaluemember = value; } }
-        public object SelectedValue { get { return GetSelectedValue(); } }      // only supporting get.
+        public event EventHandler SelectedIndexChanged;
 
-        // events
-        public delegate void OnSelectedIndexChanged(object sender, EventArgs e);
-        public event OnSelectedIndexChanged SelectedIndexChanged;
-
-        public ComboBoxCustom() : base()
+        public ComboBoxCustom()
         {
-            Items = new List<string>();
-            this.Text = "";
-            // no need - keep for reference for now. SetStyle(ControlStyles.SupportsTransparentBackColor, true);
+            this._cbsystem = new ComboBox();
+            this._cbsystem.Dock = DockStyle.Fill;
+            this._cbsystem.SelectedIndexChanged += _cbsystem_SelectedIndexChanged;
+            this._items = new ObjectCollection(this._cbsystem);
+            this.Controls.Add(this._cbsystem);
+        }
+
+        private void _cbsystem_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            this.Text = _cbsystem.Text;
+            this.Invalidate(true);
+
+            if (this.Enabled && SelectedIndexChanged != null)
+            {
+                SelectedIndexChanged(this, e);
+            }
         }
 
         protected override void OnPaint(PaintEventArgs e)
         {
-            if (firstpaint)
-            {
-                dosystem = FlatStyle == FlatStyle.System && ComboBoxRenderer.IsSupported;
+            base.OnPaint(e);
 
-                int extraborder = (FlatStyle != FlatStyle.System) ? 1 : 0;
+            if (this.FlatStyle != FlatStyle.System)
+            {
+                int extraborder = 1;
 
                 topBoxTextArea = new Rectangle(ClientRectangle.X + extraborder, ClientRectangle.Y + extraborder,
-                                     ClientRectangle.Width - 2 * extraborder - ScrollBarWidth, ClientRectangle.Height - 2 * extraborder);
+                                        ClientRectangle.Width - 2 * extraborder - ScrollBarWidth, ClientRectangle.Height - 2 * extraborder);
 
                 arrowRectangleArea = new Rectangle(ClientRectangle.Width - ScrollBarWidth - extraborder, ClientRectangle.Y + extraborder,
-                                                   ScrollBarWidth, ClientRectangle.Height - 2 * extraborder);
+                                                    ScrollBarWidth, ClientRectangle.Height - 2 * extraborder);
 
                 topBoxOutline = new Rectangle(ClientRectangle.X, ClientRectangle.Y,
                                                 ClientRectangle.Width - 1, ClientRectangle.Height - 1);
 
                 topBoxTextTotalArea = new Rectangle(ClientRectangle.X + extraborder, ClientRectangle.Y + extraborder,
-                                                         ClientRectangle.Width - 2 * extraborder, ClientRectangle.Height - 2 * extraborder);
+                                                            ClientRectangle.Width - 2 * extraborder, ClientRectangle.Height - 2 * extraborder);
 
                 int hoffset = arrowRectangleArea.Width / 3;
                 int voffset = arrowRectangleArea.Height / 3;
@@ -84,41 +306,26 @@ namespace ExtendedControls
                 arrowpt2c = new Point(arrowpt2.X, arrowpt1.Y);
                 arrowpt3c = new Point(arrowpt3.X, arrowpt2.Y);
 
-                if (!dosystem)
+                SizeF sz = e.Graphics.MeasureString("Represent THIS", this.Font);
+                topBoxTextArea.Y += (topBoxTextArea.Height - (int)sz.Height) / 2;
+
+                Brush textb;
+                Pen p, p2;
+
+                if (Enabled)
                 {
-                    SizeF sz = e.Graphics.MeasureString("Represent THIS", this.Font);
-                    topBoxTextArea.Y += (topBoxTextArea.Height - (int)sz.Height) / 2;
+                    textb = new SolidBrush(this.ForeColor);
+                    p = new Pen(BorderColor);
+                    p2 = new Pen(ForeColor);
+                    p2.Width = ArrowWidth;
+                }
+                else
+                {
+                    textb = new SolidBrush(Multiply(ForeColor, 0.5F));
+                    p = new Pen(Multiply(BorderColor, 0.5F));
+                    p2 = null;
                 }
 
-                firstpaint = false;
-            }
-
-            Brush textb;
-            Pen p, p2;
-
-            if (Enabled)
-            {
-                textb = new SolidBrush(this.ForeColor);
-                p = new Pen(this.BorderColor);
-                p2 = new Pen(this.ForeColor);
-                p2.Width = ArrowWidth;
-            }
-            else
-            {
-                textb = new SolidBrush(Multiply(this.ForeColor, 0.5F));
-                p = new Pen(Multiply(this.BorderColor, 0.5F));
-                p2 = null;
-            }
-
-
-            if (dosystem)
-            {
-                ComboBoxRenderer.DrawTextBox(e.Graphics, topBoxTextArea,
-                    this.Text, this.Font, (isActivated) ? ComboBoxState.Pressed : (Enabled) ? ComboBoxState.Normal : ComboBoxState.Disabled);
-                ComboBoxRenderer.DrawDropDownButton(e.Graphics, arrowRectangleArea, (Enabled) ? arrowState : ComboBoxState.Disabled);
-            }
-            else
-            {
                 e.Graphics.DrawRectangle(p, topBoxOutline);
 
                 Color bck;
@@ -162,353 +369,108 @@ namespace ExtendedControls
                 e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
 
                 bbck.Dispose();
+
+                textb.Dispose();
+                p.Dispose();
+
+                if (p2 != null)
+                    p2.Dispose();
             }
-
-            textb.Dispose();
-            p.Dispose();
-
-            if (p2 != null)
-                p2.Dispose();
         }
 
-        private void Activate()
+        public void Repaint()
         {
-            if (!isActivated && Items != null && Items.Count > 0)          // if not activated, and no point if no items
+            if (this.FlatStyle == FlatStyle.System)
             {
-                Point ourposonparent;
-                Control parentform = FindParentForm(out ourposonparent);        // Can't add it to parent directly, it might be a group box.
-                clc = new ListControlCustom();
-                clc.Location = new Point(ourposonparent.X, ourposonparent.Y + ClientRectangle.Height);
-
-                int fittableitems = DropDownHeight / ItemHeight;
-                if (fittableitems > Items.Count())                             // no point doing more than we have..
-                    fittableitems = Items.Count();
-
-                clc.Size = new Size(ClientRectangle.Width, fittableitems * ItemHeight + ((FlatStyle!=FlatStyle.System) ? 4 : 0)); 
-                clc.SelectionBackColor = DropDownBackgroundColor;
-                clc.ForeColor = ForeColor;
-                clc.BorderColor = BorderColor;
-                clc.Items = Items;
-                clc.ItemHeight = ItemHeight;
-                clc.SelectedIndex = selected;
-                clc.FlatStyle = FlatStyle;
-                clc.SelectedIndexChanged += UserSelectedIndex;
-                clc.Leave += UserLeftList;
-                clc.Font = Font;
-                clc.ScrollBarColor = ScrollBarColor;
-                clc.ScrollBarButtonColor = ScrollBarButtonColor;
-                parentform.Controls.Add(clc);
-                clc.Show();
-                clc.BringToFront();
-                clc.Focus();                    // so it can get events such as mouse and keyboard..
-                isActivated = true;
-                Invalidate();
+                _cbsystem.Visible = true;
+                this.Invalidate(true);
             }
-        }
-
-        private void DeActivate()
-        {
-            if (isActivated)
-            {
-                isActivated = false;
-                clc.Hide();
-                clc.Dispose();
-                Invalidate();
-                Focus();
-            }
-        }
-
-        protected void UserSelectedIndex(object sender, EventArgs e)
-        {
-            int sel = clc.SelectedIndex;
-            UpdateSelected(sel);
-        }
-
-        protected void UserLeftList(object sender, EventArgs e)
-        {
-            DeActivate();
-        }
-
-        protected override void OnMouseDown(MouseEventArgs e)
-        {
-            base.OnMouseDown(e);
-
-            if (topBoxOutline.Contains(e.Location))        // clicked anywhere in box
-            {
-                if (arrowRectangleArea.Contains(e.Location) && FlatStyle == FlatStyle.System)
-                {
-                    arrowState = ComboBoxState.Pressed;
-                    Invalidate();
-                }
-
-                if (!isActivated)
-                    Activate();
-                else
-                    DeActivate();
-            }
-        }
-
-
-        protected override void OnMouseUp(MouseEventArgs e)
-        {
-            base.OnMouseUp(e);
-
-            if (arrowRectangleArea.Contains(e.Location) && FlatStyle == FlatStyle.System)
-            {
-                arrowState = ComboBoxState.Normal;
-                Invalidate();
-            }
-        }
-
-        protected override void OnMouseEnter(EventArgs e)
-        {
-            base.OnMouseEnter(e);
-
-            if (!isActivated)
-            {
-                if (!mouseover)
-                {
-                    mouseover = true;
-                    Invalidate();
-                }
-            }
-            else if (mouseover)                                         // else if mouse on, needs to go off
-            {
-                mouseover = false;
-                Invalidate();
-            }
-        }
-
-        protected override void OnMouseLeave(EventArgs e)
-        {
-            base.OnMouseLeave(e);
-            if (mouseover)
-            {
-                mouseover = false;
-                Invalidate();
-            }
-        }
-
-        private void UpdateSelected(int v)
-        {
-            if (v == selected || Items == null)        // either means do nothing
-            {
-            }
-            else if (v >= 0 && v < Items.Count)
-            {
-                selected = v;
-                this.Text = Items[v];
-                if (SelectedIndexChanged != null)
-                    SelectedIndexChanged(this, new EventArgs());
-            }
-            else if (v != -1)
-            {
-                selected = -1;
-                this.Text = "";
-                if (SelectedIndexChanged != null)
-                    SelectedIndexChanged(this, new EventArgs());
-            }
-
-            DeActivate();
-            Invalidate();       // may not be activated so need to invalidate
-        }
-
-        private void UpdateSelected(string v)           // not used as of now - keep
-        {
-            if (Items != null)
-            {
-                int offset = 0;
-
-                foreach (string s in Items)
-                {
-                    if (v != null && s.Equals(v))
-                    {
-                        UpdateSelected(offset);
-                        return;
-                    }
-
-                    offset++;
-                }
-
-                UpdateSelected(-1);
-            }
-        }
-
-        Control FindParentForm(out Point ourposonparent)            // Find the form, in case in a groupbox..
-        {
-            ourposonparent = Location;
-            Control p = Parent;
-
-            while (!(p is Form))
-            {
-                ourposonparent.X += p.Location.X;
-                ourposonparent.Y += p.Location.Y;
-                p = p.Parent;
-            }
-
-            return p;
-        }
-
-        protected override void OnResize(EventArgs e)               // just in case a resize occurs
-        {
-            base.OnResize(e);
-            firstpaint = true;
-        }
-
-        protected override bool IsInputKey(Keys keyData)
-        {
-            if (keyData == Keys.Up || keyData == Keys.Down)        // grab these nav keys
-                return true;
             else
-                return base.IsInputKey(keyData);
+            {
+                _cbsystem.Visible = false;
+                this.Invalidate(true);
+            }
         }
 
-        protected override void OnKeyDown(KeyEventArgs e)
+        protected Form GetParentForm(Control parent, out Point location)
         {
-            base.OnKeyDown(e);
-
-            if (e.KeyCode == Keys.Down)
+            if (parent is Form)
             {
-                if (Items != null && SelectedIndex < Items.Count - 1)
-                    UpdateSelected(SelectedIndex + 1);
+                location = parent.Location;
+                return (Form)parent;
             }
-            else if (e.KeyCode == Keys.Up)
-            {
-                if (SelectedIndex > 0)
-                    UpdateSelected(SelectedIndex - 1);
-
-            }
-        }
-
-        private void SetDS(object o, string vmember)            // data source or display member is changing..
-        {
-            bool clearit = false;
-
-            if (o != datasourceobject)                        // if we changed, remember it
-            {
-                datasourceobject = o;
-                clearit = true;
-            }
-
-            if (datasourcedisplaymember == null || !datasourcedisplaymember.Equals(vmember))
-            {
-                datasourcedisplaymember = vmember;
-                clearit = true;
-            }
-
-            if (clearit)                                            // if we changed, start from scratch
-            {
-                DeActivate();                                       // just in case..
-                Items.Clear();
-                Text = "";
-                selected = -1;
-            }
-            // if we changed, and we have members
-            if (clearit && datasourcedisplaymember != null && datasourceobject != null)
-            {
-                IList objl = datasourceobject as IList;             // its an IList, so iterate
-
-                foreach (object oi in objl)
-                {
-                    Type ti = oi.GetType();
-                    PropertyInfo pi = ti.GetProperty(datasourcedisplaymember);
-
-                    if (pi != null)                                 // properties only
-                    {
-                        if (pi.PropertyType.Name.Equals("String"))  // string properties (for now) only
-                        {
-                            string s = (string)(pi.GetValue(oi, null));
-                            Items.Add(s);                           // add it to items..
-                        }
-                        else
-                            throw new ArgumentException("DisplayMember only string properties supported");
-                    }
-                    else
-                        throw new ArgumentException("DisplayMember supports only properties");
-                }
-            }
-
-            Repaint();
-        }
-
-        private object GetSelectedObject()                                  // if datasource attached, return selected object
-        {                                                                   // else return string
-            if (datasourceobject != null)
-            {
-                if (selected >= 0)
-                {
-                    IList objl = datasourceobject as IList;
-                    return objl[selected];
-                }
-                else
-                    return null;
-            }
-            else if (Items != null && selected >= 0)
-                return Items[selected];
             else
-                return null;
-        }
-
-        private void SetSelectedObject(object value)                        // if datasource attached, set index by object
-        {                                                                   // if no datasource, give a string..
-            if (datasourceobject != null)
             {
-                IList objl = datasourceobject as IList;
-
-                int index = 0;
-
-                foreach (object oi in objl)
-                {
-                    if (oi == value)            // if object match..
-                    {
-                        UpdateSelected(index);
-                        break;
-                    }
-
-                    index++;
-                }
-            }
-            else if (value is String)
-            {
-                UpdateSelected((string)value);
+                Point _location;
+                Form form = GetParentForm(parent.Parent, out _location);
+                location = new Point(_location.X + parent.Location.X, _location.Y + parent.Location.Y);
+                return form;
             }
         }
 
-        private object GetSelectedValue()                                  // if datasource attached, return selected object
+        protected override void OnClick(EventArgs e)
         {
-            if (datasourceobject != null && selected >= 0 && datasourcevaluemember != null)
+            base.OnClick(e);
+
+            _cbdropdown = new ComboBoxCustomDropdown();
+
+            int fittableitems = this.DropDownHeight / this.ItemHeight;
+
+            if (fittableitems == 0)
             {
-                IList objl = datasourceobject as IList;
-                object oi = objl[selected];
-
-                Type ti = oi.GetType();
-                PropertyInfo pi = ti.GetProperty(datasourcevaluemember);
-
-                if (pi != null)
-                    return pi.GetValue(oi, null);         // return value..
+                fittableitems = 5;
             }
 
-            return null;
+            if (fittableitems > this.Items.Count())                             // no point doing more than we have..
+                fittableitems = this.Items.Count();
+
+            _cbdropdown.Size = new Size(this.DropDownWidth, fittableitems * this.ItemHeight + 4);
+
+            _cbdropdown.SelectionBackColor = this.DropDownBackgroundColor;
+            _cbdropdown.ForeColor = this.ForeColor;
+            _cbdropdown.BorderColor = this.BorderColor;
+            _cbdropdown.Items = this.Items.ToList();
+            _cbdropdown.ItemHeight = this.ItemHeight;
+            _cbdropdown.SelectedIndex = this.SelectedIndex;
+            _cbdropdown.FlatStyle = this.FlatStyle;
+            _cbdropdown.Font = this.Font;
+            _cbdropdown.ScrollBarColor = this.ScrollBarColor;
+            _cbdropdown.ScrollBarButtonColor = this.ScrollBarButtonColor;
+
+            _cbdropdown.DropDown += _cbdropdown_DropDown;
+            _cbdropdown.DropDownClosed += _cbdropdown_DropDownClosed;
+            _cbdropdown.SelectedIndexChanged += _cbdropdown_SelectedIndexChanged;
+
+            _cbdropdown.Show();
         }
 
+        private void _cbdropdown_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            _cbsystem.SelectedIndex = _cbdropdown.SelectedIndex;
+        }
 
-        // internals
-        private int selected = -1;
-        private bool isActivated = false;
-        private bool mouseover = false;
-        private bool firstpaint = true;
-        private bool dosystem = false;
-        private ComboBoxState arrowState = ComboBoxState.Normal;
-        private Rectangle topBoxTextArea, arrowRectangleArea, topBoxOutline, topBoxTextTotalArea;
-        private Point arrowpt1, arrowpt2, arrowpt3;
-        private Point arrowpt1c, arrowpt2c, arrowpt3c;
-        private ListControlCustom clc;
-        private object datasourceobject = null;
-        private string datasourcedisplaymember = null;
-        private string datasourcevaluemember = null;
+        private void _cbdropdown_DropDownClosed(object sender, EventArgs e)
+        {
+            if (_cbdropdown != null)
+            {
+                _cbdropdown.Dispose();
+                _cbdropdown = null;
+            }
+
+            isActivated = false;
+            this.Invalidate(true);
+        }
+
+        private void _cbdropdown_DropDown(object sender, EventArgs e)
+        {
+            Point location;
+            var _parentForm = GetParentForm(this, out location);
+            _cbdropdown.Location = new Point(location.X, location.Y + this.Height);
+            isActivated = true;
+            this.Invalidate(true);
+        }
 
         private byte limit(float a) { if (a > 255F) return 255; else return (byte)a; }
         public Color Multiply(Color from, float m) { return Color.FromArgb(from.A, limit((float)from.R * m), limit((float)from.G * m), limit((float)from.B * m)); }
-
     }
 }

--- a/EDDiscovery/Controls/CustomColourTable.cs
+++ b/EDDiscovery/Controls/CustomColourTable.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class CustomColourTable : ProfessionalColorTable
+    {
+        public CustomColourTable()
+        {
+            this.UseSystemColors = false;
+        }
+
+        public Color colMenuBackground = Color.FromArgb(255, 188, 199, 216);//ControlPaint.LightLight(ControlPaint.Light(Color.SlateBlue));
+        public Color colToolStripBorder = Color.FromArgb(255, 133, 145, 162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
+        public Color colToolStripBackGround = Color.LightGray;
+        public Color colToolStripSeparator = Color.FromArgb(255, 133, 145, 162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
+        public Color colMenuSelectedBack = Color.FromArgb(255, 201, 210, 225); //ControlPaint.LightLight(ControlPaint.LightLight(Color.LightSlateGray));
+        public Color colMenuSelectedText = Color.Black;
+        public Color dark = Color.FromArgb(255, 41, 57, 85);
+        public Color colMenuText = Color.White;
+        public Color colButtonSelectedBorder = Color.FromArgb(229, 195, 101);
+        public Color colButtonSelectBackLight = Color.FromArgb(255, 252, 242);
+        public Color colButtonSelectBackDark = Color.FromArgb(255, 236, 181);
+
+        public override Color ButtonCheckedGradientBegin { get { return colButtonSelectBackLight; } } // Top of button, checked
+        public override Color ButtonCheckedGradientEnd { get { return colButtonSelectBackDark; } } // Bottom of button, checked
+        public override Color ButtonCheckedGradientMiddle { get { return Color.Empty; } } // Unused
+
+        public override Color ButtonPressedGradientBegin { get { return colButtonSelectBackLight; } } // Top of button, checked and hovered
+        public override Color ButtonPressedGradientEnd { get { return colButtonSelectBackLight; } } // Bottom of button, checked and hovered
+        public override Color ButtonPressedGradientMiddle { get { return colButtonSelectBackLight; } } // Unused
+        public override Color ButtonPressedBorder { get { return colButtonSelectedBorder; } } // MS: Unused; Mono: Border of button, checked
+
+        public override Color ButtonSelectedGradientBegin { get { return Color.FromArgb(100, colButtonSelectedBorder); } } // MS: Top of button, unchecked and hovered; Mono: Top of button or menu item, unchecked and hovered
+        public override Color ButtonSelectedGradientEnd { get { return Color.FromArgb(100, colButtonSelectedBorder); } } // MS: Bottom of button, unchecked and hovered; Mono: Bottom of button or menu item, unchecked and hovered
+        public override Color ButtonSelectedGradientMiddle { get { return Color.FromArgb(100, colButtonSelectedBorder); } } // Unused
+        public override Color ButtonSelectedBorder { get { return dark; } } // MS: Border of button, checked or hovered; Mono: Border of button, hovered
+
+        public override Color CheckBackground { get { return colButtonSelectBackLight; } }
+        public override Color CheckPressedBackground { get { return colButtonSelectBackDark; } }
+        public override Color CheckSelectedBackground { get { return colButtonSelectBackDark; } }
+
+        public override Color ToolStripGradientBegin { get { return colToolStripBackGround; } } // MS: Top of toolstrip; Mono: Top of toolstrip or active top-level menu item, Left of dropdown margin
+        public override Color ToolStripGradientEnd { get { return colToolStripBackGround; } } // MS: Bottom of toolstrip; Mono: Bottom of toolstrip or active top-level menu item, Right of dropdown margin
+        public override Color ToolStripGradientMiddle { get { return colToolStripBackGround; } } // MS: Middle of toolstrip; Mono: Unused
+        public override Color ToolStripBorder { get { return colToolStripBorder; } } // Toolstrip border
+
+        public override Color MenuStripGradientBegin { get { return colMenuBackground; } } // Left of menu
+        public override Color MenuStripGradientEnd { get { return colMenuBackground; } } // Right of menu
+        public override Color MenuBorder { get { return Color.Empty; } } // Border of drop-down menu
+
+        public override Color ToolStripDropDownBackground { get { return colMenuBackground; } } // Background of menu or toolstrip dropdown
+
+        public override Color MenuItemSelectedGradientBegin { get { return Color.FromArgb(200, colMenuSelectedBack); } } // MS: Top of top-level menu item; Mono: Unused
+        public override Color MenuItemSelectedGradientEnd { get { return Color.FromArgb(200, colMenuSelectedBack); } } // MS: Bottom of top-level menu item; Mono: Unused
+        public override Color MenuItemBorder { get { return dark; } } // Border of menuitem, or of menu or toolstrip dropdown item
+
+        public override Color MenuItemPressedGradientBegin { get { return colMenuSelectedBack; } } // Top of active top-level menu item
+        public override Color MenuItemPressedGradientEnd { get { return colMenuSelectedBack; } } // Bottom of active top-level menu item
+
+        public override Color SeparatorDark { get { return colToolStripSeparator; } } // Left edge of vertical separator, colour of horizontal separator
+        public override Color SeparatorLight { get { return colToolStripSeparator; } } // Right edge of vertical separator
+
+        public override Color GripDark { get { return colToolStripSeparator; } } // Top-left dots of toolstrip grip
+        public override Color GripLight { get { return colMenuBackground; } } // Bottom-right dots of toolstrip grip
+
+        public override Color ImageMarginGradientBegin { get { return colButtonSelectBackLight; } } // MS: Left of dropdown margin; Mono: Unused
+        public override Color ImageMarginGradientEnd { get { return colButtonSelectBackLight; } } // MS: Right of dropdown margin; Mono: Unused
+        public override Color ImageMarginGradientMiddle { get { return colButtonSelectBackLight; } } // MS: Middle of dropdown margin; Mono: Unused
+
+        public override Color StatusStripGradientBegin { get { return colToolStripBackGround; } } // Unused
+        public override Color StatusStripGradientEnd { get { return colToolStripBackGround; } } // Unused
+
+        public override Color MenuItemSelected { get { return colMenuSelectedBack; } } // Background of hovered menu or toolstrip dropdown item
+
+        public override Color OverflowButtonGradientBegin { get { return colMenuSelectedBack; } } // Top of overflow button
+        public override Color OverflowButtonGradientEnd { get { return colMenuSelectedBack; } } // Bottom of overflow button
+        public override Color OverflowButtonGradientMiddle { get { return colMenuSelectedBack; } } // MS: Middle of overflow button; Mono: Unused
+    }
+}

--- a/EDDiscovery/Controls/ListControlCustom.cs
+++ b/EDDiscovery/Controls/ListControlCustom.cs
@@ -51,7 +51,7 @@ namespace ExtendedControls
 
         private void CalculateLayout()
         { 
-            int bordersize = 0;
+            bordersize = 0;
 
             if (FlatStyle != FlatStyle.System && BorderColor != Color.Transparent)
                 bordersize = 2;
@@ -95,7 +95,6 @@ namespace ExtendedControls
         {
             if (Items != null && itemslayoutestimatedon != Items.Count())  // item count changed, rework it out.
                 CalculateLayout();
-
             if (firstindex < 0)                                           // if invalid (at start)
             {
                 if (SelectedIndex == -1 || Items == null)                  // screen out null..
@@ -119,7 +118,11 @@ namespace ExtendedControls
             if (FlatStyle != FlatStyle.System || !ComboBoxRenderer.IsSupported)
             {
                 Pen p = new Pen(this.BorderColor);
-                e.Graphics.DrawRectangle(p, borderrect);
+                for (int i = 0; i < bordersize; i++)
+                {
+                    var brect = new Rectangle(borderrect.Left + i, borderrect.Top + i, borderrect.Width - i * 2, borderrect.Height - i * 2);
+                    e.Graphics.DrawRectangle(p, borderrect);
+                }
                 p.Dispose();
 
                 Brush backb;
@@ -247,6 +250,11 @@ namespace ExtendedControls
                 GoUpOne();
         }
 
+        public void Repaint()
+        {
+            this.Invalidate(true);
+        }
+
         private byte limit(float a) { if (a > 255F) return 255; else return (byte)a; }
         public Color Multiply(Color from, float m) { return Color.FromArgb(from.A, limit((float)from.R * m), limit((float)from.G * m), limit((float)from.B * m)); }
 
@@ -254,6 +262,7 @@ namespace ExtendedControls
 
         private VScrollBarCustom vScrollBar;
         private Rectangle borderrect, mainarea;
+        private int bordersize;
         private int itemslayoutestimatedon = -1;
         private int displayableitems = -1;
         private int firstindex = -1;

--- a/EDDiscovery/Controls/StatusStripCustom.cs
+++ b/EDDiscovery/Controls/StatusStripCustom.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class StatusStripCustom : StatusStrip
+    {
+        public const int WM_NCHITTEST = 0x84;
+        public const int WM_NCLBUTTONDOWN = 0xA1;
+        public const int WM_NCLBUTTONUP = 0xA2;
+        public const int HT_CLIENT = 0x1;
+        public const int HT_BOTTOMRIGHT = 0x11;
+        public const int HT_TRANSPARENT = -1;
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+
+            if (m.Msg == WM_NCHITTEST && (int)m.Result == HT_BOTTOMRIGHT)
+            {
+                // Tell the system to test the parent
+                m.Result = (IntPtr)HT_TRANSPARENT;
+            }
+        }
+    }
+}

--- a/EDDiscovery/Controls/ToolStripComboBoxCustom.cs
+++ b/EDDiscovery/Controls/ToolStripComboBoxCustom.cs
@@ -30,13 +30,13 @@ namespace ExtendedControls
         public int ScrollBarWidth { get { return ComboBox.ScrollBarWidth; } set { ComboBox.ScrollBarWidth = value; } }
         public int ItemHeight { get { return ComboBox.ItemHeight; } set { ComboBox.ItemHeight = value; } }
         public int SelectedIndex { get { return ComboBox.SelectedIndex; } set { ComboBox.SelectedIndex = value; } }
-        public List<string> Items { get { return ComboBox.Items; } set { ComboBox.Items = value; } }
+        public ComboBoxCustom.ObjectCollection Items { get { return ComboBox.Items; } set { ComboBox.Items = value; } }
         public object DataSource { get { return ComboBox.DataSource; } set { ComboBox.DataSource = value; } }
         public string DisplayMember { get { return ComboBox.DisplayMember; } set { ComboBox.DisplayMember = value; } }
         public string ValueMember { get { return ComboBox.ValueMember; } set { ComboBox.ValueMember = value; } }
         public object SelectedItem { get { return ComboBox.SelectedItem; } set { ComboBox.SelectedItem = value; } }
         public object SelectedValue { get { return ComboBox.SelectedValue; } }
 
-        public event ComboBoxCustom.OnSelectedIndexChanged SelectedIndexChanged { add { ComboBox.SelectedIndexChanged += value; } remove { ComboBox.SelectedIndexChanged -= value; } }
+        public event EventHandler SelectedIndexChanged { add { ComboBox.SelectedIndexChanged += value; } remove { ComboBox.SelectedIndexChanged -= value; } }
     }
 }

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -760,6 +760,31 @@ namespace EDDiscovery2
 
                 MyDgv.Font = fnt;
             }
+            else if (myControl is ListControlCustom)
+            {
+                ListControlCustom MyDgv = (ListControlCustom)myControl;
+                MyDgv.ForeColor = currentsettings.colors[Settings.CI.button_text];
+
+                if (currentsettings.buttonstyle.Equals(ButtonStyles[0]))
+                {
+                    MyDgv.FlatStyle = FlatStyle.System;
+                }
+                else
+                {
+                    MyDgv.BackColor = currentsettings.colors[Settings.CI.button_back];
+                    MyDgv.BorderColor = currentsettings.colors[Settings.CI.button_border];
+                    MyDgv.ScrollBarButtonColor = currentsettings.colors[Settings.CI.textbox_scrollbutton];
+                    MyDgv.ScrollBarColor = currentsettings.colors[Settings.CI.textbox_sliderback];
+
+                    if (currentsettings.buttonstyle.Equals(ButtonStyles[1])) // flat
+                        MyDgv.FlatStyle = FlatStyle.Flat;
+                    else
+                        MyDgv.FlatStyle = FlatStyle.Popup;
+                }
+
+                myControl.Font = fnt;
+                MyDgv.Repaint();            // force a repaint as the individual settings do not by design.
+            }
             else if (myControl is ComboBoxCustom)
             {
                 ComboBoxCustom MyDgv = (ComboBoxCustom)myControl;

--- a/EDDiscovery/EDDToolStripRenderer.cs
+++ b/EDDiscovery/EDDToolStripRenderer.cs
@@ -241,12 +241,14 @@ namespace EDDiscovery2
                 e.Graphics.DrawImage(e.Item.Image, rc);
             }
         }
+#endif
 
         protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
         {
             if (!(e.ToolStrip is StatusStrip))
                 base.OnRenderStatusStripSizingGrip(e);
             
+            /*
             int kk = 5;
             Rectangle bnd = e.AffectedBounds;
 
@@ -261,9 +263,24 @@ namespace EDDiscovery2
                     kk--;
                 }
             }
+             */
             
+            using (Pen p1 = new Pen(ColorTable.GripDark))
+            {
+                int rightpx = e.AffectedBounds.Right - 1;
+                int bottompx = e.AffectedBounds.Bottom - 1;
+                int msize = 5;
+                int rightmarginpx = rightpx - msize;
+                int bottommarginpx = bottompx - msize;
+
+                for (int i = 0; i < 3; i++)
+                {
+                    e.Graphics.DrawLine(p1, new Point(rightmarginpx - i * msize, bottompx), new Point(rightpx, bottommarginpx - i * msize));
+                }
+            }
         }
 
+#if false
         protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
         {
             Rectangle rc = e.Item.ContentRectangle;

--- a/EDDiscovery/EDDToolStripRenderer.cs
+++ b/EDDiscovery/EDDToolStripRenderer.cs
@@ -9,20 +9,27 @@ namespace EDDiscovery2
 {
     public class EDDToolStripRenderer : ToolStripProfessionalRenderer//ToolStripSystemRenderer
     {
-        public Color colMenuBackground = Color.FromArgb(255, 188,199,216);//ControlPaint.LightLight(ControlPaint.Light(Color.SlateBlue));
-        public Color colToolStripBorder = Color.FromArgb(255, 133, 145, 162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
-        public Color colToolStripBackGround = Color.LightGray; 
-        public Color colToolStripSeparator = Color.FromArgb(255,133,145,162); //0x8591A2);//ControlPaint.LightLight(Color.SlateBlue);
-        public Color colMenuSelectedBack = Color.FromArgb(255, 201,210,225); //ControlPaint.LightLight(ControlPaint.LightLight(Color.LightSlateGray));
-        public Color colMenuSelectedText = Color.Black;
-        public Color Dark = Color.FromArgb(255,41, 57, 85);
-        public Color colMenuText = Color.White;
+        protected ExtendedControls.CustomColourTable _colortable;
 
-        //Bitmap bmp = new Bitmap(1, 1);
-        public Color ButtonSelectedBorder = Color.FromArgb(229, 195, 101);
-        public Color ButtonSelectBackLight = Color.FromArgb(255, 252, 242);
-        public Color ButtonSelectBackDark = Color.FromArgb(255, 236, 181);
+        public Color colMenuBackground { get { return _colortable.colMenuBackground; } set { _colortable.colMenuBackground = value; } }
+        public Color colToolStripBorder { get { return _colortable.colToolStripBorder; } set { _colortable.colToolStripBorder = value; } }
+        public Color colToolStripBackGround { get { return _colortable.colToolStripBackGround; } set { _colortable.colToolStripBackGround = value; } }
+        public Color colToolStripSeparator { get { return _colortable.colToolStripSeparator; } set { _colortable.colToolStripSeparator = value; } }
+        public Color colMenuSelectedBack { get { return _colortable.colMenuSelectedBack; } set { _colortable.colMenuSelectedBack = value; } }
+        public Color colMenuSelectedText { get { return _colortable.colMenuSelectedText; } set { _colortable.colMenuSelectedText = value; } }
+        public Color Dark { get { return _colortable.dark; } set { _colortable.dark = value; } }
+        public Color colMenuText { get { return _colortable.colMenuText; } set { _colortable.colMenuText = value; } }
+        public Color ButtonSelectedBorder { get { return _colortable.colButtonSelectedBorder; } set { _colortable.colButtonSelectedBorder = value; } }
+        public Color ButtonSelectBackLight { get { return _colortable.colButtonSelectBackLight; } set { _colortable.colButtonSelectBackLight = value; } }
+        public Color ButtonSelectBackDark { get { return _colortable.colButtonSelectBackDark; } set { _colortable.colButtonSelectBackDark = value; } }
 
+        public EDDToolStripRenderer() : base(new ExtendedControls.CustomColourTable())
+        {
+            this._colortable = (ExtendedControls.CustomColourTable)ColorTable;
+            this.RoundedEdges = true;
+        }
+
+#if false
         protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
         {
             if (e.ToolStrip is MenuStrip)
@@ -51,7 +58,7 @@ namespace EDDiscovery2
                 //    e.Graphics.FillRectangle(new SolidBrush(Border), 1, 1, 24, e.AffectedBounds.Height - 1);
             }
         }
-
+#endif
 
 
         protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -88,6 +95,7 @@ namespace EDDiscovery2
             }
         }
 
+#if false
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
             if (e.Item.Enabled)
@@ -103,6 +111,7 @@ namespace EDDiscovery2
                 }
             }
         }
+#endif
 
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
@@ -123,6 +132,7 @@ namespace EDDiscovery2
             base.OnRenderItemText(e);
         }
 
+#if false
         protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
         {
             if (e.Vertical)
@@ -358,5 +368,6 @@ namespace EDDiscovery2
             else
                 base.OnRenderItemImage(e);
         }
+#endif
     }
 }

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Controls\CheckBoxCustom.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\CustomColourTable.cs" />
     <Compile Include="Controls\DataViewScrollerPanel.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -222,6 +222,9 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\CustomColourTable.cs" />
+    <Compile Include="Controls\StatusStripCustom.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\DataViewScrollerPanel.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -72,10 +72,10 @@
             this.savedRouteExpeditionControl1 = new EDDiscovery.SavedRouteExpeditionControl();
             this.tabPageSettings = new System.Windows.Forms.TabPage();
             this.settings = new EDDiscovery2.Settings();
-            this.panel_grip = new ExtendedControls.DrawnPanel();
             this.button_test = new ExtendedControls.ButtonExt();
             this.panel_minimize = new ExtendedControls.DrawnPanel();
             this.panel_close = new ExtendedControls.DrawnPanel();
+            this.statusStrip1 = new ExtendedControls.StatusStripCustom();
             this.menuStrip1.SuspendLayout();
             this.panelInfo.SuspendLayout();
             this.tabControl1.SuspendLayout();
@@ -326,6 +326,9 @@
             // 
             // tabControl1
             // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPageTravelHistory);
             this.tabControl1.Controls.Add(this.tabPageTriletaration);
             this.tabControl1.Controls.Add(this.tabPageScreenshots);
@@ -465,21 +468,6 @@
             this.settings.Size = new System.Drawing.Size(186, 68);
             this.settings.TabIndex = 0;
             // 
-            // panel_grip
-            // 
-            this.panel_grip.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.panel_grip.BackColor = System.Drawing.SystemColors.Control;
-            this.panel_grip.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.panel_grip.Image = ExtendedControls.DrawnPanel.ImageType.Gripper;
-            this.panel_grip.Location = new System.Drawing.Point(977, 727);
-            this.panel_grip.MarginSize = 5;
-            this.panel_grip.MouseOverColor = System.Drawing.Color.White;
-            this.panel_grip.MouseSelectedColor = System.Drawing.Color.Green;
-            this.panel_grip.Name = "panel_grip";
-            this.panel_grip.Size = new System.Drawing.Size(16, 16);
-            this.panel_grip.TabIndex = 16;
-            this.panel_grip.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel_grip_MouseDown);
-            // 
             // button_test
             // 
             this.button_test.BorderColorScaling = 1.25F;
@@ -524,6 +512,14 @@
             this.panel_close.TabIndex = 19;
             this.panel_close.Click += new System.EventHandler(this.panel_close_Click);
             // 
+            // statusStrip1
+            //
+            this.statusStrip1.Location = new System.Drawing.Point(0, 722);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(993, 22);
+            this.statusStrip1.TabIndex = 22;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
             // EDDiscoveryForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -533,11 +529,11 @@
             this.Controls.Add(this.panel_eddiscovery);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.panelInfo);
-            this.Controls.Add(this.panel_grip);
             this.Controls.Add(this.button_test);
             this.Controls.Add(this.panel_minimize);
             this.Controls.Add(this.panel_close);
             this.Controls.Add(this.menuStrip1);
+            this.Controls.Add(this.statusStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "EDDiscoveryForm";
@@ -593,7 +589,6 @@
         private System.Windows.Forms.ToolStripMenuItem eDDiscoveryChatDiscordToolStripMenuItem;
         private ExtendedControls.DrawnPanel panel_close;
         private ExtendedControls.DrawnPanel panel_minimize;
-        private ExtendedControls.DrawnPanel panel_grip;
         private System.Windows.Forms.TabPage tabPageSettings;
         public  EDDiscovery2.Settings settings;
         private System.Windows.Forms.TabPage tabPageRoute;
@@ -611,6 +606,7 @@
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.TabPage tabPageRoutesExpeditions;
         private SavedRouteExpeditionControl savedRouteExpeditionControl1;
+        private ExtendedControls.StatusStripCustom statusStrip1;
         private System.Windows.Forms.ToolStripMenuItem debugBetaFixHiddenLogToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem synchroniseWithEDSMDistancesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem show3DMapsToolStripMenuItem;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -32,9 +32,12 @@ namespace EDDiscovery
         #region Variables
 
         public const int WM_NCLBUTTONDOWN = 0xA1;
+        public const int HT_CLIENT = 0x1;
         public const int HT_CAPTION = 0x2;
+        public const int HT_BOTTOMRIGHT = 0x11;
         public const int WM_NCL_RESIZE = 0x112;
         public const int HT_RESIZE = 61448;
+        public const int WM_NCHITTEST = 0x84;
 
         private IntPtr SendMessage(int msg, IntPtr wparam, IntPtr lparam)
         {
@@ -121,6 +124,7 @@ namespace EDDiscovery
 
         private void EDDiscoveryForm_Layout(object sender, LayoutEventArgs e)       // Manually position, could not get gripper under tab control with it sizing for the life of me
         {
+            /*
             if (panel_grip.Visible)
             {
                 panel_grip.Location = new Point(this.ClientSize.Width - panel_grip.Size.Width, this.ClientSize.Height - panel_grip.Size.Height);
@@ -128,6 +132,7 @@ namespace EDDiscovery
             }
             else
                 tabControl1.Size = new Size(this.ClientSize.Width, this.ClientSize.Height - tabControl1.Location.Y);
+             */
         }
 
         private void ProcessCommandLineOptions()
@@ -280,8 +285,9 @@ namespace EDDiscovery
 
         public void ApplyTheme(bool refreshhistory)
         {
+            ToolStripManager.Renderer = theme.toolstripRenderer;
             this.FormBorderStyle = theme.WindowsFrame ? FormBorderStyle.Sizable : FormBorderStyle.None;
-            panel_grip.Visible = !theme.WindowsFrame;
+            //panel_grip.Visible = !theme.WindowsFrame;
             panel_close.Visible = !theme.WindowsFrame;
             panel_minimize.Visible = !theme.WindowsFrame;
             label_version.Visible = !theme.WindowsFrame;
@@ -1008,6 +1014,7 @@ namespace EDDiscovery
             this.WindowState = FormWindowState.Minimized;
         }
 
+        /*
         private void panel_grip_MouseDown(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
@@ -1017,6 +1024,7 @@ namespace EDDiscovery
                 SendMessage(WM_NCL_RESIZE, (IntPtr)HT_RESIZE, IntPtr.Zero);
             }
         }
+         */
 
         private void changeMapColorToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -1056,6 +1064,34 @@ namespace EDDiscovery
             {
                 this.Capture = false;
                 SendMessage(WM_NCLBUTTONDOWN, (IntPtr)HT_CAPTION, IntPtr.Zero);
+            }
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_NCHITTEST)
+            {
+                base.WndProc(ref m);
+
+                if ((int)m.Result == HT_CLIENT)
+                {
+                    int x = unchecked((short)((uint)m.LParam & 0xFFFF));
+                    int y = unchecked((short)((uint)m.LParam >> 16));
+                    Point p = PointToClient(new Point(x, y));
+
+                    if (p.X > this.ClientSize.Width - statusStrip1.Height && p.Y > this.ClientSize.Height - statusStrip1.Height)
+                    {
+                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                    }
+                    else if (!theme.WindowsFrame)
+                    {
+                        m.Result = (IntPtr)HT_CAPTION;
+                    }
+                }
+            }
+            else
+            {
+                base.WndProc(ref m);
             }
         }
 

--- a/EDDiscovery/EDDiscoveryForm.resx
+++ b/EDDiscovery/EDDiscoveryForm.resx
@@ -7654,6 +7654,9 @@
         AABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>301, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>59</value>
   </metadata>

--- a/EDDiscovery/ImageHandler/ImageHandler.Designer.cs
+++ b/EDDiscovery/ImageHandler/ImageHandler.Designer.cs
@@ -437,7 +437,7 @@
             this.comboBoxFileNameFormat.Size = new System.Drawing.Size(218, 21);
             this.comboBoxFileNameFormat.TabIndex = 7;
             this.comboBoxFileNameFormat.ValueMember = null;
-            this.comboBoxFileNameFormat.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.comboBoxFileNameFormat_SelectedIndexChanged);
+            this.comboBoxFileNameFormat.SelectedIndexChanged += new System.EventHandler(this.comboBoxFileNameFormat_SelectedIndexChanged);
             // 
             // label2
             // 
@@ -519,7 +519,7 @@
             this.comboBoxScanFor.Size = new System.Drawing.Size(113, 21);
             this.comboBoxScanFor.TabIndex = 5;
             this.comboBoxScanFor.ValueMember = null;
-            this.comboBoxScanFor.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.comboBoxScanFor_SelectedIndexChanged);
+            this.comboBoxScanFor.SelectedIndexChanged += new System.EventHandler(this.comboBoxScanFor_SelectedIndexChanged);
             // 
             // comboBoxFormat
             // 
@@ -544,7 +544,7 @@
             this.comboBoxFormat.Size = new System.Drawing.Size(113, 21);
             this.comboBoxFormat.TabIndex = 5;
             this.comboBoxFormat.ValueMember = null;
-            this.comboBoxFormat.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.comboBoxFormat_SelectedIndexChanged);
+            this.comboBoxFormat.SelectedIndexChanged += new System.EventHandler(this.comboBoxFormat_SelectedIndexChanged);
             // 
             // label10
             // 

--- a/EDDiscovery/RouteControl.Designer.cs
+++ b/EDDiscovery/RouteControl.Designer.cs
@@ -80,7 +80,7 @@
             this.comboBoxRoutingMetric.Size = new System.Drawing.Size(234, 21);
             this.comboBoxRoutingMetric.TabIndex = 9;
             this.comboBoxRoutingMetric.ValueMember = null;
-            this.comboBoxRoutingMetric.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.comboBoxRoutingMetric_SelectedIndexChanged);
+            this.comboBoxRoutingMetric.SelectedIndexChanged += new System.EventHandler(this.comboBoxRoutingMetric_SelectedIndexChanged);
             // 
             // richTextBox_routeresult
             // 

--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -110,26 +110,13 @@
             // 
             // toolStripComboBoxRouteSelection
             // 
-            this.toolStripComboBoxRouteSelection.ArrowWidth = 1;
-            this.toolStripComboBoxRouteSelection.BorderColor = System.Drawing.Color.White;
-            this.toolStripComboBoxRouteSelection.ButtonColorScaling = 0.5F;
-            this.toolStripComboBoxRouteSelection.DataSource = null;
-            this.toolStripComboBoxRouteSelection.DisplayMember = null;
-            this.toolStripComboBoxRouteSelection.DropDownBackgroundColor = System.Drawing.Color.Gray;
             this.toolStripComboBoxRouteSelection.DropDownHeight = 200;
             this.toolStripComboBoxRouteSelection.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.toolStripComboBoxRouteSelection.ItemHeight = 20;
-            this.toolStripComboBoxRouteSelection.Items = ((System.Collections.Generic.List<string>)(resources.GetObject("toolStripComboBoxRouteSelection.Items")));
-            this.toolStripComboBoxRouteSelection.MouseOverBackgroundColor = System.Drawing.Color.Silver;
             this.toolStripComboBoxRouteSelection.Name = "toolStripComboBoxRouteSelection";
-            this.toolStripComboBoxRouteSelection.ScrollBarButtonColor = System.Drawing.Color.LightGray;
-            this.toolStripComboBoxRouteSelection.ScrollBarColor = System.Drawing.Color.LightGray;
-            this.toolStripComboBoxRouteSelection.ScrollBarWidth = 16;
             this.toolStripComboBoxRouteSelection.SelectedIndex = -1;
             this.toolStripComboBoxRouteSelection.SelectedItem = null;
             this.toolStripComboBoxRouteSelection.Size = new System.Drawing.Size(150, 22);
-            this.toolStripComboBoxRouteSelection.ValueMember = null;
-            this.toolStripComboBoxRouteSelection.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.toolStripComboBoxRouteSelection_SelectedIndexChanged);
+            this.toolStripComboBoxRouteSelection.SelectedIndexChanged += new System.EventHandler(this.toolStripComboBoxRouteSelection_SelectedIndexChanged);
             // 
             // panelRouteInfo
             // 

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -122,7 +122,6 @@
             this.comboBoxTheme.DropDownHeight = 100;
             this.comboBoxTheme.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.comboBoxTheme.ItemHeight = 20;
-            this.comboBoxTheme.Items = ((System.Collections.Generic.List<string>)(resources.GetObject("comboBoxTheme.Items")));
             this.comboBoxTheme.Location = new System.Drawing.Point(7, 19);
             this.comboBoxTheme.MouseOverBackgroundColor = System.Drawing.Color.Silver;
             this.comboBoxTheme.Name = "comboBoxTheme";

--- a/EDDiscovery/TravelHistoryControl.Designer.cs
+++ b/EDDiscovery/TravelHistoryControl.Designer.cs
@@ -627,7 +627,6 @@
             this.comboBoxHistoryWindow.DropDownHeight = 200;
             this.comboBoxHistoryWindow.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.comboBoxHistoryWindow.ItemHeight = 20;
-            this.comboBoxHistoryWindow.Items = ((System.Collections.Generic.List<string>)(resources.GetObject("comboBoxHistoryWindow.Items")));
             this.comboBoxHistoryWindow.Location = new System.Drawing.Point(102, 4);
             this.comboBoxHistoryWindow.MouseOverBackgroundColor = System.Drawing.Color.Silver;
             this.comboBoxHistoryWindow.Name = "comboBoxHistoryWindow";
@@ -640,7 +639,7 @@
             this.comboBoxHistoryWindow.TabIndex = 0;
             this.toolTipEddb.SetToolTip(this.comboBoxHistoryWindow, "Select the limit of age for travel history entries to show");
             this.comboBoxHistoryWindow.ValueMember = null;
-            this.comboBoxHistoryWindow.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.comboBoxHistoryWindow_SelectedIndexChanged);
+            this.comboBoxHistoryWindow.SelectedIndexChanged += new System.EventHandler(this.comboBoxHistoryWindow_SelectedIndexChanged);
             // 
             // button_RefreshHistory
             // 
@@ -718,7 +717,6 @@
             this.comboBoxCommander.DropDownHeight = 200;
             this.comboBoxCommander.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.comboBoxCommander.ItemHeight = 20;
-            this.comboBoxCommander.Items = ((System.Collections.Generic.List<string>)(resources.GetObject("comboBoxCommander.Items")));
             this.comboBoxCommander.Location = new System.Drawing.Point(114, 6);
             this.comboBoxCommander.MouseOverBackgroundColor = System.Drawing.Color.Silver;
             this.comboBoxCommander.Name = "comboBoxCommander";
@@ -732,7 +730,7 @@
             this.toolTipEddb.SetToolTip(this.comboBoxCommander, "Select your commander. Use Settings page to configure and add additional commande" +
         "rs");
             this.comboBoxCommander.ValueMember = null;
-            this.comboBoxCommander.SelectedIndexChanged += new ExtendedControls.ComboBoxCustom.OnSelectedIndexChanged(this.comboBoxCommander_SelectedIndexChanged);
+            this.comboBoxCommander.SelectedIndexChanged += new System.EventHandler(this.comboBoxCommander_SelectedIndexChanged);
             // 
             // buttonExtSummaryPopOut
             // 

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -68,6 +68,7 @@ namespace EDDiscovery
             EDSMSyncFrom = SQLiteDBClass.GetSettingBool("EDSMSyncFrom", true);
             checkBoxEDSMSyncTo.Checked = EDSMSyncTo;
             checkBoxEDSMSyncFrom.Checked = EDSMSyncFrom;
+            comboBoxHistoryWindow.Enabled = false;
             comboBoxHistoryWindow.DataSource = new[]
             {
                 TravelHistoryFilter.FromHours(6),
@@ -86,6 +87,8 @@ namespace EDDiscovery
             comboBoxHistoryWindow.DisplayMember = nameof(TravelHistoryFilter.Label);
 
             comboBoxHistoryWindow.SelectedIndex = SQLiteDBClass.GetSettingInt("EDUIHistory", DefaultTravelHistoryFilterIndex);
+            comboBoxHistoryWindow.Enabled = true;
+
             LoadCommandersListBox();
 
             closestthread = new Thread(CalculateClosestSystems) { Name = "Closest Calc", IsBackground = true };

--- a/EDDiscovery/TravelHistoryControl.resx
+++ b/EDDiscovery/TravelHistoryControl.resx
@@ -126,24 +126,6 @@
   <metadata name="toolTipEddb.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="comboBoxHistoryWindow.Items" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAJoBbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1u
-        ZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0sIG1zY29ybGliLCBWZXJzaW9u
-        PTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OQUB
-        AAAAMFN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkxpc3RgMVtbU3lzdGVtLlN0cmluZwMAAAAGX2l0
-        ZW1zBV9zaXplCF92ZXJzaW9uBgAACAgCAAAACQMAAAAAAAAAAgAAABEDAAAAAAAAAAs=
-</value>
-  </data>
-  <data name="comboBoxCommander.Items" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAJoBbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1u
-        ZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0sIG1zY29ybGliLCBWZXJzaW9u
-        PTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OQUB
-        AAAAMFN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkxpc3RgMVtbU3lzdGVtLlN0cmluZwMAAAAGX2l0
-        ZW1zBV9zaXplCF92ZXJzaW9uBgAACAgCAAAACQMAAAAAAAAAAAAAABEDAAAAAAAAAAs=
-</value>
-  </data>
   <metadata name="Col1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>


### PR DESCRIPTION
* Use a colour table for toolstrips etc.  This should reduce the amount of custom rendering code for toolstrips, improving compatibility.
* Replace the drawn panel sizing grip with the status strip's sizing grip.  This also allows us to anchor the bottom of the tab panels to the top of the status strip.
* Rework the custom combo box, using a borderless window instead of a floating panel on the main form.