### PR TITLE
Add a couple of checks for null "VisitedSystems" member when synchron…

### DIFF
--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -120,7 +120,8 @@ namespace EDDiscovery2.EDSM
                     // Check for new systems from EDSM
                     foreach (var system in log)
                     {
-                        VisitedSystemsClass ps2 = (from c in mainForm.VisitedSystems where c.Name == system.Name && c.Time.Ticks == system.Time.Ticks select c).FirstOrDefault<VisitedSystemsClass>();
+                        VisitedSystemsClass ps2 = mainForm?.VisitedSystems == null ? null : 
+                            (from c in mainForm.VisitedSystems where c.Name == system.Name && c.Time.Ticks == system.Time.Ticks select c).FirstOrDefault<VisitedSystemsClass>();
                         if (ps2 == null)  // Add to local DB...
                         {
                             if (tlu == null) // If we dontt have a travellogunit yet then create it. 

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -766,7 +766,10 @@ namespace EDDiscovery
         {
             Invoke((MethodInvoker)delegate
             {
-                visitedSystems.Clear();
+                if( visitedSystems != null)
+                {
+                    visitedSystems.Clear();
+                }
                 RefreshHistory();
             });
         }


### PR DESCRIPTION
…ising -from- EDSM.

USE CASE: New install, no netlog, sync with EDSM.


Without these checks the sync fails.

Furthermore, IF the "netlog" directory is not specified, ParseFiles() returns null (might be better to return an empty VisistedSystems list?), and the history is never refreshed properly, which means the next EDSM sync duplicates the entire list of visisted systems.

Recommend we look at refactoring the code so that "VisistedSystems" can never be null, only empty, and "ParseFiles" doesn't abort if we don't have a valid netlog location.