### PR TITLE
Speed up a few system aggregate queries

### DIFF
--- a/EDDiscovery/3DMap/StarGrid.cs
+++ b/EDDiscovery/3DMap/StarGrid.cs
@@ -393,7 +393,7 @@ namespace EDDiscovery2
             populatedgrid.dBAsk = SystemClass.SystemAskType.PopulatedStars;
             grids.Add(populatedgrid);   // add last so shown last
 
-            long total = SystemClass.GetTotalSystems();
+            long total = SystemClass.GetTotalSystemsFast();
 
             total = Math.Min(total, 10000000);                  // scaling limit at 10mil
             long offset = (total - 1000000) / 100000;           // scale down slowly.. experimental!

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -566,7 +566,7 @@ namespace EDDiscovery
                 galacticMapping.DownloadFromEDSM();
 
                 // Skip EDSM full update if update has been performed in last 4 days
-                if (DateTime.UtcNow.Subtract(SystemClass.GetLastSystemModifiedTime()).TotalDays > 4 ||
+                if (DateTime.UtcNow.Subtract(SystemClass.GetLastSystemModifiedTimeFast()).TotalDays > 4 ||
                     DateTime.UtcNow.Subtract(edsmdate).TotalDays > 28)
                 {
                     performedsmsync = true;
@@ -904,10 +904,10 @@ namespace EDDiscovery
         private void PerformSync(Func<bool> cancelRequested, Action<int, string> reportProgress)           // big check.. done in a thread.
         {
             reportProgress(-1, "");
-            syncwasfirstrun = SystemClass.GetTotalSystems() == 0;                 // remember if DB is empty
+            syncwasfirstrun = SystemClass.IsSystemsTableEmpty();                 // remember if DB is empty
 
             // Force a full sync if newest data is more than 14 days old
-            if (DateTime.UtcNow.Subtract(SystemClass.GetLastSystemModifiedTime()).TotalDays >= 14)
+            if (DateTime.UtcNow.Subtract(SystemClass.GetLastSystemModifiedTimeFast()).TotalDays >= 14)
             {
                 performedsmsync = true;
             }

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -189,14 +189,14 @@ namespace EDDiscovery2.EDSM
             // First system in EDSM is from 2015-05-01 00:39:40
             DateTime gammadate = new DateTime(2015, 5, 1, 0, 0, 0, DateTimeKind.Utc);
 
-            if (SystemClass.GetTotalSystems() == 0)
+            if (SystemClass.IsSystemsTableEmpty())
             {
                 lstsystdate = gammadate;
             }
             else
             {
                 // Get the most recent modify time returned from EDSM
-                lstsystdate = SystemClass.GetLastSystemModifiedTime() - TimeSpan.FromSeconds(1);
+                lstsystdate = SystemClass.GetLastSystemModifiedTimeFast() - TimeSpan.FromSeconds(1);
 
                 if (lstsystdate < gammadate)
                 {


### PR DESCRIPTION
* ~~Data dumps are sorted by last modify time ascending, so
  the last row should be the most recently modified~~  This is only true immediately after a full sync, though should come close as most of the systems coming in will be new systems rather than modified systems, and the EDSM API orders systems chronologically when `startDateTime` and `endDateTime` are used.
* Only recently-hidden systems in EDSM are deleted from the
  EdsmSystems table, so the maximum ID should be very close
  to the total system count
* Determine if the systems table is empty by checking if there
  is a first row rather than counting the total number of rows