### PR TITLE
Fix a couple of errors with db locking and log reading

### DIFF
--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -18,9 +18,14 @@ namespace EDDiscovery.DB
     public class SQLiteTxnLockED : IDisposable
     {
         private static object _transactionLock = new object();
+        private static System.Threading.Timer _locktimer;
         private bool _locktaken = false;
         private static ConcurrentDictionary<Thread, bool> _waitingthreads = new ConcurrentDictionary<Thread, bool>();
         private Thread _owningThread;
+        public DbCommand _executingCommand;
+        public bool _commandExecuting = false;
+        private bool _isLongRunning = false;
+        private string _commandText = null;
 
         #region Constructor and Destructor
         public SQLiteTxnLockED()
@@ -34,6 +39,61 @@ namespace EDDiscovery.DB
         #endregion
 
         #region Opening and Disposal
+        private static void DebugLongRunningOperation(object state)
+        {
+            WeakReference weakref = state as WeakReference;
+
+            if (weakref != null)
+            {
+                SQLiteTxnLockED txnlock = weakref.Target as SQLiteTxnLockED;
+
+                if (txnlock != null)
+                {
+                    txnlock._isLongRunning = true;
+
+                    if (txnlock._commandExecuting)
+                    {
+                        if (txnlock._isLongRunning)
+                        {
+                            Trace.WriteLine($"The following command is taking a long time to execute:\n{txnlock._commandText}");
+                        }
+                        if (txnlock._owningThread == Thread.CurrentThread)
+                        {
+                            StackTrace trace = new StackTrace(true);
+                            Trace.WriteLine(trace.ToString());
+                        }
+                    }
+                    else
+                    {
+                        Trace.WriteLine($"The transaction lock has been held for a long time.");
+
+                        if (txnlock._commandText != null)
+                        {
+                            Trace.WriteLine($"Last command to execute:\n{txnlock._commandText}");
+                        }
+                    }
+                }
+            }
+        }
+
+        public void BeginCommand(DbCommand cmd)
+        {
+            this._executingCommand = cmd;
+            this._commandText = cmd.CommandText;
+            this._commandExecuting = true;
+
+            if (this._isLongRunning)
+            {
+                this._isLongRunning = false;
+                DebugLongRunningOperation(new WeakReference(this));
+            }
+        }
+
+        public void EndCommand()
+        {
+            this._commandExecuting = false;
+        }
+
         public void Open()
         {
             // Only take the lock once
@@ -55,6 +115,7 @@ namespace EDDiscovery.DB
                         Monitor.Enter(_transactionLock, ref _locktaken);
                         _owningThread = Thread.CurrentThread;
                         _waitingthreads[Thread.CurrentThread] = false;
+                        _locktimer = new System.Threading.Timer(DebugLongRunningOperation, new WeakReference(this), 2000, Timeout.Infinite);
                     }
                     // Retry the lock if we are interrupted by
                     // a leaked lock being finalized
@@ -116,6 +177,12 @@ namespace EDDiscovery.DB
 
                 _locktaken = false;
             }
+
+            if (_locktimer != null)
+            {
+                _locktimer.Dispose();
+                _locktimer = null;
+            }
         }
         #endregion
     }
@@ -143,6 +210,16 @@ namespace EDDiscovery.DB
         public override void Rollback() { InnerTransaction.Rollback(); }
         #endregion
 
+        public void BeginCommand(DbCommand cmd)
+        {
+            _transactionLock.BeginCommand(cmd);
+        }
+
+        public void EndCommand()
+        {
+            _transactionLock.EndCommand();
+        }
+
         // disposing: true if Dispose() was called, false
         // if being finalized by the garbage collector
         protected override void Dispose(bool disposing)
@@ -164,6 +241,117 @@ namespace EDDiscovery.DB
             }
 
             base.Dispose(disposing);
+        }
+    }
+
+    // This class wraps a DbDataReader so it can take the
+    // above transaction lock, and to work around SQLite
+    // not using a monitor or mutex when locking the
+    // database
+    public class SQLiteDataReaderED : DbDataReader
+    {
+        // This is the wrapped reader
+        protected DbDataReader InnerReader { get; set; }
+        protected DbCommand _command;
+        protected SQLiteTransactionED _transaction;
+        protected SQLiteTxnLockED _txnlock;
+
+        public SQLiteDataReaderED(DbCommand cmd, CommandBehavior behaviour, SQLiteTransactionED txn = null, SQLiteTxnLockED txnlock = null)
+        {
+            this._command = cmd;
+            this.InnerReader = cmd.ExecuteReader(behaviour);
+            this._transaction = txn;
+            this._txnlock = txnlock;
+        }
+
+        protected void BeginCommand()
+        {
+            if (_transaction != null)
+            {
+                _transaction.BeginCommand(_command);
+            }
+            else if (_txnlock != null)
+            {
+                _txnlock.BeginCommand(_command);
+            }
+        }
+
+        protected void EndCommand()
+        {
+            if (_transaction != null)
+            {
+                _transaction.EndCommand();
+            }
+            else if (_txnlock != null)
+            {
+                _txnlock.EndCommand();
+            }
+        }
+
+        #region Overridden methods and properties passed to inner command
+        public override int Depth { get { return InnerReader.Depth; } }
+        public override int FieldCount { get { return InnerReader.FieldCount; } }
+        public override bool HasRows { get { return InnerReader.HasRows; } }
+        public override bool IsClosed { get { return InnerReader.IsClosed; } }
+        public override int RecordsAffected { get { return InnerReader.RecordsAffected; } }
+        public override int VisibleFieldCount { get { return InnerReader.VisibleFieldCount; } }
+        public override object this[int ordinal] { get { return InnerReader[ordinal]; } }
+        public override object this[string name] { get { return InnerReader[name]; } }
+        public override bool GetBoolean(int ordinal) { return InnerReader.GetBoolean(ordinal); }
+        public override byte GetByte(int ordinal) { return InnerReader.GetByte(ordinal); }
+        public override char GetChar(int ordinal) { return InnerReader.GetChar(ordinal); }
+        public override string GetDataTypeName(int ordinal) { return InnerReader.GetDataTypeName(ordinal); }
+        public override DateTime GetDateTime(int ordinal) { return InnerReader.GetDateTime(ordinal); }
+        public override decimal GetDecimal(int ordinal) { return InnerReader.GetDecimal(ordinal); }
+        public override double GetDouble(int ordinal) { return InnerReader.GetDouble(ordinal); }
+        public override Type GetFieldType(int ordinal) { return InnerReader.GetFieldType(ordinal); }
+        public override float GetFloat(int ordinal) { return InnerReader.GetFloat(ordinal); }
+        public override Guid GetGuid(int ordinal) { return InnerReader.GetGuid(ordinal); }
+        public override short GetInt16(int ordinal) { return InnerReader.GetInt16(ordinal); }
+        public override int GetInt32(int ordinal) { return InnerReader.GetInt32(ordinal); }
+        public override long GetInt64(int ordinal) { return InnerReader.GetInt64(ordinal); }
+        public override string GetName(int ordinal) { return InnerReader.GetName(ordinal); }
+        public override string GetString(int ordinal) { return InnerReader.GetString(ordinal); }
+        public override object GetValue(int ordinal) { return InnerReader.GetValue(ordinal); }
+        public override bool IsDBNull(int ordinal) { return InnerReader.IsDBNull(ordinal); }
+        public override int GetOrdinal(string name) { return InnerReader.GetOrdinal(name); }
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length) { return InnerReader.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length); }
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length) { return InnerReader.GetChars(ordinal, dataOffset, buffer, bufferOffset, length); }
+        public override int GetValues(object[] values) { return InnerReader.GetValues(values); }
+        public override DataTable GetSchemaTable() { return InnerReader.GetSchemaTable(); }
+        #endregion
+
+        public override System.Collections.IEnumerator GetEnumerator()
+        {
+            BeginCommand();
+            foreach (object val in InnerReader)
+            {
+                EndCommand();
+                yield return val;
+                BeginCommand();
+            }
+            EndCommand();
+        }
+
+        public override bool NextResult()
+        {
+            BeginCommand();
+            bool result = InnerReader.NextResult();
+            EndCommand();
+            return result;
+        }
+
+        public override bool Read()
+        {
+            BeginCommand();
+            bool result = InnerReader.Read();
+            EndCommand();
+            return result;
+        }
+
+        public override void Close()
+        {
+            InnerReader.Close();
         }
     }
 
@@ -207,7 +395,7 @@ namespace EDDiscovery.DB
             if (this._transaction != null)
             {
                 // The transaction should already have the transaction lock
-                return InnerCommand.ExecuteReader(behavior);
+                return new SQLiteDataReaderED(this, behavior, txn: this._transaction);
             }
             else
             {
@@ -215,7 +403,7 @@ namespace EDDiscovery.DB
                 using (var txnlock = new SQLiteTxnLockED())
                 {
                     txnlock.Open();
-                    return InnerCommand.ExecuteReader(behavior);
+                    return new SQLiteDataReaderED(this, behavior, txnlock: txnlock);
                 }
             }
         }
@@ -224,8 +412,11 @@ namespace EDDiscovery.DB
         {
             if (this._transaction != null)
             {
+                this._transaction.BeginCommand(this);
                 // The transaction should already have the transaction lock
-                return InnerCommand.ExecuteScalar();
+                object result = InnerCommand.ExecuteScalar();
+                this._transaction.EndCommand();
+                return result;
             }
             else
             {
@@ -233,7 +424,10 @@ namespace EDDiscovery.DB
                 using (var txnlock = new SQLiteTxnLockED())
                 {
                     txnlock.Open();
-                    return InnerCommand.ExecuteScalar();
+                    txnlock.BeginCommand(this);
+                    object result = InnerCommand.ExecuteScalar();
+                    txnlock.EndCommand();
+                    return result;
                 }
             }
         }
@@ -242,8 +436,11 @@ namespace EDDiscovery.DB
         {
             if (this._transaction != null)
             {
+                this._transaction.BeginCommand(this);
                 // The transaction should already have the transaction lock
-                return InnerCommand.ExecuteNonQuery();
+                int result = InnerCommand.ExecuteNonQuery();
+                this._transaction.EndCommand();
+                return result;
             }
             else
             {
@@ -251,7 +448,10 @@ namespace EDDiscovery.DB
                 using (var txnlock = new SQLiteTxnLockED())
                 {
                     txnlock.Open();
-                    return InnerCommand.ExecuteNonQuery();
+                    txnlock.BeginCommand(this);
+                    int result = InnerCommand.ExecuteNonQuery();
+                    txnlock.EndCommand();
+                    return result;
                 }
             }
         }

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -358,7 +358,7 @@ namespace EDDiscovery
         {
             Debug.Assert(Application.MessageLoop);              // ensure.. paranoia
 
-            if (!m_worker.IsBusy)
+            if (m_worker != null && !m_worker.IsBusy)
             {
                 m_worker.RunWorkerAsync();
             }
@@ -369,6 +369,8 @@ namespace EDDiscovery
             var worker = sender as System.ComponentModel.BackgroundWorker;
             var entries = new List<VisitedSystemsClass>();
             e.Result = entries;
+            int netlogpos = 0;
+            NetLogFileReader nfi = null;
 
             try
             {
@@ -378,7 +380,6 @@ namespace EDDiscovery
                 }
 
                 string filename = null;
-                NetLogFileReader nfi = null;
 
                 if (m_netLogFileQueue.TryDequeue(out filename))      // if a new one queued, we swap to using it
                 {
@@ -415,6 +416,8 @@ namespace EDDiscovery
                             nfi.TravelLogUnit.Add();
                     }
 
+                    netlogpos = nfi.TravelLogUnit.Size;
+
                     foreach(VisitedSystemsClass dbsys in nfi.ReadSystems())
                     {
                         dbsys.EDSM_sync = false;
@@ -443,6 +446,12 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
+                // Revert and re-read the failed entries
+                if (nfi != null && nfi.TravelLogUnit != null)
+                {
+                    nfi.TravelLogUnit.Size = netlogpos;
+                }
+
                 System.Diagnostics.Trace.WriteLine("Net tick exception : " + ex.Message);
                 System.Diagnostics.Trace.WriteLine(ex.StackTrace);
                 throw;


### PR DESCRIPTION
* Take the transaction lock when reading, so long-running selects don't cause writes to fail
* Don't run the log reader worker if it's dead
* Rollback the log when an exception occurs
* Add some diagnostics for long-running commands