### PR TITLE
Fix build failure under mono

### DIFF
--- a/EDDiscovery/Export/ExportBase.cs
+++ b/EDDiscovery/Export/ExportBase.cs
@@ -50,7 +50,7 @@ namespace EDDiscovery.Export
         protected string MakeValueCsvFriendly(object value)
         {
             if (value == null) return delimiter;
-            if (value is Nullable && ((INullable)value).IsNull) return delimiter;
+            if (value is INullable && ((INullable)value).IsNull) return delimiter;
 
             if (value is DateTime)
             {


### PR DESCRIPTION
`x is System.Nullable` causes the build to fail under Mono, likely because `System.Nullable` (not to be confused with `System.Nullable<T>` or `System.Data.SqlTypes.INullable`) is a static class and cannot be instantiated.  

Under Visual Studio, the test `x is System.Nullable` will always return false for the same reason.

**Note** that if the idea was to check if the value was a nullable type, and that it had a value, refer to [`Nullable<T> remarks`](https://msdn.microsoft.com/en-us/library/b3h38hb0(v=vs.110).aspx#Anchor_5) on MSDN.
* A `Nullable<T> val` will box to `(T)val` when `val.HasValue == true` and `null` when `val.HasValue == false`.
* `val is Nullable<T>` will always return false, even when val is declared as `Nullable<T>`.
* `val.GetType()` will return the type of the underlying value when `val.HasValue == true`, and will throw a NullReferenceException when `val.HasValue == false`, even when `val` is declared as `Nullable<T>`

