### PR TITLE
Fix a couple of issues with incremental EDSM updates

### DIFF
--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -887,7 +887,7 @@ namespace EDDiscovery.DB
                         }
                     }
 
-                    using (DbCommand cmd = cn.CreateCommand("SELECT UpdateDate FROM Systems WHERE id_edsm == 0 OR id_edsm IS NULL ORDER BY UpdateDate ASC LIMIT 1"))
+                    using (DbCommand cmd = cn.CreateCommand("SELECT UpdateDate FROM Systems WHERE id_edsm = 0 OR id_edsm IS NULL ORDER BY UpdateDate ASC LIMIT 1"))
                     {
                         using (DbDataReader reader = cmd.ExecuteReader())
                         {

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -878,12 +878,28 @@ namespace EDDiscovery.DB
             {
                 using (SQLiteConnectionED cn = new SQLiteConnectionED())
                 {
-                    using (DbCommand cmd = cn.CreateCommand("SELECT UpdateDate FROM Systems ORDER BY UpdateDate DESC LIMIT 1"))
+                    using (DbCommand cmd = cn.CreateCommand("SELECT UpdateDate FROM Systems WHERE id_edsm != 0 AND id_edsm IS NOT NULL ORDER BY UpdateDate DESC LIMIT 1"))
                     {
                         using (DbDataReader reader = cmd.ExecuteReader())
                         {
                             if (reader.Read() && System.DBNull.Value != reader["UpdateDate"])
                                 lasttime = DateTime.SpecifyKind((DateTime)reader["UpdateDate"], DateTimeKind.Utc);
+                        }
+                    }
+
+                    using (DbCommand cmd = cn.CreateCommand("SELECT UpdateDate FROM Systems WHERE id_edsm == 0 OR id_edsm IS NULL ORDER BY UpdateDate ASC LIMIT 1"))
+                    {
+                        using (DbDataReader reader = cmd.ExecuteReader())
+                        {
+                            if (reader.Read() && System.DBNull.Value != reader["UpdateDate"])
+                            {
+                                DateTime firstnonedsmtime = DateTime.SpecifyKind((DateTime)reader["UpdateDate"], DateTimeKind.Utc);
+
+                                if (firstnonedsmtime < lasttime)
+                                {
+                                    lasttime = firstnonedsmtime;
+                                }
+                            }
                         }
                     }
                 }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -895,6 +895,18 @@ namespace EDDiscovery
                     LogLine("Checking for new EDSM systems (may take a few moments).");
                     EDSMClass edsm = new EDSMClass();
                     long updates = edsm.GetNewSystems(this, cancelRequested, reportProgress);
+
+                    // Delete systems without an EDSM ID
+                    if (!cancelRequested())
+                    {
+                        using (SQLiteConnectionED cn = new SQLiteConnectionED())
+                        {
+                            using (DbCommand cmd = cn.CreateCommand("DELETE FROM Systems WHERE id_edsm IS NULL or id_edsm = 0"))
+                            {
+                                cmd.ExecuteNonQuery();
+                            }
+                        }
+                    }
                     LogLine("EDSM updated " + updates + " systems.");
                 }
 

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -209,6 +209,9 @@ namespace EDDiscovery2.EDSM
 
             while (lstsystdate < DateTime.UtcNow)
             {
+                if (cancelRequested())
+                    return updates;
+
                 DateTime enddate = lstsystdate + TimeSpan.FromHours(12);
                 if (enddate > DateTime.UtcNow)
                 {


### PR DESCRIPTION
* Re-sync as necessary where id_edsm is not set, in case the user rolled back to 3.x after installing 4.x
* Cancel incremental update when requested - previously the incremental update would keep going after clicking close.