### PR TITLE
Command-line and error-reporting improvements

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -570,7 +570,7 @@ namespace EDDiscovery
                 if (worker.CancellationPending)
                     e.Cancel = true;
             }
-            catch { }       // any exceptions, ignore
+            catch (Exception ex) { e.Result = ex; }       // any exceptions, ignore
             finally
             {
                 _checkSystemsWorkerCompletedEvent.Set();
@@ -634,13 +634,15 @@ namespace EDDiscovery
 
         private void _checkSystemsWorker_RunWorkerCompleted(object sender, System.ComponentModel.RunWorkerCompletedEventArgs e)
         {
+            Exception ex = e.Cancelled ? null : (e.Error ?? e.Result as Exception);
             ReportProgress(-1, "");
-            if (e.Error != null)
+            if (!e.Cancelled && !PendingClose)
             {
-                travelHistoryControl1.LogLineHighlight("Check Systems exception: " + e.Error.Message + "\nTrace: " + e.Error.StackTrace);
-            }
-            else if (!e.Cancelled && !PendingClose)
-            {
+                if (ex != null)
+                {
+                    travelHistoryControl1.LogLineHighlight("Check Systems exception: " + ex.Message + Environment.NewLine + "Trace: " + ex.StackTrace);
+                }
+
                 Console.WriteLine("Systems Loaded");                    // in the worker thread they were, now in UI
 
                 imageHandler1.StartWatcher();
@@ -719,7 +721,7 @@ namespace EDDiscovery
                 if (worker.CancellationPending)
                     e.Cancel = true;
             }
-            catch { }       // ignore any excepctions
+            catch (Exception ex) { e.Result = ex; }       // ignore any excepctions
             finally
             {
                 _syncWorkerCompletedEvent.Set();
@@ -795,19 +797,28 @@ namespace EDDiscovery
 
         private void _syncWorker_RunWorkerCompleted(object sender, System.ComponentModel.RunWorkerCompletedEventArgs e)
         {
-            long totalsystems = SystemClass.GetTotalSystems();
-            travelHistoryControl1.LogLineSuccess("Loading completed, total of " + totalsystems + " systems");
-
+            Exception ex = e.Cancelled ? null : (e.Error ?? e.Result as Exception);
             ReportProgress(-1, "");
 
-            if (performhistoryrefresh)
+            if (!e.Cancelled && !PendingClose)
             {
-                travelHistoryControl1.LogLine("Update visited systems due to update");
-                HistoryRefreshed += TravelHistoryControl1_HistoryRefreshed;
-                RefreshHistoryAsync();
-            }
+                if (ex != null)
+                {
+                    travelHistoryControl1.LogLineHighlight("Check Systems exception: " + ex.Message + Environment.NewLine + "Trace: " + ex.StackTrace);
+                }
 
-            edsmRefreshTimer.Enabled = true;
+                long totalsystems = SystemClass.GetTotalSystems();
+                travelHistoryControl1.LogLineSuccess("Loading completed, total of " + totalsystems + " systems");
+
+                if (performhistoryrefresh)
+                {
+                    travelHistoryControl1.LogLine("Update visited systems due to update");
+                    HistoryRefreshed += TravelHistoryControl1_HistoryRefreshed;
+                    RefreshHistoryAsync();
+                }
+
+                edsmRefreshTimer.Enabled = true;
+            }
         }
 
         private void TravelHistoryControl1_HistoryRefreshed(object sender, EventArgs e)

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -281,19 +281,15 @@ namespace EDDiscovery
 
         private void ProcessCommandLineOptions()
         {
-            string cmdline = Environment.CommandLine;
-            List<string> parts = Regex.Matches(cmdline, @"[\""].+?[\""]|[^ ]+")
-                            .Cast<Match>()
-                            .Select(m => m.Value)
-                            .ToList();
+            List<string> parts = Environment.GetCommandLineArgs().ToList();
 
             option_nowindowreposition = parts.FindIndex(x => x.Equals("-NoRepositionWindow", StringComparison.InvariantCultureIgnoreCase)) != -1 ||
                 parts.FindIndex(x => x.Equals("-NRW", StringComparison.InvariantCultureIgnoreCase)) != -1;
 
             int ai = parts.FindIndex(x => x.Equals("-Appfolder", StringComparison.InvariantCultureIgnoreCase));
-            if ( ai != -1 && ai < parts.Count )
+            if ( ai != -1 && ai < parts.Count - 1)
             {
-                Tools.appfolder = parts[ai + 1].Replace("\"","");
+                Tools.appfolder = parts[ai + 1];
             }
 
             option_debugoptions = parts.FindIndex(x => x.Equals("-Debug", StringComparison.InvariantCultureIgnoreCase)) != -1;

--- a/EDDiscovery/Tools.cs
+++ b/EDDiscovery/Tools.cs
@@ -107,30 +107,31 @@ namespace EDDiscovery
             }
         }
 
-        public static string appfolder = "EDDiscovery";
+        public static string appfolder = (System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true" ? "Data" : "EDDiscovery");
 
         static internal string GetAppDataDirectory()
         {
             try
             {
-                if (System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true")
+                string datapath;
+
+                if (Path.IsPathRooted(appfolder))
                 {
-                    return Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Data");
+                    datapath = appfolder;
                 }
-                else if ( appfolder.Contains(":") || appfolder.Contains("\\"))
+                else if (System.Configuration.ConfigurationManager.AppSettings["StoreDataInProgramDirectory"] == "true")
                 {
-                    return appfolder;
+                    datapath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, appfolder);
                 }
                 else
                 {
-                    string datapath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appfolder) + Path.DirectorySeparatorChar;
-
-                    if (!Directory.Exists(datapath))
-                        Directory.CreateDirectory(datapath);
-
-
-                    return datapath;
+                    datapath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appfolder) + Path.DirectorySeparatorChar;
                 }
+
+                if (!Directory.Exists(datapath))
+                    Directory.CreateDirectory(datapath);
+
+                return datapath;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
* Use Environment.GetCommandLineArgs() to get command line arguments
* Allow the data directory to be overridden when `StoreDataInProgramDirectory` is set
* Use `Path.IsPathRooted` to determine if the path is absolute
* Improve background worker error reporting