### PR TITLE
Only use vsc_lookup if it isn't null

### DIFF
--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -227,7 +227,7 @@ namespace EDDiscovery
             TravelLogUnit tlu;
             List<VisitedSystemsClass> vsclist = null;
 
-            if (vsc_lookup.ContainsKey(fi.Name))
+            if (vsc_lookup != null && vsc_lookup.ContainsKey(fi.Name))
             {
                 vsclist = vsc_lookup[fi.Name];
             }


### PR DESCRIPTION
Fix a crash when a new netlog is created