### PR TITLE
Only reload EDSM coords on refresh button click

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1507,9 +1507,10 @@ namespace EDDiscovery
         {
             public string NetLogPath;
             public bool ForceNetLogReload;
+            public bool CheckEdsm;
         }
 
-        public void RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false)
+        public void RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool checkedsm = false)
         {
             if (PendingClose)
             {
@@ -1526,7 +1527,8 @@ namespace EDDiscovery
                 RefreshWorkerArgs args = new RefreshWorkerArgs
                 {
                     NetLogPath = netlogpath,
-                    ForceNetLogReload = forcenetlogreload
+                    ForceNetLogReload = forcenetlogreload,
+                    CheckEdsm = checkedsm
                 };
                 _refreshWorker.RunWorkerAsync(args);
             }
@@ -1571,7 +1573,7 @@ namespace EDDiscovery
                 foreach (EliteDangerous.JournalEntry je in jlist)
                 {
                     bool journalupdate = false;
-                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, true, out journalupdate, conn);
+                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, args.CheckEdsm, out journalupdate, conn);
                     prev = he;
 
                     history.Add(he);

--- a/EDDiscovery/JournalViewControl.cs
+++ b/EDDiscovery/JournalViewControl.cs
@@ -200,7 +200,7 @@ namespace EDDiscovery
         private void buttonRefresh_Click(object sender, EventArgs e)
         {
             _discoveryForm.LogLine("Refresh History.");
-            _discoveryForm.RefreshHistoryAsync();
+            _discoveryForm.RefreshHistoryAsync(checkedsm: true);
         }
 
         private void buttonFilter_Click(object sender, EventArgs e)

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -788,7 +788,7 @@ namespace EDDiscovery
         private void button_RefreshHistory_Click(object sender, EventArgs e)
         {
             LogLine("Refresh History.");
-            _discoveryForm.RefreshHistoryAsync();
+            _discoveryForm.RefreshHistoryAsync(checkedsm: true);
         }
 
         private void textBoxFilter_KeyUp(object sender, KeyEventArgs e)


### PR DESCRIPTION
The implementation was trying to resolve all of the log entries that didn't have coordinates.  Avoid that, and only try to resolve coordinates when the user click Refresh.