### PR TITLE
Re-organise netlog parsing code

### DIFF
--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -64,6 +64,36 @@ namespace EDDiscovery2.DB
             }
         }
 
+        public VisitedSystemsClass(DbDataReader reader)
+        {
+            id = (long)reader["id"];
+            Name = (string)reader["Name"];
+            Time = (DateTime)reader["Time"];
+            Commander = (int)(long)reader["Commander"];
+            Source = (long)reader["Source"];
+            Unit = (string)reader["Unit"];
+            EDSM_sync = (bool)reader["edsm_sync"];
+            MapColour = (int)(long)reader["Map_colour"];
+
+            if (reader["X"] == DBNull.Value)
+            {
+                X = double.NaN;
+                Y = double.NaN;
+                Z = double.NaN;
+            }
+            else
+            {
+                X = (double)reader["X"];
+                Y = (double)reader["Y"];
+                Z = (double)reader["Z"];
+            }
+
+            if (reader["id_edsm_assigned"] != DBNull.Value)
+            {
+                id_edsm_assigned = (long)reader["id_edsm_assigned"];
+            }
+        }
+
         public bool HasTravelCoordinates
         {
             get
@@ -331,6 +361,27 @@ namespace EDDiscovery2.DB
                     return sys;
                 }
             }
+        }
+
+        public static VisitedSystemsClass GetLast(int cmdrid, DateTime before)
+        {
+            using (SQLiteConnectionED cn = new SQLiteConnectionED())
+            {
+                using (DbCommand cmd = cn.CreateCommand("SELECT * FROM VisitedSystems WHERE Commander = @commander AND Time < @before ORDER BY Time DESC LIMIT 1"))
+                {
+                    cmd.AddParameterWithValue("@commander", cmdrid);
+                    cmd.AddParameterWithValue("@before", before);
+                    using (DbDataReader reader = cmd.ExecuteReader())
+                    {
+                        if (reader.Read())
+                        {
+                            return new VisitedSystemsClass(reader);
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
 
         internal static bool Exist(string name, DateTime time)

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -184,6 +184,7 @@
     <Compile Include="EDSM\GalacticMapObject.cs" />
     <Compile Include="EDSM\GalacticMapping.cs" />
     <Compile Include="EDSM\GalMapType.cs" />
+    <Compile Include="EliteDangerous\LogReaderBase.cs" />
     <Compile Include="Forms\AssignTravelLogSystemForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/EDDiscovery/EliteDangerous/LogReaderBase.cs
+++ b/EDDiscovery/EliteDangerous/LogReaderBase.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using EDDiscovery2.DB;
+
+namespace EDDiscovery
+{
+    public class LogReaderBase
+    {
+        // File buffer
+        protected byte[] buffer;
+        protected long fileptr;
+        protected int bufferpos;
+        protected int bufferlen;
+
+        protected Stream stream;
+
+        // File Information
+        public string FileName { get { return Path.Combine(TravelLogUnit.Path, TravelLogUnit.Name); } }
+        public long filePos { get { return TravelLogUnit.Size; } }
+        public TravelLogUnit TravelLogUnit { get; protected set; }
+
+        public LogReaderBase(string filename)
+        {
+            FileInfo fi = new FileInfo(filename);
+
+            this.TravelLogUnit = new TravelLogUnit
+            {
+                Name = fi.Name,
+                Path = fi.DirectoryName,
+                Size = 0
+            };
+
+            this.stream = File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        }
+
+        public LogReaderBase(TravelLogUnit tlu)
+        {
+            this.TravelLogUnit = tlu;
+            this.stream = File.Open(Path.Combine(tlu.Path, tlu.Name), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        }
+
+        public bool ReadLine(out string line)
+        {
+            // Initialize buffer if not yet allocated
+            if (buffer == null)
+            {
+                buffer = new byte[16384];
+                bufferpos = 0;
+                bufferlen = 0;
+                fileptr = TravelLogUnit.Size;
+            }
+
+            // Loop while no end-of-line is found
+            while (true)
+            {
+                int endlinepos = -1;
+
+                // Only look for an end-of-line if not already at end of buffer
+                if (bufferpos < bufferlen)
+                {
+                    // Find the next end-of-line
+                    endlinepos = Array.IndexOf(buffer, (byte)'\n', bufferpos, bufferlen - bufferpos) - bufferpos;
+
+                    // End-of-line found
+                    if (endlinepos >= 0)
+                    {
+                        // Include the end-of-line in the line length
+                        int linelen = endlinepos + 1;
+
+                        // Trim any trailing carriage-return
+                        if (endlinepos > 0 && buffer[bufferpos + endlinepos - 1] == '\r')
+                        {
+                            endlinepos--;
+                        }
+
+                        // Return the trimmed string
+                        byte[] buf = new byte[endlinepos];
+                        Buffer.BlockCopy(buffer, bufferpos, buf, 0, endlinepos);
+                        bufferpos += linelen;
+                        TravelLogUnit.Size += linelen;
+                        line = new String(buf.Select(c => (char)c).ToArray());
+
+                        return true;
+                    }
+                }
+
+                // No end-of-line found
+                // Move remaining data to start of buffer
+                if (bufferpos != 0)
+                {
+                    Buffer.BlockCopy(buffer, bufferpos, buffer, 0, bufferlen - bufferpos);
+                    bufferlen -= bufferpos;
+                    bufferpos = 0;
+                }
+
+                // Expand the buffer if buffer is full
+                if (bufferlen == buffer.Length)
+                {
+                    Array.Resize(ref buffer, buffer.Length * 2);
+                }
+
+                // Read the data into the buffer
+                stream.Seek(fileptr, SeekOrigin.Begin);
+                int bytesread = stream.Read(buffer, bufferlen, buffer.Length - bufferlen);
+
+                // Return false if end-of-file is encountered
+                if (bytesread == 0)
+                {
+                    // Free the buffer if the buffer was also exhausted
+                    if (bufferpos == bufferlen)
+                    {
+                        buffer = null;
+                    }
+
+                    line = null;
+                    return false;
+                }
+
+                // Update the buffer length and next read pointer
+                bufferlen += bytesread;
+                fileptr += bytesread;
+
+                // No end-of-line encountered - try reading a line again
+            }
+        }
+    }
+}

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -16,23 +16,10 @@ using System.Globalization;
 
 namespace EDDiscovery
 {
-    public class NetLogFileReader
+    public class NetLogFileReader : LogReaderBase
     {
         // Header line regular expression
         private static Regex netlogHeaderRe = new Regex(@"^(?<Localtime>\d\d-\d\d-\d\d-\d\d:\d\d) (?<Timezone>.*) [(](?<GMT>\d\d:\d\d) GMT[)]");
-
-        // File buffer
-        protected byte[] buffer;
-        protected long fileptr;
-        protected int bufferpos;
-        protected int bufferlen;
-
-        protected Stream stream;
-
-        // File Information
-        public string FileName { get { return Path.Combine(TravelLogUnit.Path, TravelLogUnit.Name); } }
-        public long filePos { get { return TravelLogUnit.Size; } }
-        public TravelLogUnit TravelLogUnit { get; protected set; }
 
         // Close Quarters Combat
         public bool CQC { get; set; }
@@ -42,110 +29,8 @@ namespace EDDiscovery
         public TimeZoneInfo TimeZone { get; set; }
         public TimeSpan TimeZoneOffset { get; set; }
 
-        public NetLogFileReader(string filename)
-        {
-            FileInfo fi = new FileInfo(filename);
-
-            this.TravelLogUnit = new TravelLogUnit
-            {
-                Name = fi.Name,
-                Path = fi.DirectoryName,
-                Size = 0
-            };
-
-            this.stream = File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        }
-
-        public NetLogFileReader(TravelLogUnit tlu)
-        {
-            this.TravelLogUnit = tlu;
-            this.stream = File.Open(Path.Combine(tlu.Path, tlu.Name), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        }
-
-        public bool ReadLine(out string line)
-        {
-            // Initialize buffer if not yet allocated
-            if (buffer == null)
-            {
-                buffer = new byte[16384];
-                bufferpos = 0;
-                bufferlen = 0;
-                fileptr = TravelLogUnit.Size;
-            }
-
-            // Loop while no end-of-line is found
-            while (true)
-            {
-                int endlinepos = -1;
-
-                // Only look for an end-of-line if not already at end of buffer
-                if (bufferpos < bufferlen)
-                {
-                    // Find the next end-of-line
-                    endlinepos = Array.IndexOf(buffer, (byte)'\n', bufferpos, bufferlen - bufferpos) - bufferpos;
-
-                    // End-of-line found
-                    if (endlinepos >= 0)
-                    {
-                        // Include the end-of-line in the line length
-                        int linelen = endlinepos + 1;
-
-                        // Trim any trailing carriage-return
-                        if (endlinepos > 0 && buffer[bufferpos + endlinepos - 1] == '\r')
-                        {
-                            endlinepos--;
-                        }
-
-                        // Return the trimmed string
-                        byte[] buf = new byte[endlinepos];
-                        Buffer.BlockCopy(buffer, bufferpos, buf, 0, endlinepos);
-                        bufferpos += linelen;
-                        TravelLogUnit.Size += linelen;
-                        line = new String(buf.Select(c => (char)c).ToArray());
-
-                        return true;
-                    }
-                }
-
-                // No end-of-line found
-                // Move remaining data to start of buffer
-                if (bufferpos != 0)
-                {
-                    Buffer.BlockCopy(buffer, bufferpos, buffer, 0, bufferlen - bufferpos);
-                    bufferlen -= bufferpos;
-                    bufferpos = 0;
-                }
-
-                // Expand the buffer if buffer is full
-                if (bufferlen == buffer.Length)
-                {
-                    Array.Resize(ref buffer, buffer.Length * 2);
-                }
-
-                // Read the data into the buffer
-                stream.Seek(fileptr, SeekOrigin.Begin);
-                int bytesread = stream.Read(buffer, bufferlen, buffer.Length - bufferlen);
-
-                // Return false if end-of-file is encountered
-                if (bytesread == 0)
-                {
-                    // Free the buffer if the buffer was also exhausted
-                    if (bufferpos == bufferlen)
-                    {
-                        buffer = null;
-                    }
-
-                    line = null;
-                    return false;
-                }
-
-                // Update the buffer length and next read pointer
-                bufferlen += bytesread;
-                fileptr += bytesread;
-
-                // No end-of-line encountered - try reading a line again
-            }
-        }
+        public NetLogFileReader(string filename) : base(filename) { }
+        public NetLogFileReader(TravelLogUnit tlu) : base(tlu) { }
 
         public bool ReadNetLogSystem(out VisitedSystemsClass vsc)
         {


### PR DESCRIPTION
This is a significant re-organisation of the netlog reader code.

* Use a reader that will only return full lines, and keeps the offset within the file of the last byte of the last line it has returned
* Replace the NetLogFileInfo structures with this reader
* Keep the time of the last log entry read in the reader
* Separate the code that finds and returns a system line into a separate function
* Add a timezone-aware header parsing function
* Parse and process each system as it is read from the logs
* Instead of testing if the file reports a larger size, simply try to read more of the file on each tick.
* In ParseFiles, compare the system with that immediately before it rather than the last one in the list.

It is hoped that the base reader can also be used for reading the journal files (perhaps separated into a separate class file and subclassing that for the netlog reader code).