### PR TITLE
Reset reader buffer on error parsing line

### DIFF
--- a/EDDiscovery/EliteDangerous/EDJournalReader.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalReader.cs
@@ -31,81 +31,102 @@ namespace EDDiscovery.EliteDangerous
         // Journal ID
         public int JournalId { get { return (int)TravelLogUnit.id; } }
 
-        public bool ReadJournalLog(out JournalEntry je)
+        protected JournalEntry ProcessLine(string line, bool resetOnError)
         {
             int cmdrid = -2;        //-1 is hidden, -2 is never shown
 
             if (TravelLogUnit.CommanderId.HasValue)
             {
                 cmdrid = TravelLogUnit.CommanderId.Value;
-               // System.Diagnostics.Trace.WriteLine(string.Format("TLU says commander {0} at {1}", cmdrid, TravelLogUnit.Name));
+                // System.Diagnostics.Trace.WriteLine(string.Format("TLU says commander {0} at {1}", cmdrid, TravelLogUnit.Name));
             }
 
-            string line;
-            while (this.ReadLine(out line))
+            if (line.Length == 0)
+                return null;
+
+            JournalEntry je = null;
+
+            try
             {
-                if (line.Length == 0)
+                je = JournalEntry.CreateJournalEntry(line);
+            }
+            catch
+            {
+                System.Diagnostics.Trace.WriteLine($"Bad journal line:\n{line}");
+
+                if (resetOnError)
+                {
+                    throw;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            if (je.EventTypeID == JournalTypeEnum.FileHeader)
+            {
+                JournalEvents.JournalFileHeader header = (JournalEvents.JournalFileHeader)je;
+
+                if (header.Beta && !disable_beta_commander_check)
+                {
+                    TravelLogUnit.type |= 0x8000;
+                }
+            }
+            else if (je.EventTypeID == JournalTypeEnum.LoadGame)
+            {
+                string newname = (je as JournalEvents.JournalLoadGame).LoadGameCommander;
+
+                if ((TravelLogUnit.type & 0x8000) == 0x8000)
+                {
+                    newname = "[BETA] " + newname;
+                }
+
+                EDCommander _commander = EDDiscovery2.EDDConfig.Instance.ListOfCommanders.FirstOrDefault(c => c.Name.Equals(newname, StringComparison.InvariantCultureIgnoreCase));
+
+                if (_commander == null)
+                    _commander = EDDiscovery2.EDDConfig.Instance.GetNewCommander(newname, null, EDJournalClass.GetDefaultJournalDir().Equals(TravelLogUnit.Path) ? "" : TravelLogUnit.Path);
+
+                cmdrid = _commander.Nr;
+
+                if (!TravelLogUnit.CommanderId.HasValue)
+                {
+                    TravelLogUnit.CommanderId = cmdrid;
+                    TravelLogUnit.Update();
+                    System.Diagnostics.Trace.WriteLine(string.Format("TLU {0} updated with commander {1}", TravelLogUnit.Path, cmdrid));
+                }
+            }
+
+            je.TLUId = (int)TravelLogUnit.id;
+            je.CommanderId = cmdrid;
+
+            return je;
+        }
+
+        public bool ReadJournalLog(out JournalEntry jent, bool resetOnError = false)
+        {
+            while (ReadLine(out jent, l => ProcessLine(l, resetOnError)))
+            {
+                if (jent == null)
                     continue;
 
                 //System.Diagnostics.Trace.WriteLine(string.Format("Read line {0} from {1}", line, this.FileName));
 
-                try
-                {
-                    je = JournalEntry.CreateJournalEntry(line);
-                    if (je.EventTypeID == JournalTypeEnum.FileHeader)
-                    {
-                        JournalEvents.JournalFileHeader header = (JournalEvents.JournalFileHeader)je;
-
-                        if (header.Beta && !disable_beta_commander_check)
-                        {
-                            TravelLogUnit.type |= 0x8000;
-                        }
-                    }
-                    else if (je.EventTypeID == JournalTypeEnum.LoadGame)
-                    {
-                        string newname = (je as JournalEvents.JournalLoadGame).LoadGameCommander;
-
-                        if ((TravelLogUnit.type & 0x8000) == 0x8000)
-                        {
-                            newname = "[BETA] " + newname;
-                        }
-
-                        EDCommander _commander = EDDiscovery2.EDDConfig.Instance.ListOfCommanders.FirstOrDefault(c => c.Name.Equals(newname, StringComparison.InvariantCultureIgnoreCase));
-
-                        if (_commander == null)
-                            _commander = EDDiscovery2.EDDConfig.Instance.GetNewCommander(newname,null, EDJournalClass.GetDefaultJournalDir().Equals(TravelLogUnit.Path)?"":TravelLogUnit.Path);
-
-                        cmdrid = _commander.Nr;
-
-                        if (!TravelLogUnit.CommanderId.HasValue)
-                        {
-                            TravelLogUnit.CommanderId = cmdrid;
-                            TravelLogUnit.Update();
-                            System.Diagnostics.Trace.WriteLine(string.Format("TLU {0} updated with commander {1}", TravelLogUnit.Path, cmdrid));
-                        }
-                    }
-
-                    je.TLUId = (int)TravelLogUnit.id;
-                    je.CommanderId = cmdrid;
-
-                    return true;
-                }
-                catch (  Exception )          // CreateJournal Entry may except, in which case, the line is crap
-                {
-                    System.Diagnostics.Trace.WriteLine($"Bad journal line:\n{line}");
-                }
+                return true;
             }
 
-            je = null;
+            jent = null;
             return false;
         }
 
         public IEnumerable<JournalEntry> ReadJournalLog()
         {
             JournalEntry entry;
-            while (ReadJournalLog(out entry))
+            bool resetOnError = false;
+            while (ReadJournalLog(out entry, resetOnError: resetOnError))
             {
                 yield return entry;
+                resetOnError = true;
             }
         }
     }

--- a/EDDiscovery/EliteDangerous/LogReaderBase.cs
+++ b/EDDiscovery/EliteDangerous/LogReaderBase.cs
@@ -37,7 +37,7 @@ namespace EDDiscovery
             this.TravelLogUnit = tlu;
         }
 
-        public bool ReadLine(out string line, Stream stream = null, bool ownstream = false)
+        public bool ReadLine<T>(out T line, Func<string, T> processor, Stream stream = null, bool ownstream = false)
         {
             // Initialize buffer if not yet allocated
             if (buffer == null)
@@ -83,10 +83,18 @@ namespace EDDiscovery
                             byte[] buf = new byte[endlinepos];
                             Buffer.BlockCopy(buffer, bufferpos, buf, 0, endlinepos);
                             bufferpos += linelen;
-                            TravelLogUnit.Size += linelen;
-                            line = System.Text.Encoding.UTF8.GetString(buf);
-
-                            return true;
+                            try
+                            {
+                                line = processor(System.Text.Encoding.UTF8.GetString(buf));
+                                TravelLogUnit.Size += linelen;
+                                return true;
+                            }
+                            catch
+                            {
+                                buffer = null;
+                                line = default(T);
+                                return false;
+                            }
                         }
                     }
 
@@ -118,7 +126,7 @@ namespace EDDiscovery
                             buffer = null;
                         }
 
-                        line = null;
+                        line = default(T);
                         return false;
                     }
 

--- a/EDDiscovery/EliteDangerous/NetLogReader.cs
+++ b/EDDiscovery/EliteDangerous/NetLogReader.cs
@@ -210,7 +210,7 @@ namespace EDDiscovery
                     stream = File.Open(this.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     ownstream = true;
                 }
-                while (!cancelRequested() && this.ReadLine(out line, stream))
+                while (!cancelRequested() && this.ReadLine(out line, l => l, stream))
                 {
                     ParseLineTime(line);
 


### PR DESCRIPTION
Reset the journal reader buffer when an error is encountered parsing a line, in case of a temporary error.

This should prevent journal entries from mysteriously failing to be read.