### PR TITLE
Link system notes to systems by EDSM ID, and to journal entries by ID

### DIFF
--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -105,7 +105,7 @@ namespace EDDiscovery2._3DMap
             {
                 foreach (HistoryEntry vs in syslists)
                 {
-                    SystemNoteClass notecs = SystemNoteClass.GetNoteOnSystem(vs.System.name);
+                    SystemNoteClass notecs = SystemNoteClass.GetNoteOnSystem(vs.System.name, vs.System.id_edsm);
 
                     if (notecs != null)         // if we have a note..
                     {

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1563,7 +1563,7 @@ namespace EDDiscovery2
                 {                                                   // try and find the associated bookmark..
                     BookmarkClass bkmark = (curbookmark != null) ? curbookmark : BookmarkClass.bookmarks.Find(x => x.StarName != null && x.StarName.Equals(cursystem.name));
 
-                    SystemNoteClass sn = (cursystem != null) ? SystemNoteClass.GetNoteOnSystem(cursystem.name) : null;
+                    SystemNoteClass sn = (cursystem != null) ? SystemNoteClass.GetNoteOnSystem(cursystem.name, cursystem.id_edsm) : null;
                     string note = (sn != null) ? sn.Note : "";
 
                     BookmarkForm frm = new BookmarkForm();
@@ -1866,7 +1866,7 @@ namespace EDDiscovery2
                     info += Environment.NewLine + "Distance from " + _clickedGMO.name + ": " + dist.ToString("0.0");
                 }
 
-                SystemNoteClass sn = SystemNoteClass.GetNoteOnSystem(sysname);   // may be null
+                SystemNoteClass sn = SystemNoteClass.GetNoteOnSystem(sysname, hoversystem == null ? 0 : hoversystem.id_edsm);   // may be null
                 if (sn != null && sn.Note.Trim().Length>0 )
                 {
                     info += Environment.NewLine + "Notes: " + sn.Note.Trim();
@@ -2018,7 +2018,7 @@ namespace EDDiscovery2
             {
                 if ( vs.System.HasCoordinate)
                 { 
-                    SystemNoteClass notecs = SystemNoteClass.GetNoteOnSystem(vs.System.name);
+                    SystemNoteClass notecs = SystemNoteClass.GetNoteOnSystem(vs.System.name, vs.System.id_edsm);
 
                     if (notecs!=null )
                     {

--- a/EDDiscovery/DB/SQLiteDBUserClass.cs
+++ b/EDDiscovery/DB/SQLiteDBUserClass.cs
@@ -59,6 +59,8 @@ namespace EDDiscovery.DB
                 if (dbver < 105)
                     UpgradeUserDB105(conn);
 
+                if (dbver < 106)
+                    UpgradeUserDB106(conn);
 
                 CreateUserDBTableIndexes();
 
@@ -195,6 +197,12 @@ namespace EDDiscovery.DB
 
 
             SQLiteDBClass.PerformUpgrade(conn, 105, true, false, new[] { query1, query2, query3 });
+        }
+
+        private static void UpgradeUserDB106(SQLiteConnectionED conn)
+        {
+            string query1 = "ALTER TABLE SystemNote ADD COLUMN EdsmId INTEGER NOT NULL DEFAULT -1";
+            SQLiteDBClass.PerformUpgrade(conn, 106, true, false, new[] { query1 });
         }
 
 

--- a/EDDiscovery/DB/SystemNoteClass.cs
+++ b/EDDiscovery/DB/SystemNoteClass.cs
@@ -15,6 +15,7 @@ namespace EDDiscovery2.DB
         public string Name;                 //Journalid <>0, Name clear, journal marker
         public DateTime Time;
         public string Note;
+        public long EdsmId;
 
         public SystemNoteClass()
         {
@@ -27,6 +28,7 @@ namespace EDDiscovery2.DB
             Name = (string)dr["Name"];
             Time = (DateTime)dr["Time"];
             Note = (string)dr["Note"];
+            EdsmId = (long)dr["EdsmId"];
         }
 
 
@@ -41,12 +43,13 @@ namespace EDDiscovery2.DB
 
         private bool Add(SQLiteConnectionUser cn)
         {
-            using (DbCommand cmd = cn.CreateCommand("Insert into SystemNote (Name, Time, Note, journalid) values (@name, @time, @note, @journalid)"))
+            using (DbCommand cmd = cn.CreateCommand("Insert into SystemNote (Name, Time, Note, journalid, edsmid) values (@name, @time, @note, @journalid, @edsmid)"))
             {
                 cmd.AddParameterWithValue("@name", Name);
                 cmd.AddParameterWithValue("@time", Time);
                 cmd.AddParameterWithValue("@note", Note);
                 cmd.AddParameterWithValue("@journalid", Journalid);
+                cmd.AddParameterWithValue("@edsmid", EdsmId);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
 
@@ -70,13 +73,14 @@ namespace EDDiscovery2.DB
 
         private bool Update(SQLiteConnectionUser cn)
         {
-            using (DbCommand cmd = cn.CreateCommand("Update SystemNote set Name=@Name, Time=@Time, Note=@Note, Journalid=@journalid  where ID=@id")) 
+            using (DbCommand cmd = cn.CreateCommand("Update SystemNote set Name=@Name, Time=@Time, Note=@Note, Journalid=@journalid, EdsmId=@EdsmId  where ID=@id")) 
             {
                 cmd.AddParameterWithValue("@ID", id);
                 cmd.AddParameterWithValue("@Name", Name);
                 cmd.AddParameterWithValue("@Note", Note);
                 cmd.AddParameterWithValue("@Time", Time);
                 cmd.AddParameterWithValue("@journalid", Journalid);
+                cmd.AddParameterWithValue("@EdsmId", EdsmId);
 
                 SQLiteDBClass.SQLNonQueryText(cn, cmd);
             }
@@ -121,9 +125,9 @@ namespace EDDiscovery2.DB
             }
         }
 
-        public static SystemNoteClass GetNoteOnSystem(string name)      // case insensitive.. null if not there  matches journalid=0,
+        public static SystemNoteClass GetNoteOnSystem(string name, long edsmid = -1)      // case insensitive.. null if not there
         {
-            return globalSystemNotes.FindLast(x => x.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) && x.Journalid == 0 );
+            return globalSystemNotes.FindLast(x => x.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) && (edsmid <= 0 || x.EdsmId <= 0 || x.EdsmId == edsmid) );
         }
 
         public static SystemNoteClass GetNoteOnJournalEntry(long jid)

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -303,7 +303,7 @@ namespace EDDiscovery2.EDSM
             if (!IsApiKeySet)
                 return null;
 
-            string query = "get-comments?startdatetime=" + HttpUtility.UrlEncode(starttime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) + "&apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
+            string query = "get-comments?startdatetime=" + HttpUtility.UrlEncode(starttime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)) + "&apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&showId=1";
             //string query = "get-comments?apiKey=" + apiKey + "&commanderName=" + HttpUtility.UrlEncode(commanderName);
             var response = RequestGet("api-logs-v1/" + query);
 
@@ -330,13 +330,20 @@ namespace EDDiscovery2.EDSM
             return response.Body;
         }
 
-        public string SetComment(string systemName, string note)
+        public string SetComment(string systemName, string note, long edsmid = 0)
         {
             if (!IsApiKeySet)
                 return null;
 
             string query;
             query = "set-comment?systemName=" + HttpUtility.UrlEncode(systemName) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey + "&comment=" + HttpUtility.UrlEncode(note);
+
+            if (edsmid > 0)
+            {
+                // For future use when EDSM adds the ability to link a comment to a system by EDSM ID
+                query += "&systemId=" + edsmid;
+            }
+
             var response = RequestGet("api-logs-v1/" + query);
 
             if ((int)response.StatusCode >= 400)

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -236,7 +236,7 @@ namespace EDDiscovery2.EDSM
             });
         }
 
-        public static void SendComments(string star , string note) // (verified with EDSM 29/9/2016)
+        public static void SendComments(string star , string note, long edsmid = 0) // (verified with EDSM 29/9/2016)
         {
             EDSMClass edsm = new EDSMClass();
 
@@ -245,7 +245,7 @@ namespace EDDiscovery2.EDSM
 
             Task taskEDSM = Task.Factory.StartNew(() =>
             {
-                edsm.SetComment(star, note);
+                edsm.SetComment(star, note, edsmid);
             });
         }
 

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -1078,6 +1078,12 @@ namespace EDDiscovery.EliteDangerous
         static public System.Drawing.Bitmap GetIcon(string text, bool usealt = false)
         {
             Type jtype = TypeOfJournalEntry(text);
+
+            if (jtype == null)
+            {
+                return EDDiscovery.Properties.Resources.genericevent;
+            }
+
             System.Reflection.PropertyInfo p = jtype.GetProperty((usealt) ? "IconAlt" : "Icon");
             System.Reflection.MethodInfo getter = p?.GetGetMethod();
             return (getter != null) ? ((System.Drawing.Bitmap)getter.Invoke(null, null)) : EDDiscovery.Properties.Resources.genericevent;

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -229,7 +229,7 @@ namespace EDDiscovery
 
                 if (sys != null)
                 {
-                    SystemNoteClass sn = SystemNoteClass.GetNoteOnSystem(sys.name);
+                    SystemNoteClass sn = SystemNoteClass.GetNoteOnSystem(sys.name, sys.id_edsm);
                     dataGridViewRouteSystems[2, rowindex].Value = sn != null ? sn.Note : "";
                 }
 


### PR DESCRIPTION
Should prevent notes applied to one system from being applied to all of its duplicates.