### PR TITLE
Fix a few exception conditions

### DIFF
--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1464,7 +1464,13 @@ namespace EDDiscovery.DB
 
         private static long DoParseEDSMUpdateSystemsReader(JsonTextReader jr, ref string date, SQLiteConnectionED cn, EDDiscoveryForm discoveryform, Func<bool> cancelRequested, Action<int, string> reportProgress, bool useCache = true)
         {
-            DateTime maxdate = DateTime.Parse(date, CultureInfo.InvariantCulture);
+            DateTime maxdate;
+
+            if (!DateTime.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out maxdate))
+            {
+                maxdate = new DateTime(2010, 1, 1);
+            }
+
             Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> systemsByEdsmId = useCache ? GetEdsmSystemsLite(cn) : new Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase>();
             int count = 0;
             int updatecount = 0;
@@ -1517,7 +1523,7 @@ namespace EDDiscovery.DB
                             if (!jr.Read())
                             {
                                 reportProgress(-1, $"Syncing EDSM systems: {count} processed, {insertcount} new systems, {updatecount} updated systems");
-                                date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                                date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture );
                                 txn.Commit();
 
                                 Console.WriteLine($"Import took {sw.ElapsedMilliseconds}ms");

--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -301,7 +301,7 @@ namespace EDDiscovery2.DB
         {
             double dist;
             double dx, dy, dz;
-            Dictionary<long, ISystem> systems = distlist.Values.ToDictionary(s => s.id);
+            Dictionary<long, ISystem> systems = distlist.Values.GroupBy(s => s.id).ToDictionary(g => g.Key, g => g.First());
 
             foreach (VisitedSystemsClass pos in vs)
             {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -177,6 +177,11 @@ namespace EDDiscovery
         // We can't prevent an unhandled exception from killing the application.
         // See https://blog.codinghorror.com/improved-unhandled-exception-behavior-in-net-20/
         // Log the exception info if we can, and ask the user to report it.
+        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
+        [System.Security.SecurityCritical]
+        [System.Runtime.ConstrainedExecution.ReliabilityContract(
+            System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState,
+            System.Runtime.ConstrainedExecution.Cer.Success)]
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             try

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -253,7 +253,9 @@ namespace EDDiscovery
                 return;
             }
 
-            System.Diagnostics.Trace.WriteLine($"First chance exception: {e.Exception.ToString()}");
+            var trace = new StackTrace(1, true);
+
+            System.Diagnostics.Trace.WriteLine($"First chance exception: {e.Exception.Message}\n{trace.ToString()}");
         }
 
         private void EDDiscoveryForm_Layout(object sender, LayoutEventArgs e)       // Manually position, could not get gripper under tab control with it sizing for the life of me
@@ -547,7 +549,12 @@ namespace EDDiscovery
             CommanderName = EDDConfig.CurrentCommander.Name;
 
             string rwsystime = SQLiteDBClass.GetSettingString("EDSMLastSystems", "2000-01-01 00:00:00"); // Latest time from RW file.
-            DateTime edsmdate = DateTime.Parse(rwsystime, new CultureInfo("sv-SE"));
+            DateTime edsmdate;
+
+            if (!DateTime.TryParse(rwsystime, CultureInfo.InvariantCulture, DateTimeStyles.None, out edsmdate))
+            {
+                edsmdate = new DateTime(2000, 1, 1);
+            }
 
             if (DateTime.Now.Subtract(edsmdate).TotalDays > 7)  // Over 7 days do a sync from EDSM
             {
@@ -563,7 +570,7 @@ namespace EDDiscovery
                 }
                 else
                 {
-                    SQLiteDBClass.PutSettingString("EDSMLastSystems", DateTime.Now.ToString());
+                    SQLiteDBClass.PutSettingString("EDSMLastSystems", DateTime.Now.ToString(CultureInfo.InvariantCulture));
                 }
             }
 
@@ -703,7 +710,13 @@ namespace EDDiscovery
         private bool PerformEDSMFullSync(EDDiscoveryForm discoveryform, Func<bool> cancelRequested, Action<int, string> reportProgress)
         {
             string rwsystime = SQLiteDBClass.GetSettingString("EDSMLastSystems", "2000-01-01 00:00:00"); // Latest time from RW file.
-            DateTime edsmdate = DateTime.Parse(rwsystime, new CultureInfo("sv-SE"));
+            DateTime edsmdate;
+
+            if (!DateTime.TryParse(rwsystime, CultureInfo.InvariantCulture, DateTimeStyles.None, out edsmdate))
+            {
+                edsmdate = new DateTime(2000, 1, 1);
+            }
+
             long updates = 0;
 
             try

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -132,19 +132,20 @@ namespace EDDiscovery
                     Directory.CreateDirectory(logpath);
                 }
 
-#if !DEBUG
-                logname = Path.Combine(Tools.GetAppDataDirectory(), "Log", $"Trace_{DateTime.Now.ToString("yyyyMMddHHmmss")}.log");
+                if (!Debugger.IsAttached)
+                {
+                    logname = Path.Combine(Tools.GetAppDataDirectory(), "Log", $"Trace_{DateTime.Now.ToString("yyyyMMddHHmmss")}.log");
 
-                System.Diagnostics.Trace.AutoFlush = true;
-                // Log trace events to the above file
-                System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(logname));
-                // Log unhandled exceptions
-                AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-                // Log unhandled UI exceptions
-                Application.ThreadException += Application_ThreadException;
-                // Redirect console to trace
-                Console.SetOut(new TraceLogWriter());
-#endif
+                    System.Diagnostics.Trace.AutoFlush = true;
+                    // Log trace events to the above file
+                    System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(logname));
+                    // Log unhandled exceptions
+                    AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+                    // Log unhandled UI exceptions
+                    Application.ThreadException += Application_ThreadException;
+                    // Redirect console to trace
+                    Console.SetOut(new TraceLogWriter());
+                }
                 // Log first-chance exceptions to help diagnose errors
                 Register_FirstChanceException_Handler();
             }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -957,10 +957,10 @@ namespace EDDiscovery
             LogLine("Refreshing complete.");
             if (syncwasfirstrun)
             {
-                LogLine("ESDM and EDDB update complete. Please restart ED Discovery to complete the synchronisation ");
+                LogLine("EDSM and EDDB update complete. Please restart ED Discovery to complete the synchronisation ");
             }
             else if (syncwaseddboredsm)
-                LogLine("ESDM and/or EDDB update complete.");
+                LogLine("EDSM and/or EDDB update complete.");
 
             edsmRefreshTimer.Enabled = true;
         }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -247,6 +247,11 @@ namespace EDDiscovery
                     }
                 }
             }
+            // Ignore DLL Not Found exceptions from OpenTK
+            else if (e.Exception is DllNotFoundException && e.Exception.Source == "OpenTK")
+            {
+                return;
+            }
 
             System.Diagnostics.Trace.WriteLine($"First chance exception: {e.Exception.ToString()}");
         }


### PR DESCRIPTION
* Only disable unhandled exception logging when a debugger is attached
* Log and report critical exceptions such as General Protection Faults, stack overflows, etc.
* Ignore DLL not found exceptions from OpenTK
* EDSMLastSystems was being incorrectly exported in the current locale.  Use the invariant locale, and re-sync if an incorrect value is found.
* Fix the typo in the "ESDM and/or EDDB update complete" message - should be EDSM, not ESDM.
* Work around duplicate system entries being present in the distances list