### PR TITLE
Work around faulty StatusStrip implementations

### DIFF
--- a/EDDiscovery/Controls/StatusStripCustom.cs
+++ b/EDDiscovery/Controls/StatusStripCustom.cs
@@ -20,10 +20,26 @@ namespace ExtendedControls
         {
             base.WndProc(ref m);
 
-            if (m.Msg == WM_NCHITTEST && (int)m.Result == HT_BOTTOMRIGHT)
+            if (m.Msg == WM_NCHITTEST)
             {
-                // Tell the system to test the parent
-                m.Result = (IntPtr)HT_TRANSPARENT;
+                if ((int)m.Result == HT_BOTTOMRIGHT)
+                {
+                    // Tell the system to test the parent
+                    m.Result = (IntPtr)HT_TRANSPARENT;
+                }
+                else if ((int)m.Result == HT_CLIENT)
+                {
+                    // Work around the implementation returning HT_CLIENT instead of HT_BOTTOMRIGHT
+                    int x = unchecked((short)((uint)m.LParam & 0xFFFF));
+                    int y = unchecked((short)((uint)m.LParam >> 16));
+                    Point p = PointToClient(new Point(x, y));
+
+                    if (p.X >= this.ClientSize.Width - this.ClientSize.Height)
+                    {
+                        // Tell the system to test the parent
+                        m.Result = (IntPtr)HT_TRANSPARENT;
+                    }
+                }
             }
         }
     }

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -519,6 +519,9 @@
             this.statusStrip1.Size = new System.Drawing.Size(993, 22);
             this.statusStrip1.TabIndex = 22;
             this.statusStrip1.Text = "statusStrip1";
+            this.statusStrip1.SizingGrip = true;
+            this.statusStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Visible;
+            this.statusStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             // 
             // EDDiscoveryForm
             // 


### PR DESCRIPTION
Some StatusStrip implementations apparently return HT_CLIENT for the sizing grip where they should return HT_BOTTOMRIGHT.