### PR TITLE
Prevent null reference exception error opening 3D map with certain settings

### DIFF
--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -581,8 +581,10 @@ namespace EDDiscovery
 
             this.Cursor = Cursors.WaitCursor;
 
+            string HomeSystem = _discoveryForm.settings.MapHomeSystem;
+
             map.Prepare(selectedSys, _discoveryForm.settings.MapHomeSystem,
-                        _discoveryForm.settings.MapCentreOnSelection ? selectedSys?.curSystem : SystemClass.GetSystem(_discoveryForm.settings.MapHomeSystem),
+                        _discoveryForm.settings.MapCentreOnSelection ? selectedSys?.curSystem : SystemClass.GetSystem(String.IsNullOrEmpty(HomeSystem) ? "Sol" : HomeSystem),
                         _discoveryForm.settings.MapZoom, _discoveryForm.SystemNames, visitedSystems);
             map.Show();
             this.Cursor = Cursors.Default;


### PR DESCRIPTION
Namely having no home system set but the default centre toggle set to Home System.  Now just centres on Sol instead.