### PR TITLE
Add OpenTK binding redirect to portable config

### DIFF
--- a/EDDiscovery/App.Portable.config
+++ b/EDDiscovery/App.Portable.config
@@ -47,6 +47,10 @@
         <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.103.0" newVersion="1.0.103.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="OpenTK" publicKeyToken="bad199fe84eb3df4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
OpenTK binding redirect was missing from App.Portable.config, resulting in a crash when the program attempted to load an old OpenTK version.