### PR TITLE
Remove all references to VisitedSystemsClass

### DIFF
--- a/EDDiscovery/DB/DistanceClass.cs
+++ b/EDDiscovery/DB/DistanceClass.cs
@@ -297,6 +297,7 @@ namespace EDDiscovery.DB
             return ldist;
         }
 
+        /*
         public static void FillVisitedSystems(List<VisitedSystemsClass> visitedSystems, bool usedb)
         {
             try
@@ -340,7 +341,7 @@ namespace EDDiscovery.DB
                 System.Diagnostics.Trace.WriteLine(ex.StackTrace);
             }
         }
-
+        */
 
         public static long ParseEDSMUpdateDistancesString(string json, ref string date, bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress, Action<string> logline)
         {

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -394,13 +394,11 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="DB\SavedRouteClass.cs" />
-    <Compile Include="DB\InMemory\VisitedSystemsClass.cs" />
     <Compile Include="DB\ISystem.cs" />
     <Compile Include="DB\InMemory\SystemClass.cs" />
     <Compile Include="DB\IVisitedSystems.cs" />
     <Compile Include="DB\StationClass.cs" />
     <Compile Include="DB\TravelLogUnit.cs" />
-    <Compile Include="DB\VisitedSystemsClass.cs" />
     <Compile Include="DB\WantedSystemClass.cs" />
     <Compile Include="EDDB\Commodity.cs" />
     <Compile Include="EDDB\EDDBClass.cs" />

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1669,7 +1669,7 @@ namespace EDDiscovery
             journalViewControl1.Display();
         }
 
-
+        /*
         public void NewPosition(VisitedSystemsClass v)
         {
             Debug.Assert(Application.MessageLoop);              // ensure.. paranoia
@@ -1681,6 +1681,7 @@ namespace EDDiscovery
             travelHistoryControl1.AddNewEntry(he);
             journalViewControl1.AddNewEntry(he);
         }
+        */
 
 #endregion
 

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -426,7 +426,7 @@ namespace EDDiscovery.EliteDangerous
 
             using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
             {
-                using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE TravelLog = @source ORDER BY Time ASC"))
+                using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE TravelLogId = @source ORDER BY Time ASC"))
                 {
                     cmd.AddParameterWithValue("@source", tluid);
                     using (DbDataReader reader = cmd.ExecuteReader())
@@ -441,6 +441,31 @@ namespace EDDiscovery.EliteDangerous
             return vsc;
         }
 
+        public static T GetLast<T>(int cmdrid, DateTime before)
+            where T : JournalEntry
+        {
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+            {
+                using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE CommanderId = @cmdrid AND Time < @time ORDER BY Time DESC"))
+                {
+                    cmd.AddParameterWithValue("@cmdrid", cmdrid);
+                    cmd.AddParameterWithValue("@time", before);
+                    using (DbDataReader reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            JournalEntry ent = CreateJournalEntry(reader);
+                            if (ent is T)
+                            {
+                                return (T)ent;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
 
 
         static public JournalEntry CreateJournalEntry(string text)

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -35,7 +35,7 @@ namespace EDDiscovery
 
         public bool IsFSDJump { get { return EntryType == EliteDangerous.JournalTypeEnum.FSDJump; } }
 
-        public void MakeVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info)
+        public void MakeVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info, int journalid = 0)
         {
             Debug.Assert(sys != null);
             EntryType = EliteDangerous.JournalTypeEnum.FSDJump;
@@ -45,14 +45,47 @@ namespace EDDiscovery
             EventDescription = dist;
             EventDetailedInfo = info;
             MapColour = m;
-            Journalid = 0;
+            Journalid = journalid;
             EdsmSync = true; // TBD for now
+        }
+
+        public static HistoryEntry FromVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info, int journalid = 0)
+        {
+            Debug.Assert(sys != null);
+            return new HistoryEntry
+            {
+                EntryType = EliteDangerous.JournalTypeEnum.FSDJump,
+                System = sys,
+                EventTime = eventt,
+                EventSummary = "Jump to " + sys.name,
+                EventDescription = dist,
+                EventDetailedInfo = info,
+                MapColour = m,
+                Journalid = journalid,
+                EdsmSync = true // TBD for now
+            };
         }
 
         public void MakeJournalEntry(EliteDangerous.JournalTypeEnum type, long id , ISystem sys, DateTime eventt, string summary , string descr, string info, int m, bool edss)
         {
             EntryType = type; Journalid = id; System = sys; EventTime = eventt; EventSummary = summary; EventDescription = descr; EventDetailedInfo = info;
             MapColour = m; EdsmSync = edss;
+        }
+
+        public static HistoryEntry FromJournalEntry(EliteDangerous.JournalTypeEnum type, long id, ISystem sys, DateTime eventt, string summary, string descr, string info, int m, bool edss)
+        {
+            return new HistoryEntry
+            {
+                EntryType = type,
+                Journalid = id,
+                System = sys,
+                EventTime = eventt,
+                EventSummary = summary,
+                EventDescription = descr,
+                EventDetailedInfo = info,
+                MapColour = m,
+                EdsmSync = edss
+            };
         }
 
         public System.Drawing.Bitmap GetIcon


### PR DESCRIPTION
* Return JournalLocOrJump entries from NetLogClass
* Comment out any other (now unused) references to VisitedSystemsClass
* Remove VisitedSystemsClass from the compilation sources
* Add helper function to allow parsing logs from an arbitrary directory