### PR TITLE
Fix a couple of issues identified in netlog -> journal upgrade

### DIFF
--- a/EDDiscovery/DB/SQLiteDBUserClass.cs
+++ b/EDDiscovery/DB/SQLiteDBUserClass.cs
@@ -218,6 +218,11 @@ namespace EDDiscovery.DB
             SQLiteDBClass.PerformUpgrade(conn, 107, true, false, new[] { query1, query2, query3});
         }
 
+        private static void UpgradeUserDB108(SQLiteConnectionED conn)
+        {
+            string query1 = "ALTER TABLE Commanders ADD COLUMN JournalDir TEXT";
+            SQLiteDBClass.PerformUpgrade(conn, 108, true, false, new[] { query1 });
+        }
 
 
         private static void DropOldUserTables(SQLiteConnectionUser conn)

--- a/EDDiscovery/DB/SQLiteDBUserClass.cs
+++ b/EDDiscovery/DB/SQLiteDBUserClass.cs
@@ -322,8 +322,35 @@ namespace EDDiscovery.DB
                     }
                 }
 
-                                                               // 0    1    2    3         4         5          6 7 8 9
-                using (DbCommand cmd = conn.CreateCommand("Select Name,Time,Unit,Commander,edsm_sync,Map_colour,X,Y,Z,id_edsm_assigned From VisitedSystems Order By Time"))
+                int olddbver = SQLiteConnectionOld.GetSettingInt("DBVer", 1);
+
+                if (olddbver < 7) // 2.5.2
+                {
+                    System.Diagnostics.Trace.WriteLine("Database too old - unable to migrate travel log");
+                    return;
+                }
+
+                string query;
+
+                if (olddbver < 8) // 2.5.6
+                {
+                    query = "Select Name,Time,Unit,Commander,edsm_sync, -65536 AS Map_colour, NULL AS X, NULL AS Y, NULL AS Z, NULL as id_edsm_assigned From VisitedSystems Order By Time";
+                }
+                else if (olddbver < 14) // 3.2.1
+                {
+                    query = "Select Name,Time,Unit,Commander,edsm_sync,Map_colour, NULL AS X, NULL AS Y, NULL AS Z, NULL as id_edsm_assigned From VisitedSystems Order By Time";
+                }
+                else if (olddbver < 18) // 4.0.2
+                {
+                    query = "Select Name,Time,Unit,Commander,edsm_sync,Map_colour,X,Y,Z, NULL AS id_edsm_assigned From VisitedSystems Order By Time";
+                }
+                else
+                {
+                    //              0    1    2    3         4         5          6 7 8 9
+                    query = "Select Name,Time,Unit,Commander,edsm_sync,Map_colour,X,Y,Z,id_edsm_assigned From VisitedSystems Order By Time";
+                }
+
+                using (DbCommand cmd = conn.CreateCommand(query))
                 {
                     using (DbDataReader reader = cmd.ExecuteReader())
                     {

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -420,12 +420,13 @@ namespace EDDiscovery2
         {
             using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
             {
-                using (DbCommand cmd = conn.CreateCommand("UPDATE Commanders SET Name=@Name, EdsmApiKey=@EdsmApiKey, NetLogDir=@NetLogDir, SyncToEdsm=@SyncToEdsm, SyncFromEdsm=@SyncFromEdsm, SyncToEddn=@SyncToEddn WHERE Id=@Id"))
+                using (DbCommand cmd = conn.CreateCommand("UPDATE Commanders SET Name=@Name, EdsmApiKey=@EdsmApiKey, NetLogDir=@NetLogDir, JournalDir=@JournalDir, SyncToEdsm=@SyncToEdsm, SyncFromEdsm=@SyncFromEdsm, SyncToEddn=@SyncToEddn WHERE Id=@Id"))
                 {
                     cmd.AddParameter("@Id", DbType.Int32);
                     cmd.AddParameter("@Name", DbType.String);
                     cmd.AddParameter("@EdsmApiKey", DbType.String);
                     cmd.AddParameter("@NetLogDir", DbType.String);
+                    cmd.AddParameter("@JournalDir", DbType.String);
                     cmd.AddParameter("@SyncToEdsm", DbType.Boolean);
                     cmd.AddParameter("@SyncFromEdsm", DbType.Boolean);
                     cmd.AddParameter("@SyncToEddn", DbType.Boolean);
@@ -436,6 +437,7 @@ namespace EDDiscovery2
                         cmd.Parameters["@Name"].Value = edcmdr.Name;
                         cmd.Parameters["@EdsmApiKey"].Value = edcmdr.APIKey != null ? edcmdr.APIKey : "";
                         cmd.Parameters["@NetLogDir"].Value = edcmdr.NetLogDir != null ? edcmdr.NetLogDir : "";
+                        cmd.Parameters["@JournalDir"].Value = edcmdr.JournalDir != null ? edcmdr.JournalDir : "";
                         cmd.Parameters["@SyncToEdsm"].Value = edcmdr.SyncToEdsm;
                         cmd.Parameters["@SyncFromEdsm"].Value = edcmdr.SyncFromEdsm;
                         cmd.Parameters["@SyncToEddn"].Value = edcmdr.SyncToEddn;
@@ -448,17 +450,17 @@ namespace EDDiscovery2
         }
 
 
-        public EDCommander GetNewCommander(string name = null, string edsmApiKey = null, string netlogpath = null)
+        public EDCommander GetNewCommander(string name = null, string edsmApiKey = null, string journalpath = null)
         {
             EDCommander cmdr;
 
             using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
             {
-                using (DbCommand cmd = conn.CreateCommand("INSERT INTO Commanders (Name,EdsmApiKey,NetLogDir,Deleted, SyncToEdsm, SyncFromEdsm, SyncToEddn) VALUES (@Name,@EdsmApiKey,@NetLogDir,@Deleted, @SyncToEdsm, @SyncFromEdsm, @SyncToEddn)"))
+                using (DbCommand cmd = conn.CreateCommand("INSERT INTO Commanders (Name,EdsmApiKey,JournalDir,Deleted, SyncToEdsm, SyncFromEdsm, SyncToEddn) VALUES (@Name,@EdsmApiKey,@JournalDir,@Deleted, @SyncToEdsm, @SyncFromEdsm, @SyncToEddn)"))
                 {
                     cmd.AddParameterWithValue("@Name", name ?? "");
                     cmd.AddParameterWithValue("@EdsmApiKey", edsmApiKey ?? "");
-                    cmd.AddParameterWithValue("@NetLogDir", netlogpath ?? "");
+                    cmd.AddParameterWithValue("@JournalDir", journalpath ?? "");
                     cmd.AddParameterWithValue("@Deleted", false);
                     cmd.AddParameterWithValue("@SyncToEdsm", true);
                     cmd.AddParameterWithValue("@SyncFromEdsm", false);

--- a/EDDiscovery/EliteDangerous/EDCommander.cs
+++ b/EDDiscovery/EliteDangerous/EDCommander.cs
@@ -13,6 +13,7 @@ namespace EDDiscovery2
         private string name;
         private string apikey;
         private string netLogDir;
+        private string journalDir;
         private bool syncToEdsm;
         private bool syncFromEdsm;
         private bool syncToEddn;
@@ -25,6 +26,7 @@ namespace EDDiscovery2
             apikey = Convert.ToString(reader["EdsmApiKey"]);
             deleted = Convert.ToBoolean(reader["Deleted"]);
             netLogDir = Convert.ToString(reader["NetLogDir"]);
+            journalDir = Convert.ToString(reader["JournalDir"]);
 
             syncToEdsm = Convert.ToBoolean(reader["SyncToEdsm"]);
             syncFromEdsm = Convert.ToBoolean(reader["SyncFromEdsm"]);
@@ -91,6 +93,18 @@ namespace EDDiscovery2
             set
             {
                 netLogDir = value;
+            }
+        }
+
+        public string JournalDir
+        {
+            get
+            {
+                return journalDir;
+            }
+            set
+            {
+                journalDir = value;
             }
         }
 

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -427,6 +427,17 @@ namespace EDDiscovery.EliteDangerous
         {
             List<EDCommander> listCommanders = EDDConfig.Instance.ListOfCommanders;
 
+            if (frontierfolder != null && frontierfolder.Length != 0 && Directory.Exists(frontierfolder))
+            {
+                if (watchers.FindIndex(x => x.m_watcherfolder.Equals(frontierfolder)) < 0)
+                {
+                    System.Diagnostics.Trace.WriteLine(string.Format("New watch on {0}", frontierfolder));
+                    MonitorWatcher mw = new MonitorWatcher(frontierfolder);
+                    watchers.Add(mw);
+                    mw.OnNewJournalEntry += NewPosition;
+                }
+            }
+
             for (int i = 0; i < listCommanders.Count; i++)             // see if new watchers are needed
             {
                 string datapath = GetWatchFolder(listCommanders[i].NetLogDir);

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -440,7 +440,7 @@ namespace EDDiscovery.EliteDangerous
 
             for (int i = 0; i < listCommanders.Count; i++)             // see if new watchers are needed
             {
-                string datapath = GetWatchFolder(listCommanders[i].NetLogDir);
+                string datapath = GetWatchFolder(listCommanders[i].JournalDir);
 
                 if (datapath == null || datapath.Length == 0 || !Directory.Exists(datapath))
                     continue;
@@ -459,7 +459,7 @@ namespace EDDiscovery.EliteDangerous
             {
                 bool found = false;
                 for (int j = 0; j < listCommanders.Count; j++)          // all commanders, see if this watch folder is present
-                    found |= watchers[i].m_watcherfolder.Equals(GetWatchFolder(listCommanders[j].NetLogDir));
+                    found |= watchers[i].m_watcherfolder.Equals(GetWatchFolder(listCommanders[j].JournalDir));
 
                 if (!found)
                     tobedeleted.Add(i);


### PR DESCRIPTION
* Always watch the default journal directory if it exists
* Separate NetLogDir and JournalDir, and keep NetLogDir as the cache of where to look when importing netlogs for a commander
* Fix importing from 3.x and 2.5+ databases