### PR TITLE
Make EDSM sync verbose, made it closeable, fixed bug where it would constantly try and sync but never do it

### DIFF
--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -167,7 +167,7 @@ namespace EDDiscovery2.EDSM
                 return null;
         }
         
-        internal long GetNewSystems()
+        internal long GetNewSystems(EDDiscoveryForm discoveryform)
         {
             string lstsyst;
 
@@ -193,7 +193,7 @@ namespace EDDiscovery2.EDSM
             string json = RequestSystems(lstsyst);
 
             string date = "2010-01-01 00:00:00";
-            long updates = SystemClass.ParseEDSMUpdateSystemsString(json, ref date , false);
+            long updates = SystemClass.ParseEDSMUpdateSystemsString(json, ref date , false , discoveryform);
             SQLiteDBClass.PutSettingString("EDSMLastSystems", date);
 
             return updates;

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -119,7 +119,7 @@ namespace EDDiscovery
         {
             LogText("Check for new EDSM systems." + Environment.NewLine);
             EDSMClass edsm = new EDSMClass();
-            edsm.GetNewSystems();
+            edsm.GetNewSystems(_discoveryForm);
             LogText("EDSM System check complete." + Environment.NewLine);
         }
 


### PR DESCRIPTION
1. Pass discovery form to system EDSM sync do it can be verbose and
check for closure
2. Fix bug - if timestamp old, but file is not new, it just did not do
the full sync thus the timerstamp would not be updated.  Now does not
care about new file.. it gets written ever night anyway