### PR TITLE
Fix the EDSM system URL; fix EDSM ID -1

### DIFF
--- a/EDDiscovery/EDDN/EDDNClass.cs
+++ b/EDDiscovery/EDDN/EDDNClass.cs
@@ -40,7 +40,7 @@ namespace EDDiscovery.EDDN
 
         public JObject CreateEDDNMessage(JournalFSDJump journal)
         {
-            if (!journal.HasCoordinate)
+            if (!journal.HasCoordinate || journal.StarPosFromEDSM)
                 return null;
 
             JObject msg = new JObject();
@@ -61,6 +61,7 @@ namespace EDDiscovery.EDDN
             message.Remove("FuelUsed");
             message.Remove("FuelLevel");
             message.Remove("EDDMapColor");
+            message.Remove("StarPosFromEDSM");
 
             msg["message"] = message;
             return msg;

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -558,7 +558,7 @@ namespace EDDiscovery2.EDSM
                 sysID = msg["id"].Value<string>();
             }
 
-            string url = _serverAddress + "show-system/index/id/" + sysID + "/name/" + encodedSys;
+            string url = _serverAddress + "system/id/" + sysID + "/name/" + encodedSys;
             return url;
         }
 

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -97,7 +97,7 @@ namespace EDDiscovery2.EDSM
                             string errmsg;              // (verified with EDSM 29/9/2016)
 
                                                         // it converts to UTC inside the function, supply local for now
-                            if ( edsm.SendTravelLog(he.System.name, he.EventTimeUTC, he.System.HasCoordinate, he.System.x, he.System.y, he.System.z, out errmsg) )
+                            if ( edsm.SendTravelLog(he.System.name, he.EventTimeUTC, he.System.HasCoordinate && !he.IsStarPosFromEDSM, he.System.x, he.System.y, he.System.z, out errmsg) )
                                 he.SetEdsmSync();
 
                             if (errmsg.Length > 0)

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -441,6 +441,7 @@ namespace EDDiscovery.EliteDangerous
                     if (jsonpos)
                     {
                         jo["StarPos"] = new JArray() { system.x, system.y, system.z };
+                        jo["StarPosFromEDSM"] = true;
                     }
 
                     if (dist > 0)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLocOrJump.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLocOrJump.cs
@@ -11,12 +11,14 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     {
         public string StarSystem { get; set; }
         public Vector3 StarPos { get; set; }
+        public bool StarPosFromEDSM { get; set; }
 
         public bool HasCoordinate { get { return !float.IsNaN(StarPos.X); } }
 
         protected JournalLocOrJump(JObject jo, JournalTypeEnum jtype ) : base(jo, jtype)
         {
             StarSystem = Tools.GetStringDef(jo["StarSystem"],"Unknown!");
+            StarPosFromEDSM = Tools.GetBool(jo["StarPosFromEDSM"], false);
 
             Vector3 pos = new Vector3();
 

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
@@ -176,7 +176,8 @@ namespace EDDiscovery.Forms
         {
             if (_linkSystem != null)
             {
-                string url = String.Format("https://www.edsm.net/show-system/index/id/{0}/name/{1}", _linkSystem.id_edsm, Uri.EscapeDataString(_linkSystem.name));
+                var edsm = new EDDiscovery2.EDSM.EDSMClass();
+                string url = edsm.GetUrlToEDSMSystem(_linkSystem.name, _linkSystem.id_edsm);
                 System.Diagnostics.Process.Start(url);
             }
         }

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -38,6 +38,7 @@ namespace EDDiscovery
 
         public int MapColour;
 
+        public bool IsStarPosFromEDSM;  // flag populated from journal entry when HE is made. Was the star position taken from EDSM?
         public bool EdsmSync;           // flag populated from journal entry when HE is made. Have we synced?
         public bool EDDNSync;           // flag populated from journal entry when HE is made. Have we synced?
         public bool StartMarker;        // flag populated from journal entry when HE is made. Is this a system distance measurement system
@@ -76,6 +77,7 @@ namespace EDDiscovery
 
             int mapcolour = 0;
             journalupdate = false;
+            bool starposfromedsm = false;
 
             if (je.EventTypeID == EliteDangerous.JournalTypeEnum.Location || je.EventTypeID == EliteDangerous.JournalTypeEnum.FSDJump)
             {
@@ -135,6 +137,7 @@ namespace EDDiscovery
                 }
 
                 isys = newsys;
+                starposfromedsm = jl.HasCoordinate ? jl.StarPosFromEDSM : newsys.HasCoordinate;
             }
 
             string summary, info, detailed;
@@ -154,7 +157,8 @@ namespace EDDiscovery
                 StopMarker = je.StopMarker,
                 EventSummary = summary,
                 EventDescription = info,
-                EventDetailedInfo = detailed
+                EventDetailedInfo = detailed,
+                IsStarPosFromEDSM = starposfromedsm
             };
 
             if (prev != null && prev.travelling)      // if we are travelling..

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -756,7 +756,7 @@ namespace EDDiscovery
                 if (!String.IsNullOrEmpty(sys.System.name))
                 {
                     long? id_edsm = sys.System.id_edsm;
-                    if (id_edsm == 0)
+                    if (id_edsm <= 0)
                     {
                         id_edsm = null;
                     }
@@ -1275,7 +1275,7 @@ namespace EDDiscovery
             EDSMClass edsm = new EDSMClass();
             long? id_edsm = rightclicksystem.System?.id_edsm;
 
-            if (id_edsm == 0)
+            if (id_edsm <= 0)
             {
                 id_edsm = null;
             }


### PR DESCRIPTION
* Fix the EDSM system URL - stop using the old `/show-system/index` URL
* Treat EdsmId=-1 as unresolved when getting EDSM URL
* Avoid feeding system positions sourced from EDSM (i.e. where the original log did not have a position) back into EDSM or EDDN