### PR TITLE
Mono compatibility fixes

### DIFF
--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -368,7 +368,13 @@ namespace EDDiscovery.DB
 
     public static class SQLiteDBClass
     {
+        #region Private properties / fields
         private static DbProviderFactory _factory;
+        private static Object lockDBInit = new Object();                    // lock to sequence construction
+        private static string constring;                                           // connection string to use..
+        #endregion
+
+        #region Public properties
         public static DbProviderFactory DbFactory
         {
             get
@@ -380,25 +386,9 @@ namespace EDDiscovery.DB
                 return _factory;
             }
         }
+        #endregion
 
-        public static DbConnection CreateCN()
-        {
-            lock (lockDBInit)                                           // one at a time chaps
-            {
-                if (_factory == null)                                        // first one to ask for a connection sets the db up
-                {
-                    InitializeDatabase();
-                }
-            }
-
-            DbConnection cn = DbFactory.CreateConnection();
-            cn.ConnectionString = constring;
-            return cn;
-        }
-
-        private static Object lockDBInit = new Object();                    // lock to sequence construction
-        private static string constring;                                           // connection string to use..
-
+        #region Database Initialization
         private static void InitializeDatabase()
         {
             string dbfile = GetSQLiteDBFile();
@@ -714,6 +704,23 @@ namespace EDDiscovery.DB
 
             PerformUpgrade(conn, 19, true, true, new[] { query1, query2, query3, query4 });
         }
+        #endregion
+
+            #region Database access
+        public static DbConnection CreateCN()
+        {
+            lock (lockDBInit)                                           // one at a time chaps
+            {
+                if (_factory == null)                                        // first one to ask for a connection sets the db up
+                {
+                    InitializeDatabase();
+                }
+            }
+
+            DbConnection cn = DbFactory.CreateConnection();
+            cn.ConnectionString = constring;
+            return cn;
+        }
 
         ///----------------------------
         /// STATIC code helpers for other DB classes
@@ -765,7 +772,9 @@ namespace EDDiscovery.DB
                 throw;
             }
         }
+        #endregion
 
+        #region Settings
         ///----------------------------
         /// STATIC functions for discrete values
 
@@ -1107,6 +1116,6 @@ namespace EDDiscovery.DB
                 return false;
             }
         }
-
+        #endregion
     }
 }

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -703,6 +703,13 @@ namespace EDDiscovery.DB
                 return GetWindowsSqliteProviderFactory();
             }
 
+            var factory = GetMonoSqliteProviderFactory();
+
+            if (DbFactoryWorks(factory))
+            {
+                return factory;
+            }
+
             throw new InvalidOperationException("Unable to get a working Sqlite driver");
         }
 
@@ -717,6 +724,41 @@ namespace EDDiscovery.DB
             catch
             {
                 return false;
+            }
+        }
+
+        private static bool DbFactoryWorks(DbProviderFactory factory)
+        {
+            if (factory != null)
+            {
+                try
+                {
+                    using (var conn = factory.CreateConnection())
+                    {
+                        conn.ConnectionString = constring;
+                        conn.Open();
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            return false;
+        }
+
+        private static DbProviderFactory GetMonoSqliteProviderFactory()
+        {
+            try
+            {
+                var asm = System.Reflection.Assembly.LoadWithPartialName("Mono.Data.Sqlite");
+                var factorytype = asm.GetType("Mono.Data.Sqlite.SqliteFactory");
+                return (DbProviderFactory)factorytype.GetConstructor(new Type[0]).Invoke(new object[0]);
+            }
+            catch
+            {
+                return null;
             }
         }
 

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -13,53 +13,6 @@ using System.Threading;
 
 namespace EDDiscovery.DB
 {
-    public static class SQLiteDBExtensions
-    {
-        public static void AddParameterWithValue(this DbCommand cmd, string name, object val)
-        {
-            var par = cmd.CreateParameter();
-            par.ParameterName = name;
-            par.Value = val;
-            cmd.Parameters.Add(par);
-        }
-
-        public static void AddParameter(this DbCommand cmd, string name, DbType type)
-        {
-            var par = cmd.CreateParameter();
-            par.ParameterName = name;
-            par.DbType = type;
-            cmd.Parameters.Add(par);
-        }
-
-        public static void SetParameterValue(this DbCommand cmd, string name, object val)
-        {
-            cmd.Parameters[name].Value = val;
-        }
-
-        public static DbDataAdapter CreateDataAdapter(this DbCommand cmd)
-        {
-            DbDataAdapter da = SQLiteDBClass.DbFactory.CreateDataAdapter();
-            da.SelectCommand = cmd;
-            return da;
-        }
-
-        public static DbCommand CreateCommand(this DbConnection conn, string query)
-        {
-            DbCommand cmd = conn.CreateCommand();
-            cmd.CommandType = CommandType.Text;
-            cmd.CommandTimeout = 30;
-            cmd.CommandText = query;
-            return cmd;
-        }
-
-        public static DbCommand CreateCommand(this DbConnection conn, string query, DbTransaction transaction)
-        {
-            DbCommand cmd = conn.CreateCommand(query);
-            cmd.Transaction = transaction;
-            return cmd;
-        }
-    }
-
     // This class uses a monitor to ensure only one can be
     // active at any one time
     public class SQLiteTxnLockED : IDisposable
@@ -371,10 +324,7 @@ namespace EDDiscovery.DB
         #region Private properties / fields
         private static Object lockDBInit = new Object();                    // lock to sequence construction
         private static string constring;                                           // connection string to use..
-        #endregion
-
-        #region Public properties
-        public static DbProviderFactory DbFactory { get; private set; }
+        private static DbProviderFactory DbFactory;
         #endregion
 
         #region Database Initialization
@@ -775,7 +725,7 @@ namespace EDDiscovery.DB
         }
         #endregion
 
-            #region Database access
+        #region Database access
         public static DbConnection CreateCN()
         {
             lock (lockDBInit)                                           // one at a time chaps
@@ -840,6 +790,52 @@ namespace EDDiscovery.DB
                 System.Diagnostics.Debug.WriteLine("SqlNonQuery Exception: " + ex.Message);
                 throw;
             }
+        }
+        #endregion
+
+        #region Extension Methods
+        public static void AddParameterWithValue(this DbCommand cmd, string name, object val)
+        {
+            var par = cmd.CreateParameter();
+            par.ParameterName = name;
+            par.Value = val;
+            cmd.Parameters.Add(par);
+        }
+
+        public static void AddParameter(this DbCommand cmd, string name, DbType type)
+        {
+            var par = cmd.CreateParameter();
+            par.ParameterName = name;
+            par.DbType = type;
+            cmd.Parameters.Add(par);
+        }
+
+        public static void SetParameterValue(this DbCommand cmd, string name, object val)
+        {
+            cmd.Parameters[name].Value = val;
+        }
+
+        public static DbDataAdapter CreateDataAdapter(this DbCommand cmd)
+        {
+            DbDataAdapter da = DbFactory.CreateDataAdapter();
+            da.SelectCommand = cmd;
+            return da;
+        }
+
+        public static DbCommand CreateCommand(this DbConnection conn, string query)
+        {
+            DbCommand cmd = conn.CreateCommand();
+            cmd.CommandType = CommandType.Text;
+            cmd.CommandTimeout = 30;
+            cmd.CommandText = query;
+            return cmd;
+        }
+
+        public static DbCommand CreateCommand(this DbConnection conn, string query, DbTransaction transaction)
+        {
+            DbCommand cmd = conn.CreateCommand(query);
+            cmd.Transaction = transaction;
+            return cmd;
         }
         #endregion
 

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -366,7 +366,7 @@ namespace EDDiscovery.DB
     }
 
 
-    public class SQLiteDBClass
+    public static class SQLiteDBClass
     {
         private static DbProviderFactory _factory;
         public static DbProviderFactory DbFactory
@@ -385,28 +385,21 @@ namespace EDDiscovery.DB
         {
             lock (lockDBInit)                                           // one at a time chaps
             {
-                if (_db == null)                                        // first one to ask for a connection sets the db up
+                if (_factory == null)                                        // first one to ask for a connection sets the db up
                 {
-                    _db = new SQLiteDBClass();
-                    _db.InitializeDatabase();
+                    InitializeDatabase();
                 }
             }
 
             DbConnection cn = DbFactory.CreateConnection();
-            cn.ConnectionString = _db.constring;
+            cn.ConnectionString = constring;
             return cn;
         }
 
-        private static SQLiteDBClass _db = null;                            // one db class for everyone
         private static Object lockDBInit = new Object();                    // lock to sequence construction
-        private string constring;                                           // connection string to use..
-        SQLiteConnectionED m_SQLiteConnectionED;                            // only used by class constructor
+        private static string constring;                                           // connection string to use..
 
-        private SQLiteDBClass()         // non static class functions in here are only used by the construction
-        {                               // so this is private to make sure you don't try and initialise a DB anywhere..
-        }
-
-        private void InitializeDatabase()
+        private static void InitializeDatabase()
         {
             string dbfile = GetSQLiteDBFile();
             constring = "Data Source=" + dbfile + ";Pooling=true;";
@@ -417,12 +410,12 @@ namespace EDDiscovery.DB
                 if (!fileexist)                                         // no file, create it
                     SQLiteConnection.CreateFile(dbfile);
 
-                using (m_SQLiteConnectionED = new SQLiteConnectionED(new SQLiteConnection(constring)))
+                using (var conn = new SQLiteConnectionED())
                 {
                     if (!fileexist)                                       // first time, create the register
-                        ExecuteQuery("CREATE TABLE Register (ID TEXT PRIMARY KEY  NOT NULL  UNIQUE , \"ValueInt\" INTEGER, \"ValueDouble\" DOUBLE, \"ValueString\" TEXT, \"ValueBlob\" BLOB)");
+                        ExecuteQuery(conn, "CREATE TABLE Register (ID TEXT PRIMARY KEY  NOT NULL  UNIQUE , \"ValueInt\" INTEGER, \"ValueDouble\" DOUBLE, \"ValueString\" TEXT, \"ValueBlob\" BLOB)");
 
-                    UpgradeDB();                                            // upgrade it
+                    UpgradeDB(conn);                                            // upgrade it
                 }
             }
             catch (Exception ex)
@@ -431,75 +424,75 @@ namespace EDDiscovery.DB
             }
         }
 
-        private void ExecuteQuery(string query)
+        private static void ExecuteQuery(SQLiteConnectionED conn, string query)
         {
-            using (DbCommand command = m_SQLiteConnectionED.CreateCommand(query))
+            using (DbCommand command = conn.CreateCommand(query))
                 command.ExecuteNonQuery();
         }
 
-        private string GetSQLiteDBFile()
+        private static string GetSQLiteDBFile()
         {
             return Path.Combine(Tools.GetAppDataDirectory(), "EDDiscovery.sqlite");
         }
 
-        private bool UpgradeDB()
+        private static bool UpgradeDB(SQLiteConnectionED conn)
         {
             int dbver;
             try
             {
-                dbver = GetSettingInt("DBVer", 1, m_SQLiteConnectionED);        // use the constring one, as don't want to go back into ConnectionString code
+                dbver = GetSettingInt("DBVer", 1, conn);        // use the constring one, as don't want to go back into ConnectionString code
                 if (dbver < 2)
-                    UpgradeDB2();
+                    UpgradeDB2(conn);
 
                 if (dbver < 3)
-                    UpgradeDB3();
+                    UpgradeDB3(conn);
 
                 if (dbver < 4)
-                    UpgradeDB4();
+                    UpgradeDB4(conn);
 
                 if (dbver < 5)
-                    UpgradeDB5();
+                    UpgradeDB5(conn);
 
                 if (dbver < 6)
-                    UpgradeDB6();
+                    UpgradeDB6(conn);
 
                 if (dbver < 7)
-                    UpgradeDB7();
+                    UpgradeDB7(conn);
 
                 if (dbver < 8)
-                    UpgradeDB8();
+                    UpgradeDB8(conn);
 
                 if (dbver < 9)
-                    UpgradeDB9();
+                    UpgradeDB9(conn);
 
                 if (dbver < 10)
-                    UpgradeDB10();
+                    UpgradeDB10(conn);
 
                 if (dbver < 11)
-                    UpgradeDB11();
+                    UpgradeDB11(conn);
 
                 if (dbver < 12)
-                    UpgradeDB12();
+                    UpgradeDB12(conn);
 
                 // 15 remove due to conflict between 2 branches...
 
                 if (dbver < 14)
-                    UpgradeDB14();
+                    UpgradeDB14(conn);
 
                 if (dbver < 15)
-                    UpgradeDB15();
+                    UpgradeDB15(conn);
 
                 if (dbver < 16)
-                    UpgradeDB16();
+                    UpgradeDB16(conn);
 
                 if (dbver < 17)
-                    UpgradeDB17();
+                    UpgradeDB17(conn);
 
                 if (dbver < 18)
-                    UpgradeDB18();
+                    UpgradeDB18(conn);
 
                 if (dbver < 19)
-                    UpgradeDB19();
+                    UpgradeDB19(conn);
 
                 return true;
             }
@@ -511,7 +504,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        private void PerformUpgrade(int newVersion, bool catchErrors, bool backupDbFile, string[] queries, Action doAfterQueries = null)
+        private static void PerformUpgrade(SQLiteConnectionED conn, int newVersion, bool catchErrors, bool backupDbFile, string[] queries, Action doAfterQueries = null)
         {
             if (backupDbFile)
             {
@@ -532,7 +525,7 @@ namespace EDDiscovery.DB
             {
                 foreach (var query in queries)
                 {
-                    ExecuteQuery(query);
+                    ExecuteQuery(conn, query);
                 }
             }
             catch (Exception ex)
@@ -547,10 +540,10 @@ namespace EDDiscovery.DB
 
             doAfterQueries?.Invoke();
 
-            PutSettingInt("DBVer", newVersion, m_SQLiteConnectionED);
+            PutSettingInt("DBVer", newVersion, conn);
         }
 
-        private void UpgradeDB2()
+        private static void UpgradeDB2(SQLiteConnectionED conn)
         {
             string query = "CREATE TABLE Systems (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , name TEXT NOT NULL COLLATE NOCASE , x FLOAT, y FLOAT, z FLOAT, cr INTEGER, commandercreate TEXT, createdate DATETIME, commanderupdate TEXT, updatedate DATETIME, status INTEGER, population INTEGER )";
             string query2 = "CREATE  INDEX main.SystemsIndex ON Systems (name ASC)";
@@ -561,31 +554,30 @@ namespace EDDiscovery.DB
             string query7 = "CREATE TABLE Stations (station_id INTEGER PRIMARY KEY  NOT NULL ,system_id INTEGER REFERENCES Systems(id), name TEXT NOT NULL ,blackmarket BOOL DEFAULT (null) ,max_landing_pad_size INTEGER,distance_to_star INTEGER,type TEXT,faction TEXT,shipyard BOOL,outfitting BOOL, commodities_market BOOL)";
             string query8 = "CREATE  INDEX stationIndex ON Stations (system_id ASC)";
 
-            PerformUpgrade(2, false, false, new[] { query, query2, query3, query4, query5, query6, query7, query8 });
+            PerformUpgrade(conn, 2, false, false, new[] { query, query2, query3, query4, query5, query6, query7, query8 });
         }
 
-        private void UpgradeDB3()
+        private static void UpgradeDB3(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN Note TEXT";
-            PerformUpgrade(3, false, false, new[] { query1 });
+            PerformUpgrade(conn, 3, false, false, new[] { query1 });
         }
 
-        private void UpgradeDB4()
+        private static void UpgradeDB4(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE SystemNote ADD COLUMN Note TEXT";
-            PerformUpgrade(4, true, true, new[] { query1 }, () =>
-            {  });
+            PerformUpgrade(conn, 4, true, true, new[] { query1 });
         }
 
-        private void UpgradeDB5()
+        private static void UpgradeDB5(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE VisitedSystems ADD COLUMN Unit TEXT";
             string query3 = "ALTER TABLE VisitedSystems ADD COLUMN Commander Integer";
             string query4 = "CREATE INDEX VisitedSystemIndex ON VisitedSystems (Name ASC, Time ASC)";
-            PerformUpgrade(5, true, true, new[] {query1, query3, query4});
+            PerformUpgrade(conn, 5, true, true, new[] {query1, query3, query4});
         }
 
-        private void UpgradeDB6()
+        private static void UpgradeDB6(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN id_eddb Integer";
             string query2 = "ALTER TABLE Systems ADD COLUMN faction TEXT";
@@ -609,57 +601,57 @@ namespace EDDiscovery.DB
             string query16 = "CREATE INDEX StationsIndex_system_ID  ON Stations (system_id ASC)";
             string query17 = "CREATE INDEX StationsIndex_system_Name  ON Stations (Name ASC)";
 
-            PerformUpgrade(6, true, true, new[] {
+            PerformUpgrade(conn, 6, true, true, new[] {
                 query1, query2, query4, query5, query6, query7, query8, query9, query10,
                 query11, query12, query13, query14, query15, query16, query17 });
         }
 
 
-        private void UpgradeDB7()
+        private static void UpgradeDB7(SQLiteConnectionED conn)
         {
             string query1 = "DROP TABLE VisitedSystems";
             string query2 = "CREATE TABLE VisitedSystems(id INTEGER PRIMARY KEY  NOT NULL, Name TEXT NOT NULL, Time DATETIME NOT NULL, Unit Text, Commander Integer, Source Integer, edsm_sync BOOL DEFAULT (null))";
             string query3 = "CREATE TABLE TravelLogUnit(id INTEGER PRIMARY KEY  NOT NULL, type INTEGER NOT NULL, name TEXT NOT NULL, size INTEGER, path TEXT)";
-            PerformUpgrade(7, true, true, new[] { query1, query2, query3 });
+            PerformUpgrade(conn, 7, true, true, new[] { query1, query2, query3 });
         }
 
-        private void UpgradeDB8()
+        private static void UpgradeDB8(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE VisitedSystems ADD COLUMN Map_colour INTEGER DEFAULT (-65536)";
-            PerformUpgrade(8, true, true, new[] { query1 });
+            PerformUpgrade(conn, 8, true, true, new[] { query1 });
         }
 
-        private void UpgradeDB9()
+        private static void UpgradeDB9(SQLiteConnectionED conn)
         {
             string query1 = "CREATE TABLE Objects (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , SystemName TEXT NOT NULL , ObjectName TEXT NOT NULL , ObjectType INTEGER NOT NULL , ArrivalPoint Float, Gravity FLOAT, Atmosphere Integer, Vulcanism Integer, Terrain INTEGER, Carbon BOOL, Iron BOOL, Nickel BOOL, Phosphorus BOOL, Sulphur BOOL, Arsenic BOOL, Chromium BOOL, Germanium BOOL, Manganese BOOL, Selenium BOOL NOT NULL , Vanadium BOOL, Zinc BOOL, Zirconium BOOL, Cadmium BOOL, Mercury BOOL, Molybdenum BOOL, Niobium BOOL, Tin BOOL, Tungsten BOOL, Antimony BOOL, Polonium BOOL, Ruthenium BOOL, Technetium BOOL, Tellurium BOOL, Yttrium BOOL, Commander  Text, UpdateTime DATETIME, Status INTEGER )";
-            PerformUpgrade(9, true, true, new[] { query1 });
+            PerformUpgrade(conn, 9, true, true, new[] { query1 });
         }
 
-        private void UpgradeDB10()
+        private static void UpgradeDB10(SQLiteConnectionED conn)
         {
             string query1 = "CREATE TABLE wanted_systems (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, systemname TEXT UNIQUE NOT NULL)";
-            PerformUpgrade(10, true, true, new[] { query1 });
+            PerformUpgrade(conn, 10, true, true, new[] { query1 });
         }
 
-        private void UpgradeDB11()
+        private static void UpgradeDB11(SQLiteConnectionED conn)
         {
             //Default is Color.Red.ToARGB()
             string query1 = "ALTER TABLE Systems ADD COLUMN FirstDiscovery BOOL";
             string query2 = "ALTER TABLE Objects ADD COLUMN Landed BOOL";
             string query3 = "ALTER TABLE Objects ADD COLUMN terraform Integer";
             string query4 = "ALTER TABLE VisitedSystems ADD COLUMN Status BOOL";
-            PerformUpgrade(11, true, true, new[] { query1, query2, query3, query4 });
+            PerformUpgrade(conn, 11, true, true, new[] { query1, query2, query3, query4 });
         }
 
-        private void UpgradeDB12()
+        private static void UpgradeDB12(SQLiteConnectionED conn)
         {
             string query1 = "CREATE TABLE routes_expeditions (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT UNIQUE NOT NULL, start DATETIME, end DATETIME)";
             string query2 = "CREATE TABLE route_systems (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, routeid INTEGER NOT NULL, systemname TEXT NOT NULL)";
-            PerformUpgrade(12, true, true, new[] { query1, query2 });
+            PerformUpgrade(conn, 12, true, true, new[] { query1, query2 });
         }
 
 
-        private bool UpgradeDB14()
+        private static bool UpgradeDB14(SQLiteConnectionED conn)
         {
             //Default is Color.Red.ToARGB()
             string query1 = "ALTER TABLE VisitedSystems ADD COLUMN X double";
@@ -667,26 +659,26 @@ namespace EDDiscovery.DB
             string query3 = "ALTER TABLE VisitedSystems ADD COLUMN Z double";
             string dbfile = GetSQLiteDBFile();
 
-            PerformUpgrade(14, true, true, new[] { query1, query2, query3 });
+            PerformUpgrade(conn, 14, true, true, new[] { query1, query2, query3 });
             return true;
         }
 
-        private void UpgradeDB15()
+        private static void UpgradeDB15(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN versiondate DATETIME";
             string query2 = "UPDATE Systems SET versiondate = datetime('now')";
             string query3 = "CREATE INDEX IDX_Systems_versiondate ON Systems (versiondate ASC)";
 
-            PerformUpgrade(15, true, true, new[] { query1, query2, query3 });
+            PerformUpgrade(conn, 15, true, true, new[] { query1, query2, query3 });
         }
 
-        private void UpgradeDB16()
+        private static void UpgradeDB16(SQLiteConnectionED conn)
         {
             string query = "CREATE TABLE Bookmarks (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , StarName TEXT, x double NOT NULL, y double NOT NULL, z double NOT NULL, Time DATETIME NOT NULL, Heading TEXT, Note TEXT NOT Null )";
-            PerformUpgrade(16, true, true, new[] { query });
+            PerformUpgrade(conn, 16, true, true, new[] { query });
         }
 
-        private void UpgradeDB17()
+        private static void UpgradeDB17(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE Systems ADD COLUMN id_edsm Integer";
             string query2 = "CREATE INDEX Systems_EDSM_ID_Index ON Systems (id_edsm ASC)";
@@ -695,32 +687,32 @@ namespace EDDiscovery.DB
             string query5 = "CREATE INDEX Distances_EDSM_ID_Index ON Distances (id_edsm ASC)";
             string query6 = "Update VisitedSystems set x=null, y=null, z=null where x=0 and y=0 and z=0 and name!=\"Sol\"";
 
-            PerformUpgrade(17, true, true, new[] { query1,query2,query3,query4,query5,query6 }, () =>
+            PerformUpgrade(conn, 17, true, true, new[] { query1,query2,query3,query4,query5,query6 }, () =>
             {
-                PutSettingString("EDSMLastSystems", "2010 - 01 - 01 00:00:00", m_SQLiteConnectionED);        // force EDSM sync..
-                PutSettingString("EDDBSystemsTime", "0", m_SQLiteConnectionED);                               // force EDDB
-                PutSettingString("EDSCLastDist", "2010-01-01 00:00:00", m_SQLiteConnectionED);                // force distances
+                PutSettingString("EDSMLastSystems", "2010 - 01 - 01 00:00:00", conn);        // force EDSM sync..
+                PutSettingString("EDDBSystemsTime", "0", conn);                               // force EDDB
+                PutSettingString("EDSCLastDist", "2010-01-01 00:00:00", conn);                // force distances
             });
         }
 
-        private void UpgradeDB18()
+        private static void UpgradeDB18(SQLiteConnectionED conn)
         {
             string query1 = "ALTER TABLE VisitedSystems ADD COLUMN id_edsm_assigned Integer";
             string query2 = "CREATE INDEX VisitedSystems_id_edsm_assigned ON VisitedSystems (id_edsm_assigned)";
             string query3 = "CREATE INDEX VisitedSystems_position ON VisitedSystems (X, Y, Z)";
             string query4 = "CREATE INDEX Systems_position ON Systems (X, Y, Z)";
 
-            PerformUpgrade(18, true, true, new[] { query1, query2, query3, query4 });
+            PerformUpgrade(conn, 18, true, true, new[] { query1, query2, query3, query4 });
         }
 
-        private void UpgradeDB19()
+        private static void UpgradeDB19(SQLiteConnectionED conn)
         {
             string query1 = "CREATE TABLE SystemAliases (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT, id_edsm INTEGER, id_edsm_mergedto INTEGER)";
             string query2 = "CREATE INDEX SystemAliases_name ON SystemAliases (name)";
             string query3 = "CREATE UNIQUE INDEX SystemAliases_id_edsm ON SystemAliases (id_edsm)";
             string query4 = "CREATE INDEX SystemAliases_id_edsm_mergedto ON SystemAliases (id_edsm_mergedto)";
 
-            PerformUpgrade(19, true, true, new[] { query1, query2, query3, query4 });
+            PerformUpgrade(conn, 19, true, true, new[] { query1, query2, query3, query4 });
         }
 
         ///----------------------------

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -73,7 +73,8 @@ namespace EDDiscovery2
             { "MapColour_TrilatSuggestedReference", () => System.Drawing.Color.DarkOrange.ToArgb() },
             { "MapColour_PlannedRoute", () => System.Drawing.Color.Green.ToArgb() },
             { "MapColour_NamedStar", () => System.Drawing.Color.Yellow.ToArgb() },
-            { "MapColour_NamedStarUnpop", () => System.Drawing.Color.FromArgb(255,192,192,0).ToArgb() }
+            { "MapColour_NamedStarUnpop", () => System.Drawing.Color.FromArgb(255,192,192,0).ToArgb() },
+            { "UseTheme", () => true }
         };
 
         private Dictionary<string, Action> onchange = new Dictionary<string, Action>
@@ -202,6 +203,7 @@ namespace EDDiscovery2
         public bool NetLogDirAutoMode { get { return GetSettingBool("NetlogDirAutoMode"); } set { PutSettingBool("NetlogDirAutoMode", value); } }
         public int DefaultMapColour { get { return GetSettingInt("DefaultMap"); } set { PutSettingInt("DefaultMap", value); } }
         public MapColoursClass MapColours { get; private set; } = new EDDConfig.MapColoursClass();
+        public bool UseTheme { get { return GetSettingBool("UseTheme"); } set { PutSettingBool("UseTheme", value); } }
 
         public event Action NetLogDirChanged { add { onchange["Netlogdir"] += value; } remove { onchange["Netlogdir"] -= value; } }
         public event Action NetLogDirAutoModeChanged { add { onchange["NetlogDirAutoMode"] += value; } remove { onchange["NetlogDirAutoMode"] -= value; } }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -114,7 +114,6 @@ namespace EDDiscovery
                 Trace.WriteLine($"Exception: {ex.Message}");
             }
 
-            ToolStripManager.Renderer = theme.toolstripRenderer;
             theme.LoadThemes();                                         // default themes and ones on disk loaded
             theme.RestoreSettings();                                    // theme, remember your saved settings
 
@@ -296,7 +295,11 @@ namespace EDDiscovery
 
         public void ApplyTheme(bool refreshhistory)
         {
-            ToolStripManager.Renderer = theme.toolstripRenderer;
+            if (settings.ThemeName != "None")
+                ToolStripManager.Renderer = theme.toolstripRenderer;
+            else
+                ToolStripManager.Renderer = new ToolStripProfessionalRenderer();
+
             this.FormBorderStyle = theme.WindowsFrame ? FormBorderStyle.Sizable : FormBorderStyle.None;
             //panel_grip.Visible = !theme.WindowsFrame;
             panel_close.Visible = !theme.WindowsFrame;
@@ -308,7 +311,8 @@ namespace EDDiscovery
 
             this.Text = "EDDiscovery " + label_version.Text;            // note in no border mode, this is not visible on the title bar but it is in the taskbar..
 
-            theme.ApplyColors(this);
+            if (settings.ThemeName != "None")
+                theme.ApplyColors(this);
 
             if (refreshhistory)
                 travelHistoryControl1.RefreshHistory();             // so we repaint this with correct colours.

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -31,7 +31,14 @@ namespace EDDiscovery
     {
         #region Variables
 
+        public const int WM_MOVE = 3;
+        public const int WM_SIZE = 5;
+        public const int WM_MOUSEMOVE = 0x200;
+        public const int WM_LBUTTONDOWN = 0x201;
+        public const int WM_LBUTTONUP = 0x202;
         public const int WM_NCLBUTTONDOWN = 0xA1;
+        public const int WM_NCLBUTTONUP = 0xA2;
+        public const int WM_NCMOUSEMOVE = 0xA0;
         public const int HT_CLIENT = 0x1;
         public const int HT_CAPTION = 0x2;
         public const int HT_BOTTOMRIGHT = 0x11;
@@ -46,6 +53,10 @@ namespace EDDiscovery
             return message.Result;
         }
 
+        // Mono compatibility
+        private bool _window_dragging = false;
+        private Point _window_dragMousePos = Point.Empty;
+        private Point _window_dragWindowPos = Point.Empty;
         public EDDTheme theme;
 
         public AutoCompleteStringCollection SystemNames;       
@@ -1074,7 +1085,37 @@ namespace EDDiscovery
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == WM_NCHITTEST)
+            // Compatibility movement for Mono
+            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !theme.WindowsFrame)
+            {
+                int x = unchecked((short)((uint)m.LParam & 0xFFFF));
+                int y = unchecked((short)((uint)m.LParam >> 16));
+                _window_dragMousePos = new Point(x, y);
+                _window_dragWindowPos = this.Location;
+                _window_dragging = true;
+                m.Result = IntPtr.Zero;
+                this.Capture = true;
+            }
+            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            {
+                int x = unchecked((short)((uint)m.LParam & 0xFFFF));
+                int y = unchecked((short)((uint)m.LParam >> 16));
+                Point delta = new Point(x - _window_dragMousePos.X, y - _window_dragMousePos.Y);
+                _window_dragWindowPos = new Point(_window_dragWindowPos.X + delta.X, _window_dragWindowPos.Y + delta.Y);
+                this.Location = _window_dragWindowPos;
+                this.Update();
+                m.Result = IntPtr.Zero;
+            }
+            else if (m.Msg == WM_LBUTTONUP)
+            {
+                _window_dragging = false;
+                _window_dragMousePos = Point.Empty;
+                _window_dragWindowPos = Point.Empty;
+                m.Result = IntPtr.Zero;
+                this.Capture = false;
+            }
+            // Windows honours NCHITTEST; Mono does not
+            else if (m.Msg == WM_NCHITTEST)
             {
                 base.WndProc(ref m);
 


### PR DESCRIPTION
* Make SQLiteDBClass a static class, as nothing uses any instances of it
* Use a `GetSqliteProviderFactory()` method to get the provider factory
* Have this factory provide a `Mono.Sqlite.SqliteProviderFactory` when System.Data.SQLite is non-functional (e.g. under Mono, or perhaps on ARM)
* Merge the DbConnection etc. extension methods into the SQLiteDBClass static class
* Mono does not honour the results of NCHITTEST, so move the window ourselves if a mousedown / mousemove is detected where we said the non-client area is
* Allow the user to select that they don't want to use a theme - i.e. use the system theme.