### PR TITLE
Remove OpenTK reference from EDDiscoveryTests project

### DIFF
--- a/EDDiscoveryTests/EDDiscoveryTests.csproj
+++ b/EDDiscoveryTests/EDDiscoveryTests.csproj
@@ -117,9 +117,6 @@
       <HintPath>..\packages\NUnit3TestAdapter.3.4.1\lib\NUnit3.TestAdapter.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OpenTK">
-      <HintPath>..\packages\OpenTK.1.1.1589.5942\lib\NET40\OpenTK.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.SQLite, Version=1.0.103.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.103\lib\net46\System.Data.SQLite.dll</HintPath>
@@ -129,7 +126,6 @@
       <HintPath>..\packages\System.Data.SQLite.Linq.1.0.103\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Drawing" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/EDDiscoveryTests/packages.config
+++ b/EDDiscoveryTests/packages.config
@@ -3,7 +3,6 @@
   <package id="NFluent" version="1.3.1.0" targetFramework="net40" />
   <package id="NUnit" version="3.5.0" targetFramework="net46" />
   <package id="NUnit3TestAdapter" version="3.4.1" targetFramework="net46" />
-  <package id="OpenTK" version="1.1.1589.5942" targetFramework="net40" />
   <package id="System.Data.SQLite.Core" version="1.0.103" targetFramework="net46" />
   <package id="System.Data.SQLite.Linq" version="1.0.103" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
OpenTK isn't used by the test project, and it was sitting at an old version, causing a reference mismatch warning on build.