### PR TITLE
Ignore first-chance exceptions outside our code

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -278,7 +278,19 @@ namespace EDDiscovery
 
             var trace = new StackTrace(1, true);
 
-            System.Diagnostics.Trace.WriteLine($"First chance exception: {e.Exception.Message}\n{trace.ToString()}");
+            // Ignore first-chance exceptions in threads outside our code
+            bool ourcode = false;
+            foreach (var frame in trace.GetFrames())
+            {
+                if (frame.GetMethod().DeclaringType.Assembly == Assembly.GetExecutingAssembly())
+                {
+                    ourcode = true;
+                    break;
+                }
+            }
+
+            if (ourcode)
+                System.Diagnostics.Trace.WriteLine($"First chance exception: {e.Exception.Message}\n{trace.ToString()}");
         }
 
         private void EDDiscoveryForm_Layout(object sender, LayoutEventArgs e)       // Manually position, could not get gripper under tab control with it sizing for the life of me


### PR DESCRIPTION
On some systems, the runtime tries to send Windows messages to non-existent threads, which floods the trace log with first-chance exceptions.  Don't log these, because there's nothing we can do about them.