### PR TITLE
Remove MessageBox.Show from background processing

### DIFF
--- a/EDDiscovery/DB/DistanceClass.cs
+++ b/EDDiscovery/DB/DistanceClass.cs
@@ -342,20 +342,20 @@ namespace EDDiscovery.DB
         }
 
 
-        public static long ParseEDSMUpdateDistancesString(string json, ref string date, bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress)
+        public static long ParseEDSMUpdateDistancesString(string json, ref string date, bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress, Action<string> logline)
         {
             JsonTextReader jr = new JsonTextReader(new StringReader(json));
-            return ParseEDSMUpdateDistancesReader(jr, ref date, removenonedsmids, cancelRequested, reportProgress);
+            return ParseEDSMUpdateDistancesReader(jr, ref date, removenonedsmids, cancelRequested, reportProgress, logline);
         }
 
-        public static long ParseEDSMUpdateDistancesFile(string filename, ref string date, bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress)
+        public static long ParseEDSMUpdateDistancesFile(string filename, ref string date, bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress, Action<string> logline)
         {
             StreamReader sr = new StreamReader(filename);         // read directly from file..
             JsonTextReader jr = new JsonTextReader(sr);
-            return ParseEDSMUpdateDistancesReader(jr, ref date, removenonedsmids, cancelRequested, reportProgress);
+            return ParseEDSMUpdateDistancesReader(jr, ref date, removenonedsmids, cancelRequested, reportProgress, logline);
         }
 
-        private static long ParseEDSMUpdateDistancesReader(JsonTextReader jr, ref string date , bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress)
+        private static long ParseEDSMUpdateDistancesReader(JsonTextReader jr, ref string date , bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress, Action<string> logline)
         {
             List<DistanceClass> toupdate = new List<DistanceClass>();
             List<DistanceClass> newpairs = new List<DistanceClass>();
@@ -429,8 +429,8 @@ namespace EDDiscovery.DB
                 }
                 catch
                 {
-                    MessageBox.Show("There is a problem using the EDSM distance file." + Environment.NewLine +
-                                    "Please perform a manual EDSM distance sync (see Admin menu) next time you run the program ", "ESDM Sync Error");
+                    logline("There is a problem using the EDSM distance file." + Environment.NewLine +
+                                    "Please perform a manual EDSM distance sync (see Admin menu) next time you run the program ");
                 }
                 finally
                 {

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -628,7 +628,7 @@ namespace EDDiscovery.DB
             }
             catch (Exception ex)
             {
-                System.Windows.Forms.MessageBox.Show(ex.Message, "Error creating data base file, Exception", System.Windows.Forms.MessageBoxButtons.OK);
+                System.Windows.Forms.MessageBox.Show($"Error creating data base file, Exception: {ex.Message}", "Error creating data base file", System.Windows.Forms.MessageBoxButtons.OK);
             }
         }
 
@@ -711,8 +711,7 @@ namespace EDDiscovery.DB
             }
             catch (Exception ex)
             {
-                MessageBox.Show("UpgradeDB error: " + ex.Message);
-                MessageBox.Show(ex.StackTrace);
+                MessageBox.Show("UpgradeDB error: " + ex.Message + Environment.NewLine + ex.StackTrace);
                 return false;
             }
         }

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1744,7 +1744,7 @@ namespace EDDiscovery.DB
         }
 
 
-        static public long ParseEDDBUpdateSystems(string filename)
+        static public long ParseEDDBUpdateSystems(string filename, Action<string> logline)
         {
             StreamReader sr = new StreamReader(filename);         // read directly from file..
 
@@ -1830,8 +1830,8 @@ namespace EDDiscovery.DB
                 }
                 catch
                 {
-                    MessageBox.Show("There is a problem using the EDDB systems file." + Environment.NewLine +
-                                    "Please perform a manual EDDB sync (see Admin menu) next time you run the program ", "EDDB Sync Error");
+                     logline("There is a problem using the EDDB systems file." + Environment.NewLine +
+                                    "Please perform a manual EDDB sync (see Admin menu) next time you run the program ");
                 }
                 finally
                 {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -295,8 +295,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                System.Windows.Forms.MessageBox.Show("EDDiscoveryForm_Load exception: " + ex.Message);
-                System.Windows.Forms.MessageBox.Show("Trace: " + ex.StackTrace);
+                System.Windows.Forms.MessageBox.Show("EDDiscoveryForm_Load exception: " + ex.Message + "\n" + "Trace: " + ex.StackTrace);
             }
         }
 
@@ -470,7 +469,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("DownloadImages exception: " + ex.Message, "ERROR", MessageBoxButtons.OK);
+                LogLineHighlight("DownloadImages exception: " + ex.Message);
                 var tcs = new TaskCompletionSource<bool>();
                 tcs.SetException(ex);
                 return tcs.Task;
@@ -601,8 +600,7 @@ namespace EDDiscovery
             ReportProgress(-1, "");
             if (e.Error != null)
             {
-                System.Windows.Forms.MessageBox.Show("Check Systems exception: " + e.Error.Message);
-                System.Windows.Forms.MessageBox.Show("Trace: " + e.Error.StackTrace);
+                LogLineHighlight("Check Systems exception: " + e.Error.Message + "\nTrace: " + e.Error.StackTrace);
             }
             else if (!e.Cancelled && !PendingClose)
             {
@@ -777,7 +775,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("GetAllEDSMSystems exception:" + ex.Message);
+                LogLineHighlight("GetAllEDSMSystems exception:" + ex.Message);
             }
 
             return (updates > 0);
@@ -798,7 +796,7 @@ namespace EDDiscovery
 
                     LogLine("Resyncing all downloaded EDDB data with local database." + Environment.NewLine + "This will take a while.");
 
-                    long number = SystemClass.ParseEDDBUpdateSystems(eddb.SystemFileName);
+                    long number = SystemClass.ParseEDDBUpdateSystems(eddb.SystemFileName, LogLineHighlight);
 
                     LogLine("Local database updated with EDDB data, " + number + " systems updated");
                     SQLiteDBClass.PutSettingString("EDDBSystemsTime", DateTime.UtcNow.Ticks.ToString());
@@ -811,7 +809,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("GetEDDBUpdate exception: " + ex.Message, "ERROR", MessageBoxButtons.OK);
+                LogLineHighlight("GetEDDBUpdate exception: " + ex.Message);
             }
         }
 
@@ -835,7 +833,7 @@ namespace EDDiscovery
                     if (filename != null)
                     {
                         LogLine("Updating all distances with EDSM distance data.");
-                        long numberx = DistanceClass.ParseEDSMUpdateDistancesFile(filename, ref lstdist, true, cancelRequested, reportProgress);
+                        long numberx = DistanceClass.ParseEDSMUpdateDistancesFile(filename, ref lstdist, true, cancelRequested, reportProgress, LogLineHighlight);
                         numbertotal += numberx;
                         SQLiteDBClass.PutSettingString("EDSCLastDist", lstdist);
                         LogLine("Local database updated with EDSM Distance data, " + numberx + " distances updated.");
@@ -856,7 +854,7 @@ namespace EDDiscovery
                         LogLine("No response from EDSM Distance server.");
                     else
                     {
-                        long number = DistanceClass.ParseEDSMUpdateDistancesString(json, ref lstdist, false, cancelRequested, reportProgress);
+                        long number = DistanceClass.ParseEDSMUpdateDistancesString(json, ref lstdist, false, cancelRequested, reportProgress, LogLineHighlight);
                         numbertotal += number;
                     }
                 }
@@ -888,7 +886,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("GetEDSMDistances exception: " + ex.Message, "ERROR", MessageBoxButtons.OK);
+                LogLineHighlight("GetEDSMDistances exception: " + ex.Message);
             }
 
             return (numbertotal != 0);
@@ -1021,6 +1019,7 @@ namespace EDDiscovery
         {
             try
             {
+                Trace.WriteLine(text);
                 Invoke((MethodInvoker)delegate
                 {
                     travelHistoryControl1.LogTextHighlight(text + Environment.NewLine);

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -107,7 +107,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("GetNetLogPath exception: " + ex.Message);
+                Trace.WriteLine("GetNetLogPath exception: " + ex.Message);
                 return null;
             }
         }
@@ -303,7 +303,6 @@ namespace EDDiscovery
                 }
                 catch (Exception ex)
                 {
-                    System.Windows.Forms.MessageBox.Show("Start Monitor exception : " + ex.Message, "EDDiscovery Error");
                     System.Diagnostics.Trace.WriteLine("Start Monitor exception : " + ex.Message);
                     System.Diagnostics.Trace.WriteLine(ex.StackTrace);
                 }


### PR DESCRIPTION
MessageBox.Show should only be used for fatal errors or messages resulting directly from user input, not for errors in background processing.