### PR TITLE
Prevent DB deadlocks

### DIFF
--- a/EDDiscovery/DB/SQLiteDBSystemClass.cs
+++ b/EDDiscovery/DB/SQLiteDBSystemClass.cs
@@ -46,7 +46,7 @@ namespace EDDiscovery.DB
                 if (dbver < 102)
                     UpgradeSystemsDB102(conn);
 
-                CreateSystemDBTableIndexes();
+                CreateSystemDBTableIndexes(conn);
 
                 return true;
             }
@@ -57,7 +57,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        public static void UpgradeSystemsDB2(SQLiteConnectionED conn)
+        private static void UpgradeSystemsDB2(SQLiteConnectionED conn)
         {
             string query = "CREATE TABLE Systems (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , name TEXT NOT NULL COLLATE NOCASE , x FLOAT, y FLOAT, z FLOAT, cr INTEGER, commandercreate TEXT, createdate DATETIME, commanderupdate TEXT, updatedate DATETIME, status INTEGER, population INTEGER )";
             string query3 = "CREATE TABLE Distances (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL  UNIQUE , NameA TEXT NOT NULL , NameB TEXT NOT NULL , Dist FLOAT NOT NULL , CommanderCreate TEXT NOT NULL , CreateTime DATETIME NOT NULL , Status INTEGER NOT NULL )";
@@ -216,7 +216,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        private static void CreateSystemDBTableIndexes()
+        private static void CreateSystemDBTableIndexes(SQLiteConnectionSystem conn)
         {
             string[] queries = new[]
             {
@@ -231,14 +231,12 @@ namespace EDDiscovery.DB
                 "CREATE INDEX IF NOT EXISTS StationsIndex_system_ID  ON Stations (system_id ASC)",
                 "CREATE INDEX IF NOT EXISTS StationsIndex_system_Name  ON Stations (Name ASC)",
             };
-            using (SQLiteConnectionSystem conn = new SQLiteConnectionSystem())
+
+            foreach (string query in queries)
             {
-                foreach (string query in queries)
+                using (DbCommand cmd = conn.CreateCommand(query))
                 {
-                    using (DbCommand cmd = conn.CreateCommand(query))
-                    {
-                        cmd.ExecuteNonQuery();
-                    }
+                    cmd.ExecuteNonQuery();
                 }
             }
         }

--- a/EDDiscovery/DB/SQLiteDBUserClass.cs
+++ b/EDDiscovery/DB/SQLiteDBUserClass.cs
@@ -75,7 +75,7 @@ namespace EDDiscovery.DB
                 if (dbver < 110)
                     UpgradeUserDB110(conn);
 
-                CreateUserDBTableIndexes();
+                CreateUserDBTableIndexes(conn);
 
                 return true;
             }
@@ -322,7 +322,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        private static void CreateUserDBTableIndexes()
+        private static void CreateUserDBTableIndexes(SQLiteConnectionUser conn)
         {
             string[] queries = new[]
             {
@@ -334,14 +334,12 @@ namespace EDDiscovery.DB
                 "CREATE INDEX IF NOT EXISTS JournalEntry_EventTime ON JournalEntries (EventTime)",
                 "CREATE INDEX IF NOT EXISTS MaterialsCommodities_ClassName ON MaterialsCommodities (Category,Name)",
             };
-            using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
+
+            foreach (string query in queries)
             {
-                foreach (string query in queries)
+                using (DbCommand cmd = conn.CreateCommand(query))
                 {
-                    using (DbCommand cmd = conn.CreateCommand(query))
-                    {
-                        cmd.ExecuteNonQuery();
-                    }
+                    cmd.ExecuteNonQuery();
                 }
             }
         }
@@ -465,7 +463,7 @@ namespace EDDiscovery.DB
                 }
             }
 
-            using (SQLiteConnectionUserUTC conn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser conn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbTransaction txn = conn.BeginTransaction())
                 {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1666,7 +1666,7 @@ namespace EDDiscovery
             {
                 worker.ReportProgress(-1, "Updating journal entries");
 
-                using (SQLiteConnectionUserUTC conn = new SQLiteConnectionUserUTC())
+                using (SQLiteConnectionUser conn = new SQLiteConnectionUser(utc: true))
                 {
                     using (DbTransaction txn = conn.BeginTransaction())
                     {

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -233,7 +233,7 @@ namespace EDDiscovery2.EDSM
                         tlu.CommanderId = EDDiscoveryForm.EDDConfig.CurrentCommander.Nr;
                         tlu.Add();  // Add to Database
 
-                        using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+                        using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                         {
                             foreach (HistoryEntry he in toadd)
                             {

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -77,7 +77,7 @@ namespace EDDiscovery.EliteDangerous
                 }
             }
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true, shortlived: false))
             {
                 for (int i = 0; i < readersToUpdate.Count; i++)
                 {
@@ -97,7 +97,7 @@ namespace EDDiscovery.EliteDangerous
                         tn.Commit();
                     }
 
-                    reader.TravelLogUnit.Update();
+                    reader.TravelLogUnit.Update(cn);
 
                     updateProgress((i + 1) * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);
 
@@ -313,7 +313,7 @@ namespace EDDiscovery.EliteDangerous
                     netlogpos = nfi.TravelLogUnit.Size;
                     List<JournalEntry> ents = nfi.ReadJournalLog().ToList();
 
-                    using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+                    using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                     {
                         using (DbTransaction txn = cn.BeginTransaction())
                         {

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -363,14 +363,14 @@ namespace EDDiscovery.EliteDangerous
 
         public bool Add()
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 bool ret = Add(cn);
                 return ret;
             }
         }
 
-        public bool Add(SQLiteConnectionUserUTC cn, DbTransaction tn = null)
+        public bool Add(SQLiteConnectionUser cn, DbTransaction tn = null)
         {
             using (DbCommand cmd = cn.CreateCommand("Insert into JournalEntries (EventTime, TravelLogID, CommanderId, EventTypeId , EventType, EventData, EdsmId, Synced) values (@EventTime, @TravelLogID, @CommanderID, @EventTypeId , @EventStrName, @EventData, @EdsmId, @Synced)", tn))
             {
@@ -395,13 +395,13 @@ namespace EDDiscovery.EliteDangerous
 
         public bool Update()
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 return Update(cn);
             }
         }
 
-        private bool Update(SQLiteConnectionUserUTC cn, DbTransaction tn = null)
+        private bool Update(SQLiteConnectionUser cn, DbTransaction tn = null)
         {
             using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set EventTime=@EventTime, TravelLogID=@TravelLogID, CommanderID=@CommanderID, EventTypeId=@EventTypeId, EventType=@EventStrName, EventData=@EventData, EdsmId=@EdsmId, Synced=@Synced where ID=@id",tn))
             {
@@ -421,7 +421,7 @@ namespace EDDiscovery.EliteDangerous
         }
 
         //dist >0 to update
-        public static void UpdateEDSMIDPosJump(long journalid, ISystem system, bool jsonpos , double dist, SQLiteConnectionUserUTC cn = null, DbTransaction tn = null)
+        public static void UpdateEDSMIDPosJump(long journalid, ISystem system, bool jsonpos , double dist, SQLiteConnectionUser cn = null, DbTransaction tn = null)
         {
             bool ownconn = false;
 
@@ -430,7 +430,7 @@ namespace EDDiscovery.EliteDangerous
                 if (cn == null)
                 {
                     ownconn = true;
-                    cn = new SQLiteConnectionUserUTC();
+                    cn = new SQLiteConnectionUser(utc: true);
                 }
 
                 JournalEntry ent = Get(journalid, cn, tn);
@@ -470,7 +470,7 @@ namespace EDDiscovery.EliteDangerous
 
         public static void UpdateMapColour(long journalid, int mapcolour)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 JournalEntry ent = Get(journalid, cn);
 
@@ -494,7 +494,7 @@ namespace EDDiscovery.EliteDangerous
 
         public static void UpdateSyncFlagBit(long journalid, SyncFlags bit, bool value)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 JournalEntry je = Get(journalid, cn);
 
@@ -518,7 +518,7 @@ namespace EDDiscovery.EliteDangerous
 
         public static void UpdateCommanderID(long journalid, int cmdrid)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set CommanderID = @cmdrid where ID=@journalid"))
                 {
@@ -530,7 +530,7 @@ namespace EDDiscovery.EliteDangerous
             }
         }
 
-        static public JournalEntry Get(long journalid, SQLiteConnectionUserUTC cn, DbTransaction tn = null)
+        static public JournalEntry Get(long journalid, SQLiteConnectionUser cn, DbTransaction tn = null)
         {
             using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where ID=@journalid", tn))
             {
@@ -550,7 +550,7 @@ namespace EDDiscovery.EliteDangerous
 
         static public JournalEntry Get(long journalid)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 return Get(journalid, cn);
             }
@@ -563,7 +563,7 @@ namespace EDDiscovery.EliteDangerous
         {
             List<JournalEntry> list = new List<JournalEntry>();
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where CommanderID=@commander Order by EventTime ASC"))
                 {
@@ -593,7 +593,7 @@ namespace EDDiscovery.EliteDangerous
         {
             List<JournalEntry> vsc = new List<JournalEntry>();
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE EventTypeID = @eventtype and  CommanderID=@commander and  EventTime >@start and EventTime<@Stop ORDER BY EventTime ASC"))
                 {
@@ -619,7 +619,7 @@ namespace EDDiscovery.EliteDangerous
         {
             List<JournalEntry> vsc = new List<JournalEntry>();
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE TravelLogId = @source ORDER BY EventTime ASC"))
                 {
@@ -639,7 +639,7 @@ namespace EDDiscovery.EliteDangerous
         public static T GetLast<T>(int cmdrid, DateTime before)
             where T : JournalEntry
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE CommanderId = @cmdrid AND EventTime < @time ORDER BY EventTime DESC"))
                 {
@@ -1129,7 +1129,7 @@ namespace EDDiscovery.EliteDangerous
 
         static public bool ResetCommanderID(int from , int to)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set CommanderID = @cmdridto where CommanderID=@cmdridfrom"))
                 {

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -128,7 +128,7 @@ namespace EDDiscovery
                 }
             }
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true, shortlived: false))
             {
                 for (int i = 0; i < readersToUpdate.Count; i++)
                 {


### PR DESCRIPTION
It appears that the new SQLite library uses speculative
locking - it locks the database when it is freshly
opened, in anticipation of a command being executed.
Prevent the deadlocks this creates by locking the database
for the entire life of short-lived connections.

Also remove some recursive DB opens, and report any other
recursive opens.