### PR TITLE
Don't setup viewport until glControl_Load has run

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -108,6 +108,7 @@ namespace EDDiscovery2
         private float _znear;
 
         private bool _isActivated = false;
+        private bool _glControlLoaded = false;
 
         private ToolStripMenuItem _toolstripToggleNamingButton;     // for picking up this option quickly
 
@@ -393,10 +394,15 @@ namespace EDDiscovery2
 
             SetupViewport();
             Repaint();
+
+            _glControlLoaded = true;
         }
 
         private void FormMap_Resize(object sender, EventArgs e)         // resizes changes glcontrol width/height, so needs a new viewport
         {
+            if (!_glControlLoaded)
+                return;
+
             SetupViewport();
             Repaint();
         }


### PR DESCRIPTION
This should hopefully fix the AccessViolationException a few people have been getting when opening the 3D map.