### PR TITLE
Show visited systems when draw lines is unset (4.3)

### DIFF
--- a/EDDiscovery/3DMap/StarGrid.cs
+++ b/EDDiscovery/3DMap/StarGrid.cs
@@ -88,9 +88,14 @@ namespace EDDiscovery2
 
             foreach (VisitedSystemsClass vs in cls)
             {                                                               // all vs stars which are not in edsm and have co-ords.
-                if (vs.curSystem != null && vs.curSystem.status != SystemStatusEnum.EDSC && vs.curSystem.HasCoordinate )
+                if (vs.HasTravelCoordinates)
                 {
-                    carray[total] = cx;      // Visited systems grid does not use the carray as its overriden, but starnames does
+                    carray[total] = unchecked((uint)vs.MapColour);
+                    array[total++] = new Vector3((float)vs.X, (float)vs.Y, (float)vs.Z);
+                }
+                else if (vs.curSystem != null && vs.curSystem.HasCoordinate)
+                {
+                    carray[total] = unchecked((uint)vs.MapColour);
                     array[total++] = new Vector3((float)vs.curSystem.x, (float)vs.curSystem.y, (float)vs.curSystem.z);
                     //Console.WriteLine("Added {0} due to not being in star database", vs.Name);
                 }
@@ -600,6 +605,8 @@ namespace EDDiscovery2
             {
                 populatedgrid.Draw(control);
             }
+
+            visitedsystemsgrid.Draw(control);
         }
 
 #endregion

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -115,11 +115,6 @@ namespace EDDiscovery
             InitializeComponent();
             ProcessCommandLineOptions();
 
-            theme = new EDDTheme();
-
-            EDDConfig = EDDConfig.Instance;
-            galacticMapping = new GalacticMapping();
-
             string logpath = "";
             try
             {
@@ -151,6 +146,11 @@ namespace EDDiscovery
                 Trace.WriteLine($"Unable to create the folder '{logpath}'");
                 Trace.WriteLine($"Exception: {ex.Message}");
             }
+
+            theme = new EDDTheme();
+
+            EDDConfig = EDDConfig.Instance;
+            galacticMapping = new GalacticMapping();
 
             ToolStripManager.Renderer = theme.toolstripRenderer;
             theme.LoadThemes();                                         // default themes and ones on disk loaded


### PR DESCRIPTION
* Show visited system points regardless of whether lines are drawn or all systems are shown.
* Move any functions that access the database to after the log directory is set up (which also creates the data directory) - should fix #390