### PR TITLE
Use the newly added systemId to disambiguate EDSM notes

### DIFF
--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -314,13 +314,15 @@ namespace EDDiscovery2.EDSM
         }
 
 
-        public string GetComment(string systemName)
+        public string GetComment(string systemName, long edsmid = 0)
         {
             if (!IsApiKeySet)
                 return null;
 
             string query;
-            query = "get-comment?systemName=" + HttpUtility.UrlEncode(systemName);
+            query = "get-comment?systemName=" + HttpUtility.UrlEncode(systemName) + "&commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey;
+            if (edsmid > 0)
+                query += "&systemId=" + edsmid;
 
             var response = RequestGet("api-logs-v1/" + query);
 

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -131,10 +131,15 @@ namespace EDDiscovery2.EDSM
                                 string name = jo["system"].Value<string>();
                                 string note = jo["comment"].Value<string>();
                                 string utctime = jo["lastUpdate"].Value<string>();
+                                int edsmid = 0;
+
+                                if (!Int32.TryParse(Tools.GetStringDef(jo["systemId"], "0"), out edsmid))
+                                    edsmid = 0;
+
                                 DateTime localtime = DateTime.ParseExact(utctime, "yyyy-MM-dd HH:mm:ss", 
                                             CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal).ToLocalTime();
 
-                                SystemNoteClass curnote = SystemNoteClass.GetNoteOnSystem(name);
+                                SystemNoteClass curnote = SystemNoteClass.GetNoteOnSystem(name, edsmid);
 
                                 if (curnote != null)
                                 {
@@ -143,6 +148,7 @@ namespace EDDiscovery2.EDSM
                                     {
                                         curnote.Note += ". EDSM: " + note;
                                         curnote.Time = localtime;
+                                        curnote.EdsmId = edsmid;
                                         curnote.Update();
                                         commentsadded++;
                                     }
@@ -154,6 +160,7 @@ namespace EDDiscovery2.EDSM
                                     curnote.Time = localtime;
                                     curnote.Name = name;
                                     curnote.Journalid = 0;
+                                    curnote.EdsmId = edsmid;
                                     curnote.Add();
                                     commentsadded++;
                                 }

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -822,7 +822,7 @@ namespace EDDiscovery
 
                 if (sc != null && sc.HasCoordinate)
                 {
-                    SystemNoteClass nc = SystemNoteClass.GetNoteOnSystem(sn);        // has it got a note?
+                    SystemNoteClass nc = SystemNoteClass.GetNoteOnSystem(sc.name, sc.id_edsm);        // has it got a note?
 
                     if (nc != null)
                     {


### PR DESCRIPTION
Use the newly added systemId parameter / field for EDSM comments to determine which duplicate system a comment is attached to.