### PR TITLE
Fix issue with summary panel being closed via the user taskbar, and race conditions

### DIFF
--- a/EDDiscovery/Forms/SummaryPopOut.Designer.cs
+++ b/EDDiscovery/Forms/SummaryPopOut.Designer.cs
@@ -38,10 +38,10 @@
             this.showNotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showXYZToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showTargetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.blackBoxAroundTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripComboBoxOrder = new System.Windows.Forms.ToolStripComboBox();
             this.labelExt_NoSystems = new ExtendedControls.LabelExt();
             this.panel_grip = new ExtendedControls.DrawnPanel();
-            this.blackBoxAroundTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStripConfig.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -58,7 +58,7 @@
             this.blackBoxAroundTextToolStripMenuItem,
             this.toolStripComboBoxOrder});
             this.contextMenuStripConfig.Name = "contextMenuStripConfig";
-            this.contextMenuStripConfig.Size = new System.Drawing.Size(261, 229);
+            this.contextMenuStripConfig.Size = new System.Drawing.Size(261, 207);
             // 
             // toolStripMenuItemTargetLine
             // 
@@ -130,6 +130,16 @@
             this.showTargetToolStripMenuItem.Text = "Show Target Distance per Star";
             this.showTargetToolStripMenuItem.Click += new System.EventHandler(this.showTargetPerStarToolStripMenuItem_Click);
             // 
+            // blackBoxAroundTextToolStripMenuItem
+            // 
+            this.blackBoxAroundTextToolStripMenuItem.Checked = true;
+            this.blackBoxAroundTextToolStripMenuItem.CheckOnClick = true;
+            this.blackBoxAroundTextToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.blackBoxAroundTextToolStripMenuItem.Name = "blackBoxAroundTextToolStripMenuItem";
+            this.blackBoxAroundTextToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
+            this.blackBoxAroundTextToolStripMenuItem.Text = "Black box around text";
+            this.blackBoxAroundTextToolStripMenuItem.Click += new System.EventHandler(this.blackBoxAroundTextToolStripMenuItem_Click);
+            // 
             // toolStripComboBoxOrder
             // 
             this.toolStripComboBoxOrder.Items.AddRange(new object[] {
@@ -166,16 +176,6 @@
             this.panel_grip.Size = new System.Drawing.Size(20, 20);
             this.panel_grip.TabIndex = 17;
             this.panel_grip.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel_grip_MouseDown);
-            // 
-            // blackBoxAroundTextToolStripMenuItem
-            // 
-            this.blackBoxAroundTextToolStripMenuItem.Checked = true;
-            this.blackBoxAroundTextToolStripMenuItem.CheckOnClick = true;
-            this.blackBoxAroundTextToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.blackBoxAroundTextToolStripMenuItem.Name = "blackBoxAroundTextToolStripMenuItem";
-            this.blackBoxAroundTextToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
-            this.blackBoxAroundTextToolStripMenuItem.Text = "Black box around text";
-            this.blackBoxAroundTextToolStripMenuItem.Click += new System.EventHandler(this.blackBoxAroundTextToolStripMenuItem_Click);
             // 
             // SummaryPopOut
             // 

--- a/EDDiscovery/Forms/SummaryPopOut.cs
+++ b/EDDiscovery/Forms/SummaryPopOut.cs
@@ -29,6 +29,7 @@ namespace EDDiscovery2
             return message.Result;
         }
 
+        public bool IsFormClosed { get; set; } = false;
         private Color transparentkey = Color.Red;
         private Timer autofade = new Timer();
         private ControlTable lt;
@@ -297,8 +298,11 @@ namespace EDDiscovery2
             }
         }
 
+
         private void SummaryPopOut_FormClosing(object sender, FormClosingEventArgs e)
         {
+            IsFormClosed = true;
+
             SQLiteDBClass.PutSettingInt("PopOutFormWidth", this.Width);
             SQLiteDBClass.PutSettingInt("PopOutFormHeight", this.Height);
             SQLiteDBClass.PutSettingInt("PopOutFormTop", this.Top);

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -1166,36 +1166,39 @@ namespace EDDiscovery
                 toolTipEddb.SetToolTip(textBoxTarget, "On 3D Map right click to make a bookmark, region mark or click on a notemark and then tick on Set Target, or type it here and hit enter");
             }
 
-            if (summaryPopOut != null)
+            if (IsSummaryPopOutReady)
                 summaryPopOut.RefreshTarget(dataGridViewTravel,visitedSystems);
         }
 
-        #endregion 
+        #endregion
 
         #region Summary Pop out
+        
+        public bool IsSummaryPopOutReady { get { return summaryPopOut != null && !summaryPopOut.IsFormClosed; } }
 
-        public bool IsSummaryPopOutOn {  get { return summaryPopOut != null; } }
         public bool ToggleSummaryPopOut()
         {
-            if (summaryPopOut == null )
+            if (summaryPopOut == null || summaryPopOut.IsFormClosed)
             {
-                summaryPopOut = new SummaryPopOut();
-                summaryPopOut.RequiresRefresh += SummaryRefreshRequested;
-                RedrawSummary();
-                summaryPopOut.Show();
+                SummaryPopOut p = new SummaryPopOut();
+                p.RequiresRefresh += SummaryRefreshRequested;
+                p.SetGripperColour(_discoveryForm.theme.LabelColor);
+                p.ResetForm(dataGridViewTravel);
+                p.RefreshTarget(dataGridViewTravel, visitedSystems); 
+                p.Show();
+                summaryPopOut = p;          // do it like this in case of race conditions 
+                return true;
             }
             else
             { 
-                summaryPopOut.Close();
-                summaryPopOut = null;
+                summaryPopOut.Close();      // there is no point null it, as if the user closes it, it never gets the chance to be nulled
+                return false;
             }
-
-            return (summaryPopOut != null);     // on screen?
         }
 
         public void RedrawSummary()
         {
-            if (summaryPopOut != null)
+            if (IsSummaryPopOutReady)
             {
                 summaryPopOut.SetGripperColour(_discoveryForm.theme.LabelColor);
                 summaryPopOut.ResetForm(dataGridViewTravel);
@@ -1210,7 +1213,7 @@ namespace EDDiscovery
 
         public void RefreshSummaryRow(DataGridViewRow row , bool add = false )
         {
-            if (summaryPopOut != null)
+            if (IsSummaryPopOutReady)
                 summaryPopOut.RefreshRow(dataGridViewTravel, row, add);
         }
 


### PR DESCRIPTION
If the user closes it, we don't get any knowledge via the variable, so
cock up
If another entry comes in, we call the non null variable and crash

Change the logic around. Add a summary form closed variable, and test it
in the main code