### PR TITLE
Fix interrupted EDSM download, remove SystemsUpdating flag

### DIFF
--- a/EDDiscovery/DB/VisitedSystemsClass.cs
+++ b/EDDiscovery/DB/VisitedSystemsClass.cs
@@ -387,7 +387,8 @@ namespace EDDiscovery2.DB
                     }
                 }
 
-                vsc.strDistance = "";                                       // set empty, must have a string in there.
+                if (vsc.strDistance == null)
+                    vsc.strDistance = "";                                       // set empty, must have a string in there.
             }
 
             DistanceClass.FillVisitedSystems(visitedSystems, usedistancedb);    // finally fill in the distances, indicating if can use db or not

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -80,9 +80,6 @@ namespace EDDiscovery
 
         public CancellationTokenSource CancellationTokenSource { get; private set; } = new CancellationTokenSource();
 
-        public bool SystemsUpdating { get; private set; } = true;
-        public object SystemsUpdatingLock { get; } = new object();
-
         private ManualResetEvent _syncWorkerCompletedEvent = new ManualResetEvent(false);
         private ManualResetEvent _checkSystemsWorkerCompletedEvent = new ManualResetEvent(false);
 
@@ -576,7 +573,7 @@ namespace EDDiscovery
 
             if (!cancelRequested())
             {
-
+                SQLiteDBClass.CreateSystemsTableIndexes();
                 SystemNoteClass.GetAllSystemNotes();                                // fill up memory with notes, bookmarks, galactic mapping
                 BookmarkClass.GetAllBookmarks();
                 galacticMapping.ParseData();                            // at this point, EDSM data is loaded..
@@ -723,11 +720,6 @@ namespace EDDiscovery
 
             try
             {
-                lock (SystemsUpdatingLock)
-                {
-                    SystemsUpdating = true;
-                }
-
                 // Delete all old systems
                 SQLiteDBClass.PutSettingString("EDSMLastSystems", "2010-01-01 00:00:00");
                 SQLiteDBClass.PutSettingString("EDDBSystemsTime", "0");
@@ -936,8 +928,6 @@ namespace EDDiscovery
                     }
                     LogLine("EDSM updated " + updates + " systems.");
                 }
-
-                SystemsUpdating = false;
             }
 
             syncwaseddboredsm = edsmoreddbsync;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -762,6 +762,10 @@ namespace EDDiscovery
                         SQLiteDBClass.ReplaceSystemsTable();
                         reportProgress(-1, "");
                     }
+                    else
+                    {
+                        throw new OperationCanceledException();
+                    }
                 });
 
                 if (!success)

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -231,11 +231,7 @@ namespace EDDiscovery
             if (visitedSystems == null)
                 return;
 
-            // Prevent the indexes from being removed from under our feet
-            lock (_discoveryForm.SystemsUpdatingLock)
-            {
-                VisitedSystemsClass.UpdateSys(visitedSystems, true, !_discoveryForm.SystemsUpdating);   // always use db distances
-            }
+            VisitedSystemsClass.UpdateSys(visitedSystems, true, true);   // always use db distances
 
             var filter = (TravelHistoryFilter) comboBoxHistoryWindow.SelectedItem ?? TravelHistoryFilter.NoFilter;
             List<VisitedSystemsClass> result = filter.Filter(visitedSystems);


### PR DESCRIPTION
* Fix an interrupted EDSM download causing problems until the EDSM dump is updated
* Remove the SystemsUpdating flag now that the bulk import is done to a temporary table
* Only empty distance if not already set