### PR TITLE
Better system matching

### DIFF
--- a/EDDiscovery/DB/InMemory/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/InMemory/VisitedSystemsClass.cs
@@ -20,7 +20,7 @@ namespace EDDiscovery2.DB.InMemory
         public double X { get; set; }
         public double Y { get; set; }
         public double Z { get; set; }
-
+        public long? id_edsm_assigned { get; set; }
 
         public bool Update()
         {

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -498,6 +498,9 @@ namespace EDDiscovery.DB
                 if (dbver < 18)
                     UpgradeDB18();
 
+                if (dbver < 19)
+                    UpgradeDB19();
+
                 return true;
             }
             catch (Exception ex)
@@ -708,6 +711,16 @@ namespace EDDiscovery.DB
             string query4 = "CREATE INDEX Systems_position ON Systems (X, Y, Z)";
 
             PerformUpgrade(18, true, true, new[] { query1, query2, query3, query4 });
+        }
+
+        private void UpgradeDB19()
+        {
+            string query1 = "CREATE TABLE SystemAliases (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT, id_edsm INTEGER, id_edsm_mergedto INTEGER)";
+            string query2 = "CREATE INDEX SystemAliases_name ON SystemAliases (name)";
+            string query3 = "CREATE UNIQUE INDEX SystemAliases_id_edsm ON SystemAliases (id_edsm)";
+            string query4 = "CREATE INDEX SystemAliases_id_edsm_mergedto ON SystemAliases (id_edsm_mergedto)";
+
+            PerformUpgrade(19, true, true, new[] { query1, query2, query3, query4 });
         }
 
         ///----------------------------

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -495,6 +495,9 @@ namespace EDDiscovery.DB
                 if (dbver < 17)
                     UpgradeDB17();
 
+                if (dbver < 18)
+                    UpgradeDB18();
+
                 return true;
             }
             catch (Exception ex)
@@ -697,6 +700,15 @@ namespace EDDiscovery.DB
             });
         }
 
+        private void UpgradeDB18()
+        {
+            string query1 = "ALTER TABLE VisitedSystems ADD COLUMN id_edsm_assigned Integer";
+            string query2 = "CREATE INDEX VisitedSystems_id_edsm_assigned ON VisitedSystems (id_edsm_assigned)";
+            string query3 = "CREATE INDEX VisitedSystems_position ON VisitedSystems (X, Y, Z)";
+            string query4 = "CREATE INDEX Systems_position ON Systems (X, Y, Z)";
+
+            PerformUpgrade(18, true, true, new[] { query1, query2, query3, query4 });
+        }
 
         ///----------------------------
         /// STATIC code helpers for other DB classes

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -958,6 +958,18 @@ namespace EDDiscovery.DB
 
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
+                    // Check that the SystemAliases table is not empty
+                    using (DbCommand cmd = cn.CreateCommand("SELECT COUNT(id) FROM SystemAliases"))
+                    {
+                        long nrows = (long)cmd.ExecuteScalar();
+
+                        if (nrows == 0)
+                        {
+                            Console.WriteLine("Populating system aliases table");
+                            RemoveHiddenSystems();
+                        }
+                    }
+
                     // Retrieve systems matching on name, position or EDSM ID.
                     // Having the database filter the systems is much quicker
                     // than having to sift through all of the systems
@@ -993,7 +1005,7 @@ namespace EDDiscovery.DB
                                 {
                                     isalias = true;
                                 }
-                                
+
                                 if (id != lastid)
                                 {
                                     sys = new SystemClass(reader);
@@ -1353,6 +1365,16 @@ namespace EDDiscovery.DB
 
             date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
             return toupdate.Count + newsystems.Count;
+        }
+
+        public static void RemoveHiddenSystems()
+        {
+            EDDiscovery2.EDSM.EDSMClass edsm = new EDDiscovery2.EDSM.EDSMClass();
+
+            string strhiddensystems = edsm.GetHiddenSystems();
+
+            if (strhiddensystems != null && strhiddensystems.Length >= 6)
+                RemoveHiddenSystems(strhiddensystems);
         }
 
         public static void RemoveHiddenSystems(string json)

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1122,6 +1122,8 @@ namespace EDDiscovery.DB
                         SystemClass edsmidmatch = null;
                         bool multimatch = false;
                         Dictionary<long, SystemClass> matches;
+                        bool hastravcoords = vsc.HasTravelCoordinates &&
+                            (vsc.Name.ToLower() == "sol" || vsc.X != 0 || vsc.Y != 0 || vsc.Z != 0);
 
                         if (systemsByVscId.ContainsKey(vsc.id))
                         {
@@ -1143,7 +1145,7 @@ namespace EDDiscovery.DB
                             }
                         }
 
-                        if (vsc.HasTravelCoordinates)
+                        if (hastravcoords)
                         {
                             posmatches = matches.Values.Where(s => s.x >= vsc.X - 0.125 && s.x <= vsc.X + 0.125 && s.y >= vsc.X - 0.125 && s.y <= vsc.Y + 0.125 && s.z >= vsc.Z - 0.125 && s.z <= vsc.Z + 0.125).ToList();
                             if (posmatches.Count >= 1)
@@ -1182,17 +1184,17 @@ namespace EDDiscovery.DB
                             SystemClass sys = edsmidmatch;
                             vsc.curSystem = sys;
 
-                            if (sys.SearchName == vsc_searchname && sys.x >= vsc.X - 0.125 && sys.x <= vsc.X + 0.125 && sys.y >= vsc.Y - 0.125 && sys.y <= vsc.Y + 0.125 && sys.z >= vsc.Z - 0.125 && sys.z <= vsc.Z + 0.125) // name and position matches
+                            if (sys.SearchName == vsc_searchname && hastravcoords && sys.x >= vsc.X - 0.125 && sys.x <= vsc.X + 0.125 && sys.y >= vsc.Y - 0.125 && sys.y <= vsc.Y + 0.125 && sys.z >= vsc.Z - 0.125 && sys.z <= vsc.Z + 0.125) // name and position matches
                             {
                                 vsc.NameStatus = "Exact match";
                                 continue; // Continue to next system
                             }
-                            else if (sys.x >= vsc.X - 0.125 && sys.x <= vsc.X + 0.125 && sys.y >= vsc.Y - 0.125 && sys.y <= vsc.Y + 0.125 && sys.z >= vsc.Z - 0.125 && sys.z <= vsc.Z + 0.125) // position matches
+                            else if (hastravcoords && sys.x >= vsc.X - 0.125 && sys.x <= vsc.X + 0.125 && sys.y >= vsc.Y - 0.125 && sys.y <= vsc.Y + 0.125 && sys.z >= vsc.Z - 0.125 && sys.z <= vsc.Z + 0.125) // position matches
                             {
                                 vsc.NameStatus = "Name differs";
                                 continue; // Continue to next system
                             }
-                            else if (!vsc.HasTravelCoordinates || !sys.HasCoordinate) // no coordinates available
+                            else if (!hastravcoords || !sys.HasCoordinate) // no coordinates available
                             {
                                 if (sys.SearchName == vsc_searchname) // name matches
                                 {

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -696,6 +696,45 @@ namespace EDDiscovery.DB
             return sys;
         }
 
+        public static List<SystemClass> GetSystemsByName(string name, SQLiteConnectionED cn = null)
+        {
+            List<SystemClass> systems = new List<SystemClass>();
+            bool closeit = false;
+
+            try
+            {
+                if (cn == null)
+                {
+                    closeit = true;
+                    cn = new SQLiteConnectionED();
+                }
+
+                using (DbCommand cmd = cn.CreateCommand("select * from Systems where name = @name"))
+                {
+                    cmd.AddParameterWithValue("name", name);
+                    using (DbDataReader reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                            systems.Add(new SystemClass(reader));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine("Exception : " + ex.Message);
+                System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+            }
+            finally
+            {
+                if (closeit && cn != null)
+                {
+                    cn.Dispose();
+                }
+            }
+
+            return systems;
+        }
+
         public static SystemClass GetSystem(long id, SQLiteConnectionED cn = null, SystemIDType idtype = SystemIDType.id )      // using an id
         {
             SystemClass sys = null;

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -995,7 +995,7 @@ namespace EDDiscovery.DB
 
                             while (reader.Read())
                             {
-                                string name = ((string)reader["name"]).ToUpper();
+                                string name = ((string)reader["name"]).ToLower();
                                 long id_edsm = 0;
                                 long id = (long)reader["id"];
                                 long vscid = (long)reader["vscid"];
@@ -1062,7 +1062,7 @@ namespace EDDiscovery.DB
                 // we determine what and how well they match
                 foreach (VisitedSystemsClass vsc in visitedSystems)
                 {
-                    string vsc_searchname = vsc.Name.ToUpper();
+                    string vsc_searchname = vsc.Name.ToLower();
 
                     if (vsc.curSystem == null)                                              // if not set before, look it up
                     {
@@ -1130,17 +1130,16 @@ namespace EDDiscovery.DB
                         if (edsmidmatch != null)
                         {
                             SystemClass sys = edsmidmatch;
+                            vsc.curSystem = sys;
 
                             if (sys.SearchName == vsc_searchname && sys.x >= vsc.X - 0.125 && sys.x <= vsc.X + 0.125 && sys.y >= vsc.Y - 0.125 && sys.y <= vsc.Y + 0.125 && sys.z >= vsc.Z - 0.125 && sys.z <= vsc.Z + 0.125) // name and position matches
                             {
                                 vsc.NameStatus = "Exact match";
-                                vsc.curSystem = sys;
                                 continue; // Continue to next system
                             }
                             else if (sys.x >= vsc.X - 0.125 && sys.x <= vsc.X + 0.125 && sys.y >= vsc.Y - 0.125 && sys.y <= vsc.Y + 0.125 && sys.z >= vsc.Z - 0.125 && sys.z <= vsc.Z + 0.125) // position matches
                             {
                                 vsc.NameStatus = "Name differs";
-                                vsc.curSystem = sys;
                                 continue; // Continue to next system
                             }
                             else if (!vsc.HasTravelCoordinates || !sys.HasCoordinate) // no coordinates available
@@ -1158,6 +1157,10 @@ namespace EDDiscovery.DB
 
                                     vsc.curSystem = sys;
                                     continue; // Continue to next system
+                                }
+                                else if (!vsc.HasTravelCoordinates)
+                                {
+                                    vsc.NameStatus = "Name differs";
                                 }
                             }
                         }

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -346,13 +346,15 @@ namespace EDDiscovery2.DB
             }
         }
 
-        public static void CalculateSqDistances(List<VisitedSystemsClass> vs, SortedList<double,string> distlist , double x, double y, double z, int maxitems , bool removezerodiststar )
+        public static void CalculateSqDistances(List<VisitedSystemsClass> vs, SortedList<double,ISystem> distlist , double x, double y, double z, int maxitems , bool removezerodiststar )
         {
             double dist;
             double dx, dy, dz;
+            Dictionary<long, ISystem> systems = distlist.Values.ToDictionary(s => s.id);
+
             foreach (VisitedSystemsClass pos in vs)
             {
-                if (pos.HasTravelCoordinates && distlist.IndexOfValue(pos.Name) == -1)   // if co-ords, and not in list already..
+                if (pos.HasTravelCoordinates && (pos.curSystem == null || !systems.ContainsKey(pos.curSystem.id)))   // if co-ords, and not in list already..
                 {
                     dx = (pos.X - x);
                     dy = (pos.Y - y);
@@ -362,10 +364,10 @@ namespace EDDiscovery2.DB
                     if (dist > 0.001 || !removezerodiststar)
                     {
                         if (distlist.Count < maxitems)          // if less than max, add..
-                            distlist.Add(dist, pos.Name);
+                            distlist.Add(dist, pos.curSystem);
                         else if (dist < distlist.Last().Key)   // if last entry (which must be the biggest) is greater than dist..
                         {
-                            distlist.Add(dist, pos.Name);           // add in
+                            distlist.Add(dist, pos.curSystem);           // add in
                             distlist.RemoveAt(maxitems);        // remove last..
                         }
                     }

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -15,6 +15,8 @@ namespace EDDiscovery2.DB
         public ISystem prevSystem;
         public ISystem lastKnownSystem;
         public string strDistance;
+        public string NameStatus;
+        public List<ISystem> alternatives;
 
         public VisitedSystemsClass()
         {
@@ -46,6 +48,11 @@ namespace EDDiscovery2.DB
                 Y = (double)dr["Y"];
                 Z = (double)dr["Z"];
             }
+
+            if (dr["id_edsm_assigned"] != System.DBNull.Value)
+            {
+                id_edsm_assigned = (long)dr["id_edsm_assigned"];
+            }
         }
 
         public bool HasTravelCoordinates
@@ -67,7 +74,7 @@ namespace EDDiscovery2.DB
 
         private bool Add(SQLiteConnectionED cn)
         {
-            using (DbCommand cmd = cn.CreateCommand("Insert into VisitedSystems (Name, Time, Unit, Commander, Source, edsm_sync, map_colour, X, Y, Z) values (@name, @time, @unit, @commander, @source, @edsm_sync, @map_colour, @x, @y, @z)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into VisitedSystems (Name, Time, Unit, Commander, Source, edsm_sync, map_colour, X, Y, Z, id_edsm_assigned) values (@name, @time, @unit, @commander, @source, @edsm_sync, @map_colour, @x, @y, @z, @id_edsm_assigned)"))
             {
                 cmd.AddParameterWithValue("@name", Name);
                 cmd.AddParameterWithValue("@time", Time);
@@ -79,6 +86,7 @@ namespace EDDiscovery2.DB
                 cmd.AddParameterWithValue("@x", X);
                 cmd.AddParameterWithValue("@y", Y);
                 cmd.AddParameterWithValue("@z", Z);
+                cmd.AddParameterWithValue("@id_edsm_assigned", id_edsm_assigned);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
@@ -100,7 +108,7 @@ namespace EDDiscovery2.DB
 
         private bool Update(SQLiteConnectionED cn)
         {
-            using (DbCommand cmd = cn.CreateCommand("Update VisitedSystems set Name=@Name, Time=@Time, Unit=@Unit, Commander=@commander, Source=@Source, edsm_sync=@edsm_sync, map_colour=@map_colour, X=@x, Y=@y, Z=@z  where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Update VisitedSystems set Name=@Name, Time=@Time, Unit=@Unit, Commander=@commander, Source=@Source, edsm_sync=@edsm_sync, map_colour=@map_colour, X=@x, Y=@y, Z=@z, id_edsm_assigned=@id_edsm_assigned where ID=@id"))
             {
                 cmd.AddParameterWithValue("@ID", id);
                 cmd.AddParameterWithValue("@Name", Name);
@@ -113,6 +121,7 @@ namespace EDDiscovery2.DB
                 cmd.AddParameterWithValue("@x", X);
                 cmd.AddParameterWithValue("@y", Y);
                 cmd.AddParameterWithValue("@z", Z);
+                cmd.AddParameterWithValue("@id_edsm_assigned", id_edsm_assigned);
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
                 return true;

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -354,7 +354,7 @@ namespace EDDiscovery2.DB
 
             foreach (VisitedSystemsClass pos in vs)
             {
-                if (pos.HasTravelCoordinates && (pos.curSystem == null || !systems.ContainsKey(pos.curSystem.id)))   // if co-ords, and not in list already..
+                if (pos.HasTravelCoordinates && pos.curSystem != null && !systems.ContainsKey(pos.curSystem.id))   // if co-ords, and not in list already..
                 {
                     dx = (pos.X - x);
                     dy = (pos.Y - y);

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -18,6 +18,14 @@ namespace EDDiscovery2.DB
         public string NameStatus;
         public List<ISystem> alternatives;
 
+        public bool IsAmbiguous
+        {
+            get
+            {
+                return alternatives != null && (alternatives.Count > 1 || (curSystem == null && alternatives.Count >= 1));
+            }
+        }
+
         public VisitedSystemsClass()
         {
             X = double.NaN;             // construct class with nulls/0's except for these, which use NaN as their no content marker.

--- a/EDDiscovery/EDDB/EDDBClass.cs
+++ b/EDDiscovery/EDDB/EDDBClass.cs
@@ -89,6 +89,10 @@ namespace EDDiscovery2.EDDB
                 {
                     request.Headers[HttpRequestHeader.IfNoneMatch] = etag;
                 }
+                else
+                {
+                    request.IfModifiedSince = File.GetLastWriteTimeUtc(etagFilename);
+                }
             }
 
             try

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -180,6 +180,12 @@
     <Compile Include="EDSM\GalacticMapObject.cs" />
     <Compile Include="EDSM\GalacticMapping.cs" />
     <Compile Include="EDSM\GalMapType.cs" />
+    <Compile Include="Forms\AssignTravelLogSystemForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\AssignTravelLogSystemForm.Designer.cs">
+      <DependentUpon>AssignTravelLogSystemForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Forms\BookmarkForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -451,6 +457,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\AboutForm.resx">
       <DependentUpon>AboutForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\AssignTravelLogSystemForm.resx">
+      <DependentUpon>AssignTravelLogSystemForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\BookmarkForm.resx">
       <DependentUpon>BookmarkForm.cs</DependentUpon>

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -538,10 +538,7 @@ namespace EDDiscovery
 
                     LogLine("Get hidden systems and remove from EDSM.");
 
-                    string strhiddensystems = edsm.GetHiddenSystems();
-
-                    if (strhiddensystems != null && strhiddensystems.Length >= 6)
-                        SystemClass.RemoveHiddenSystems(strhiddensystems);
+                    SystemClass.RemoveHiddenSystems();
 
                     LogLine("Get systems from EDSM.");
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -548,7 +548,7 @@ namespace EDDiscovery
 
                     long updates = 0;
 
-                    if (newfile)
+                    if (newfile || firstrun)
                     {
                         LogLine("Resyncing all downloaded EDSM systems with local database." + Environment.NewLine + "This will take a while.");
 

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -413,7 +413,7 @@ namespace EDDiscovery2.EDSM
 
         }
 
-        public bool ShowSystemInEDSM(string sysName)
+        public bool ShowSystemInEDSM(string sysName, long? id_edsm = null)
         {
             string url = GetUrlToEDSMSystem(sysName);
             if (string.IsNullOrEmpty(url))
@@ -427,17 +427,26 @@ namespace EDDiscovery2.EDSM
             return true;
         }
 
-        public string GetUrlToEDSMSystem(string sysName)
+        public string GetUrlToEDSMSystem(string sysName, long? id_edsm = null)
         {
+            string sysID;
             string encodedSys = HttpUtility.UrlEncode(sysName);
-            string query = "system?sysname=" + encodedSys + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&showId=1";
-            var response = RequestGet("api-v1/" + query);
-            var json = response.Body;
-            if (json == null || json.ToString() == "[]")
-                return "";
 
-            JObject msg = JObject.Parse(json);
-            string sysID = msg["id"].Value<string>();
+            if (id_edsm != null)
+            {
+                sysID = id_edsm.ToString();
+            }
+            else
+            {
+                string query = "system?sysname=" + encodedSys + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&showId=1";
+                var response = RequestGet("api-v1/" + query);
+                var json = response.Body;
+                if (json == null || json.ToString() == "[]")
+                    return "";
+
+                JObject msg = JObject.Parse(json);
+                sysID = msg["id"].Value<string>();
+            }
 
             string url = "https://www.edsm.net/show-system/index/id/" + sysID + "/name/" + encodedSys;
             return url;

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -415,7 +415,7 @@ namespace EDDiscovery2.EDSM
 
         public bool ShowSystemInEDSM(string sysName, long? id_edsm = null)
         {
-            string url = GetUrlToEDSMSystem(sysName);
+            string url = GetUrlToEDSMSystem(sysName, id_edsm);
             if (string.IsNullOrEmpty(url))
             {
                 return false;

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
@@ -1,0 +1,262 @@
+﻿namespace EDDiscovery.Forms
+{
+    partial class AssignTravelLogSystemForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.cbSystemLink = new System.Windows.Forms.ComboBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.tbLogSystemName = new System.Windows.Forms.TextBox();
+            this.tbDateVisited = new System.Windows.Forms.TextBox();
+            this.tbLogCoordX = new System.Windows.Forms.TextBox();
+            this.tbLogCoordY = new System.Windows.Forms.TextBox();
+            this.tbLogCoordZ = new System.Windows.Forms.TextBox();
+            this.tbManualSystemName = new System.Windows.Forms.TextBox();
+            this.tbSysCoordX = new System.Windows.Forms.TextBox();
+            this.tbSysCoordY = new System.Windows.Forms.TextBox();
+            this.tbSysCoordZ = new System.Windows.Forms.TextBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnFindSystem = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(13, 13);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(129, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Travel Log System Name:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(13, 39);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(67, 13);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Date Visited:";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(12, 91);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(96, 13);
+            this.label3.TabIndex = 4;
+            this.label3.Text = "New system name:";
+            // 
+            // cbSystemLink
+            // 
+            this.cbSystemLink.FormattingEnabled = true;
+            this.cbSystemLink.Location = new System.Drawing.Point(151, 88);
+            this.cbSystemLink.Name = "cbSystemLink";
+            this.cbSystemLink.Size = new System.Drawing.Size(216, 21);
+            this.cbSystemLink.TabIndex = 5;
+            this.cbSystemLink.SelectedIndexChanged += new System.EventHandler(this.cbSystemLink_SelectedIndexChanged);
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(13, 65);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(120, 13);
+            this.label4.TabIndex = 6;
+            this.label4.Text = "Travel Log Coordinates:";
+            // 
+            // tbLogSystemName
+            // 
+            this.tbLogSystemName.Location = new System.Drawing.Point(151, 10);
+            this.tbLogSystemName.Name = "tbLogSystemName";
+            this.tbLogSystemName.ReadOnly = true;
+            this.tbLogSystemName.Size = new System.Drawing.Size(216, 20);
+            this.tbLogSystemName.TabIndex = 7;
+            // 
+            // tbDateVisited
+            // 
+            this.tbDateVisited.Location = new System.Drawing.Point(151, 36);
+            this.tbDateVisited.Name = "tbDateVisited";
+            this.tbDateVisited.ReadOnly = true;
+            this.tbDateVisited.Size = new System.Drawing.Size(216, 20);
+            this.tbDateVisited.TabIndex = 8;
+            // 
+            // tbLogCoordX
+            // 
+            this.tbLogCoordX.Location = new System.Drawing.Point(151, 62);
+            this.tbLogCoordX.Name = "tbLogCoordX";
+            this.tbLogCoordX.ReadOnly = true;
+            this.tbLogCoordX.Size = new System.Drawing.Size(68, 20);
+            this.tbLogCoordX.TabIndex = 9;
+            this.tbLogCoordX.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // tbLogCoordY
+            // 
+            this.tbLogCoordY.Location = new System.Drawing.Point(225, 62);
+            this.tbLogCoordY.Name = "tbLogCoordY";
+            this.tbLogCoordY.ReadOnly = true;
+            this.tbLogCoordY.Size = new System.Drawing.Size(68, 20);
+            this.tbLogCoordY.TabIndex = 10;
+            this.tbLogCoordY.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // tbLogCoordZ
+            // 
+            this.tbLogCoordZ.Location = new System.Drawing.Point(299, 62);
+            this.tbLogCoordZ.Name = "tbLogCoordZ";
+            this.tbLogCoordZ.ReadOnly = true;
+            this.tbLogCoordZ.Size = new System.Drawing.Size(68, 20);
+            this.tbLogCoordZ.TabIndex = 11;
+            this.tbLogCoordZ.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // tbManualSystemName
+            // 
+            this.tbManualSystemName.Location = new System.Drawing.Point(151, 116);
+            this.tbManualSystemName.Name = "tbManualSystemName";
+            this.tbManualSystemName.Size = new System.Drawing.Size(135, 20);
+            this.tbManualSystemName.TabIndex = 12;
+            // 
+            // tbSysCoordX
+            // 
+            this.tbSysCoordX.Location = new System.Drawing.Point(151, 142);
+            this.tbSysCoordX.Name = "tbSysCoordX";
+            this.tbSysCoordX.ReadOnly = true;
+            this.tbSysCoordX.Size = new System.Drawing.Size(68, 20);
+            this.tbSysCoordX.TabIndex = 13;
+            this.tbSysCoordX.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // tbSysCoordY
+            // 
+            this.tbSysCoordY.Location = new System.Drawing.Point(225, 142);
+            this.tbSysCoordY.Name = "tbSysCoordY";
+            this.tbSysCoordY.ReadOnly = true;
+            this.tbSysCoordY.Size = new System.Drawing.Size(68, 20);
+            this.tbSysCoordY.TabIndex = 14;
+            this.tbSysCoordY.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // tbSysCoordZ
+            // 
+            this.tbSysCoordZ.Location = new System.Drawing.Point(299, 142);
+            this.tbSysCoordZ.Name = "tbSysCoordZ";
+            this.tbSysCoordZ.ReadOnly = true;
+            this.tbSysCoordZ.Size = new System.Drawing.Size(68, 20);
+            this.tbSysCoordZ.TabIndex = 15;
+            this.tbSysCoordZ.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(12, 145);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(100, 13);
+            this.label5.TabIndex = 16;
+            this.label5.Text = "System Coordinates";
+            // 
+            // btnOK
+            // 
+            this.btnOK.Location = new System.Drawing.Point(292, 179);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.TabIndex = 17;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(211, 179);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 18;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnFindSystem
+            // 
+            this.btnFindSystem.Location = new System.Drawing.Point(292, 115);
+            this.btnFindSystem.Name = "btnFindSystem";
+            this.btnFindSystem.Size = new System.Drawing.Size(75, 23);
+            this.btnFindSystem.TabIndex = 19;
+            this.btnFindSystem.Text = "Find";
+            this.btnFindSystem.UseVisualStyleBackColor = true;
+            // 
+            // AssignTravelLogSystemForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(387, 214);
+            this.Controls.Add(this.btnFindSystem);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.tbSysCoordZ);
+            this.Controls.Add(this.tbSysCoordY);
+            this.Controls.Add(this.tbSysCoordX);
+            this.Controls.Add(this.tbManualSystemName);
+            this.Controls.Add(this.tbLogCoordZ);
+            this.Controls.Add(this.tbLogCoordY);
+            this.Controls.Add(this.tbLogCoordX);
+            this.Controls.Add(this.tbDateVisited);
+            this.Controls.Add(this.tbLogSystemName);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.cbSystemLink);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Name = "AssignTravelLogSystemForm";
+            this.Text = "AssignTravelLogSystemForm";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.ComboBox cbSystemLink;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.TextBox tbLogSystemName;
+        private System.Windows.Forms.TextBox tbDateVisited;
+        private System.Windows.Forms.TextBox tbLogCoordX;
+        private System.Windows.Forms.TextBox tbLogCoordY;
+        private System.Windows.Forms.TextBox tbLogCoordZ;
+        private System.Windows.Forms.TextBox tbManualSystemName;
+        private System.Windows.Forms.TextBox tbSysCoordX;
+        private System.Windows.Forms.TextBox tbSysCoordY;
+        private System.Windows.Forms.TextBox tbSysCoordZ;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnFindSystem;
+    }
+}

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
@@ -46,6 +46,8 @@
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnFindSystem = new System.Windows.Forms.Button();
+            this.label6 = new System.Windows.Forms.Label();
+            this.lblEDSMLink = new System.Windows.Forms.LinkLabel();
             this.SuspendLayout();
             // 
             // label1
@@ -77,6 +79,7 @@
             // 
             // cbSystemLink
             // 
+            this.cbSystemLink.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbSystemLink.FormattingEnabled = true;
             this.cbSystemLink.Location = new System.Drawing.Point(151, 88);
             this.cbSystemLink.Name = "cbSystemLink";
@@ -181,7 +184,7 @@
             // 
             // btnOK
             // 
-            this.btnOK.Location = new System.Drawing.Point(292, 179);
+            this.btnOK.Location = new System.Drawing.Point(292, 210);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
             this.btnOK.TabIndex = 17;
@@ -191,7 +194,7 @@
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(211, 179);
+            this.btnCancel.Location = new System.Drawing.Point(211, 210);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 18;
@@ -208,11 +211,33 @@
             this.btnFindSystem.Text = "Find";
             this.btnFindSystem.UseVisualStyleBackColor = true;
             // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(15, 178);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(64, 13);
+            this.label6.TabIndex = 20;
+            this.label6.Text = "EDSM Link:";
+            // 
+            // lblEDSMLink
+            // 
+            this.lblEDSMLink.AutoSize = true;
+            this.lblEDSMLink.Location = new System.Drawing.Point(148, 178);
+            this.lblEDSMLink.Name = "lblEDSMLink";
+            this.lblEDSMLink.Size = new System.Drawing.Size(58, 13);
+            this.lblEDSMLink.TabIndex = 21;
+            this.lblEDSMLink.TabStop = true;
+            this.lblEDSMLink.Text = "EDSMLink";
+            this.lblEDSMLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lblEDSMLink_LinkClicked);
+            // 
             // AssignTravelLogSystemForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(387, 214);
+            this.ClientSize = new System.Drawing.Size(387, 245);
+            this.Controls.Add(this.lblEDSMLink);
+            this.Controls.Add(this.label6);
             this.Controls.Add(this.btnFindSystem);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
@@ -258,5 +283,7 @@
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Button btnFindSystem;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.LinkLabel lblEDSMLink;
     }
 }

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
@@ -210,6 +210,7 @@
             this.btnFindSystem.TabIndex = 19;
             this.btnFindSystem.Text = "Find";
             this.btnFindSystem.UseVisualStyleBackColor = true;
+            this.btnFindSystem.Click += new System.EventHandler(this.btnFindSystem_Click);
             // 
             // label6
             // 

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
@@ -24,7 +24,18 @@ namespace EDDiscovery.Forms
             {
                 get
                 {
-                    return LinkSystem != null ? LinkSystem.ToString() : Name;
+                    if (LinkSystem == null)
+                    {
+                        return Name;
+                    }
+                    else if (LinkSystem.HasCoordinate)
+                    {
+                        return $"{LinkSystem.name} ({LinkSystem.x},{LinkSystem.y},{LinkSystem.z}) #{LinkSystem.id_edsm}";
+                    }
+                    else
+                    {
+                        return $"{LinkSystem.name} #{LinkSystem.id_edsm}";
+                    }
                 }
             }
         }
@@ -69,7 +80,7 @@ namespace EDDiscovery.Forms
             links.Add(new SystemLink { Name = "Other", Id = -1, LinkSystem = null, UseOther = true });
 
             this.cbSystemLink.DataSource = links;
-            this.cbSystemLink.DisplayMember = "Name";
+            this.cbSystemLink.DisplayMember = "DisplayName";
             this.cbSystemLink.ValueMember = "Id";
 
             if (vsc.curSystem != null && vsc.alternatives.Contains(vsc.curSystem))
@@ -83,6 +94,15 @@ namespace EDDiscovery.Forms
         {
             SystemLink selectedItem = (SystemLink)cbSystemLink.SelectedItem;
             _linkSystem = selectedItem.LinkSystem;
+
+            if (selectedItem.LinkSystem != null)
+            {
+                lblEDSMLink.Text = selectedItem.LinkSystem.name;
+            }
+            else
+            {
+                lblEDSMLink.Text = "";
+            }
 
             if (selectedItem.LinkSystem != null && selectedItem.LinkSystem.HasCoordinate)
             {
@@ -119,6 +139,15 @@ namespace EDDiscovery.Forms
         private void cbSystemLink_SelectedIndexChanged(object sender, EventArgs e)
         {
             UpdateLinkedSystem();
+        }
+
+        private void lblEDSMLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            if (_linkSystem != null)
+            {
+                string url = String.Format("https://www.edsm.net/show-system/index/id/{0}/name/{1}", _linkSystem.id_edsm, Uri.EscapeDataString(_linkSystem.name));
+                System.Diagnostics.Process.Start(url);
+            }
         }
     }
 }

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using EDDiscovery2.DB;
+using EDDiscovery.DB;
+
+namespace EDDiscovery.Forms
+{
+    public partial class AssignTravelLogSystemForm : Form
+    {
+        private class SystemLink
+        {
+            public string Name { get; set; }
+            public long Id { get; set; }
+            public bool UseOther { get; set; }
+            public ISystem LinkSystem { get; set; }
+
+            public string DisplayName
+            {
+                get
+                {
+                    return LinkSystem != null ? LinkSystem.ToString() : Name;
+                }
+            }
+        }
+
+        public long AssignedEdsmId { get { return _linkSystem == null ? 0 : _linkSystem.id_edsm; } }
+        public ISystem AssignedSystem { get { return _linkSystem; } }
+
+        private TravelHistoryControl _travelHistory;
+        private ISystem _linkSystem;
+        private VisitedSystemsClass _travelLogEntry;
+
+        public AssignTravelLogSystemForm(TravelHistoryControl travelHistory, VisitedSystemsClass vsc)
+        {
+            InitializeComponent();
+            this._travelHistory = travelHistory;
+            this._travelLogEntry = vsc;
+            this._linkSystem = vsc.curSystem;
+
+            this.tbLogSystemName.Text = vsc.Name;
+            this.tbDateVisited.Text = vsc.Time.ToString();
+            this.tbLogCoordX.Text = vsc.HasTravelCoordinates ? vsc.X.ToString("0.000") : "?";
+            this.tbLogCoordY.Text = vsc.HasTravelCoordinates ? vsc.Y.ToString("0.000") : "?";
+            this.tbLogCoordZ.Text = vsc.HasTravelCoordinates ? vsc.Z.ToString("0.000") : "?";
+            this.tbLogCoordX.TextAlign = vsc.HasTravelCoordinates ? HorizontalAlignment.Right : HorizontalAlignment.Center;
+            this.tbLogCoordY.TextAlign = vsc.HasTravelCoordinates ? HorizontalAlignment.Right : HorizontalAlignment.Center;
+            this.tbLogCoordZ.TextAlign = vsc.HasTravelCoordinates ? HorizontalAlignment.Right : HorizontalAlignment.Center;
+
+            this.tbManualSystemName.ReadOnly = true;
+            this.btnFindSystem.Enabled = false;
+
+            List<SystemLink> links = new List<SystemLink>();
+            links.Add(new SystemLink { Name = "None", Id = 0, LinkSystem = null, UseOther = false });
+            
+            if (vsc.alternatives != null)
+            {
+                foreach (var sys in vsc.alternatives)
+                {
+                    links.Add(new SystemLink { Name = sys.name, Id = sys.id_edsm, LinkSystem = sys, UseOther = false });
+                }
+            }
+
+            links.Add(new SystemLink { Name = "Other", Id = -1, LinkSystem = null, UseOther = true });
+
+            this.cbSystemLink.DataSource = links;
+            this.cbSystemLink.DisplayMember = "Name";
+            this.cbSystemLink.ValueMember = "Id";
+
+            if (vsc.curSystem != null && vsc.alternatives.Contains(vsc.curSystem))
+            {
+                this.cbSystemLink.SelectedItem = links.First(l => l.LinkSystem == vsc.curSystem);
+                UpdateLinkedSystem();
+            }
+        }
+
+        protected void UpdateLinkedSystem()
+        {
+            SystemLink selectedItem = (SystemLink)cbSystemLink.SelectedItem;
+            _linkSystem = selectedItem.LinkSystem;
+
+            if (selectedItem.LinkSystem != null && selectedItem.LinkSystem.HasCoordinate)
+            {
+                tbSysCoordX.Text = selectedItem.LinkSystem.x.ToString("0.000");
+                tbSysCoordY.Text = selectedItem.LinkSystem.y.ToString("0.000");
+                tbSysCoordZ.Text = selectedItem.LinkSystem.z.ToString("0.000");
+                tbSysCoordX.TextAlign = HorizontalAlignment.Right;
+                tbSysCoordY.TextAlign = HorizontalAlignment.Right;
+                tbSysCoordZ.TextAlign = HorizontalAlignment.Right;
+            }
+            else
+            {
+                tbSysCoordX.Text = "?";
+                tbSysCoordY.Text = "?";
+                tbSysCoordZ.Text = "?";
+                tbSysCoordX.TextAlign = HorizontalAlignment.Center;
+                tbSysCoordY.TextAlign = HorizontalAlignment.Center;
+                tbSysCoordZ.TextAlign = HorizontalAlignment.Center;
+            }
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+            this.Close();
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.OK;
+            this.Close();
+        }
+
+        private void cbSystemLink_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateLinkedSystem();
+        }
+    }
+}

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.resx
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/EDDiscovery/RouteControl.cs
+++ b/EDDiscovery/RouteControl.cs
@@ -390,7 +390,7 @@ namespace EDDiscovery
                 Point3D curpos;
                 if (GetCoordsFrom(out curpos))
                 {
-                    SystemClass nearest = SystemClass.FindNearestSystem(curpos.X, curpos.Y, curpos.Z);
+                    ISystem nearest = SystemClass.FindNearestSystem(curpos.X, curpos.Y, curpos.Z);
 
                     if (nearest != null)
                     {
@@ -500,7 +500,7 @@ namespace EDDiscovery
                 Point3D curpos;
                 if (GetCoordsTo(out curpos))
                 {
-                    SystemClass nearest = SystemClass.FindNearestSystem(curpos.X, curpos.Y, curpos.Z);
+                    ISystem nearest = SystemClass.FindNearestSystem(curpos.X, curpos.Y, curpos.Z);
 
                     if (nearest != null)
                     {

--- a/EDDiscovery/TravelHistoryControl.Designer.cs
+++ b/EDDiscovery/TravelHistoryControl.Designer.cs
@@ -42,6 +42,7 @@
             this.bothToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewOnEDSMToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.enterDistanceToPreviousStarToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectCorrectSystemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.label2 = new System.Windows.Forms.Label();
             this.labelclosests = new System.Windows.Forms.Label();
             this.panel_system = new System.Windows.Forms.Panel();
@@ -129,9 +130,10 @@
             this.moveToAnotherCommanderToolStripMenuItem,
             this.addToTrilaterationToolStripMenuItem,
             this.viewOnEDSMToolStripMenuItem,
-            this.enterDistanceToPreviousStarToolStripMenuItem});
+            this.enterDistanceToPreviousStarToolStripMenuItem,
+            this.selectCorrectSystemToolStripMenuItem});
             this.historyContextMenu.Name = "historyContextMenu";
-            this.historyContextMenu.Size = new System.Drawing.Size(233, 158);
+            this.historyContextMenu.Size = new System.Drawing.Size(233, 202);
             this.historyContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.historyContextMenu_Opening);
             // 
             // mapGotoStartoolStripMenuItem
@@ -206,6 +208,13 @@
             this.enterDistanceToPreviousStarToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.enterDistanceToPreviousStarToolStripMenuItem.Text = "Enter distance to previous star";
             this.enterDistanceToPreviousStarToolStripMenuItem.Click += new System.EventHandler(this.enterDistanceToPreviousStarToolStripMenuItem_Click);
+            // 
+            // selectCorrectSystemToolStripMenuItem
+            // 
+            this.selectCorrectSystemToolStripMenuItem.Name = "selectCorrectSystemToolStripMenuItem";
+            this.selectCorrectSystemToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.selectCorrectSystemToolStripMenuItem.Text = "Assign new system";
+            this.selectCorrectSystemToolStripMenuItem.Click += new System.EventHandler(this.selectCorrectSystemToolStripMenuItem_Click);
             // 
             // label2
             // 
@@ -1100,5 +1109,6 @@
         private System.Windows.Forms.ToolStripMenuItem mapGotoStartoolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem enterDistanceToPreviousStarToolStripMenuItem;
         private ExtendedControls.DrawnPanel buttonEDSM;
+        private System.Windows.Forms.ToolStripMenuItem selectCorrectSystemToolStripMenuItem;
     }
 }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -754,8 +754,14 @@ namespace EDDiscovery
             {
                 if (!String.IsNullOrEmpty(currentSysPos.curSystem.name))
                 {
+                    long? id_edsm = currentSysPos.curSystem.id_edsm;
+                    if (id_edsm == 0)
+                    {
+                        id_edsm = null;
+                    }
+
                     EDSMClass edsm = new EDSMClass();
-                    string url = edsm.GetUrlToEDSMSystem(currentSysPos.curSystem.name);
+                    string url = edsm.GetUrlToEDSMSystem(currentSysPos.curSystem.name, id_edsm);
 
                     if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                         Process.Start(url);
@@ -888,9 +894,9 @@ namespace EDDiscovery
                                                                         .OrderBy(cell => cell.Index);
 
             this.Cursor = Cursors.WaitCursor;
-            string sysName = selectedRows.First<DataGridViewRow>().Cells[ClosestSystemsColumns.SystemName].Value.ToString();
+            ISystem system = (ISystem)selectedRows.First<DataGridViewRow>().Tag;
             EDSMClass edsm = new EDSMClass();
-            if (!edsm.ShowSystemInEDSM(sysName))
+            if (!edsm.ShowSystemInEDSM(system.name, system.id_edsm))
                 LogTextHighlight("System could not be found - has not been synched or EDSM is unavailable" + Environment.NewLine);
 
             this.Cursor = Cursors.Default;
@@ -1124,8 +1130,14 @@ namespace EDDiscovery
         {
             this.Cursor = Cursors.WaitCursor;
             EDSMClass edsm = new EDSMClass();
+            long? id_edsm = rightclicksystem.curSystem?.id_edsm;
 
-            if (!edsm.ShowSystemInEDSM(rightclicksystem.Name))
+            if (id_edsm == 0)
+            {
+                id_edsm = null;
+            }
+
+            if (!edsm.ShowSystemInEDSM(rightclicksystem.Name, id_edsm))
                 LogTextHighlight("System could not be found - has not been synched or EDSM is unavailable" + Environment.NewLine);
 
             this.Cursor = Cursors.Default;

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -1181,6 +1181,17 @@ namespace EDDiscovery
 
         #endregion
 
+        private void selectCorrectSystemToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Forms.AssignTravelLogSystemForm form = new Forms.AssignTravelLogSystemForm(this, rightclicksystem);
+            DialogResult result = form.ShowDialog();
+            if (result == DialogResult.OK)
+            {
+                rightclicksystem.id_edsm_assigned = form.AssignedEdsmId;
+                rightclicksystem.curSystem = form.AssignedSystem;
+                rightclicksystem.Update();
+                RefreshHistory();
+            }
+        }
     }
-
 }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -180,6 +180,11 @@ namespace EDDiscovery
             object[] rowobj = { item.Time, item.Name, item.strDistance, SystemNoteClass.GetSystemNoteOrEmpty(item.curSystem.name), "█" };
             int rownr;
 
+            if (item.curSystem != null && item.curSystem.name.ToLower() != item.Name.ToLower())
+            {
+                rowobj[1] = $"{item.curSystem.name} ({item.Name})";
+            }
+
             if (insert)
             {
                 dataGridViewTravel.Rows.Insert(0, rowobj);

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -182,7 +182,7 @@ namespace EDDiscovery
 
             if (item.curSystem != null && item.curSystem.name.ToLower() != item.Name.ToLower())
             {
-                rowobj[1] = $"{item.curSystem.name} ({item.Name})";
+                rowobj[1] = $"{item.Name} ({item.curSystem.name})";
             }
 
             if (insert)

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -1183,14 +1183,16 @@ namespace EDDiscovery
 
         private void selectCorrectSystemToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Forms.AssignTravelLogSystemForm form = new Forms.AssignTravelLogSystemForm(this, rightclicksystem);
-            DialogResult result = form.ShowDialog();
-            if (result == DialogResult.OK)
+            using (Forms.AssignTravelLogSystemForm form = new Forms.AssignTravelLogSystemForm(this, rightclicksystem))
             {
-                rightclicksystem.id_edsm_assigned = form.AssignedEdsmId;
-                rightclicksystem.curSystem = form.AssignedSystem;
-                rightclicksystem.Update();
-                RefreshHistory();
+                DialogResult result = form.ShowDialog();
+                if (result == DialogResult.OK)
+                {
+                    rightclicksystem.id_edsm_assigned = form.AssignedEdsmId;
+                    rightclicksystem.curSystem = form.AssignedSystem;
+                    rightclicksystem.Update();
+                    RefreshHistory();
+                }
             }
         }
     }


### PR DESCRIPTION
* Match systems by name, position and/or EDSM ID
* Use the Hidden Systems from EDSM to match systems that have been renamed
* Allow the user to select which system is the correct system when the match is ambiguous
* Use the disambiguation to direct to the correct system on EDSM, and for the nearest systems list
* Limit the search volume to a 2000ly cubed area for the nearest systems list
* Display both original and new system names in the travel log for systems that have been renamed since they were visited

Requested in #267