### PR TITLE
Set Combobox dropdown owner window

### DIFF
--- a/EDDiscovery/Controls/ComboBoxCustom.cs
+++ b/EDDiscovery/Controls/ComboBoxCustom.cs
@@ -447,7 +447,13 @@ namespace ExtendedControls
             _cbdropdown.DropDownClosed += _cbdropdown_DropDownClosed;
             _cbdropdown.SelectedIndexChanged += _cbdropdown_SelectedIndexChanged;
 
-            _cbdropdown.Show();
+            Control parent = this.Parent;
+            while (parent != null && !(parent is Form))
+            {
+                parent = parent.Parent;
+            }
+
+            _cbdropdown.Show(parent);
         }
 
         private void _cbdropdown_DropDownClosed(object sender, EventArgs e)


### PR DESCRIPTION
This prevents the dropdown from appearing behind the window
when the window is set as keep on top.