### PR TITLE
Rearrange EDSM sync 

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EDDiscoveryForm));
             ExtendedControls.TabStyleSquare tabStyleSquare2 = new ExtendedControls.TabStyleSquare();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
@@ -80,6 +81,7 @@
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this._syncWorker = new System.ComponentModel.BackgroundWorker();
             this._checkSystemsWorker = new System.ComponentModel.BackgroundWorker();
+            this.edsmRefreshTimer = new System.Windows.Forms.Timer(this.components);
             this.menuStrip1.SuspendLayout();
             this.panelInfo.SuspendLayout();
             this.tabControl1.SuspendLayout();
@@ -557,6 +559,11 @@
             this._checkSystemsWorker.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this._checkSystemsWorker_ProgressChanged);
             this._checkSystemsWorker.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this._checkSystemsWorker_RunWorkerCompleted);
             // 
+            // edsmRefreshTimer
+            // 
+            this.edsmRefreshTimer.Interval = 900000;
+            this.edsmRefreshTimer.Tick += new System.EventHandler(this.edsmRefreshTimer_Tick);
+            // 
             // EDDiscoveryForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -653,6 +660,7 @@
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private System.ComponentModel.BackgroundWorker _syncWorker;
         private System.ComponentModel.BackgroundWorker _checkSystemsWorker;
+        private System.Windows.Forms.Timer edsmRefreshTimer;
     }
 }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -88,6 +88,7 @@ namespace EDDiscovery
 
         Action cancelDownloadMaps = null;
         Task<bool> downloadMapsTask = null;
+        Task checkInstallerTask = null;
         private string logname;
         private bool logsetupfailed;
 
@@ -295,8 +296,9 @@ namespace EDDiscovery
             downloadMapsTask = DownloadMaps((cb) => cancelDownloadMaps = cb);
         }
 
-        private void CheckForNewInstaller()
+        private Task CheckForNewInstaller()
         {
+            return Task.Factory.StartNew(() =>
             {
                 EDDiscoveryServer eds = new EDDiscoveryServer();
 
@@ -316,11 +318,11 @@ namespace EDDiscovery
 
                     if (v1.CompareTo(v2) > 0) // Test if newver installer exists:
                     {
-                        LogLineHighlight("New EDDiscovery installer available " + "http://eddiscovery.astronet.se/release/" + newInstaller);
+                        this.BeginInvoke(new Action(() => LogLineHighlight("New EDDiscovery installer available " + "http://eddiscovery.astronet.se/release/" + newInstaller)));
                     }
 
                 }
-            }
+            });
         }
 
         private void InitFormControls()
@@ -639,11 +641,11 @@ namespace EDDiscovery
 
                 panelInfo.Visible = false;
 
-                CheckForNewInstaller();
-
                 LogLine("Reading travel history");
                 travelHistoryControl1.HistoryRefreshed += _travelHistoryControl1_InitialRefreshDone;
                 travelHistoryControl1.RefreshHistoryAsync();
+
+                checkInstallerTask = CheckForNewInstaller();
             }
         }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -574,11 +574,19 @@ namespace EDDiscovery
 
             if (DateTime.Now.Subtract(edsmdate).TotalDays > 7)  // Over 7 days do a sync from EDSM
             {
-                performedsmsync = true;
-
                 // Also update galactic mapping from EDSM (MOVED here for now since we don't use this yet..)
                 LogLine("Get galactic mapping from EDSM.");
                 galacticMapping.DownloadFromEDSM();
+
+                // Skip EDSM full update if update has been performed in last 4 days
+                if (DateTime.UtcNow.Subtract(SystemClass.GetLastSystemModifiedTime()).TotalDays > 4)
+                {
+                    performedsmsync = true;
+                }
+                else
+                {
+                    SQLiteDBClass.PutSettingString("EDSMLastSystems", DateTime.Now.ToString());
+                }
             }
 
             if (!cancelRequested())

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -785,6 +785,10 @@ namespace EDDiscovery
                     return false;
                 }
 
+                // Stop if requested
+                if (cancelRequested())
+                    return false;
+
                 LogLine("Indexing systems table");
                 SQLiteDBClass.CreateSystemsTableIndexes();
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -457,42 +457,6 @@ namespace EDDiscovery
                 }, 
                 (s) => LogLine("Map check complete."),
                 registerCancelCallback);
-
-                /*
-                if (DownloadMapFile("SC-01.jpg"))  // If server down only try one.
-                {
-                    DownloadMapFile("SC-02.jpg");
-                    DownloadMapFile("SC-03.jpg");
-                    DownloadMapFile("SC-04.jpg");
-
-                    DownloadMapFile("SC-L4.jpg");
-                    DownloadMapFile("SC-U4.jpg");
-
-                    DownloadMapFile("SC-00.png");
-                    DownloadMapFile("SC-00.json");
-
-
-                    DownloadMapFile("Galaxy_L.jpg");
-                    DownloadMapFile("Galaxy_L.json");
-                    DownloadMapFile("Galaxy_L_Grid.jpg");
-                    DownloadMapFile("Galaxy_L_Grid.json");
-
-                    DownloadMapFile("DW1.jpg");
-                    DownloadMapFile("DW1.json");
-                    DownloadMapFile("DW2.jpg");
-                    DownloadMapFile("DW2.json");
-                    DownloadMapFile("DW3.jpg");
-                    DownloadMapFile("DW3.json");
-                    DownloadMapFile("DW4.jpg");
-                    DownloadMapFile("DW4.json");
-
-                    DownloadMapFile("Formidine.png");
-                    DownloadMapFile("Formidine.json");
-                    DownloadMapFile("Formidine trans.png");
-                    DownloadMapFile("Formidine trans.json");
-                    
-                }
-                */
             }
             catch (Exception ex)
             {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -687,6 +687,7 @@ namespace EDDiscovery
         {
             if (!_syncWorker.IsBusy)
             {
+                edsmRefreshTimer.Enabled = false;
                 _syncWorker.RunWorkerAsync();
             }
         }
@@ -945,6 +946,14 @@ namespace EDDiscovery
             }
             else if (syncwaseddboredsm)
                 LogLine("ESDM and/or EDDB update complete.");
+
+            edsmRefreshTimer.Enabled = true;
+        }
+
+
+        private void edsmRefreshTimer_Tick(object sender, EventArgs e)
+        {
+            AsyncPerformSync();
         }
 
         internal void AsyncRefreshHistory()
@@ -1074,6 +1083,7 @@ namespace EDDiscovery
             if (safeClose == null)                  // so a close is a request now, and it launches a thread which cleans up the system..
             {
                 e.Cancel = true;
+                edsmRefreshTimer.Enabled = false;
                 CancellationTokenSource.Cancel();
                 travelHistoryControl1.CancelHistoryRefresh();
                 _syncWorker.CancelAsync();

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -650,6 +650,18 @@ namespace EDDiscovery
 
                 CheckForNewInstaller();
 
+                LogLine("Reading travel history");
+                travelHistoryControl1.HistoryRefreshed += _travelHistoryControl1_InitialRefreshDone;
+                travelHistoryControl1.RefreshHistoryAsync();
+            }
+        }
+
+        private void _travelHistoryControl1_InitialRefreshDone(object sender, EventArgs e)
+        {
+            travelHistoryControl1.HistoryRefreshed -= _travelHistoryControl1_InitialRefreshDone;
+
+            if (!PendingClose)
+            {
                 if (performedsmsync || performeddbsync || EDDConfig.UseDistances)
                 {
                     AsyncPerformSync();                              // perform any async synchronisations
@@ -667,11 +679,6 @@ namespace EDDiscovery
                 {
                     long totalsystems = SystemClass.GetTotalSystems();
                     LogLineSuccess("Loading completed, total of " + totalsystems + " systems");
-
-                    //long tickc = Environment.TickCount;
-                    LogLine("Reading travel history");
-                    travelHistoryControl1.RefreshHistoryAsync();
-                    //LogLine("Time " + (Environment.TickCount-tickc) );
                 }
             }
         }

--- a/EDDiscovery/EDDiscoveryForm.resx
+++ b/EDDiscovery/EDDiscoveryForm.resx
@@ -7663,6 +7663,9 @@
   <metadata name="_checkSystemsWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>538, 17</value>
   </metadata>
+  <metadata name="edsmRefreshTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>710, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>59</value>
   </metadata>

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -227,7 +227,6 @@ namespace EDDiscovery2.EDSM
                 }
 
                 updates += SystemClass.ParseEDSMUpdateSystemsString(json, ref lstsyst, false, discoveryform, cancelRequested, reportProgress, false);
-                SQLiteDBClass.PutSettingString("EDSMLastSystems", lstsyst);
                 lstsystdate += TimeSpan.FromHours(12);
             }
             discoveryform.LogLine($"System download complete");

--- a/EDDiscovery/RouteControl.Designer.cs
+++ b/EDDiscovery/RouteControl.Designer.cs
@@ -68,7 +68,6 @@
             this.comboBoxRoutingMetric.Enabled = false;
             this.comboBoxRoutingMetric.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.comboBoxRoutingMetric.ItemHeight = 20;
-            this.comboBoxRoutingMetric.Items = ((System.Collections.Generic.List<string>)(resources.GetObject("comboBoxRoutingMetric.Items")));
             this.comboBoxRoutingMetric.Location = new System.Drawing.Point(326, 76);
             this.comboBoxRoutingMetric.MouseOverBackgroundColor = System.Drawing.Color.Silver;
             this.comboBoxRoutingMetric.Name = "comboBoxRoutingMetric";

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -103,7 +103,6 @@ namespace EDDiscovery
             visitedSystems = null;
             try
             {
-                TriggerEDSMRefresh();
                 LogText("Refresh History." + Environment.NewLine);
                 RefreshHistoryAsync();
             }
@@ -116,15 +115,6 @@ namespace EDDiscovery
                 LogTextHighlight(ex.StackTrace);
             }
         }
-
-        public void TriggerEDSMRefresh()
-        {
-            LogText("Check for new EDSM systems." + Environment.NewLine);
-            EDSMClass edsm = new EDSMClass();
-            edsm.GetNewSystems(_discoveryForm, () => _discoveryForm.PendingClose, _discoveryForm.ReportProgress);
-            LogText("EDSM System check complete." + Environment.NewLine);
-        }
-
 
         public void LogText(string text)
         {

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -42,7 +42,7 @@ namespace EDDiscovery
         public int defaultMapColour;
         public EDSMSync sync;
 
-        internal List<VisitedSystemsClass> visitedSystems;
+        internal List<VisitedSystemsClass> visitedSystems = new List<VisitedSystemsClass>();
         internal bool EDSMSyncTo = true;
         internal bool EDSMSyncFrom = true;
 
@@ -100,7 +100,7 @@ namespace EDDiscovery
 
         private void button_RefreshHistory_Click(object sender, EventArgs e)
         {
-            visitedSystems = null;
+            visitedSystems.Clear();
             try
             {
                 LogText("Refresh History." + Environment.NewLine);

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -863,7 +863,6 @@ namespace EDDiscovery
                    {
                     //Visible = false;
                     UnfreezeTrilaterationUI();
-                       travelHistoryControl.TriggerEDSMRefresh(); // TODO we might eventually avoid this by further parsing EDSC response
                     travelHistoryControl.RefreshHistoryAsync();
                        checkForUnknownSystemsNowKnown();
                    });


### PR DESCRIPTION
* Only update the EDSMLastSystems setting when performing a full EDSM sync
* Refresh the history before and after syncing the EDSM systems
* Move the incremental EDSM sync to the end of the sync
* Don't sync EDSM systems during history refresh - leave that up to the initial and periodic syncs
* Ensure TravelHistoryControl.visitedSystems is never null
* Add a 15 minute periodic EDSM sync timer
* Skip the full EDSM sync if an incremental sync has been done in the last 4 days