### PR TITLE
Switch to Reader/Writer lock, prevent DB deadlocks

### DIFF
--- a/EDDiscovery/3DMap/StarNamesList.cs
+++ b/EDDiscovery/3DMap/StarNamesList.cs
@@ -239,9 +239,9 @@ namespace EDDiscovery2
 
                 //string res = "";  // used to view whats added/removed/draw..
 
-                using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem())
+                foreach (StarGrid.InViewInfo inview in inviewlist.Values)            // for all in viewport, sorted by distance from camera position
                 {
-                    foreach (StarGrid.InViewInfo inview in inviewlist.Values)            // for all in viewport, sorted by distance from camera position
+                    using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem())
                     {
                         StarNames sys = null;
                         bool draw = false;

--- a/EDDiscovery/DB/BookmarkClass.cs
+++ b/EDDiscovery/DB/BookmarkClass.cs
@@ -135,7 +135,7 @@ namespace EDDiscovery2.DB
         {
             try
             {
-                using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+                using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
                 {
                     using (DbCommand cmd = cn.CreateCommand("select * from Bookmarks"))
                     {

--- a/EDDiscovery/DB/MaterialCommodities.cs
+++ b/EDDiscovery/DB/MaterialCommodities.cs
@@ -125,7 +125,7 @@ namespace EDDiscovery2.DB
 
         public static MaterialCommodities Get(string c, string name)
         {
-            using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
             {
                 return Get(c, name, cn);
             }

--- a/EDDiscovery/DB/SQLiteDBSystemClass.cs
+++ b/EDDiscovery/DB/SQLiteDBSystemClass.cs
@@ -46,7 +46,7 @@ namespace EDDiscovery.DB
                 if (dbver < 102)
                     UpgradeSystemsDB102(conn);
 
-                CreateSystemDBTableIndexes();
+                CreateSystemDBTableIndexes(conn);
 
                 return true;
             }
@@ -57,7 +57,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        public static void UpgradeSystemsDB2(SQLiteConnectionED conn)
+        private static void UpgradeSystemsDB2(SQLiteConnectionED conn)
         {
             string query = "CREATE TABLE Systems (id INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE , name TEXT NOT NULL COLLATE NOCASE , x FLOAT, y FLOAT, z FLOAT, cr INTEGER, commandercreate TEXT, createdate DATETIME, commanderupdate TEXT, updatedate DATETIME, status INTEGER, population INTEGER )";
             string query3 = "CREATE TABLE Distances (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL  UNIQUE , NameA TEXT NOT NULL , NameB TEXT NOT NULL , Dist FLOAT NOT NULL , CommanderCreate TEXT NOT NULL , CreateTime DATETIME NOT NULL , Status INTEGER NOT NULL )";
@@ -216,7 +216,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        private static void CreateSystemDBTableIndexes()
+        private static void CreateSystemDBTableIndexes(SQLiteConnectionSystem conn)
         {
             string[] queries = new[]
             {
@@ -231,14 +231,12 @@ namespace EDDiscovery.DB
                 "CREATE INDEX IF NOT EXISTS StationsIndex_system_ID  ON Stations (system_id ASC)",
                 "CREATE INDEX IF NOT EXISTS StationsIndex_system_Name  ON Stations (Name ASC)",
             };
-            using (SQLiteConnectionSystem conn = new SQLiteConnectionSystem())
+
+            foreach (string query in queries)
             {
-                foreach (string query in queries)
+                using (DbCommand cmd = conn.CreateCommand(query))
                 {
-                    using (DbCommand cmd = conn.CreateCommand(query))
-                    {
-                        cmd.ExecuteNonQuery();
-                    }
+                    cmd.ExecuteNonQuery();
                 }
             }
         }

--- a/EDDiscovery/DB/SQLiteDBUserClass.cs
+++ b/EDDiscovery/DB/SQLiteDBUserClass.cs
@@ -75,7 +75,7 @@ namespace EDDiscovery.DB
                 if (dbver < 110)
                     UpgradeUserDB110(conn);
 
-                CreateUserDBTableIndexes();
+                CreateUserDBTableIndexes(conn);
 
                 return true;
             }
@@ -322,7 +322,7 @@ namespace EDDiscovery.DB
             }
         }
 
-        private static void CreateUserDBTableIndexes()
+        private static void CreateUserDBTableIndexes(SQLiteConnectionUser conn)
         {
             string[] queries = new[]
             {
@@ -334,14 +334,12 @@ namespace EDDiscovery.DB
                 "CREATE INDEX IF NOT EXISTS JournalEntry_EventTime ON JournalEntries (EventTime)",
                 "CREATE INDEX IF NOT EXISTS MaterialsCommodities_ClassName ON MaterialsCommodities (Category,Name)",
             };
-            using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
+
+            foreach (string query in queries)
             {
-                foreach (string query in queries)
+                using (DbCommand cmd = conn.CreateCommand(query))
                 {
-                    using (DbCommand cmd = conn.CreateCommand(query))
-                    {
-                        cmd.ExecuteNonQuery();
-                    }
+                    cmd.ExecuteNonQuery();
                 }
             }
         }
@@ -465,7 +463,7 @@ namespace EDDiscovery.DB
                 }
             }
 
-            using (SQLiteConnectionUserUTC conn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser conn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbTransaction txn = conn.BeginTransaction())
                 {

--- a/EDDiscovery/DB/SavedRouteClass.cs
+++ b/EDDiscovery/DB/SavedRouteClass.cs
@@ -160,7 +160,7 @@ namespace EDDiscovery.DB
 
             try
             {
-                using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+                using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
                 {
                     using (DbCommand cmd1 = cn.CreateCommand("select * from routes_expeditions"))
                     {

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1081,49 +1081,52 @@ namespace EDDiscovery.DB
                 return ParseEDSMUpdateSystemsReader(jr, ref date, ref outoforder, removenonedsmids, discoveryform, cancelRequested, reportProgress, useCache, useTempSystems);
         }
 
-        private static Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> GetEdsmSystemsLite(SQLiteConnectionSystem cn)
+        private static Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> GetEdsmSystemsLite()
         {
-            Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> systemsByEdsmId = new Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase>();
-
-            using (DbCommand cmd = cn.CreateCommand("SELECT s.id, s.EdsmId, n.Name, s.x, s.y, s.z, s.UpdateTimestamp, s.gridid, s.randomid FROM EdsmSystems s JOIN SystemNames n ON n.EdsmId = s.EdsmId"))
+            using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Reader))
             {
-                using (DbDataReader reader = cmd.ExecuteReader())
+                Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> systemsByEdsmId = new Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase>();
+
+                using (DbCommand cmd = cn.CreateCommand("SELECT s.id, s.EdsmId, n.Name, s.x, s.y, s.z, s.UpdateTimestamp, s.gridid, s.randomid FROM EdsmSystems s JOIN SystemNames n ON n.EdsmId = s.EdsmId"))
                 {
-                    while (reader.Read())
+                    using (DbDataReader reader = cmd.ExecuteReader())
                     {
-                        EDDiscovery2.DB.InMemory.SystemClassBase sys = new EDDiscovery2.DB.InMemory.SystemClassBase
+                        while (reader.Read())
                         {
-                            id = (long)reader["id"],
-                            name = (string)reader["name"]
-                        };
+                            EDDiscovery2.DB.InMemory.SystemClassBase sys = new EDDiscovery2.DB.InMemory.SystemClassBase
+                            {
+                                id = (long)reader["id"],
+                                name = (string)reader["name"]
+                            };
 
-                        string searchname = sys.name.ToLower();
+                            string searchname = sys.name.ToLower();
 
-                        if (System.DBNull.Value == reader["x"])
-                        {
-                            sys.x = double.NaN;
-                            sys.y = double.NaN;
-                            sys.z = double.NaN;
+                            if (System.DBNull.Value == reader["x"])
+                            {
+                                sys.x = double.NaN;
+                                sys.y = double.NaN;
+                                sys.z = double.NaN;
+                            }
+                            else
+                            {
+                                sys.x = ((double)(long)reader["x"]) / XYZScalar;
+                                sys.y = ((double)(long)reader["y"]) / XYZScalar;
+                                sys.z = ((double)(long)reader["z"]) / XYZScalar;
+                            }
+
+                            sys.id_edsm = (long)reader["EdsmId"];
+                            systemsByEdsmId[sys.id_edsm] = sys;
+                            sys.gridid = reader["gridid"] == DBNull.Value ? 0 : (int)((long)reader["gridid"]);
+                            sys.randomid = reader["randomid"] == DBNull.Value ? 0 : (int)((long)reader["randomid"]);
                         }
-                        else
-                        {
-                            sys.x = ((double)(long)reader["x"]) / XYZScalar;
-                            sys.y = ((double)(long)reader["y"]) / XYZScalar;
-                            sys.z = ((double)(long)reader["z"]) / XYZScalar;
-                        }
-
-                        sys.id_edsm = (long)reader["EdsmId"];
-                        systemsByEdsmId[sys.id_edsm] = sys;
-                        sys.gridid = reader["gridid"] == DBNull.Value ? 0 : (int)((long)reader["gridid"]);
-                        sys.randomid = reader["randomid"] == DBNull.Value ? 0 : (int)((long)reader["randomid"]);
                     }
                 }
-            }
 
-            return systemsByEdsmId;
+                return systemsByEdsmId;
+            }
         }
 
-        private static long DoParseEDSMUpdateSystemsReader(JsonTextReader jr, ref string date, ref bool outoforder, SQLiteConnectionSystem cn, EDDiscoveryForm discoveryform, Func<bool> cancelRequested, Action<int, string> reportProgress, bool useCache = true, bool useTempSystems = false)
+        private static long DoParseEDSMUpdateSystemsReader(JsonTextReader jr, ref string date, ref bool outoforder, EDDiscoveryForm discoveryform, Func<bool> cancelRequested, Action<int, string> reportProgress, bool useCache = true, bool useTempSystems = false)
         {
             DateTime maxdate;
 
@@ -1132,7 +1135,7 @@ namespace EDDiscovery.DB
                 maxdate = new DateTime(2010, 1, 1);
             }
 
-            Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> systemsByEdsmId = useCache ? GetEdsmSystemsLite(cn) : new Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase>();
+            Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase> systemsByEdsmId = useCache ? GetEdsmSystemsLite() : new Dictionary<long, EDDiscovery2.DB.InMemory.SystemClassBase>();
             int count = 0;
             int updatecount = 0;
             int insertcount = 0;
@@ -1167,211 +1170,213 @@ namespace EDDiscovery.DB
                         break;
                     }
                 }
-                 
 
-                using (DbTransaction txn = cn.BeginTransaction())
+                using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))
                 {
-                    DbCommand updateNameCmd = null;
-                    DbCommand updateSysCmd = null;
-                    DbCommand insertNameCmd = null;
-                    DbCommand insertSysCmd = null;
-                    DbCommand selectSysCmd = null;
-                    DbCommand selectNameCmd = null;
-
-                    try
+                    using (DbTransaction txn = cn.BeginTransaction())
                     {
-                        updateNameCmd = cn.CreateCommand("UPDATE SystemNames SET Name=@Name WHERE EdsmId=@EdsmId", txn);
-                        updateNameCmd.AddParameter("@Name", DbType.String);
-                        updateNameCmd.AddParameter("@EdsmId", DbType.Int64);
+                        DbCommand updateNameCmd = null;
+                        DbCommand updateSysCmd = null;
+                        DbCommand insertNameCmd = null;
+                        DbCommand insertSysCmd = null;
+                        DbCommand selectSysCmd = null;
+                        DbCommand selectNameCmd = null;
 
-                        updateSysCmd = cn.CreateCommand("UPDATE EdsmSystems SET X=@X, Y=@Y, Z=@Z, UpdateTimestamp=@UpdateTimestamp, VersionTimestamp=@VersionTimestamp, GridId=@GridId, RandomId=@RandomId WHERE EdsmId=@EdsmId", txn);
-                        updateSysCmd.AddParameter("@X", DbType.Int64);
-                        updateSysCmd.AddParameter("@Y", DbType.Int64);
-                        updateSysCmd.AddParameter("@Z", DbType.Int64);
-                        updateSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
-                        updateSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
-                        updateSysCmd.AddParameter("@GridId", DbType.Int64);
-                        updateSysCmd.AddParameter("@RandomId", DbType.Int64);
-                        updateSysCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                        insertNameCmd = cn.CreateCommand("INSERT INTO " + sysnamesTableName + " (Name, EdsmId) VALUES (@Name, @EdsmId)", txn);
-                        insertNameCmd.AddParameter("@Name", DbType.String);
-                        insertNameCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                        insertSysCmd = cn.CreateCommand("INSERT INTO " + edsmsysTableName + " (EdsmId, X, Y, Z, CreateTimestamp, UpdateTimestamp, VersionTimestamp, GridId, RandomId) VALUES (@EdsmId, @X, @Y, @Z, @CreateTimestamp, @UpdateTimestamp, @VersionTimestamp, @GridId, @RandomId)", txn);
-                        insertSysCmd.AddParameter("@EdsmId", DbType.Int64);
-                        insertSysCmd.AddParameter("@X", DbType.Int64);
-                        insertSysCmd.AddParameter("@Y", DbType.Int64);
-                        insertSysCmd.AddParameter("@Z", DbType.Int64);
-                        insertSysCmd.AddParameter("@CreateTimestamp", DbType.Int64);
-                        insertSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
-                        insertSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
-                        insertSysCmd.AddParameter("@GridId", DbType.Int64);
-                        insertSysCmd.AddParameter("@RandomId", DbType.Int64);
-
-                        selectSysCmd = cn.CreateCommand("SELECT Id, X, Y, Z, GridId, RandomId FROM EdsmSystems WHERE EdsmId=@EdsmId");
-                        selectSysCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                        selectNameCmd = cn.CreateCommand("SELECT Name FROM SystemNames WHERE EdsmId = @EdsmId");
-                        selectNameCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                        IEnumerator<JObject> jo_enum = objs.GetEnumerator();
-
-                        while (!cancelRequested())
+                        try
                         {
-                            if (!jo_enum.MoveNext())
+                            updateNameCmd = cn.CreateCommand("UPDATE SystemNames SET Name=@Name WHERE EdsmId=@EdsmId", txn);
+                            updateNameCmd.AddParameter("@Name", DbType.String);
+                            updateNameCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                            updateSysCmd = cn.CreateCommand("UPDATE EdsmSystems SET X=@X, Y=@Y, Z=@Z, UpdateTimestamp=@UpdateTimestamp, VersionTimestamp=@VersionTimestamp, GridId=@GridId, RandomId=@RandomId WHERE EdsmId=@EdsmId", txn);
+                            updateSysCmd.AddParameter("@X", DbType.Int64);
+                            updateSysCmd.AddParameter("@Y", DbType.Int64);
+                            updateSysCmd.AddParameter("@Z", DbType.Int64);
+                            updateSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
+                            updateSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
+                            updateSysCmd.AddParameter("@GridId", DbType.Int64);
+                            updateSysCmd.AddParameter("@RandomId", DbType.Int64);
+                            updateSysCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                            insertNameCmd = cn.CreateCommand("INSERT INTO " + sysnamesTableName + " (Name, EdsmId) VALUES (@Name, @EdsmId)", txn);
+                            insertNameCmd.AddParameter("@Name", DbType.String);
+                            insertNameCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                            insertSysCmd = cn.CreateCommand("INSERT INTO " + edsmsysTableName + " (EdsmId, X, Y, Z, CreateTimestamp, UpdateTimestamp, VersionTimestamp, GridId, RandomId) VALUES (@EdsmId, @X, @Y, @Z, @CreateTimestamp, @UpdateTimestamp, @VersionTimestamp, @GridId, @RandomId)", txn);
+                            insertSysCmd.AddParameter("@EdsmId", DbType.Int64);
+                            insertSysCmd.AddParameter("@X", DbType.Int64);
+                            insertSysCmd.AddParameter("@Y", DbType.Int64);
+                            insertSysCmd.AddParameter("@Z", DbType.Int64);
+                            insertSysCmd.AddParameter("@CreateTimestamp", DbType.Int64);
+                            insertSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
+                            insertSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
+                            insertSysCmd.AddParameter("@GridId", DbType.Int64);
+                            insertSysCmd.AddParameter("@RandomId", DbType.Int64);
+
+                            selectSysCmd = cn.CreateCommand("SELECT Id, X, Y, Z, GridId, RandomId FROM EdsmSystems WHERE EdsmId=@EdsmId");
+                            selectSysCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                            selectNameCmd = cn.CreateCommand("SELECT Name FROM SystemNames WHERE EdsmId = @EdsmId");
+                            selectNameCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                            IEnumerator<JObject> jo_enum = objs.GetEnumerator();
+
+                            while (!cancelRequested())
                             {
-                                reportProgress(-1, $"Syncing EDSM systems: {count} processed, {insertcount} new systems, {updatecount} updated systems");
-                                txn.Commit();
-
-                                if (jr_eof)
+                                if (!jo_enum.MoveNext())
                                 {
-                                    date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                                    reportProgress(-1, $"Syncing EDSM systems: {count} processed, {insertcount} new systems, {updatecount} updated systems");
+                                    txn.Commit();
 
-                                    Console.WriteLine($"Import took {sw.ElapsedMilliseconds}ms");
-
-                                    for (int id = 0; id < histogramsystems.Length; id++)
+                                    if (jr_eof)
                                     {
-                                        if (histogramsystems[id] != 0)
-                                            Console.WriteLine("Id " + id + " count " + histogramsystems[id]);
-                                    }
+                                        date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
-                                    return updatecount + insertcount;
-                                }
+                                        Console.WriteLine($"Import took {sw.ElapsedMilliseconds}ms");
 
-                                break;
-                            }
-
-                            JObject jo = jo_enum.Current;
-
-                            JObject coords = (JObject)jo["coords"];
-
-                            if (coords != null && (coords["x"].Type == JTokenType.Float || coords["x"].Type == JTokenType.Integer))
-                            {
-                                double x = coords["x"].Value<double>();
-                                double y = coords["y"].Value<double>();
-                                double z = coords["z"].Value<double>();
-                                long edsmid = jo["id"].Value<long>();
-                                string name = jo["name"].Value<string>();
-                                int gridid = GridId.Id(x, z);
-                                int randomid = rnd.Next(0, 99);
-                                DateTime updatedate = jo["date"].Value<DateTime>();
-                                histogramsystems[gridid]++;
-
-                                if (updatedate > maxdate)
-                                    maxdate = updatedate;
-                                else if (updatedate < maxdate - TimeSpan.FromHours(1))
-                                    outoforder = true;
-
-                                EDDiscovery2.DB.InMemory.SystemClassBase dbsys = null;
-
-                                if (!useTempSystems)
-                                {
-                                    if (useCache && systemsByEdsmId.ContainsKey(edsmid))
-                                        dbsys = systemsByEdsmId[edsmid];
-
-                                    if (!useCache)
-                                    {
-                                        selectSysCmd.Parameters["@EdsmId"].Value = edsmid;
-                                        using (DbDataReader reader = selectSysCmd.ExecuteReader())
+                                        for (int id = 0; id < histogramsystems.Length; id++)
                                         {
-                                            if (reader.Read())
-                                            {
-                                                dbsys = new EDDiscovery2.DB.InMemory.SystemClassBase
-                                                {
-                                                    id = (long)reader["id"],
-                                                    id_edsm = edsmid
-                                                };
-
-                                                if (System.DBNull.Value == reader["x"])
-                                                {
-                                                    dbsys.x = double.NaN;
-                                                    dbsys.y = double.NaN;
-                                                    dbsys.z = double.NaN;
-                                                }
-                                                else
-                                                {
-                                                    dbsys.x = ((double)(long)reader["X"]) / XYZScalar;
-                                                    dbsys.y = ((double)(long)reader["Y"]) / XYZScalar;
-                                                    dbsys.z = ((double)(long)reader["Z"]) / XYZScalar;
-                                                }
-
-                                                dbsys.id_edsm = edsmid;
-                                                dbsys.gridid = reader["GridId"] == DBNull.Value ? 0 : (int)((long)reader["GridId"]);
-                                                dbsys.randomid = reader["RandomId"] == DBNull.Value ? 0 : (int)((long)reader["RandomId"]);
-                                            }
+                                            if (histogramsystems[id] != 0)
+                                                Console.WriteLine("Id " + id + " count " + histogramsystems[id]);
                                         }
 
-                                        if (dbsys != null)
+                                        return updatecount + insertcount;
+                                    }
+
+                                    break;
+                                }
+
+                                JObject jo = jo_enum.Current;
+
+                                JObject coords = (JObject)jo["coords"];
+
+                                if (coords != null && (coords["x"].Type == JTokenType.Float || coords["x"].Type == JTokenType.Integer))
+                                {
+                                    double x = coords["x"].Value<double>();
+                                    double y = coords["y"].Value<double>();
+                                    double z = coords["z"].Value<double>();
+                                    long edsmid = jo["id"].Value<long>();
+                                    string name = jo["name"].Value<string>();
+                                    int gridid = GridId.Id(x, z);
+                                    int randomid = rnd.Next(0, 99);
+                                    DateTime updatedate = jo["date"].Value<DateTime>();
+                                    histogramsystems[gridid]++;
+
+                                    if (updatedate > maxdate)
+                                        maxdate = updatedate;
+                                    else if (updatedate < maxdate - TimeSpan.FromHours(1))
+                                        outoforder = true;
+
+                                    EDDiscovery2.DB.InMemory.SystemClassBase dbsys = null;
+
+                                    if (!useTempSystems)
+                                    {
+                                        if (useCache && systemsByEdsmId.ContainsKey(edsmid))
+                                            dbsys = systemsByEdsmId[edsmid];
+
+                                        if (!useCache)
                                         {
-                                            selectNameCmd.Parameters["@EdsmId"].Value = edsmid;
-                                            using (DbDataReader reader = selectNameCmd.ExecuteReader())
+                                            selectSysCmd.Parameters["@EdsmId"].Value = edsmid;
+                                            using (DbDataReader reader = selectSysCmd.ExecuteReader())
                                             {
                                                 if (reader.Read())
                                                 {
-                                                    dbsys.name = (string)reader["Name"];
+                                                    dbsys = new EDDiscovery2.DB.InMemory.SystemClassBase
+                                                    {
+                                                        id = (long)reader["id"],
+                                                        id_edsm = edsmid
+                                                    };
+
+                                                    if (System.DBNull.Value == reader["x"])
+                                                    {
+                                                        dbsys.x = double.NaN;
+                                                        dbsys.y = double.NaN;
+                                                        dbsys.z = double.NaN;
+                                                    }
+                                                    else
+                                                    {
+                                                        dbsys.x = ((double)(long)reader["X"]) / XYZScalar;
+                                                        dbsys.y = ((double)(long)reader["Y"]) / XYZScalar;
+                                                        dbsys.z = ((double)(long)reader["Z"]) / XYZScalar;
+                                                    }
+
+                                                    dbsys.id_edsm = edsmid;
+                                                    dbsys.gridid = reader["GridId"] == DBNull.Value ? 0 : (int)((long)reader["GridId"]);
+                                                    dbsys.randomid = reader["RandomId"] == DBNull.Value ? 0 : (int)((long)reader["RandomId"]);
+                                                }
+                                            }
+
+                                            if (dbsys != null)
+                                            {
+                                                selectNameCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                using (DbDataReader reader = selectNameCmd.ExecuteReader())
+                                                {
+                                                    if (reader.Read())
+                                                    {
+                                                        dbsys.name = (string)reader["Name"];
+                                                    }
                                                 }
                                             }
                                         }
                                     }
+
+                                    if (dbsys != null)
+                                    {
+                                        // see if EDSM data changed..
+                                        if (!dbsys.name.Equals(name))
+                                        {
+                                            updateNameCmd.Parameters["@Name"].Value = name;
+                                            updateNameCmd.Parameters["@EdsmId"].Value = edsmid;
+                                            updateNameCmd.ExecuteNonQuery();
+                                        }
+
+                                        if (Math.Abs(dbsys.x - x) > 0.01 ||
+                                            Math.Abs(dbsys.y - y) > 0.01 ||
+                                            Math.Abs(dbsys.z - z) > 0.01 ||
+                                            dbsys.gridid != gridid)  // position changed
+                                        {
+                                            updateSysCmd.Parameters["@X"].Value = (long)(x * XYZScalar);
+                                            updateSysCmd.Parameters["@Y"].Value = (long)(y * XYZScalar);
+                                            updateSysCmd.Parameters["@Z"].Value = (long)(z * XYZScalar);
+                                            updateSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                            updateSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                            updateSysCmd.Parameters["@GridId"].Value = gridid;
+                                            updateSysCmd.Parameters["@RandomId"].Value = randomid;
+                                            updateSysCmd.Parameters["@EdsmId"].Value = edsmid;
+                                            updateSysCmd.ExecuteNonQuery();
+                                            updatecount++;
+                                        }
+                                    }
+                                    else                                                                  // not in database..
+                                    {
+                                        insertNameCmd.Parameters["@Name"].Value = name;
+                                        insertNameCmd.Parameters["@EdsmId"].Value = edsmid;
+                                        insertNameCmd.ExecuteNonQuery();
+                                        insertSysCmd.Parameters["@EdsmId"].Value = edsmid;
+                                        insertSysCmd.Parameters["@X"].Value = (long)(x * XYZScalar);
+                                        insertSysCmd.Parameters["@Y"].Value = (long)(y * XYZScalar);
+                                        insertSysCmd.Parameters["@Z"].Value = (long)(z * XYZScalar);
+                                        insertSysCmd.Parameters["@CreateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                        insertSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                        insertSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                        insertSysCmd.Parameters["@GridId"].Value = gridid;
+                                        insertSysCmd.Parameters["@RandomId"].Value = randomid;
+                                        insertSysCmd.ExecuteNonQuery();
+                                        insertcount++;
+                                    }
                                 }
 
-                                if (dbsys != null)
-                                {
-                                    // see if EDSM data changed..
-                                    if (!dbsys.name.Equals(name))
-                                    {
-                                        updateNameCmd.Parameters["@Name"].Value = name;
-                                        updateNameCmd.Parameters["@EdsmId"].Value = edsmid;
-                                        updateNameCmd.ExecuteNonQuery();
-                                    }
-
-                                    if (Math.Abs(dbsys.x - x) > 0.01 ||
-                                        Math.Abs(dbsys.y - y) > 0.01 ||
-                                        Math.Abs(dbsys.z - z) > 0.01 ||
-                                        dbsys.gridid != gridid)  // position changed
-                                    {
-                                        updateSysCmd.Parameters["@X"].Value = (long)(x * XYZScalar);
-                                        updateSysCmd.Parameters["@Y"].Value = (long)(y * XYZScalar);
-                                        updateSysCmd.Parameters["@Z"].Value = (long)(z * XYZScalar);
-                                        updateSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                        updateSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                        updateSysCmd.Parameters["@GridId"].Value = gridid;
-                                        updateSysCmd.Parameters["@RandomId"].Value = randomid;
-                                        updateSysCmd.Parameters["@EdsmId"].Value = edsmid;
-                                        updateSysCmd.ExecuteNonQuery();
-                                        updatecount++;
-                                    }
-                                }
-                                else                                                                  // not in database..
-                                {
-                                    insertNameCmd.Parameters["@Name"].Value = name;
-                                    insertNameCmd.Parameters["@EdsmId"].Value = edsmid;
-                                    insertNameCmd.ExecuteNonQuery();
-                                    insertSysCmd.Parameters["@EdsmId"].Value = edsmid;
-                                    insertSysCmd.Parameters["@X"].Value = (long)(x * XYZScalar);
-                                    insertSysCmd.Parameters["@Y"].Value = (long)(y * XYZScalar);
-                                    insertSysCmd.Parameters["@Z"].Value = (long)(z * XYZScalar);
-                                    insertSysCmd.Parameters["@CreateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                    insertSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                    insertSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                    insertSysCmd.Parameters["@GridId"].Value = gridid;
-                                    insertSysCmd.Parameters["@RandomId"].Value = randomid;
-                                    insertSysCmd.ExecuteNonQuery();
-                                    insertcount++;
-                                }
+                                count++;
                             }
-
-                            count++;
                         }
-                    }
-                    finally
-                    {
-                        if (updateNameCmd != null) updateNameCmd.Dispose();
-                        if (updateSysCmd != null) updateSysCmd.Dispose();
-                        if (insertNameCmd != null) insertNameCmd.Dispose();
-                        if (insertSysCmd != null) insertSysCmd.Dispose();
-                        if (selectSysCmd != null) selectSysCmd.Dispose();
+                        finally
+                        {
+                            if (updateNameCmd != null) updateNameCmd.Dispose();
+                            if (updateSysCmd != null) updateSysCmd.Dispose();
+                            if (insertNameCmd != null) insertNameCmd.Dispose();
+                            if (insertSysCmd != null) insertSysCmd.Dispose();
+                            if (selectSysCmd != null) selectSysCmd.Dispose();
+                        }
                     }
                 }
             }
@@ -1386,10 +1391,7 @@ namespace EDDiscovery.DB
 
         private static long ParseEDSMUpdateSystemsReader(JsonTextReader jr, ref string date, ref bool outoforder, bool removenonedsmids, EDDiscoveryForm discoveryform, Func<bool> cancelRequested, Action<int, string> reportProgress, bool useCache = true, bool useTempSystems = false)
         {
-            using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(shortlived: false))  // open the db
-            {
-                return DoParseEDSMUpdateSystemsReader(jr, ref date, ref outoforder, cn, discoveryform, cancelRequested, reportProgress, useCache, useTempSystems);
-            }
+            return DoParseEDSMUpdateSystemsReader(jr, ref date, ref outoforder, discoveryform, cancelRequested, reportProgress, useCache, useTempSystems);
         }
 
         public static void RemoveHiddenSystems()
@@ -1406,7 +1408,7 @@ namespace EDDiscovery.DB
         {
             JsonTextReader jr = new JsonTextReader(new StringReader(json));
 
-            using (SQLiteConnectionSystem cn2 = new SQLiteConnectionSystem())  // open the db
+            using (SQLiteConnectionSystem cn2 = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))  // open the db
             {
                 using (DbTransaction txn = cn2.BeginTransaction())
                 {
@@ -1484,7 +1486,7 @@ namespace EDDiscovery.DB
             int updated = 0;
             int inserted = 0;
 
-            using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(shortlived: false))  // open the db
+            using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))  // open the db
             {
                 DbCommand selectCmd = null;
                 DbCommand insertCmd = null;

--- a/EDDiscovery/DB/SystemNoteClass.cs
+++ b/EDDiscovery/DB/SystemNoteClass.cs
@@ -96,7 +96,7 @@ namespace EDDiscovery2.DB
         {
             try
             {
-                using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+                using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
                 {
                     using (DbCommand cmd = cn.CreateCommand("select * from SystemNote"))
                     {

--- a/EDDiscovery/DB/TravelLogUnit.cs
+++ b/EDDiscovery/DB/TravelLogUnit.cs
@@ -131,7 +131,7 @@ namespace EDDiscovery2.DB
         {
             List<TravelLogUnit> list = new List<TravelLogUnit>();
 
-            using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
             {
                 using (DbCommand cmd = cn.CreateCommand("select * from TravelLogUnit"))
                 {
@@ -153,7 +153,7 @@ namespace EDDiscovery2.DB
         public static List<string> GetAllNames()
         {
             List<string> names = new List<string>();
-            using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT DISTINCT Name FROM TravelLogUnit"))
                 {
@@ -171,7 +171,7 @@ namespace EDDiscovery2.DB
 
         public static TravelLogUnit Get(string name)
         {
-            using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM TravelLogUnit WHERE Name = @name ORDER BY Id DESC"))
                 {

--- a/EDDiscovery/DB/WantedSystemClass.cs
+++ b/EDDiscovery/DB/WantedSystemClass.cs
@@ -77,7 +77,7 @@ namespace EDDiscovery.DB
         {
             try
             {
-                using (SQLiteConnectionUser cn = new SQLiteConnectionUser())
+                using (SQLiteConnectionUser cn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
                 {
                     using (DbCommand cmd = cn.CreateCommand("select * from wanted_systems"))
                     {

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -341,7 +341,7 @@ namespace EDDiscovery2
 
                 int maxnr = -1;
 
-                using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
+                using (SQLiteConnectionUser conn = new SQLiteConnectionUser(mode: EDDbAccessMode.Reader))
                 {
                     using (DbCommand cmd = conn.CreateCommand("SELECT * FROM Commanders"))
                     {
@@ -364,8 +364,11 @@ namespace EDDiscovery2
                             }
                         }
                     }
+                }
 
-                    if (maxnr == -1)        // migrate from really old code
+                if (maxnr == -1)        // migrate from really old code
+                {
+                    using (SQLiteConnectionUser conn = new SQLiteConnectionUser())
                     {
                         using (DbCommand cmd = conn.CreateCommand("INSERT OR REPLACE INTO Commanders (Id, Name, EdsmName, EdsmApiKey, NetLogDir, Deleted, SyncToEdsm, SyncFromEdsm, SyncToEddn) VALUES (@Id, @Name, @EdsmName, @EdsmApiKey, @NetLogDir, @Deleted, @SyncToEdsm, @SyncFromEdsm, @SyncToEddn)"))
                         {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1666,7 +1666,7 @@ namespace EDDiscovery
             {
                 worker.ReportProgress(-1, "Updating journal entries");
 
-                using (SQLiteConnectionUserUTC conn = new SQLiteConnectionUserUTC())
+                using (SQLiteConnectionUser conn = new SQLiteConnectionUser(utc: true))
                 {
                     using (DbTransaction txn = conn.BeginTransaction())
                     {

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -233,7 +233,7 @@ namespace EDDiscovery2.EDSM
                         tlu.CommanderId = EDDiscoveryForm.EDDConfig.CurrentCommander.Nr;
                         tlu.Add();  // Add to Database
 
-                        using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+                        using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                         {
                             foreach (HistoryEntry he in toadd)
                             {

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -77,9 +77,9 @@ namespace EDDiscovery.EliteDangerous
                 }
             }
 
-            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true, shortlived: false))
+            for (int i = 0; i < readersToUpdate.Count; i++)
             {
-                for (int i = 0; i < readersToUpdate.Count; i++)
+                using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                 {
                     EDJournalReader reader = readersToUpdate[i];
                     updateProgress(i * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -77,7 +77,7 @@ namespace EDDiscovery.EliteDangerous
                 }
             }
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true, shortlived: false))
             {
                 for (int i = 0; i < readersToUpdate.Count; i++)
                 {
@@ -97,7 +97,7 @@ namespace EDDiscovery.EliteDangerous
                         tn.Commit();
                     }
 
-                    reader.TravelLogUnit.Update();
+                    reader.TravelLogUnit.Update(cn);
 
                     updateProgress((i + 1) * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);
 
@@ -313,7 +313,7 @@ namespace EDDiscovery.EliteDangerous
                     netlogpos = nfi.TravelLogUnit.Size;
                     List<JournalEntry> ents = nfi.ReadJournalLog().ToList();
 
-                    using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+                    using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                     {
                         using (DbTransaction txn = cn.BeginTransaction())
                         {

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -363,14 +363,14 @@ namespace EDDiscovery.EliteDangerous
 
         public bool Add()
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 bool ret = Add(cn);
                 return ret;
             }
         }
 
-        public bool Add(SQLiteConnectionUserUTC cn, DbTransaction tn = null)
+        public bool Add(SQLiteConnectionUser cn, DbTransaction tn = null)
         {
             using (DbCommand cmd = cn.CreateCommand("Insert into JournalEntries (EventTime, TravelLogID, CommanderId, EventTypeId , EventType, EventData, EdsmId, Synced) values (@EventTime, @TravelLogID, @CommanderID, @EventTypeId , @EventStrName, @EventData, @EdsmId, @Synced)", tn))
             {
@@ -395,13 +395,13 @@ namespace EDDiscovery.EliteDangerous
 
         public bool Update()
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 return Update(cn);
             }
         }
 
-        private bool Update(SQLiteConnectionUserUTC cn, DbTransaction tn = null)
+        private bool Update(SQLiteConnectionUser cn, DbTransaction tn = null)
         {
             using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set EventTime=@EventTime, TravelLogID=@TravelLogID, CommanderID=@CommanderID, EventTypeId=@EventTypeId, EventType=@EventStrName, EventData=@EventData, EdsmId=@EdsmId, Synced=@Synced where ID=@id",tn))
             {
@@ -421,7 +421,7 @@ namespace EDDiscovery.EliteDangerous
         }
 
         //dist >0 to update
-        public static void UpdateEDSMIDPosJump(long journalid, ISystem system, bool jsonpos , double dist, SQLiteConnectionUserUTC cn = null, DbTransaction tn = null)
+        public static void UpdateEDSMIDPosJump(long journalid, ISystem system, bool jsonpos , double dist, SQLiteConnectionUser cn = null, DbTransaction tn = null)
         {
             bool ownconn = false;
 
@@ -430,7 +430,7 @@ namespace EDDiscovery.EliteDangerous
                 if (cn == null)
                 {
                     ownconn = true;
-                    cn = new SQLiteConnectionUserUTC();
+                    cn = new SQLiteConnectionUser(utc: true);
                 }
 
                 JournalEntry ent = Get(journalid, cn, tn);
@@ -470,7 +470,7 @@ namespace EDDiscovery.EliteDangerous
 
         public static void UpdateMapColour(long journalid, int mapcolour)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 JournalEntry ent = Get(journalid, cn);
 
@@ -494,7 +494,7 @@ namespace EDDiscovery.EliteDangerous
 
         public static void UpdateSyncFlagBit(long journalid, SyncFlags bit, bool value)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 JournalEntry je = Get(journalid, cn);
 
@@ -518,7 +518,7 @@ namespace EDDiscovery.EliteDangerous
 
         public static void UpdateCommanderID(long journalid, int cmdrid)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set CommanderID = @cmdrid where ID=@journalid"))
                 {
@@ -530,7 +530,7 @@ namespace EDDiscovery.EliteDangerous
             }
         }
 
-        static public JournalEntry Get(long journalid, SQLiteConnectionUserUTC cn, DbTransaction tn = null)
+        static public JournalEntry Get(long journalid, SQLiteConnectionUser cn, DbTransaction tn = null)
         {
             using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where ID=@journalid", tn))
             {
@@ -550,7 +550,7 @@ namespace EDDiscovery.EliteDangerous
 
         static public JournalEntry Get(long journalid)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 return Get(journalid, cn);
             }
@@ -563,7 +563,7 @@ namespace EDDiscovery.EliteDangerous
         {
             List<JournalEntry> list = new List<JournalEntry>();
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where CommanderID=@commander Order by EventTime ASC"))
                 {
@@ -593,7 +593,7 @@ namespace EDDiscovery.EliteDangerous
         {
             List<JournalEntry> vsc = new List<JournalEntry>();
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE EventTypeID = @eventtype and  CommanderID=@commander and  EventTime >@start and EventTime<@Stop ORDER BY EventTime ASC"))
                 {
@@ -619,7 +619,7 @@ namespace EDDiscovery.EliteDangerous
         {
             List<JournalEntry> vsc = new List<JournalEntry>();
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE TravelLogId = @source ORDER BY EventTime ASC"))
                 {
@@ -639,7 +639,7 @@ namespace EDDiscovery.EliteDangerous
         public static T GetLast<T>(int cmdrid, DateTime before)
             where T : JournalEntry
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE CommanderId = @cmdrid AND EventTime < @time ORDER BY EventTime DESC"))
                 {
@@ -1129,7 +1129,7 @@ namespace EDDiscovery.EliteDangerous
 
         static public bool ResetCommanderID(int from , int to)
         {
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
                 using (DbCommand cmd = cn.CreateCommand("Update JournalEntries set CommanderID = @cmdridto where CommanderID=@cmdridfrom"))
                 {

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -128,7 +128,7 @@ namespace EDDiscovery
                 }
             }
 
-            using (SQLiteConnectionUserUTC cn = new SQLiteConnectionUserUTC())
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true, shortlived: false))
             {
                 for (int i = 0; i < readersToUpdate.Count; i++)
                 {

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -128,9 +128,9 @@ namespace EDDiscovery
                 }
             }
 
-            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true, shortlived: false))
+            for (int i = 0; i < readersToUpdate.Count; i++)
             {
-                for (int i = 0; i < readersToUpdate.Count; i++)
+                using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                 {
                     int ji = 0;
 


### PR DESCRIPTION
It appears that the new SQLite library uses speculative locking - it locks the database when it is freshly opened, in anticipation of a command being executed.

* Remove some recursive DB opens, and report any other recursive opens.
* Use a ReaderWriterLock instead of a Monitor when locking the database, in order to allow multiple threads to read.
* Reduce the lifetime of some connections to that of the inner transaction.

This should clear up some of the performance issues with DB access, and further prevent any "database is locked" errors.