### PR TITLE
Fixes to ensure CommanderList is never empty; specifically:

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -337,9 +337,9 @@ namespace EDDiscovery2
                     {
                         while (reader.Read())
                         {
-                            int id = (int)(long)reader["Id"];
-                            string name = (string)reader["Name"];
-                            string edsmapikey = (string)reader["EdsmApiKey"];
+                            int id = Convert.ToInt32(reader["Id"]);
+                            string name = Convert.ToString(reader["Name"]);
+                            string edsmapikey = Convert.ToString(reader["EdsmApiKey"]);
 
                             if (id > maxnr)
                                 maxnr = id;
@@ -347,7 +347,7 @@ namespace EDDiscovery2
                             if ((long)reader["Deleted"] == 0)
                             {
                                 EDCommander edcmdr = new EDCommander(id, name, edsmapikey);
-                                edcmdr.NetLogPath = (string)reader["NetLogPath"];
+                                edcmdr.NetLogDir = Convert.ToString(reader["NetLogDir"]);
                                 _listCommanders.Add(edcmdr);
                             }
                         }
@@ -356,12 +356,12 @@ namespace EDDiscovery2
 
                 if (maxnr == -1)
                 {
-                    using (DbCommand cmd = conn.CreateCommand("INSERT OR REPLACE INTO Commanders (Id, Name, EdsmApiKey, NetLogPath, Deleted) VALUES (@Id, @Name, @EdsmApiKey, @NetLogPath, @Deleted)"))
+                    using (DbCommand cmd = conn.CreateCommand("INSERT OR REPLACE INTO Commanders (Id, Name, EdsmApiKey, NetLogDir, Deleted) VALUES (@Id, @Name, @EdsmApiKey, @NetLogDir, @Deleted)"))
                     {
                         cmd.AddParameter("@Id", DbType.Int32);
                         cmd.AddParameter("@Name", DbType.String);
                         cmd.AddParameter("@EdsmApiKey", DbType.String);
-                        cmd.AddParameter("@NetLogPath", DbType.String);
+                        cmd.AddParameter("@NetLogDir", DbType.String);
                         cmd.AddParameter("@Deleted", DbType.Boolean);
 
                         // Migrate old settigns.
@@ -373,7 +373,7 @@ namespace EDDiscovery2
                             EDCommander cmdr = new EDCommander(0,
                                 SQLiteDBClass.GetSettingString("EDCommanderName" + i.ToString(), commanderName, conn),
                                 SQLiteDBClass.GetSettingString("EDCommanderApiKey" + i.ToString(), apikey, conn));
-                            cmdr.NetLogPath = SQLiteDBClass.GetSettingString("EDCommanderNetLogPath" + i.ToString(), null, conn);
+                            cmdr.NetLogDir = SQLiteDBClass.GetSettingString("EDCommanderNetLogDir" + i.ToString(), null, conn);
                             bool deleted = SQLiteDBClass.GetSettingBool("EDCommanderDeleted" + i.ToString(), false, conn);
 
                             if (cmdr.Name != "")
@@ -381,7 +381,7 @@ namespace EDDiscovery2
                                 cmd.Parameters["@Id"].Value = cmdr.Nr;
                                 cmd.Parameters["@Name"].Value = cmdr.Name;
                                 cmd.Parameters["@EdsmApiKey"].Value = cmdr.APIKey;
-                                cmd.Parameters["@NetLogPath"].Value = cmdr.NetLogPath;
+                                cmd.Parameters["@NetLogDir"].Value = cmdr.NetLogDir;
                                 cmd.Parameters["@Deleted"].Value = deleted;
                                 cmd.ExecuteNonQuery();
 
@@ -406,19 +406,19 @@ namespace EDDiscovery2
         {
             using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
             {
-                using (DbCommand cmd = conn.CreateCommand("UPDATE Commanders SET Name=@Name, EdsmApiKey=@EdsmApiKey, NetLogPath=@NetLogPath WHERE Id=@Id"))
+                using (DbCommand cmd = conn.CreateCommand("UPDATE Commanders SET Name=@Name, EdsmApiKey=@EdsmApiKey, NetLogDir=@NetLogDir WHERE Id=@Id"))
                 {
                     cmd.AddParameter("@Id", DbType.Int32);
                     cmd.AddParameter("@Name", DbType.String);
                     cmd.AddParameter("@EdsmApiKey", DbType.String);
-                    cmd.AddParameter("@NetLogPath", DbType.String);
+                    cmd.AddParameter("@NetLogDir", DbType.String);
 
                     foreach (EDCommander edcmdr in _listCommanders)
                     {
                         cmd.Parameters["@Id"].Value = edcmdr.Nr;
                         cmd.Parameters["@Name"].Value = edcmdr.Name;
                         cmd.Parameters["@EdsmApiKey"].Value = edcmdr.APIKey;
-                        cmd.Parameters["@NetLogPath"].Value = edcmdr.NetLogPath;
+                        cmd.Parameters["@NetLogDir"].Value = edcmdr.NetLogDir;
                         cmd.ExecuteNonQuery();
                     }
                 }
@@ -427,21 +427,23 @@ namespace EDDiscovery2
             LoadCommanders();
         }
 
-        internal EDCommander GetNewCommander(string name = null)
+        internal EDCommander GetNewCommander(string name = null, string edsmApiKey = null)
         {
             EDCommander cmdr;
 
             using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
             {
-                using (DbCommand cmd = conn.CreateCommand("INSERT INTO Commanders (Name) VALUES (@Name)"))
+                using (DbCommand cmd = conn.CreateCommand("INSERT INTO Commanders (Name,EdsmApiKey,Deleted) VALUES (@Name,@EdsmApiKey,@Deleted)"))
                 {
                     cmd.AddParameterWithValue("@Name", name ?? "");
+                    cmd.AddParameterWithValue("@EdsmApiKey", edsmApiKey ?? "");
+                    cmd.AddParameterWithValue("@Deleted", false);
                     cmd.ExecuteNonQuery();
                 }
 
                 using (DbCommand cmd = conn.CreateCommand("SELECT Id FROM Commanders WHERE rowid = last_insert_rowid()"))
                 {
-                    int nr = (int)cmd.ExecuteScalar();
+                    int nr = Convert.ToInt32(cmd.ExecuteScalar());
                     cmdr = new EDCommander(nr, name ?? ("CMDR " + nr.ToString()), "");
                 }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1249,7 +1249,7 @@ namespace EDDiscovery
         {
             try
             {
-                Process.Start(travelHistoryControl1.netlog.GetNetLogPath());
+                Process.Start(travelHistoryControl1.netlog.GetNetLogDir());
             }
             catch (Exception ex)
             {

--- a/EDDiscovery/EliteDangerous/EDCommander.cs
+++ b/EDDiscovery/EliteDangerous/EDCommander.cs
@@ -10,7 +10,7 @@ namespace EDDiscovery2
         private int nr;
         private string name;
         private string apikey;
-        private string netLogPath;
+        private string netLogDir;
 
         public EDCommander(int id, string Name, string APIKey)
         {
@@ -58,16 +58,16 @@ namespace EDDiscovery2
             }
         }
 
-        public string NetLogPath
+        public string NetLogDir
         {
             get
             {
-                return netLogPath;
+                return netLogDir;
             }
 
             set
             {
-                netLogPath = value;
+                netLogDir = value;
             }
         }
     }

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -38,7 +38,7 @@ namespace EDDiscovery
         {
         }
 
-        public string GetNetLogPath()
+        public string GetNetLogDir()
         {
             try
             {
@@ -96,7 +96,7 @@ namespace EDDiscovery
                 else
                 {
                     datapath = EDDConfig.Instance.NetLogDir;
-                    string cmdrpath = EDDConfig.Instance.CurrentCommander.NetLogPath;
+                    string cmdrpath = EDDConfig.Instance.CurrentCommander.NetLogDir;
                     if (cmdrpath != null && cmdrpath != "" && Directory.Exists(cmdrpath))
                     {
                         datapath = cmdrpath;
@@ -107,7 +107,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("GetNetLogPath exception: " + ex.Message);
+                MessageBox.Show("GetNetLogDir exception: " + ex.Message);
                 return null;
             }
         }
@@ -118,7 +118,7 @@ namespace EDDiscovery
         {
             error = null;
 
-            string datapath = GetNetLogPath();
+            string datapath = GetNetLogDir();
 
             if (datapath == null)
             {
@@ -272,7 +272,7 @@ namespace EDDiscovery
             {
                 try
                 {
-                    string logpath = GetNetLogPath();
+                    string logpath = GetNetLogDir();
 
                     if (Directory.Exists(logpath))
                     {
@@ -392,10 +392,10 @@ namespace EDDiscovery
                     nfi = OpenFileReader(new FileInfo(filename));
                     lastnfi = nfi;
                 }
-                else if (!File.Exists(lastnfi.FileName) || lastnfi.filePos >= new FileInfo(lastnfi.FileName).Length)
+                else if (lastnfi != null && (!File.Exists(lastnfi.FileName) || lastnfi.filePos >= new FileInfo(lastnfi.FileName).Length))
                 {
                     HashSet<string> tlunames = new HashSet<string>(TravelLogUnit.GetAllNames());
-                    string[] filenames = Directory.EnumerateFiles(GetNetLogPath(), "netLog.*.log", SearchOption.AllDirectories)
+                    string[] filenames = Directory.EnumerateFiles(GetNetLogDir(), "netLog.*.log", SearchOption.AllDirectories)
                                                   .Select(s => new { name = Path.GetFileName(s), fullname = s })
                                                   .Where(s => !tlunames.Contains(s.name))
                                                   .OrderBy(s => s.name)

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -59,7 +59,7 @@
             this.ColumnNr = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnCommander = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnEDSMAPIKey = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ColumnNetLogPath = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnNetLogDir = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.groupBox1 = new ExtendedControls.GroupBoxCustom();
             this.button_Browse = new ExtendedControls.ButtonExt();
             this.textBoxNetLogDir = new ExtendedControls.TextBoxBorder();
@@ -447,7 +447,7 @@
             this.ColumnNr,
             this.ColumnCommander,
             this.ColumnEDSMAPIKey,
-            this.ColumnNetLogPath});
+            this.ColumnNetLogDir});
             this.dataGridViewCommanders.Location = new System.Drawing.Point(11, 45);
             this.dataGridViewCommanders.MultiSelect = false;
             this.dataGridViewCommanders.Name = "dataGridViewCommanders";
@@ -483,13 +483,13 @@
             this.ColumnEDSMAPIKey.MinimumWidth = 150;
             this.ColumnEDSMAPIKey.Name = "ColumnEDSMAPIKey";
             // 
-            // ColumnNetLogPath
+            // ColumnNetLogDir
             // 
-            this.ColumnNetLogPath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.ColumnNetLogPath.DataPropertyName = "NetLogPath";
-            this.ColumnNetLogPath.HeaderText = "NetLog path";
-            this.ColumnNetLogPath.MinimumWidth = 150;
-            this.ColumnNetLogPath.Name = "ColumnNetLogPath";
+            this.ColumnNetLogDir.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ColumnNetLogDir.DataPropertyName = "NetLogDir";
+            this.ColumnNetLogDir.HeaderText = "NetLog directory";
+            this.ColumnNetLogDir.MinimumWidth = 150;
+            this.ColumnNetLogDir.Name = "ColumnNetLogDir";
             // 
             // groupBox1
             // 
@@ -646,7 +646,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNr;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnCommander;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnEDSMAPIKey;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNetLogPath;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNetLogDir;
         private ExtendedControls.ButtonExt btnDeleteCommander;
     }
 }

--- a/EDDiscovery/Settings.resx
+++ b/EDDiscovery/Settings.resx
@@ -138,7 +138,7 @@
   <metadata name="ColumnEDSMAPIKey.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="ColumnNetLogPath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ColumnNetLogDir.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>


### PR DESCRIPTION
* fix creating a new commander which requires a non-null EdsmApiKey.
* fix reading values from DB (some conversion were throwing exceptions due to long -> int or NULL -> string)

Rename "NetLogPath" -> "NetLogDir" throughout the code to ensure consistency and prevent future bugs (attempt was made to read the wrong one from the database).