### PR TITLE
Rewrite Config Commander system due to thread problems, and allow multiple scanning of folders

### DIFF
--- a/EDDiscovery/EliteDangerous/EDJournalReader.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalReader.cs
@@ -18,10 +18,6 @@ namespace EDDiscovery.EliteDangerous
         public TimeZoneInfo TimeZone { get; set; }
         public TimeSpan TimeZoneOffset { get; set; }
 
-        // Commander
-        //protected EDCommander _commander;
-        //public EDCommander Commander { get { return _commander; } set { _commander = value; } }
-
         // Journal ID
         public int JournalId { get { return (int)TravelLogUnit.id; } }
 
@@ -35,12 +31,12 @@ namespace EDDiscovery.EliteDangerous
 
         public bool ReadJournalLog(out JournalEntry je)
         {
-            int cmdrid = -1;
+            int cmdrid = -2;        //-1 is hidden, -2 is never shown
 
             if (TravelLogUnit.CommanderId.HasValue)
             {
                 cmdrid = TravelLogUnit.CommanderId.Value;
-                System.Diagnostics.Trace.WriteLine(string.Format("TLU says commander {0} ", cmdrid));
+               // System.Diagnostics.Trace.WriteLine(string.Format("TLU says commander {0} at {1}", cmdrid, TravelLogUnit.Name));
             }
 
             string line;
@@ -72,7 +68,7 @@ namespace EDDiscovery.EliteDangerous
                             newname = "[BETA] " + newname;
                         }
 
-                        EDCommander _commander = EDDiscovery2.EDDConfig.Instance.listCommanders.FirstOrDefault(c => c.Name.Equals(newname, StringComparison.InvariantCultureIgnoreCase));
+                        EDCommander _commander = EDDiscovery2.EDDConfig.Instance.ListOfCommanders.FirstOrDefault(c => c.Name.Equals(newname, StringComparison.InvariantCultureIgnoreCase));
 
                         if (_commander == null)
                             _commander = EDDiscovery2.EDDConfig.Instance.GetNewCommander(newname,null,(cmdrid>=0) ? EDDConfig.Instance.Commander(cmdrid).NetLogDir : null);

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -480,6 +480,20 @@ namespace EDDiscovery.EliteDangerous
             }
         }
 
+        public static void UpdateCommanderID(long journalid, int cmdrid)
+        {
+            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            {
+                using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set CommanderID = @cmdrid where ID=@journalid"))
+                {
+                    cmd.AddParameterWithValue("@journalid", journalid);
+                    cmd.AddParameterWithValue("@cmdrid", cmdrid);
+                    System.Diagnostics.Trace.WriteLine(string.Format("Update cmdr id ID {0} with map colour", journalid));
+                    SQLiteDBClass.SQLNonQueryText(cn, cmd);
+                }
+            }
+        }
+
         static public List<JournalEntry> GetAll(int commander = -999)
         {
             List<JournalEntry> list = new List<JournalEntry>();

--- a/EDDiscovery/Forms/MoveToCommander.cs
+++ b/EDDiscovery/Forms/MoveToCommander.cs
@@ -33,12 +33,11 @@ namespace EDDiscovery2
 
         private void MoveToCommander_Load(object sender, EventArgs e)
         {
-            BindingList<EDCommander>  commanders = EDDiscovery.EDDiscoveryForm.EDDConfig.listCommanders;
+            List<EDCommander>  commanders = EDDiscovery.EDDiscoveryForm.EDDConfig.ListOfCommanders;
 
             comboBoxCommanders.DataSource = commanders;
             comboBoxCommanders.DisplayMember = "Name";
             comboBoxCommanders.ValueMember = "Nr";
-
         }
 
         private void comboBoxCommanders_SelectedIndexChanged(object sender, EventArgs e)

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -142,9 +142,9 @@ namespace EDDiscovery
 
         public bool UpdateCommanderID(int v)
         {
-            //TBD how do we do this..
             if (Journalid != 0)
             {
+                EliteDangerous.JournalEntry.UpdateCommanderID(Journalid, v);
             }
             return false;
         }

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -30,11 +30,6 @@
         {
             this.components = new System.ComponentModel.Container();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.groupBox1 = new ExtendedControls.GroupBoxCustom();
-            this.button_Browse = new ExtendedControls.ButtonExt();
-            this.textBoxNetLogDir = new ExtendedControls.TextBoxBorder();
-            this.radioButton_Manual = new ExtendedControls.RadioButtonCustom();
-            this.radioButton_Auto = new ExtendedControls.RadioButtonCustom();
             this.groupBoxTheme = new ExtendedControls.GroupBoxCustom();
             this.checkBoxKeepOnTop = new ExtendedControls.CheckBoxCustom();
             this.comboBoxTheme = new ExtendedControls.ComboBoxCustom();
@@ -65,92 +60,13 @@
             this.ColumnCommander = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnEDSMAPIKey = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnNetLogDir = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.groupBox1.SuspendLayout();
+            this.label1 = new System.Windows.Forms.Label();
             this.groupBoxTheme.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewCommanders)).BeginInit();
             this.SuspendLayout();
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.AlternateClientBackColor = System.Drawing.Color.Blue;
-            this.groupBox1.BackColorScaling = 0.5F;
-            this.groupBox1.BorderColor = System.Drawing.Color.LightGray;
-            this.groupBox1.BorderColorScaling = 0.5F;
-            this.groupBox1.Controls.Add(this.button_Browse);
-            this.groupBox1.Controls.Add(this.textBoxNetLogDir);
-            this.groupBox1.Controls.Add(this.radioButton_Manual);
-            this.groupBox1.Controls.Add(this.radioButton_Auto);
-            this.groupBox1.FillClientAreaWithAlternateColor = false;
-            this.groupBox1.Location = new System.Drawing.Point(0, 3);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(819, 87);
-            this.groupBox1.TabIndex = 19;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Elite Dangerous Journal location (Set to manual to use folder below or commander " +
-    "specific journal path)";
-            this.groupBox1.TextPadding = 0;
-            this.groupBox1.TextStartPosition = -1;
-            // 
-            // button_Browse
-            // 
-            this.button_Browse.BorderColorScaling = 1.25F;
-            this.button_Browse.ButtonColorScaling = 0.5F;
-            this.button_Browse.ButtonDisabledScaling = 0.5F;
-            this.button_Browse.Location = new System.Drawing.Point(728, 46);
-            this.button_Browse.Name = "button_Browse";
-            this.button_Browse.Size = new System.Drawing.Size(75, 23);
-            this.button_Browse.TabIndex = 3;
-            this.button_Browse.Text = "Browse";
-            this.button_Browse.UseVisualStyleBackColor = true;
-            this.button_Browse.Click += new System.EventHandler(this.button_Browse_Click);
-            // 
-            // textBoxNetLogDir
-            // 
-            this.textBoxNetLogDir.BorderColor = System.Drawing.Color.Transparent;
-            this.textBoxNetLogDir.BorderColorScaling = 0.5F;
-            this.textBoxNetLogDir.Location = new System.Drawing.Point(97, 48);
-            this.textBoxNetLogDir.Name = "textBoxNetLogDir";
-            this.textBoxNetLogDir.Size = new System.Drawing.Size(623, 20);
-            this.textBoxNetLogDir.TabIndex = 2;
-            this.textBoxNetLogDir.Validated += new System.EventHandler(this.textBoxNetLogDir_Validated);
-            // 
-            // radioButton_Manual
-            // 
-            this.radioButton_Manual.AutoSize = true;
-            this.radioButton_Manual.FontNerfReduction = 0.5F;
-            this.radioButton_Manual.Location = new System.Drawing.Point(17, 49);
-            this.radioButton_Manual.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.radioButton_Manual.Name = "radioButton_Manual";
-            this.radioButton_Manual.RadioButtonColor = System.Drawing.Color.Gray;
-            this.radioButton_Manual.RadioButtonInnerColor = System.Drawing.Color.White;
-            this.radioButton_Manual.SelectedColor = System.Drawing.Color.DarkBlue;
-            this.radioButton_Manual.SelectedColorRing = System.Drawing.Color.Black;
-            this.radioButton_Manual.Size = new System.Drawing.Size(60, 17);
-            this.radioButton_Manual.TabIndex = 1;
-            this.radioButton_Manual.TabStop = true;
-            this.radioButton_Manual.Text = "Manual";
-            this.radioButton_Manual.UseVisualStyleBackColor = true;
-            // 
-            // radioButton_Auto
-            // 
-            this.radioButton_Auto.AutoSize = true;
-            this.radioButton_Auto.FontNerfReduction = 0.5F;
-            this.radioButton_Auto.Location = new System.Drawing.Point(17, 26);
-            this.radioButton_Auto.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.radioButton_Auto.Name = "radioButton_Auto";
-            this.radioButton_Auto.RadioButtonColor = System.Drawing.Color.Gray;
-            this.radioButton_Auto.RadioButtonInnerColor = System.Drawing.Color.White;
-            this.radioButton_Auto.SelectedColor = System.Drawing.Color.DarkBlue;
-            this.radioButton_Auto.SelectedColorRing = System.Drawing.Color.Black;
-            this.radioButton_Auto.Size = new System.Drawing.Size(47, 17);
-            this.radioButton_Auto.TabIndex = 0;
-            this.radioButton_Auto.TabStop = true;
-            this.radioButton_Auto.Text = "Auto";
-            this.radioButton_Auto.UseVisualStyleBackColor = true;
-            this.radioButton_Auto.CheckedChanged += new System.EventHandler(this.radioButton_Auto_CheckedChanged);
             // 
             // groupBoxTheme
             // 
@@ -163,7 +79,7 @@
             this.groupBoxTheme.Controls.Add(this.button_edittheme);
             this.groupBoxTheme.Controls.Add(this.buttonSaveTheme);
             this.groupBoxTheme.FillClientAreaWithAlternateColor = false;
-            this.groupBoxTheme.Location = new System.Drawing.Point(3, 435);
+            this.groupBoxTheme.Location = new System.Drawing.Point(3, 372);
             this.groupBoxTheme.Name = "groupBoxTheme";
             this.groupBoxTheme.Size = new System.Drawing.Size(426, 120);
             this.groupBoxTheme.TabIndex = 18;
@@ -257,7 +173,7 @@
             this.groupBox2.Controls.Add(this.textBoxHomeSystem);
             this.groupBox2.Controls.Add(this.panel_defaultmapcolor);
             this.groupBox2.FillClientAreaWithAlternateColor = false;
-            this.groupBox2.Location = new System.Drawing.Point(440, 280);
+            this.groupBox2.Location = new System.Drawing.Point(440, 217);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(379, 100);
             this.groupBox2.TabIndex = 17;
@@ -389,7 +305,7 @@
             this.groupBox3.Controls.Add(this.checkBoxEDSMLog);
             this.groupBox3.Controls.Add(this.checkboxSkipSlowUpdates);
             this.groupBox3.FillClientAreaWithAlternateColor = false;
-            this.groupBox3.Location = new System.Drawing.Point(3, 280);
+            this.groupBox3.Location = new System.Drawing.Point(3, 217);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(426, 149);
             this.groupBox3.TabIndex = 16;
@@ -490,12 +406,13 @@
             this.groupBox4.BorderColorScaling = 0.5F;
             this.groupBox4.Controls.Add(this.btnDeleteCommander);
             this.groupBox4.Controls.Add(this.buttonAddCommander);
+            this.groupBox4.Controls.Add(this.label1);
             this.groupBox4.Controls.Add(this.label2);
             this.groupBox4.Controls.Add(this.dataGridViewCommanders);
             this.groupBox4.FillClientAreaWithAlternateColor = false;
-            this.groupBox4.Location = new System.Drawing.Point(0, 93);
+            this.groupBox4.Location = new System.Drawing.Point(0, 4);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(819, 184);
+            this.groupBox4.Size = new System.Drawing.Size(819, 210);
             this.groupBox4.TabIndex = 15;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Commanders";
@@ -531,7 +448,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(125, 21);
+            this.label2.Location = new System.Drawing.Point(134, 40);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(309, 13);
             this.label2.TabIndex = 1;
@@ -550,7 +467,7 @@
             this.ColumnCommander,
             this.ColumnEDSMAPIKey,
             this.ColumnNetLogDir});
-            this.dataGridViewCommanders.Location = new System.Drawing.Point(11, 45);
+            this.dataGridViewCommanders.Location = new System.Drawing.Point(11, 71);
             this.dataGridViewCommanders.MultiSelect = false;
             this.dataGridViewCommanders.Name = "dataGridViewCommanders";
             this.dataGridViewCommanders.RowHeadersWidth = 20;
@@ -593,19 +510,25 @@
             this.ColumnNetLogDir.MinimumWidth = 150;
             this.ColumnNetLogDir.Name = "ColumnNetLogDir";
             // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(133, 16);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(370, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Leave Journal Location blank to use the standard frontier location for journals";
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.groupBoxTheme);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox4);
             this.Name = "Settings";
             this.Size = new System.Drawing.Size(937, 725);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
             this.groupBoxTheme.ResumeLayout(false);
             this.groupBoxTheme.PerformLayout();
             this.groupBox2.ResumeLayout(false);
@@ -651,10 +574,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnCommander;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnEDSMAPIKey;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNetLogDir;
-        private ExtendedControls.ButtonExt button_Browse;
-        private ExtendedControls.TextBoxBorder textBoxNetLogDir;
-        private ExtendedControls.RadioButtonCustom radioButton_Manual;
-        private ExtendedControls.RadioButtonCustom radioButton_Auto;
-        private ExtendedControls.GroupBoxCustom groupBox1;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -54,13 +54,13 @@
             this.groupBox4 = new ExtendedControls.GroupBoxCustom();
             this.btnDeleteCommander = new ExtendedControls.ButtonExt();
             this.buttonAddCommander = new ExtendedControls.ButtonExt();
+            this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.dataGridViewCommanders = new System.Windows.Forms.DataGridView();
             this.ColumnNr = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnCommander = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnEDSMAPIKey = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnNetLogDir = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.label1 = new System.Windows.Forms.Label();
             this.groupBoxTheme.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -445,14 +445,24 @@
             this.buttonAddCommander.UseVisualStyleBackColor = true;
             this.buttonAddCommander.Click += new System.EventHandler(this.buttonAddCommander_Click);
             // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(133, 16);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(416, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Leave Override Journal Location blank to use the standard Frontier location for j" +
+    "ournals";
+            // 
             // label2
             // 
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(134, 40);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(309, 13);
+            this.label2.Size = new System.Drawing.Size(354, 13);
             this.label2.TabIndex = 1;
-            this.label2.Text = "Get Api key from https://www.edsm.net in  \"My account\" menu.";
+            this.label2.Text = "Get an EDSM API key from https://www.edsm.net in \"My account\" menu";
             // 
             // dataGridViewCommanders
             // 
@@ -488,7 +498,6 @@
             // 
             // ColumnCommander
             // 
-            this.ColumnCommander.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ColumnCommander.DataPropertyName = "Name";
             this.ColumnCommander.HeaderText = "Commander";
             this.ColumnCommander.MinimumWidth = 150;
@@ -496,9 +505,8 @@
             // 
             // ColumnEDSMAPIKey
             // 
-            this.ColumnEDSMAPIKey.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ColumnEDSMAPIKey.DataPropertyName = "APIKey";
-            this.ColumnEDSMAPIKey.HeaderText = "EDSM api key";
+            this.ColumnEDSMAPIKey.HeaderText = "EDSM API key";
             this.ColumnEDSMAPIKey.MinimumWidth = 150;
             this.ColumnEDSMAPIKey.Name = "ColumnEDSMAPIKey";
             // 
@@ -507,17 +515,8 @@
             this.ColumnNetLogDir.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ColumnNetLogDir.DataPropertyName = "NetLogDir";
             this.ColumnNetLogDir.HeaderText = "Override Journal Location";
-            this.ColumnNetLogDir.MinimumWidth = 150;
+            this.ColumnNetLogDir.MinimumWidth = 50;
             this.ColumnNetLogDir.Name = "ColumnNetLogDir";
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(133, 16);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(370, 13);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "Leave Journal Location blank to use the standard frontier location for journals";
             // 
             // Settings
             // 
@@ -570,10 +569,10 @@
         private ExtendedControls.CheckBoxCustom checkBoxFocusNewSystem;
         private ExtendedControls.CheckBoxCustom checkBoxKeepOnTop;
         private ExtendedControls.ButtonExt btnDeleteCommander;
+        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNr;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnCommander;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnEDSMAPIKey;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnNetLogDir;
-        private System.Windows.Forms.Label label1;
     }
 }

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -81,6 +81,7 @@ namespace EDDiscovery2
             }
 
             dataGridViewCommanders.DataSource = EDDiscoveryForm.EDDConfig.ListOfCommanders;
+            dataGridViewCommanders.AutoGenerateColumns = false;
 
             panel_defaultmapcolor.BackColor = Color.FromArgb(EDDConfig.Instance.DefaultMapColour);
 

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -55,23 +55,6 @@ namespace EDDiscovery2
 
         public void InitSettingsTab()
         {
-            radioButton_Auto.Enabled = textBoxNetLogDir.Enabled = false;
-
-            bool auto = EDDConfig.Instance.JournalDirAutoMode;
-
-            if (auto)
-            {
-                radioButton_Auto.Checked = auto;
-            }
-            else
-            {
-                radioButton_Manual.Checked = true;
-            }
-
-            textBoxNetLogDir.Text = EDDConfig.Instance.JournalDir;
-
-            radioButton_Auto.Enabled = textBoxNetLogDir.Enabled = true;
-
             checkBox_Distances.Enabled = false;         // disable over checked to indicate its not a user thing
             checkBox_Distances.Checked = EDDiscoveryForm.EDDConfig.UseDistances;
             checkBox_Distances.Enabled = true;
@@ -97,7 +80,7 @@ namespace EDDiscovery2
                 radioButtonCentreHome.Checked = true;
             }
 
-            dataGridViewCommanders.DataSource = EDDiscoveryForm.EDDConfig.listCommanders;
+            dataGridViewCommanders.DataSource = EDDiscoveryForm.EDDConfig.ListOfCommanders;
 
             panel_defaultmapcolor.BackColor = Color.FromArgb(EDDConfig.Instance.DefaultMapColour);
 
@@ -106,9 +89,6 @@ namespace EDDiscovery2
 
         public void SaveSettings()
         {
-            EDDConfig.Instance.JournalDirAutoMode = radioButton_Auto.Checked;
-            EDDConfig.Instance.JournalDir = textBoxNetLogDir.Text;
-
             SQLiteDBClass.PutSettingString("DefaultMapCenter", textBoxHomeSystem.Text);
             double zoom = 1;
             SQLiteDBClass.PutSettingDouble("DefaultMapZoom", Double.TryParse(textBoxDefaultZoom.Text, out zoom) ? zoom : 1.0);
@@ -120,12 +100,6 @@ namespace EDDiscovery2
             EDDiscoveryForm.EDDConfig.OrderRowsInverted = checkBoxOrderRowsInverted.Checked;
             EDDiscoveryForm.EDDConfig.FocusOnNewSystem = checkBoxFocusNewSystem.Checked;
             EDDiscoveryForm.EDDConfig.KeepOnTop = checkBoxKeepOnTop.Checked;
-
-            BindingList<EDCommander> edcommanders = (BindingList<EDCommander>)dataGridViewCommanders.DataSource;
-            EDDiscoveryForm.EDDConfig.StoreCommanders(edcommanders);
-            dataGridViewCommanders.DataSource = null;
-            dataGridViewCommanders.DataSource = EDDiscoveryForm.EDDConfig.listCommanders;
-            dataGridViewCommanders.Update();
         }
 
         private void textBoxDefaultZoom_Validating(object sender, System.ComponentModel.CancelEventArgs e)
@@ -138,21 +112,52 @@ namespace EDDiscovery2
             }
         }
 
+        public void UpdateCommandersListBox()
+        {
+            dataGridViewCommanders.DataSource = null;
+            dataGridViewCommanders.DataSource = EDDiscoveryForm.EDDConfig.ListOfCommanders;
+            dataGridViewCommanders.Update();
+        }
 
         private void buttonAddCommander_Click(object sender, EventArgs e)
         {
-            EDCommander cmdr = EDDiscoveryForm.EDDConfig.GetNewCommander();
-            //dataGridViewCommanders.DataSource = null;           // changing data source ends up, after this, screwing the column sizing..
-            dataGridViewCommanders.DataSource = EDDiscoveryForm.EDDConfig.listCommanders;
-            dataGridViewCommanders.Update();
+            EDDiscoveryForm.EDDConfig.GetNewCommander();
+            UpdateCommandersListBox();
             _discoveryForm.TravelControl.LoadCommandersListBox();
         }
 
         private void dataGridViewCommanders_CellEndEdit(object sender, DataGridViewCellEventArgs e)
         {
-            BindingList<EDCommander> edcommanders = (BindingList<EDCommander>)dataGridViewCommanders.DataSource;
-            EDDiscoveryForm.EDDConfig.StoreCommanders(edcommanders);
+            List<EDCommander> edcommanders = (List<EDCommander>)dataGridViewCommanders.DataSource;
+            EDDiscoveryForm.EDDConfig.UpdateCommanders(edcommanders);
             _discoveryForm.TravelControl.LoadCommandersListBox();
+        }
+
+        private void btnDeleteCommander_Click(object sender, EventArgs e)
+        {
+            var cells = dataGridViewCommanders.SelectedCells;
+
+            HashSet<int> rowindexes = new HashSet<int>();
+
+            foreach (var cell in cells.OfType<DataGridViewCell>())
+            {
+                if (!rowindexes.Contains(cell.RowIndex))
+                {
+                    rowindexes.Add(cell.RowIndex);
+                }
+            }
+
+            if (rowindexes.Count == 1)
+            {
+                var row = dataGridViewCommanders.Rows[rowindexes.Single()].DataBoundItem as EDCommander;
+                var result = MessageBox.Show("Do you wish to delete commander " + row.Name + "?", "Delete commander", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+                if (result == DialogResult.Yes)
+                {
+                    EDDConfig.Instance.DeleteCommander(row);
+                    UpdateCommandersListBox();
+                    _discoveryForm.TravelControl.LoadCommandersListBox();
+                }
+            }
         }
 
         public void panel_defaultmapcolor_Click(object sender, EventArgs e)
@@ -267,76 +272,6 @@ namespace EDDiscovery2
             }
         }
 
-        private void btnDeleteCommander_Click(object sender, EventArgs e)
-        {
-            var cells = dataGridViewCommanders.SelectedCells;
 
-            HashSet<int> rowindexes = new HashSet<int>();
-
-            foreach (var cell in cells.OfType<DataGridViewCell>())
-            {
-                if (!rowindexes.Contains(cell.RowIndex))
-                {
-                    rowindexes.Add(cell.RowIndex);
-                }
-            }
-
-            if (rowindexes.Count == 1)
-            {
-                var row = dataGridViewCommanders.Rows[rowindexes.Single()].DataBoundItem as EDCommander;
-                var result = MessageBox.Show("Do you wish to delete commander " + row.Name + "?", "Delete commander", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-                if (result == DialogResult.Yes)
-                {
-                    EDDConfig.Instance.DeleteCommander(row);
-                    //dataGridViewCommanders.DataSource = null;           // changing data source ends up, after this, screwing the column sizing..
-                    dataGridViewCommanders.DataSource = EDDConfig.Instance.listCommanders;
-                    dataGridViewCommanders.Update();
-                    _discoveryForm.TravelControl.LoadCommandersListBox();
-
-                }
-            }
-        }
-
-        private void button_Browse_Click(object sender, EventArgs e)
-        {
-            FolderBrowserDialog dirdlg = new FolderBrowserDialog();
-
-            DialogResult dlgResult = dirdlg.ShowDialog();
-
-            if (dlgResult == DialogResult.OK && EDDConfig.Instance.JournalDir != dirdlg.SelectedPath)
-                SetManualJournal(dirdlg.SelectedPath);
-        }
-
-        private void radioButton_Auto_CheckedChanged(object sender, EventArgs e)
-        {
-            if (radioButton_Auto.Enabled)
-            {
-                EDDConfig.Instance.JournalDirAutoMode = radioButton_Auto.Checked;
-                _discoveryForm.ChangedJournalSettings();
-                System.Diagnostics.Trace.WriteLine("Journal folder " + EDDiscovery.EliteDangerous.EDJournalClass.GetJournalDir());
-            }
-        }
-
-        private void textBoxNetLogDir_Validated(object sender, EventArgs e)
-        {
-            if (textBoxNetLogDir.Enabled && EDDConfig.Instance.JournalDir != textBoxNetLogDir.Text)
-            {
-                SetManualJournal(textBoxNetLogDir.Text);
-            }
-        }
-
-        private void SetManualJournal(string s)
-        {
-            EDDConfig.Instance.JournalDir = textBoxNetLogDir.Text = s;
-            radioButton_Manual.Checked = true;      // no trigger
-
-            if (radioButton_Auto.Checked)
-                radioButton_Auto.Checked = false;        // triggers off the check function Checked change
-            else
-            {
-                _discoveryForm.ChangedJournalSettings();
-                System.Diagnostics.Trace.WriteLine("Journal folder " + EDDiscovery.EliteDangerous.EDJournalClass.GetJournalDir());
-            }
-        }
     }
 }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -145,7 +145,7 @@ namespace EDDiscovery
             dataGridViewTravel.Rows[rownr].Cells[TravelHistoryColumns.HistoryTag].Tag = item;
             dataGridViewTravel.Rows[rownr].Cells[TravelHistoryColumns.NoteTag].Tag = snc;
 
-            dataGridViewTravel.Rows[rownr].DefaultCellStyle.ForeColor = (item.System.HasCoordinate) ? _discoveryForm.theme.VisitedSystemColor : _discoveryForm.theme.NonVisitedSystemColor;
+            dataGridViewTravel.Rows[rownr].DefaultCellStyle.ForeColor = (item.System.HasCoordinate || item.EntryType != JournalTypeEnum.FSDJump) ? _discoveryForm.theme.VisitedSystemColor : _discoveryForm.theme.NonVisitedSystemColor;
 
             string tip = item.EventSummary + Environment.NewLine + item.EventDescription + Environment.NewLine + item.EventDetailedInfo;
             dataGridViewTravel.Rows[rownr].Cells[0].ToolTipText = tip;
@@ -427,13 +427,20 @@ namespace EDDiscovery
 
         #endregion
 
+
+        public void CheckCommandersListBox()
+        {
+            if (comboBoxCommander.Items.Count-1 != EDDConfig.Instance.ListOfCommanders.Count)       // account for hidden log
+                LoadCommandersListBox();
+        }
+
         public void LoadCommandersListBox()
         {
             comboBoxCommander.Enabled = false;
             commanders = new List<EDCommander>();
 
             commanders.Add(new EDCommander(-1, "Hidden log", ""));
-            commanders.AddRange(EDDiscoveryForm.EDDConfig.listCommanders);
+            commanders.AddRange(EDDiscoveryForm.EDDConfig.ListOfCommanders);
 
             comboBoxCommander.DataSource = null;
             comboBoxCommander.DataSource = commanders;


### PR DESCRIPTION
1. Config has a bindinglist on commander id, changing it in a thread
caused a cross thread exception.  Now a straight list with a lock.
2. Discovery form makes sure commander select and settings know if a new
commander auto created.  moved getting the list to the worker complete,
and used displayedcommander.
3. hidden system turned on, both display and right click set
4. Journal watcher can kick off multiple watchers on multiple folders,
all split cleanly
5. Unknown commander entries set to -2 so not to clash with hidden -1
6. Settings removed all manual/auto stuff, added note on how to set the
location
7. Coloured entries are only shown for FSD jumps in list.