### PR TITLE
Don't migrate EDSM entries from old DB; exclude DST duplicates on EDSM import

### DIFF
--- a/EDDiscovery/DB/SQLiteDBUserClass.cs
+++ b/EDDiscovery/DB/SQLiteDBUserClass.cs
@@ -316,6 +316,12 @@ namespace EDDiscovery.DB
                             reader.GetValues(array);                    // love this call.
 
                             string tluname = (string)array[2];          // 2 is in terms of its name.. look it up
+
+                            if (tluname.StartsWith("EDSM-")) // Don't migrate the entries that were synced from EDSM
+                            {                                // We can sync them from EDSM later.
+                                continue;
+                            }
+
                             EDDiscovery2.DB.TravelLogUnit tlu = tlus.Find(x => x.Name.Equals(tluname, StringComparison.InvariantCultureIgnoreCase));
 
                             array[15] = (tlu != null) ? (long)tlu.id : 0;      // even if we don't find it, tlu may be screwed up, still want to import


### PR DESCRIPTION
* Don't migrate the VisitedSystems entries that were originally synced from EDSM.  Instead, allow a later EDSM sync to re-fetch the EDSM travellog entries.
* Check for and exclude EDSM log entries where the time differs by exactly 1 or 2 hours in order to exclude entries that were duplicated due to DST mismatch.