### PR TITLE
Fix crash in netlog due to no discovery form, found a few more nulls

### DIFF
--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -507,10 +507,14 @@ namespace EDDiscovery2.DB
             if (visitedSystems != null)
             {
                 IEnumerable<ISystem> slist = (from systems in visitedSystems orderby systems.Time descending select systems.curSystem);
-                ISystem sel = slist.First(s => s.HasCoordinate);
 
-                if (sel != null)
-                    return (SystemClass)sel;
+                if (slist != null && slist.Any() )
+                {
+                    ISystem sel = slist.First(s => s.HasCoordinate);
+
+                    if (sel != null)
+                        return (SystemClass)sel;
+                }
             }
 
             return null;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -479,7 +479,7 @@ namespace EDDiscovery
                         travelHistoryControl1.RefreshHistory();
                         //LogLine("Time " + (Environment.TickCount-tickc) );
 
-                        travelHistoryControl1.netlog.StartMonitor(this);
+                        travelHistoryControl1.netlog.StartMonitor();
 
                         if (EliteDangerous.CheckStationLogging())
                         {

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -36,8 +36,13 @@ namespace EDDiscovery
         AutoResetEvent NewLogEvent = new AutoResetEvent(false);
         ConcurrentQueue<NetLogFileInfo> NetLogFileQueue = new ConcurrentQueue<NetLogFileInfo>();
         public event NetLogEventHandler OnNewPosition;
-
+        private EDDiscoveryForm _discoveryform;
         public List<TravelLogUnit> tlUnits;
+
+        public NetLogClass(EDDiscoveryForm ed )
+        {
+            _discoveryform = ed;
+        }
 
         public string GetNetLogPath()
         {
@@ -388,15 +393,12 @@ namespace EDDiscovery
             Application.DoEvents();
         }
 
-        private EDDiscoveryForm _discoveryform;
 
-        public bool StartMonitor(EDDiscoveryForm ed)
+        public bool StartMonitor()
         {
-            _discoveryform = ed;
             ThreadNetLog = new System.Threading.Thread(new System.Threading.ThreadStart(NetLogMain));
             ThreadNetLog.Name = "Net log";
             ThreadNetLog.Start();
-
             return true;
         }
 
@@ -410,8 +412,7 @@ namespace EDDiscovery
                 ThreadNetLog.Join();
             }
        
-                ThreadNetLog = null;
-            
+            ThreadNetLog = null;
         }
 
         public void ReloadMonitor()
@@ -439,10 +440,7 @@ namespace EDDiscovery
         public void RestartMonitor()
         {
             StopMonitor();
-            if (_discoveryform != null)
-            {
-                StartMonitor(_discoveryform);
-            }
+            StartMonitor();
         }
 
         private void NetLogMain()               // THREAD watching the files..

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -46,7 +46,7 @@ namespace EDDiscovery
         internal bool EDSMSyncTo = true;
         internal bool EDSMSyncFrom = true;
 
-        public NetLogClass netlog = new NetLogClass();
+        public NetLogClass netlog;
         private VisitedSystemsClass currentSysPos = null;
 
         SummaryPopOut summaryPopOut = null;
@@ -62,6 +62,7 @@ namespace EDDiscovery
         public void InitControl(EDDiscoveryForm discoveryForm)
         {
             _discoveryForm = discoveryForm;
+            netlog = new NetLogClass(_discoveryForm);
             sync = new EDSMSync(_discoveryForm);
             defaultMapColour = EDDConfig.Instance.DefaultMapColour;
             EDSMSyncTo = SQLiteDBClass.GetSettingBool("EDSMSyncTo", true);
@@ -612,12 +613,15 @@ namespace EDDiscovery
 
         private void UpdateDependentsWithSelection()
         {
-            int rowi = dataGridViewTravel.CurrentCell.RowIndex;
-            if (rowi>=0)
+            if (dataGridViewTravel.CurrentCell != null)
             {
-                VisitedSystemsClass currentsys = (VisitedSystemsClass)(dataGridViewTravel.Rows[rowi].Cells[TravelHistoryColumns.SystemName].Tag);
-                _discoveryForm.Map.UpdateHistorySystem(currentsys.Name);
-                _discoveryForm.RouteControl.UpdateHistorySystem(currentsys.Name);
+                int rowi = dataGridViewTravel.CurrentCell.RowIndex;
+                if (rowi >= 0)
+                {
+                    VisitedSystemsClass currentsys = (VisitedSystemsClass)(dataGridViewTravel.Rows[rowi].Cells[TravelHistoryColumns.SystemName].Tag);
+                    _discoveryForm.Map.UpdateHistorySystem(currentsys.Name);
+                    _discoveryForm.RouteControl.UpdateHistorySystem(currentsys.Name);
+                }
             }
         }
 


### PR DESCRIPTION
VSC - if visitedsystems was empty, crash
Monitor gets is discovery form from creation