### PR TITLE
Add force-reload of netlogs; identify jumps between duplicate systems in netlogs

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -46,6 +46,7 @@
             this.openEliteDangerousDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.dEBUGResetAllHistoryToFirstCommandeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.read21AndFormerLogFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gitHubToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -104,7 +105,7 @@
             this.helpToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(155, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(246, 24);
             this.menuStrip1.TabIndex = 16;
             this.menuStrip1.Text = "menuStrip1";
             this.menuStrip1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.menuStrip1_MouseDown);
@@ -119,7 +120,7 @@
             this.editThemeToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
             this.toolsToolStripMenuItem.Text = "Tools";
             // 
             // show2DMapsToolStripMenuItem
@@ -214,10 +215,19 @@
             // 
             // read21AndFormerLogFilesToolStripMenuItem
             // 
+            this.read21AndFormerLogFilesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem});
             this.read21AndFormerLogFilesToolStripMenuItem.Name = "read21AndFormerLogFilesToolStripMenuItem";
             this.read21AndFormerLogFilesToolStripMenuItem.Size = new System.Drawing.Size(340, 22);
             this.read21AndFormerLogFilesToolStripMenuItem.Text = "Read 2.1 and former log files";
             this.read21AndFormerLogFilesToolStripMenuItem.Click += new System.EventHandler(this.read21AndFormerLogFilesToolStripMenuItem_Click);
+            // 
+            // read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem
+            // 
+            this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem.Name = "read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem";
+            this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem.Text = "Force reload logs";
+            this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem.Click += new System.EventHandler(this.read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -675,6 +685,7 @@
         private System.Windows.Forms.ToolStripMenuItem read21AndFormerLogFilesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showLogfilesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openEliteDangerousDirectoryToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem;
     }
 }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1455,6 +1455,24 @@ namespace EDDiscovery
             }
         }
 
+        private void read21AndFormerLogFiles_forceReloadLogsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FolderBrowserDialog dirdlg = new FolderBrowserDialog();
+
+            DialogResult dlgResult = dirdlg.ShowDialog();
+
+            if (dlgResult == DialogResult.OK)
+            {
+                string errstr = null;
+                string logpath = dirdlg.SelectedPath;
+                //string logpath = "c:\\games\\edlaunch\\products\\elite-dangerous-64\\logs";
+                this.Cursor = Cursors.WaitCursor;
+                NetLogClass.ParseFiles(logpath, out errstr, EDDConfig.Instance.DefaultMapColour, () => false, (p, s) => { }, true);
+                RefreshHistoryAsync();
+                this.Cursor = Cursors.Default;
+            }
+        }
+
         private void dEBUGResetAllHistoryToFirstCommandeToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MessageBox.Show("Confirm you wish to reset all history entries to the current commander", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -66,12 +66,17 @@ namespace EDDiscovery
 
             if (vsSystemsList != null)
             {
+                JournalLocOrJump last = visitedSystems.LastOrDefault();
+
                 foreach (JournalLocOrJump vs in vsSystemsList)
                 {
                     if (visitedSystems.Count == 0)
                         visitedSystems.Add(vs);
-                    else if (!visitedSystems.Last().StarSystem.Equals(vs.StarSystem, StringComparison.CurrentCultureIgnoreCase))  // Avoid duplicate if times exist in same system from different files.
+                    else if (last == null ||
+                             (!last.StarSystem.Equals(vs.StarSystem, StringComparison.CurrentCultureIgnoreCase) &&
+                              (!last.HasCoordinate || !vs.HasCoordinate || (last.StarPos - vs.StarPos).LengthSquared < 0.001)))  // Avoid duplicate if times exist in same system from different files.
                         visitedSystems.Add(vs);
+                    last = vs;
                 }
             }
 

--- a/EDDiscovery/EliteDangerous/NetLogReader.cs
+++ b/EDDiscovery/EliteDangerous/NetLogReader.cs
@@ -424,7 +424,8 @@ namespace EDDiscovery
                         }
                     }
 
-                    if (last != null && je.StarSystem.Equals(last.StarSystem, StringComparison.InvariantCultureIgnoreCase))
+                    if (last != null && je.StarSystem.Equals(last.StarSystem, StringComparison.InvariantCultureIgnoreCase)
+                                     && (!je.HasCoordinate || !last.HasCoordinate || (je.StarPos - last.StarPos).LengthSquared < 0.001))
                         continue;
 
                     if (je.EventTimeUTC.Subtract(gammastart).TotalMinutes > 0)  // Ta bara med efter gamma.


### PR DESCRIPTION
* Add an option to force-reload netlogs when loading old logs
* There are some systems with identical names within jump range of each other, so check if the coordinates match before discarding them as duplicates.