### PR TITLE
Netlogreader fixes

### DIFF
--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -332,6 +332,8 @@ namespace EDDiscovery
 
         private void ScanTick(object sender, EventArgs e)
         {
+            var timer = sender as System.Windows.Forms.Timer;
+
             Debug.Assert(Application.MessageLoop);              // ensure.. paranoia
 
             try
@@ -373,6 +375,11 @@ namespace EDDiscovery
                         visitedSystems.Add(dbsys);
                         OnNewPosition(dbsys);
                         lastnfi.TravelLogUnit.Update();
+
+                        if (!timer.Enabled)
+                        {
+                            break;
+                        }
                     }
                 }
             }

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -255,7 +255,8 @@ namespace EDDiscovery
             VisitedSystemsClass ps;
             while (sr.ReadNetLogSystem(out ps))
             {
-                if (ps.Name.Equals(VisitedSystemsClass.GetLast(EDDConfig.Instance.CurrentCmdrID, ps.Time).Name, StringComparison.InvariantCultureIgnoreCase))
+                VisitedSystemsClass last = VisitedSystemsClass.GetLast(EDDConfig.Instance.CurrentCmdrID, ps.Time);
+                if (last != null && ps.Name.Equals(last.Name, StringComparison.InvariantCultureIgnoreCase))
                     continue;
 
                 if (ps.Time.Subtract(gammastart).TotalMinutes > 0)  // Ta bara med efter gamma.

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -335,8 +335,11 @@ namespace EDDiscovery
             Debug.Assert(Application.MessageLoop);              // ensure.. paranoia
 
             try
-            { 
-                EliteDangerous.CheckED();
+            {
+                if (EDDConfig.Instance.NetLogDirAutoMode)
+                {
+                    EliteDangerous.CheckED();
+                }
 
                 string filename = null;
                 NetLogFileReader nfi = null;

--- a/EDDiscovery/EliteDangerous/NetLogReader.cs
+++ b/EDDiscovery/EliteDangerous/NetLogReader.cs
@@ -138,6 +138,7 @@ namespace EDDiscovery
                     else
                     {
                         System.Diagnostics.Trace.WriteLine("System parse error 1:" + line);
+                        return false;
                     }
 
                 }
@@ -157,6 +158,7 @@ namespace EDDiscovery
                     else
                     {
                         System.Diagnostics.Trace.WriteLine("System parse error 2:" + line);
+                        return false;
                     }
                 }
 
@@ -191,7 +193,7 @@ namespace EDDiscovery
                 if (line.Contains("[PG] Found matchmaking lobby object"))
                     this.CQC = true;
 
-                int offset = line.IndexOf("} System:") - 9;
+                int offset = line.IndexOf("} System:") - 8;
                 if (offset >= 0 && ParseTime(line.Substring(offset, 8)) && this.CQC == false)
                 {
                     //Console.WriteLine(" RD:" + line );
@@ -199,7 +201,7 @@ namespace EDDiscovery
                         continue;
 
                     VisitedSystemsClass ps;
-                    if (ParseVisitedSystem(this.LastLogTime, this.TimeZoneOffset, line.Substring(offset + 11), out ps))
+                    if (ParseVisitedSystem(this.LastLogTime, this.TimeZoneOffset, line.Substring(offset + 10), out ps))
                     {   // Remove some training systems
                         if (ps.Name.Equals("Training"))
                             continue;

--- a/EDDiscovery/EliteDangerous/NetLogReader.cs
+++ b/EDDiscovery/EliteDangerous/NetLogReader.cs
@@ -62,7 +62,7 @@ namespace EDDiscovery
 
         protected bool ParseLineTime(string line)
         {
-            if (line[0] == '{' && line[3] == ':' && line[6] == ':' && line[9] == '}' && line[10] == ' ')
+            if (line.Length > 11 && line[0] == '{' && line[3] == ':' && line[6] == ':' && line[9] == '}' && line[10] == ' ')
             {
                 return ParseTime(line.Substring(1, 8));
             }
@@ -194,7 +194,7 @@ namespace EDDiscovery
                     this.CQC = true;
 
                 int offset = line.IndexOf("} System:") - 8;
-                if (offset >= 0 && ParseTime(line.Substring(offset, 8)) && this.CQC == false)
+                if (offset >= 1 && ParseTime(line.Substring(offset, 8)) && this.CQC == false)
                 {
                     //Console.WriteLine(" RD:" + line );
                     if (line.Contains("ProvingGround"))


### PR DESCRIPTION
* Fix an off-by-one error that was causing the netlogreader to fail to properly read netlog lines.
* Only use CheckED() when in automatic directory detection mode, as it sets the netlog directory in the database.
* Exit the timer callback as soon as possible after the timer is stopped
* Fix a NullReferenceException when reading visited systems for the first time