### PR TITLE
Fixes for cancellation (4.3)

### DIFF
--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1661,6 +1661,11 @@ namespace EDDiscovery.DB
                 }
             }
 
+            if (cancelRequested())
+            {
+                throw new OperationCanceledException();
+            }
+
             return updatecount + insertcount;
         }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -835,7 +835,7 @@ namespace EDDiscovery
                     if (filename != null)
                     {
                         LogLine("Updating all distances with EDSM distance data.");
-                        long numberx = DistanceClass.ParseEDSMUpdateDistancesFile(filename, ref lstdist, true);
+                        long numberx = DistanceClass.ParseEDSMUpdateDistancesFile(filename, ref lstdist, true, cancelRequested, reportProgress);
                         numbertotal += numberx;
                         SQLiteDBClass.PutSettingString("EDSCLastDist", lstdist);
                         LogLine("Local database updated with EDSM Distance data, " + numberx + " distances updated.");
@@ -852,9 +852,12 @@ namespace EDDiscovery
                     LogLine("No response from EDSM Distance server.");
                 else
                 {
-                    long number = DistanceClass.ParseEDSMUpdateDistancesString(json, ref lstdist, false);
+                    long number = DistanceClass.ParseEDSMUpdateDistancesString(json, ref lstdist, false, cancelRequested, reportProgress);
                     numbertotal += number;
                 }
+
+                if (cancelRequested())
+                    return false;
 
                 LogLine("Local database updated with EDSM Distance data, " + numbertotal + " distances updated.");
                 SQLiteDBClass.PutSettingString("EDSCLastDist", lstdist);

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -874,6 +874,13 @@ namespace EDDiscovery
         {
             reportProgress(-1, "");
             syncwasfirstrun = SystemClass.GetTotalSystems() == 0;                 // remember if DB is empty
+
+            // Force a full sync if newest data is more than 14 days old
+            if (DateTime.UtcNow.Subtract(SystemClass.GetLastSystemModifiedTime()).TotalDays >= 14)
+            {
+                performedsmsync = true;
+            }
+
             bool edsmoreddbsync = performedsmsync || performeddbsync;           // remember if we are syncing
 
             if (performedsmsync || performeddbsync)


### PR DESCRIPTION
* Fail EDSM dump download when cancellation is requested
* Force full EDSM sync if data is more than 14 days old
* Add cancellation and reporting to distances sync