### PR TITLE
Download EDSM systems in chunks

### DIFF
--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -870,6 +870,33 @@ namespace EDDiscovery.DB
             return lasttime;
         }
 
+        public static DateTime GetLastSystemModifiedTime()
+        {
+            DateTime lasttime = new DateTime(2010, 1, 1, 0, 0, 0);
+
+            try
+            {
+                using (SQLiteConnectionED cn = new SQLiteConnectionED())
+                {
+                    using (DbCommand cmd = cn.CreateCommand("SELECT UpdateDate FROM Systems ORDER BY UpdateDate DESC LIMIT 1"))
+                    {
+                        using (DbDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read() && System.DBNull.Value != reader["UpdateDate"])
+                                lasttime = DateTime.SpecifyKind((DateTime)reader["UpdateDate"], DateTimeKind.Utc);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine("Exception : " + ex.Message);
+                System.Diagnostics.Trace.WriteLine(ex.StackTrace);
+            }
+
+            return lasttime;
+        }
+
         public static void TouchSystem(SQLiteConnectionED cn, string systemName)
         {
             using (DbCommand cmd = cn.CreateCommand("update systems set versiondate=datetime('now') where name=@systemName"))

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -140,8 +140,6 @@ namespace EDDiscovery
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
                 // Log unhandled UI exceptions
                 Application.ThreadException += Application_ThreadException;
-                // Always direct unhandled exceptions to the above handler
-                Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
                 // Redirect console to trace
                 Console.SetOut(new TraceLogWriter());
             }

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -236,7 +236,7 @@ namespace EDDiscovery2.EDSM
                     break;
                 }
 
-                updates += SystemClass.ParseEDSMUpdateSystemsString(json, ref lstsyst, false, discoveryform, cancelRequested, reportProgress);
+                updates += SystemClass.ParseEDSMUpdateSystemsString(json, ref lstsyst, false, discoveryform, cancelRequested, reportProgress, false);
                 SQLiteDBClass.PutSettingString("EDSMLastSystems", lstsyst);
                 lstsystdate += TimeSpan.FromHours(12);
             }

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -182,7 +182,6 @@ namespace EDDiscovery2.EDSM
         {
             string lstsyst;
 
-            DateTime NewSystemTime;
             DateTime lstsystdate;
             // First system in EDSM is from 2015-05-01 00:39:40
             DateTime gammadate = new DateTime(2015, 5, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -194,20 +193,11 @@ namespace EDDiscovery2.EDSM
             else
             {
                 // Get the most recent modify time returned from EDSM
-                NewSystemTime = SystemClass.GetLastSystemModifiedTime();
-                lstsyst = NewSystemTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                lstsyst = SQLiteDBClass.GetSettingString("EDSMLastSystems", lstsyst);
+                lstsystdate = SystemClass.GetLastSystemModifiedTime();
 
-                if (!DateTime.TryParseExact(lstsyst, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out lstsystdate))
+                if (lstsystdate < gammadate)
                 {
-                    lstsystdate = NewSystemTime;
-                }
-                else if (lstsystdate < gammadate)
-                {
-                    if (NewSystemTime > gammadate)
-                        lstsystdate = NewSystemTime;
-                    else
-                        lstsystdate = gammadate;
+                    lstsystdate = gammadate;
                 }
             }
 

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -193,7 +193,7 @@ namespace EDDiscovery2.EDSM
             else
             {
                 // Get the most recent modify time returned from EDSM
-                lstsystdate = SystemClass.GetLastSystemModifiedTime();
+                lstsystdate = SystemClass.GetLastSystemModifiedTime() - TimeSpan.FromSeconds(1);
 
                 if (lstsystdate < gammadate)
                 {

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -128,7 +128,21 @@ namespace EDDiscovery2.EDSM
             }
         }
 
-        
+        public string RequestSystems(DateTime startdate, DateTime enddate)
+        {
+            DateTime gammadate = new DateTime(2015, 5, 10, 0, 0, 0, DateTimeKind.Utc);
+            if (startdate < gammadate)
+            {
+                startdate = gammadate;
+            }
+
+            string query = "api-v1/systems" +
+                "?startdatetime=" + HttpUtility.UrlEncode(startdate.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) +
+                "&enddatetime=" + HttpUtility.UrlEncode(enddate.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) +
+                "&coords=1&submitted=1&known=1&showId=1";
+            var response = RequestGet(query);
+            return response.Body;
+        }
 
         public string RequestSystems(string date)
         {
@@ -169,36 +183,64 @@ namespace EDDiscovery2.EDSM
             string lstsyst;
 
             DateTime NewSystemTime;
+            DateTime lstsystdate;
+            // First system in EDSM is from 2015-05-01 00:39:40
+            DateTime gammadate = new DateTime(2015, 5, 1, 0, 0, 0, DateTimeKind.Utc);
 
             if (SystemClass.GetTotalSystems() == 0)
             {
-                lstsyst = "2010-01-01 00:00:00";
+                lstsystdate = gammadate;
             }
             else
             {
-                NewSystemTime = SystemClass.GetLastSystemEntryTime();
+                // Get the most recent modify time returned from EDSM
+                NewSystemTime = SystemClass.GetLastSystemModifiedTime();
                 lstsyst = NewSystemTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                 lstsyst = SQLiteDBClass.GetSettingString("EDSMLastSystems", lstsyst);
-                DateTime lstsystdate;
 
-                if (lstsyst.Equals("2010-01-01 00:00:00") || !DateTime.TryParseExact(lstsyst, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out lstsystdate))
-                    lstsyst = NewSystemTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                if (!DateTime.TryParseExact(lstsyst, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out lstsystdate))
+                {
+                    lstsystdate = NewSystemTime;
+                }
+                else if (lstsystdate < gammadate)
+                {
+                    if (NewSystemTime > gammadate)
+                        lstsystdate = NewSystemTime;
+                    else
+                        lstsystdate = gammadate;
+                }
             }
 
-            Console.WriteLine("EDSM Check date" + lstsyst);
+            lstsyst = lstsystdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
-            string json = RequestSystems(lstsyst);
+            Console.WriteLine("EDSM Check date: " + lstsyst);
 
             long updates = 0;
 
-            if (json != null)       // bad download could cause this..
+            while (lstsystdate < DateTime.UtcNow)
             {
-                string date = SQLiteDBClass.GetSettingString("EDSMLastSystems", "2000-01-02 00:00:00"); // Latest time from RW file.
-                updates = SystemClass.ParseEDSMUpdateSystemsString(json, ref date, false, discoveryform, cancelRequested, reportProgress);
-                SQLiteDBClass.PutSettingString("EDSMLastSystems", date);
+                DateTime enddate = lstsystdate + TimeSpan.FromHours(12);
+                if (enddate > DateTime.UtcNow)
+                {
+                    enddate = DateTime.UtcNow;
+                }
+
+                discoveryform.LogLine($"Downloading systems from {lstsystdate.ToLocalTime().ToString()} to {enddate.ToLocalTime().ToString()}");
+                reportProgress(-1, "Requesting systems from EDSM");
+                string json = RequestSystems(lstsystdate, enddate);
+
+                if (json == null)
+                {
+                    reportProgress(-1, "EDSM request failed");
+                    discoveryform.LogLine("Download of EDSM systems from the server failed, will try next time program is run");
+                    break;
+                }
+
+                updates += SystemClass.ParseEDSMUpdateSystemsString(json, ref lstsyst, false, discoveryform, cancelRequested, reportProgress);
+                SQLiteDBClass.PutSettingString("EDSMLastSystems", lstsyst);
+                lstsystdate += TimeSpan.FromHours(12);
             }
-            else
-                discoveryform.LogLine("Download of EDSM systems from the server failed, will try next time program is run");
+            discoveryform.LogLine($"System download complete");
 
             return updates;
         }


### PR DESCRIPTION
* Download EDSM systems in chunks of 12 hours
* Show when downloading systems and when processing systems
* Don't use a cache for chunked updates - it takes longer to grab the cache than it does to process the systems without it.
* Fix an error when initializing logging - the Thread exception mode cannot be changed after form creation
* Use the system UpdateDate exclusively when determining what date ranges to fetch, in order to avoid missing updates
* Include the most recent second from the systems data in order to catch systems that were added just after the last query