### PR TITLE
Better command-line handling; better error reporting (v4.3)

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -261,18 +261,19 @@ namespace EDDiscovery
 
         private void ProcessCommandLineOptions()
         {
-            string cmdline = Environment.CommandLine;
-            option_nowindowreposition = (cmdline.IndexOf("-NoRepositionWindow", 0, StringComparison.InvariantCultureIgnoreCase) != -1 || cmdline.IndexOf("-NRW", 0, StringComparison.InvariantCultureIgnoreCase) != -1);
+            //string cmdline = Environment.CommandLine;
+            List<string> parts = Environment.GetCommandLineArgs().ToList();
 
-            int pos = cmdline.IndexOf("-Appfolder", 0, StringComparison.InvariantCultureIgnoreCase);
-            if ( pos != -1 )
+            option_nowindowreposition = parts.FindIndex(x => x.Equals("-NoRepositionWindow", StringComparison.InvariantCultureIgnoreCase)) != -1 ||
+                                        parts.FindIndex(x => x.Equals("-NRW", StringComparison.InvariantCultureIgnoreCase)) != -1;
+
+            int ai = parts.FindIndex(x => x.Equals("-Appfolder", StringComparison.InvariantCultureIgnoreCase));
+            if (ai != -1 && ai < parts.Count - 1)
             {
-                string[] nextwords = cmdline.Substring(pos + 10).Trim().Split(' ');
-                if (nextwords.Length > 0)
-                    Tools.appfolder = nextwords[0];
+                Tools.appfolder = parts[ai + 1];
             }
 
-            option_debugoptions = cmdline.IndexOf("-Debug", 0, StringComparison.InvariantCultureIgnoreCase) != -1;
+            option_debugoptions = parts.FindIndex(x => x.Equals("-Debug", StringComparison.InvariantCultureIgnoreCase)) != -1;
         }
 
         private void EDDiscoveryForm_Load(object sender, EventArgs e)

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -598,13 +598,16 @@ namespace EDDiscovery
 
         private void _checkSystemsWorker_RunWorkerCompleted(object sender, System.ComponentModel.RunWorkerCompletedEventArgs e)
         {
+            Exception ex = e.Cancelled ? null : e.Error;
             ReportProgress(-1, "");
-            if (e.Error != null)
+            if (!e.Cancelled && !PendingClose)
             {
-                LogLineHighlight("Check Systems exception: " + e.Error.Message + "\nTrace: " + e.Error.StackTrace);
-            }
-            else if (!e.Cancelled && !PendingClose)
-            {
+                if (ex != null)
+                {
+                    LogLineHighlight("Check Systems exception: " + ex.Message + Environment.NewLine + "Trace: " + ex.StackTrace);
+                    return;
+                }
+
                 Console.WriteLine("Systems Loaded");                    // in the worker thread they were, now in UI
 
                 routeControl1.textBox_From.AutoCompleteCustomSource = SystemNames;
@@ -966,11 +969,21 @@ namespace EDDiscovery
 
         private void _syncWorker_RunWorkerCompleted(object sender, System.ComponentModel.RunWorkerCompletedEventArgs e)
         {
-            long totalsystems = SystemClass.GetTotalSystems();
-            LogLineSuccess("Loading completed, total of " + totalsystems + " systems");
+            Exception ex = e.Cancelled ? null : e.Error;
+            if (!e.Cancelled && !PendingClose)
+            {
+                if (ex != null)
+                {
+                    LogLineHighlight("System Sync exception: " + ex.Message + Environment.NewLine + "Trace: " + ex.StackTrace);
+                    return;
+                }
 
-            travelHistoryControl1.HistoryRefreshed += TravelHistoryControl1_HistoryRefreshed;
-            travelHistoryControl1.RefreshHistoryAsync();
+                long totalsystems = SystemClass.GetTotalSystems();
+                LogLineSuccess("Loading completed, total of " + totalsystems + " systems");
+
+                travelHistoryControl1.HistoryRefreshed += TravelHistoryControl1_HistoryRefreshed;
+                travelHistoryControl1.RefreshHistoryAsync();
+            }
         }
 
         private void TravelHistoryControl1_HistoryRefreshed(object sender, EventArgs e)

--- a/EDDiscovery/Tools.cs
+++ b/EDDiscovery/Tools.cs
@@ -106,30 +106,31 @@ namespace EDDiscovery
             }
         }
 
-        public static string appfolder = "EDDiscovery";
+        public static string appfolder = (System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true" ? "Data" : "EDDiscovery");
 
         static internal string GetAppDataDirectory()
         {
             try
             {
-                if (appfolder == "EDDiscovery" && System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true")
+                string datapath;
+
+                if (Path.IsPathRooted(appfolder))
                 {
-                    return Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Data");
+                    datapath = appfolder;
                 }
-                else if (Path.IsPathRooted(appfolder))
+                else if (System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true")
                 {
-                    return appfolder;
+                    datapath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, appfolder);
                 }
                 else
                 {
-                    string datapath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appfolder) + Path.DirectorySeparatorChar;
-
-                    if (!Directory.Exists(datapath))
-                        Directory.CreateDirectory(datapath);
-
-
-                    return datapath;
+                    datapath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appfolder) + Path.DirectorySeparatorChar;
                 }
+
+                if (!Directory.Exists(datapath))
+                    Directory.CreateDirectory(datapath);
+
+                return datapath;
             }
             catch (Exception ex)
             {

--- a/EDDiscovery/Tools.cs
+++ b/EDDiscovery/Tools.cs
@@ -112,9 +112,13 @@ namespace EDDiscovery
         {
             try
             {
-                if (System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true")
+                if (appfolder == "EDDiscovery" && System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true")
                 {
                     return Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Data");
+                }
+                else if (Path.IsPathRooted(appfolder))
+                {
+                    return appfolder;
                 }
                 else
                 {

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -189,10 +189,12 @@ namespace EDDiscovery
 
             if (errmsg != null)
             {
-                throw new InvalidOperationException(errmsg);
+                e.Result = errmsg;
             }
-
-            e.Result = vsclist;
+            else
+            {
+                e.Result = vsclist;
+            }
         }
 
         private void RefreshHistoryWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
@@ -201,14 +203,23 @@ namespace EDDiscovery
             {
                 if (e.Error != null)
                 {
-                    LogTextHighlight("History Refresh Error: " + e.Error.Message + Environment.NewLine);
+                    LogTextHighlight("History Refresh Error: " + e.Error.Message);
                 }
                 else if (e.Result != null)
                 {
-                    RefreshHistory((List<VisitedSystemsClass>)e.Result);
+                    if (e.Result is string)
+                    {
+                        LogTextHighlight("History Refresh Error: " + (string)e.Result);
+                    }
+                    else if (e.Result is List<VisitedSystemsClass>)
+                    {
+                        RefreshHistory((List<VisitedSystemsClass>)e.Result);
+                    }
+
                     _discoveryForm.ReportProgress(-1, "");
-                    LogText("Refresh Complete." + Environment.NewLine);
+                    LogText("Refresh Complete.");
                 }
+
                 button_RefreshHistory.Enabled = true;
 
                 netlog.StartMonitor();


### PR DESCRIPTION
* Use the inbuilt command-line splitting in `Enviroment.GetCommandLineArgs()`
* Allow an absolute path to be specified to the `-appfolder` command-line argument
* Allow the `StoreDataInProgramDirectory` setting to be overridden by the `-appfolder` command-line argument
* Improve the background worker error reporting