### PR TITLE
Background more of the refresh process; load system if necessary

### DIFF
--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1691,13 +1691,26 @@ namespace EDDiscovery.DB
 
                 if (system == null)                   // not found, so  try
                 {
-                    if (s.HasCoordinate)                // if has co-ord, its cardinal, only match on this
+                    List<SystemClass> systemsByName = GetSystemsByName(s.name, conn);
+
+                    if (systemsByName.Count == 0 && s.HasCoordinate)
                     {
-                        system = SystemClass.GetSystemNearestTo(s.x, s.y, s.z, conn);       // find it
+                        system = GetSystemNearestTo(s.x, s.y, s.z, conn);
                     }
                     else
                     {
-                        system = SystemClass.GetSystem(s.name, conn);   // find on name
+                        double mindist = 0.5;
+
+                        foreach (SystemClass sys in systemsByName)
+                        {
+                            double dist = Distance(sys, s);
+
+                            if (dist < mindist)
+                            {
+                                mindist = dist;
+                                system = sys;
+                            }
+                        }
                     }
                 }
 

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -99,14 +99,13 @@ namespace EDDiscovery.EliteDangerous
 
                     reader.TravelLogUnit.Update();
 
-                    if (updateProgress != null)
-                    {
-                        updateProgress((i + 1) * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);
-                    }
+                    updateProgress((i + 1) * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);
 
                     lastnfi = reader;
                 }
             }
+
+            updateProgress(-1, "");
         }
 
         private EDJournalReader OpenFileReader(FileInfo fi, Dictionary<string, TravelLogUnit> tlu_lookup = null)

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -420,11 +420,19 @@ namespace EDDiscovery.EliteDangerous
         }
 
         //dist >0 to update
-        public static void UpdateEDSMIDPosJump(long journalid, ISystem system, bool jsonpos , double dist )
+        public static void UpdateEDSMIDPosJump(long journalid, ISystem system, bool jsonpos , double dist, SQLiteConnectionUserUTC cn = null, DbTransaction tn = null)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            bool ownconn = false;
+
+            try
             {
-                JournalEntry ent = Get(journalid, cn);
+                if (cn == null)
+                {
+                    ownconn = true;
+                    cn = new SQLiteConnectionUserUTC();
+                }
+
+                JournalEntry ent = Get(journalid, cn, tn);
 
                 if (ent != null)
                 {
@@ -438,15 +446,22 @@ namespace EDDiscovery.EliteDangerous
                     if (dist > 0)
                         jo["JumpDist"] = dist;
 
-                    using (DbCommand cmd2 = cn.CreateCommand("Update JournalEntries set EventData = @EventData, EdsmId = @EdsmId where ID = @ID"))
+                    using (DbCommand cmd2 = cn.CreateCommand("Update JournalEntries set EventData = @EventData, EdsmId = @EdsmId where ID = @ID", tn))
                     {
                         cmd2.AddParameterWithValue("@ID", journalid);
                         cmd2.AddParameterWithValue("@EventData", jo.ToString());
                         cmd2.AddParameterWithValue("@EdsmId", system.id_edsm);
 
                         System.Diagnostics.Trace.WriteLine(string.Format("Update journal ID {0} with pos {1}/edsmid {2} dist {3}", journalid, jsonpos, system.id_edsm, dist));
-                        SQLiteDBClass.SQLNonQueryText(cn, cmd2);
+                        cmd2.ExecuteNonQuery();
                     }
+                }
+            }
+            finally
+            {
+                if (ownconn)
+                {
+                    cn.Dispose();
                 }
             }
         }
@@ -513,9 +528,9 @@ namespace EDDiscovery.EliteDangerous
             }
         }
 
-        static public JournalEntry Get(long journalid, SQLiteConnectionUserUTC cn)
+        static public JournalEntry Get(long journalid, SQLiteConnectionUserUTC cn, DbTransaction tn = null)
         {
-            using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where ID=@journalid"))
+            using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where ID=@journalid", tn))
             {
                 cmd.AddParameterWithValue("@journalid", journalid);
 

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -69,12 +69,13 @@ namespace EDDiscovery
             EdsmSync = true; 
         }
 
-        public static HistoryEntry FromJournalEntry(EliteDangerous.JournalEntry je, HistoryEntry prev, bool checkedsm, SQLiteConnectionSystem conn = null)
+        public static HistoryEntry FromJournalEntry(EliteDangerous.JournalEntry je, HistoryEntry prev, bool checkedsm, out bool journalupdate, SQLiteConnectionSystem conn = null)
         {
             ISystem isys = prev == null ? new SystemClass("Unknown") : prev.System;
             int indexno = prev == null ? 1 : prev.Indexno + 1;
 
             int mapcolour = 0;
+            journalupdate = false;
 
             if (je.EventTypeID == EliteDangerous.JournalTypeEnum.Location || je.EventTypeID == EliteDangerous.JournalTypeEnum.FSDJump)
             {
@@ -86,12 +87,12 @@ namespace EDDiscovery
                 if (jl.HasCoordinate)       // LAZY LOAD IF it has a co-ord.. the front end will when it needs it
                 {
                     newsys = new SystemClass(jl.StarSystem, jl.StarPos.X, jl.StarPos.Y, jl.StarPos.Z);
-                    newsys.id_edsm = jl.EdsmID;       // pass across the EDSMID for the lazy load process.
+                    newsys.id_edsm = jl.EdsmID < 0 ? 0 : jl.EdsmID;       // pass across the EDSMID for the lazy load process.
 
                     if (jfsd != null && jfsd.JumpDist <= 0 && isys.HasCoordinate)     // if we don't have a jump distance (pre 2.2) but the last sys does, we can compute
                     {
                         jfsd.JumpDist = SystemClass.Distance(isys, newsys); // fill it out here
-                        EliteDangerous.JournalEntry.UpdateEDSMIDPosJump(jl.Id, newsys, false, jfsd.JumpDist);   // no need to do pos, already have it
+                        journalupdate = true;
                     }
 
                 }
@@ -109,9 +110,15 @@ namespace EDDiscovery
                             newsys = s;
 
                             if (jfsd != null && jfsd.JumpDist <= 0 && newsys.HasCoordinate && isys.HasCoordinate)     // if we don't have a jump distance (pre 2.2) but the last sys does, we can compute
+                            {
                                 jfsd.JumpDist = SystemClass.Distance(isys, newsys); // fill it out here.  EDSM systems always have co-ords, but we should check anyway
+                                journalupdate = true;
+                            }
 
-                            EliteDangerous.JournalEntry.UpdateEDSMIDPosJump(jl.Id, newsys, newsys.HasCoordinate, jfsd.JumpDist);
+                            if (jl.EdsmID <= 0 && newsys.id_edsm > 0)
+                            {
+                                journalupdate = true;
+                            }
                         }
                     }
                 }
@@ -119,8 +126,10 @@ namespace EDDiscovery
                 if (jfsd != null)
                 {
                     if (jfsd.JumpDist <= 0 && isys.HasCoordinate && newsys.HasCoordinate) // if no JDist, its a really old entry, and if previous has a co-ord
-                     
+                    {
                         jfsd.JumpDist = SystemClass.Distance(isys, newsys); // fill it out here
+                        journalupdate = true;
+                    }
 
                     mapcolour = jfsd.MapColor;
                 }
@@ -364,9 +373,9 @@ namespace EDDiscovery
         }
 
 
-        public int GetVisitsCount(string name)
+        public int GetVisitsCount(string name, long edsmid = 0)
         {
-            return (from row in historylist where row.System.name.Equals(name, StringComparison.InvariantCultureIgnoreCase) select row).Count();
+            return historylist.Where(he => he.IsFSDJump && he.System.name.Equals(name, StringComparison.InvariantCultureIgnoreCase) && (edsmid <= 0 || he.System.id_edsm == edsmid)).Count();
         }
 
         public int GetFSDJumps( TimeSpan t )
@@ -387,9 +396,9 @@ namespace EDDiscovery
             }
         }
 
-        public void FillEDSM(HistoryEntry syspos, SQLiteConnectionSystem conn = null)       // call to fill in ESDM data for entry, and also fills in all others pointing to the system object
+        public void FillEDSM(HistoryEntry syspos, SQLiteConnectionSystem conn = null, bool reload = false)       // call to fill in ESDM data for entry, and also fills in all others pointing to the system object
         {
-            if (syspos.System.status == SystemStatusEnum.EDSC || syspos.System.id_edsm == -1 )  // if set already, or we tried and failed..
+            if (syspos.System.status == SystemStatusEnum.EDSC || (!reload && syspos.System.id_edsm == -1) )  // if set already, or we tried and failed..
                 return;
 
             bool closeit = false;

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -198,7 +198,7 @@ namespace EDDiscovery
 
                 if (he.IsFSDJump)
                 {
-                    int count = _discoveryForm.history.GetVisitsCount(he.System.name);
+                    int count = _discoveryForm.history.GetVisitsCount(he.System.name, he.System.id_edsm);
                     LogLine(string.Format("Arrived at system {0} Visit No. {1}", he.System.name, count));
 
                     System.Diagnostics.Trace.WriteLine("Arrived at system: " + he.System.name + " " + count + ":th visit.");
@@ -246,7 +246,7 @@ namespace EDDiscovery
             }
             else
             {
-                _discoveryForm.history.FillEDSM(rw.Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry); // Fill in any EDSM info we have
+                _discoveryForm.history.FillEDSM(rw.Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry, reload: true); // Fill in any EDSM info we have
 
                 SystemNoteClass note = rw.Cells[TravelHistoryColumns.NoteTag].Tag as SystemNoteClass;
                 HistoryEntry syspos = rw.Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry;     // reload, it may have changed
@@ -270,7 +270,7 @@ namespace EDDiscovery
                     textBoxSolDist.Text = "";
                 }
 
-                int count = _discoveryForm.history.GetVisitsCount(syspos.System.name);
+                int count = _discoveryForm.history.GetVisitsCount(syspos.System.name, syspos.System.id_edsm);
                 textBoxVisits.Text = count.ToString();
 
                 bool enableedddross = (syspos.System.id_eddb > 0);  // Only enable eddb/ross for system that it knows about

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -740,6 +740,7 @@ namespace EDDiscovery
         private void buttonRoss_Click(object sender, EventArgs e)
         {
             HistoryEntry sys = currentGridRow.Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry;
+            _discoveryForm.history.FillEDSM(sys, reload: true);
 
             if (currentGridRow!= null && sys.System.id_eddb>0)
                 Process.Start("http://ross.eddb.io/system/update/" + sys.System.id_eddb.ToString());
@@ -748,6 +749,7 @@ namespace EDDiscovery
         private void buttonEDSM_Click(object sender, EventArgs e)
         {
             HistoryEntry sys = currentGridRow.Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry;
+            _discoveryForm.history.FillEDSM(sys, reload: true);
 
             if (currentGridRow != null && sys.System != null) // solve a possible exception
             {


### PR DESCRIPTION
This should speed up history refresh, and prevent the UI hanging during refresh and netlog loading.

Also fix a few places where the EDSM ID was not loaded when it should have been.