### PR TITLE
Exclude netlog entries with associated journal entries

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1537,20 +1537,20 @@ namespace EDDiscovery
             RefreshWorkerArgs args = e.Argument as RefreshWorkerArgs;
             var worker = (BackgroundWorker)sender;
 
-            if (args != null)
-            {
-                if (args.NetLogPath != null)
-                {
-                    string errstr = null;
-                    NetLogClass.ParseFiles(args.NetLogPath, out errstr, EDDConfig.Instance.DefaultMapColour, () => worker.CancellationPending, (p, s) => worker.ReportProgress(p, s), args.ForceNetLogReload);
-                }
-            }
-
             List<HistoryEntry> history = new List<HistoryEntry>();
 
             if (DisplayedCommander >= 0)
             {
                 journalmonitor.ParseJournalFiles(() => worker.CancellationPending, (p, s) => worker.ReportProgress(p, s));   // Parse files stop monitor..
+
+                if (args != null)
+                {
+                    if (args.NetLogPath != null)
+                    {
+                        string errstr = null;
+                        NetLogClass.ParseFiles(args.NetLogPath, out errstr, EDDConfig.Instance.DefaultMapColour, () => worker.CancellationPending, (p, s) => worker.ReportProgress(p, s), args.ForceNetLogReload);
+                    }
+                }
             }
 
             worker.ReportProgress(-1, "Resolving systems");


### PR DESCRIPTION
The Journal FSDJump is logged up to 30 seconds after the Netlog FSDJump.  Exclude the netlog FSDJump if a jump to the same system occurs either before or after the current netlog entry.