### PR TITLE
Improve netlog performance

### DIFF
--- a/EDDiscovery/DB/TravelLogUnit.cs
+++ b/EDDiscovery/DB/TravelLogUnit.cs
@@ -32,6 +32,15 @@ namespace EDDiscovery2.DB
 
         }
 
+        public TravelLogUnit(DbDataReader dr)
+        {
+            id = (long)dr["id"];
+            Name = (string)dr["Name"];
+            type = (int)(long)dr["type"];
+            Size = (int)(long)dr["size"];
+            Path = (string)dr["Path"];
+        }
+
         public bool Beta
         {
             get
@@ -122,6 +131,51 @@ namespace EDDiscovery2.DB
                     return list;
                 }
             }
+        }
+
+        public static List<string> GetAllNames()
+        {
+            List<string> names = new List<string>();
+            using (SQLiteConnectionED cn = new SQLiteConnectionED())
+            {
+                using (DbCommand cmd = cn.CreateCommand("SELECT DISTINCT Name FROM TravelLogUnit"))
+                {
+                    using (DbDataReader reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            names.Add((string)reader["Name"]);
+                        }
+                    }
+                }
+            }
+            return names;
+        }
+
+        public static TravelLogUnit Get(string name)
+        {
+            using (SQLiteConnectionED cn = new SQLiteConnectionED())
+            {
+                using (DbCommand cmd = cn.CreateCommand("SELECT * FROM TravelLogUnit WHERE Name = @name ORDER BY Id DESC"))
+                {
+                    cmd.AddParameterWithValue("@name", name);
+                    using (DbDataReader reader = cmd.ExecuteReader())
+                    {
+                        if (reader.Read())
+                        {
+                            return new TravelLogUnit(reader);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static bool TryGet(string name, out TravelLogUnit tlu)
+        {
+            tlu = Get(name);
+            return tlu != null;
         }
     }
 }

--- a/EDDiscovery/DB/TravelLogUnit.cs
+++ b/EDDiscovery/DB/TravelLogUnit.cs
@@ -94,9 +94,9 @@ namespace EDDiscovery2.DB
             }
         }
 
-        private bool Update(SQLiteConnectionED cn)
+        public bool Update(SQLiteConnectionED cn, DbTransaction tn = null)
         {
-            using (DbCommand cmd = cn.CreateCommand("Update TravelLogUnit set Name=@Name, Type=@type, size=@size, Path=@Path  where ID=@id"))
+            using (DbCommand cmd = cn.CreateCommand("Update TravelLogUnit set Name=@Name, Type=@type, size=@size, Path=@Path  where ID=@id", tn))
             {
                 cmd.AddParameterWithValue("@ID", id);
                 cmd.AddParameterWithValue("@Name", Name);

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -111,9 +111,9 @@ namespace EDDiscovery2.DB
             }
         }
 
-        private bool Add(SQLiteConnectionED cn)
+        public bool Add(SQLiteConnectionED cn, DbTransaction tn = null)
         {
-            using (DbCommand cmd = cn.CreateCommand("Insert into VisitedSystems (Name, Time, Unit, Commander, Source, edsm_sync, map_colour, X, Y, Z, id_edsm_assigned) values (@name, @time, @unit, @commander, @source, @edsm_sync, @map_colour, @x, @y, @z, @id_edsm_assigned)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into VisitedSystems (Name, Time, Unit, Commander, Source, edsm_sync, map_colour, X, Y, Z, id_edsm_assigned) values (@name, @time, @unit, @commander, @source, @edsm_sync, @map_colour, @x, @y, @z, @id_edsm_assigned)", tn))
             {
                 cmd.AddParameterWithValue("@name", Name);
                 cmd.AddParameterWithValue("@time", Time);

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -222,6 +222,26 @@ namespace EDDiscovery2.DB
             }
         }
 
+        public static List<VisitedSystemsClass> GetAll(TravelLogUnit tlu)
+        {
+            List<VisitedSystemsClass> vsc = new List<VisitedSystemsClass>();
+            using (SQLiteConnectionED cn = new SQLiteConnectionED())
+            {
+                using (DbCommand cmd = cn.CreateCommand("SELECT * FROM VisitedSystems WHERE Source = @source ORDER BY Time ASC"))
+                {
+                    cmd.AddParameterWithValue("@source", tlu.id);
+                    using (DbDataReader reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            vsc.Add(new VisitedSystemsClass(reader));
+                        }
+                    }
+                }
+            }
+            return vsc;
+        }
+
         static public VisitedSystemsClass GetLast()
         {
             List<VisitedSystemsClass> list = new List<VisitedSystemsClass>();

--- a/EDDiscovery/EliteDangerous/LogReaderBase.cs
+++ b/EDDiscovery/EliteDangerous/LogReaderBase.cs
@@ -81,7 +81,7 @@ namespace EDDiscovery
                         Buffer.BlockCopy(buffer, bufferpos, buf, 0, endlinepos);
                         bufferpos += linelen;
                         TravelLogUnit.Size += linelen;
-                        line = new String(buf.Select(c => (char)c).ToArray());
+                        line = System.Text.Encoding.UTF8.GetString(buf);
 
                         return true;
                     }

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -232,10 +232,13 @@ namespace EDDiscovery
                 var tlu = m_travelogUnits[fi.Name];
                 tlu.Path = fi.DirectoryName;
                 reader = new NetLogFileReader(tlu);
+                netlogreaders[fi.Name] = reader;
             }
             else
             {
                 reader = new NetLogFileReader(fi.FullName);
+                m_travelogUnits[fi.Name] = reader.TravelLogUnit;
+                netlogreaders[fi.Name] = reader;
             }
 
             return reader;
@@ -354,6 +357,19 @@ namespace EDDiscovery
                 {
                     nfi = OpenFileReader(new FileInfo(filename));
                     lastnfi = nfi;
+                }
+                else if (!File.Exists(lastnfi.FileName) || lastnfi.filePos >= new FileInfo(lastnfi.FileName).Length)
+                {
+                    string[] filenames = Directory.EnumerateFiles(GetNetLogPath(), "netLog.*.log", SearchOption.AllDirectories).OrderBy(s => Path.GetFileName(s).ToLower()).ToArray();
+                    foreach (var name in filenames)
+                    {
+                        if (!m_travelogUnits.ContainsKey(Path.GetFileName(name)))
+                        {
+                            nfi = OpenFileReader(new FileInfo(name));
+                            lastnfi = nfi;
+                            break;
+                        }
+                    }
                 }
 
                 if (lastnfi != null)

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -22,8 +22,6 @@ namespace EDDiscovery
 
         public event NetLogEventHandler OnNewPosition;          // called in foreground, no need for invoke
 
-        public List<VisitedSystemsClass> visitedSystems = new List<VisitedSystemsClass>();
-
         Dictionary<string, NetLogFileReader> netlogreaders = new Dictionary<string, NetLogFileReader>();
 
         FileSystemWatcher m_Watcher;
@@ -149,7 +147,7 @@ namespace EDDiscovery
 
             List<VisitedSystemsClass> vsSystemsList = VisitedSystemsClass.GetAll(EDDConfig.Instance.CurrentCmdrID);
 
-            visitedSystems.Clear();
+            List<VisitedSystemsClass> visitedSystems = new List<VisitedSystemsClass>();
 
             if (vsSystemsList != null)
             {
@@ -352,7 +350,6 @@ namespace EDDiscovery
                 string filename = null;
                 NetLogFileReader nfi = null;
 
-                int nrsystems = visitedSystems.Count;
                 if (m_netLogFileQueue.TryDequeue(out filename))      // if a new one queued, we swap to using it
                 {
                     nfi = OpenFileReader(new FileInfo(filename));
@@ -389,9 +386,8 @@ namespace EDDiscovery
 
                         // here we need to make sure the cursystem is set up.. need to do it here because OnNewPosition expects all cursystems to be non null..
 
-                        VisitedSystemsClass item2 = visitedSystems.LastOrDefault();
+                        VisitedSystemsClass item2 = VisitedSystemsClass.GetLast(dbsys.Commander, dbsys.Time);
                         VisitedSystemsClass.UpdateVisitedSystemsEntries(dbsys, item2, EDDiscoveryForm.EDDConfig.UseDistances);       // ensure they have system classes behind them..
-                        visitedSystems.Add(dbsys);
                         OnNewPosition(dbsys);
                         lastnfi.TravelLogUnit.Update();
 

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -774,6 +774,7 @@ namespace EDDiscovery
         public void NewPosition(VisitedSystemsClass item)         // in UI Thread..
         {
             Debug.Assert(Application.MessageLoop);              // ensure.. paranoia
+            visitedSystems.Add(item);
 
             try
             {


### PR DESCRIPTION
* Enumerate files in the logs directory when the FileSystemWatcher doesn't give any events
* The visitedSystems list is now owned by the TravelHistoryControl
* Get the TravelLogUnit from the database instead of caching the list in NetLogClass
* Cache netlog visited systems read by the NetLogReader in order to reduce the amount of time querying visited systems from the database
* Enter the new systems from a netlog in a single transaction in order to speed up initial import
* Read the files as UTF-8