### PR TITLE
Added Above and Below as position options for surface scan

### DIFF
--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
@@ -116,22 +116,22 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
         public string DisplayString()
         {
             StringBuilder scanText = new StringBuilder();
-            scanText.AppendLine(BodyName);
-            scanText.AppendLine();
+            scanText.AppendFormat("{0}\n", BodyName);
+            scanText.Append("\n");
             if (!String.IsNullOrEmpty(StarType))
             {
                 //star
                 switch (StarType)
                 {
                     case "N":
-                        scanText.AppendLine("Neutron Star");
+                        scanText.Append("Neutron Star\n");
                         break;
                     case "AeBe":
-                        scanText.AppendLine("Herbig Ae/Be");
+                        scanText.Append("Herbig Ae/Be\n");
                         break;
                     case "H":
                         // currently speculative, not confirmed with actual data...
-                        scanText.AppendLine("Black Hole");
+                        scanText.Append("Black Hole\n");
                         break;
                     default:
                         scanText.AppendFormat("Class {0} star\n", StarType.Replace("_", " "));
@@ -155,9 +155,9 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             else
             {
                 //planet
-                scanText.AppendLine(System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.
+                scanText.AppendFormat("{0}\n", System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.
                                         ToTitleCase(PlanetClass.ToLower()));
-                scanText.AppendLine(TerraformState == "Terraformable" ? "Candidate for terraforming\n" : String.Empty);
+                scanText.Append(TerraformState == "Terraformable" ? "Candidate for terraforming\n" : "\n");
                 scanText.AppendFormat("Earth Masses: {0}\n", MassEM);
                 scanText.AppendFormat("Radius: {0}km\n", (Radius.Value / 1000).ToString("###,##0"));
                 scanText.AppendFormat("Gravity: {0}g\n", SurfaceGravity / 10);
@@ -175,14 +175,14 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
                 scanText.AppendFormat("Orbtial Inclination: {0}°\n", OrbitalInclination);
                 scanText.AppendFormat("Arg Of Periapsis: {0}°\n", Periapsis);
                 scanText.AppendFormat("Rotation Period: {0} days", (RotationPeriod / oneDay_s).ToString("###,###,##0.0"));
-                scanText.AppendLine(TidalLock ? " (Tidally locked)" : "");
+                scanText.Append(TidalLock ? " (Tidally locked)\n" : "\n");
                 if (Rings != null && Rings.Any())
                 {
-                    scanText.AppendLine();
+                    scanText.Append("\n");
                     scanText.AppendFormat("Ring{0}", Rings.Count() == 1 ? "" : "s");
                     foreach(PlanetRing ring in Rings)
                     {
-                        scanText.AppendLine();
+                        scanText.Append("\n");
                         scanText.AppendFormat("{0} ({1})\n", ring.Name, ring.RingClass.Replace("eRingClass_", ""));
                         scanText.AppendFormat("Mass: {0}MT\n", ring.MassMT.ToString("#,###,###,###,###,###,###,###,###"));
                         scanText.AppendFormat("Inner Radius: {0}km\n", (ring.InnerRad / 1000).ToString("#,###,###,###,###"));
@@ -191,8 +191,8 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
                 }
                 if (Materials != null && Materials.Any())
                 {
-                    scanText.AppendLine();
-                    scanText.AppendLine("Materials");
+                    scanText.Append("\n");
+                    scanText.Append("Materials\n");
                     foreach(KeyValuePair<string, double> mat in Materials)
                     {
                         scanText.AppendFormat("{0} - {1}%\n", 

--- a/EDDiscovery/Forms/SummaryPopOut.Designer.cs
+++ b/EDDiscovery/Forms/SummaryPopOut.Designer.cs
@@ -53,11 +53,13 @@
             this.showInPositionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.scanRightMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.scanLeftMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scanBelowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.scanOnTopMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.labelExt_NoSystems = new ExtendedControls.LabelExt();
             this.panel_grip = new ExtendedControls.DrawnPanel();
             this.labelExtDockedLanded = new ExtendedControls.LabelExt();
             this.labelBodyScanData = new ExtendedControls.LabelExt();
+            this.scanAboveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStripConfig.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -79,7 +81,7 @@
             this.toolStripComboBoxOrder,
             this.surfaceScanDetailsToolStripMenuItem});
             this.contextMenuStripConfig.Name = "contextMenuStripConfig";
-            this.contextMenuStripConfig.Size = new System.Drawing.Size(328, 339);
+            this.contextMenuStripConfig.Size = new System.Drawing.Size(328, 317);
             this.contextMenuStripConfig.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStripConfig_Closed);
             // 
             // toolStripMenuItemTargetLine
@@ -272,6 +274,8 @@
             this.showInPositionToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.scanRightMenuItem,
             this.scanLeftMenuItem,
+            this.scanAboveMenuItem,
+            this.scanBelowMenuItem,
             this.scanOnTopMenuItem});
             this.showInPositionToolStripMenuItem.Name = "showInPositionToolStripMenuItem";
             this.showInPositionToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
@@ -290,6 +294,13 @@
             this.scanLeftMenuItem.Size = new System.Drawing.Size(152, 22);
             this.scanLeftMenuItem.Text = "To left";
             this.scanLeftMenuItem.Click += new System.EventHandler(this.scanLeftMenuItem_Click);
+            // 
+            // scanBelowMenuItem
+            // 
+            this.scanBelowMenuItem.Name = "scanBelowMenuItem";
+            this.scanBelowMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.scanBelowMenuItem.Text = "Below";
+            this.scanBelowMenuItem.Click += new System.EventHandler(this.scanBelowMenuItem_Click);
             // 
             // scanOnTopMenuItem
             // 
@@ -346,6 +357,14 @@
             this.labelBodyScanData.Size = new System.Drawing.Size(0, 20);
             this.labelBodyScanData.TabIndex = 19;
             // 
+            // scanAboveMenuItem
+            // 
+            this.scanAboveMenuItem.DoubleClickEnabled = true;
+            this.scanAboveMenuItem.Name = "scanAboveMenuItem";
+            this.scanAboveMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.scanAboveMenuItem.Text = "Above";
+            this.scanAboveMenuItem.Click += new System.EventHandler(this.scanAboveMenuItem_Click);
+            // 
             // SummaryPopOut
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -400,5 +419,7 @@
         private System.Windows.Forms.ToolStripMenuItem scanRightMenuItem;
         private System.Windows.Forms.ToolStripMenuItem scanLeftMenuItem;
         private System.Windows.Forms.ToolStripMenuItem scanOnTopMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scanBelowMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scanAboveMenuItem;
     }
 }


### PR DESCRIPTION
"Above" is still a bit ropey in terms of sizing things right and if the S-Panel overlaps the Windows task bar then the transparency doesn't get set right but it basically works, and "Below" appears good.