### PR TITLE
Only update the TLU if it has changed

### DIFF
--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -269,24 +269,27 @@ namespace EDDiscovery.EliteDangerous
                     netlogpos = nfi.TravelLogUnit.Size;
                     List<JournalEntry> ents = nfi.ReadJournalLog().ToList();
 
-                    using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
+                    if (ents.Count > 0)
                     {
-                        using (DbTransaction txn = cn.BeginTransaction())
+                        using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
                         {
-                            ents = ents.Where(je => JournalEntry.FindEntry(je).Count == 0).ToList();
-
-                            foreach (JournalEntry je in ents)
+                            using (DbTransaction txn = cn.BeginTransaction())
                             {
-                                entries.Add(je);
-                                je.Add(cn, txn);
-                                ticksNoActivity = 0;
-                            }
+                                ents = ents.Where(je => JournalEntry.FindEntry(je).Count == 0).ToList();
 
-                            txn.Commit();
+                                foreach (JournalEntry je in ents)
+                                {
+                                    entries.Add(je);
+                                    je.Add(cn, txn);
+                                    ticksNoActivity = 0;
+                                }
+
+                                nfi.TravelLogUnit.Update(cn);
+
+                                txn.Commit();
+                            }
                         }
                     }
-
-                    nfi.TravelLogUnit.Update();
                 }
 
                 return entries;


### PR DESCRIPTION
This should reduce the amount of data that EDDiscovery writes when Elite Dangerous is inactive.