### PR TITLE
Implement log splitting and duplicate detection

### DIFF
--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -221,6 +221,7 @@
     <Compile Include="RoutingUtils.cs" />
     <Compile Include="ExportImport\ExportNotes.cs" />
     <Compile Include="ExportImport\ImportHistory.cs" />
+    <Compile Include="TraceLog.cs" />
     <Compile Include="Trilateration\DistanceParser.cs" />
     <Compile Include="Controls\SplitContainerCustom.cs">
       <SubType>Component</SubType>

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -77,6 +77,8 @@ namespace EDDiscovery
 
         public bool option_nowindowreposition { get; set; } = false;                             // Cmd line options
         public bool option_debugoptions { get; set; } = false;
+        public bool option_tracelog { get; set; } = false;
+        public bool option_fcexcept { get; set; } = false;
 
         public EDDiscovery2._3DMap.MapManager Map { get; private set; }
 
@@ -142,9 +144,13 @@ namespace EDDiscovery
                     Directory.CreateDirectory(logpath);
                 }
 
-                if (!Debugger.IsAttached)
+                if (!Debugger.IsAttached || option_tracelog)
                 {
-                    TraceLog.Init();
+                    TraceLog.LogFileWriterException += ex =>
+                    {
+                        LogLineHighlight($"Log Writer Exception: {ex}");
+                    };
+                    TraceLog.Init(option_fcexcept);
                 }
             }
             catch (Exception ex)
@@ -229,6 +235,8 @@ namespace EDDiscovery
             }
 
             option_debugoptions = parts.FindIndex(x => x.Equals("-Debug", StringComparison.InvariantCultureIgnoreCase)) != -1;
+            option_tracelog = parts.FindIndex(x => x.Equals("-TraceLog", StringComparison.InvariantCultureIgnoreCase)) != -1;
+            option_fcexcept = parts.FindIndex(x => x.Equals("-LogExceptions", StringComparison.InvariantCultureIgnoreCase)) != -1;
 
             if (parts.FindIndex(x => x.Equals("-EDSMBeta", StringComparison.InvariantCultureIgnoreCase)) != -1)
             {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -125,15 +125,6 @@ namespace EDDiscovery
 
         #region Initialisation
 
-        private class TraceLogWriter : TextWriter
-        {
-            public override Encoding Encoding { get { return Encoding.UTF8; } }
-            public override IFormatProvider FormatProvider { get { return CultureInfo.InvariantCulture; } }
-            public override void Write(string value) { Trace.Write(value); }
-            public override void WriteLine(string value) { Trace.WriteLine(value); }
-            public override void WriteLine() { Trace.WriteLine(""); }
-        }
-
         public EDDiscoveryForm()
         {
             InitializeComponent();
@@ -153,19 +144,7 @@ namespace EDDiscovery
 
                 if (!Debugger.IsAttached)
                 {
-                    logname = Path.Combine(Tools.GetAppDataDirectory(), "Log", $"Trace_{DateTime.Now.ToString("yyyyMMddHHmmss")}.log");
-
-                    System.Diagnostics.Trace.AutoFlush = true;
-                    // Log trace events to the above file
-                    System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(logname));
-                    // Log unhandled exceptions
-                    AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-                    // Log unhandled UI exceptions
-                    Application.ThreadException += Application_ThreadException;
-                    // Redirect console to trace
-                    Console.SetOut(new TraceLogWriter());
-                    // Log first-chance exceptions to help diagnose errors
-                    Register_FirstChanceException_Handler();
+                    TraceLog.Init();
                 }
             }
             catch (Exception ex)
@@ -229,102 +208,6 @@ namespace EDDiscovery
             {
                 splashform.Close();
             }
-        }
-
-        // We can't prevent an unhandled exception from killing the application.
-        // See https://blog.codinghorror.com/improved-unhandled-exception-behavior-in-net-20/
-        // Log the exception info if we can, and ask the user to report it.
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
-        [System.Security.SecurityCritical]
-        [System.Runtime.ConstrainedExecution.ReliabilityContract(
-            System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState,
-            System.Runtime.ConstrainedExecution.Cer.Success)]
-        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-        {
-            try
-            {
-                System.Diagnostics.Trace.WriteLine($"\n==== UNHANDLED EXCEPTION ====\n{e.ExceptionObject.ToString()}\n==== cut ====");
-                MessageBox.Show($"There was an unhandled exception.\nPlease report this at https://github.com/EDDiscovery/EDDiscovery/issues and attach {logname}\nException: {e.ExceptionObject.ToString()}\n\nThis application must now close", "Unhandled Exception");
-            }
-            catch
-            {
-            }
-
-            Environment.Exit(1);
-        }
-
-        // Handling a ThreadException leaves the application in an undefined state.
-        // See https://msdn.microsoft.com/en-us/library/system.windows.forms.application.threadexception(v=vs.100).aspx
-        // Log the exception, ask the user to report it, and exit.
-        private void Application_ThreadException(object sender, ThreadExceptionEventArgs e)
-        {
-            try
-            {
-                System.Diagnostics.Trace.WriteLine($"\n==== UNHANDLED EXCEPTION ON {Thread.CurrentThread.Name} THREAD ====\n{e.Exception.ToString()}\n==== cut ====");
-                MessageBox.Show($"There was an unhandled exception.\nPlease report this at https://github.com/EDDiscovery/EDDiscovery/issues and attach {logname}\nException: {e.Exception.Message}\n{e.Exception.StackTrace}\n\nThis application must now close", "Unhandled Exception");
-            }
-            catch
-            {
-            }
-
-            Environment.Exit(1);
-        }
-
-        // Mono does not implement AppDomain.CurrentDomain.FirstChanceException
-        private static void Register_FirstChanceException_Handler()
-        {
-            try
-            {
-                Type adtype = AppDomain.CurrentDomain.GetType();
-                EventInfo fcexevent = adtype.GetEvent("FirstChanceException");
-                if (fcexevent != null)
-                {
-                    fcexevent.AddEventHandler(AppDomain.CurrentDomain, new EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>(CurrentDomain_FirstChanceException));
-                }
-            }
-            catch
-            {
-            }
-        }
-
-        // Log exceptions were they occur so we can try to  some
-        // hard to debug issues.
-        private static void CurrentDomain_FirstChanceException(object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e)
-        {
-            // Ignore HTTP NotModified exceptions
-            if (e.Exception is System.Net.WebException)
-            {
-                var webex = (WebException)e.Exception;
-                if (webex.Response != null && webex.Response is HttpWebResponse)
-                {
-                    var resp = (HttpWebResponse)webex.Response;
-                    if (resp.StatusCode == HttpStatusCode.NotModified)
-                    {
-                        return;
-                    }
-                }
-            }
-            // Ignore DLL Not Found exceptions from OpenTK
-            else if (e.Exception is DllNotFoundException && e.Exception.Source == "OpenTK")
-            {
-                return;
-            }
-
-            var trace = new StackTrace(1, true);
-
-            // Ignore first-chance exceptions in threads outside our code
-            bool ourcode = false;
-            foreach (var frame in trace.GetFrames())
-            {
-                if (frame.GetMethod().DeclaringType.Assembly == Assembly.GetExecutingAssembly())
-                {
-                    ourcode = true;
-                    break;
-                }
-            }
-
-            if (ourcode)
-                System.Diagnostics.Trace.WriteLine($"First chance exception: {e.Exception.Message}\n{trace.ToString()}");
         }
 
         private void EDDiscoveryForm_Layout(object sender, LayoutEventArgs e)       // Manually position, could not get gripper under tab control with it sizing for the life of me
@@ -794,9 +677,6 @@ namespace EDDiscovery
 
                 RefreshHistoryAsync();
 
-                DeleteOldLogFiles();
-
-
                 ShowInfoPanel("", false);
 
                 checkInstallerTask = CheckForNewInstallerAsync();
@@ -1170,41 +1050,6 @@ namespace EDDiscovery
             }
         }
 
-        void DeleteOldLogFiles()
-        {
-            try
-            {
-                // Create a reference to the Log directory.
-                DirectoryInfo di = new DirectoryInfo(Path.Combine(Tools.GetAppDataDirectory(), "Log"));
-
-                Trace.WriteLine("Running logfile age check");
-                // Create an array representing the files in the current directory.
-                FileInfo[] fi = di.GetFiles("*.log");
-
-                System.Collections.IEnumerator myEnum = fi.GetEnumerator();
-
-                while (myEnum.MoveNext())
-                {
-                    FileInfo fiTemp = (FileInfo)(myEnum.Current);
-
-                    DateTime time = fiTemp.CreationTime;
-
-                    //Trace.WriteLine(String.Format("File {0}  time {1}", fiTemp.Name, __box(time)));
-
-                    TimeSpan maxage = new TimeSpan(30, 0, 0, 0);
-                    TimeSpan fileage = DateTime.Now - time;
-
-                    if (fileage > maxage)
-                    {
-                        Trace.WriteLine(String.Format("File {0} is older then maximum age. Removing file from Logs.", fiTemp.Name));
-                        fiTemp.Delete();
-                    }
-                }
-            }
-            catch
-            {
-            }
-        }
 
 #endregion
 

--- a/EDDiscovery/TraceLog.cs
+++ b/EDDiscovery/TraceLog.cs
@@ -53,7 +53,7 @@ namespace EDDiscovery
             public override void WriteLine() { Write("\n"); }
         }
 
-        public static void Init()
+        public static void Init(bool logfcexcept)
         {
             string logname = Path.Combine(Tools.GetAppDataDirectory(), "Log", $"Trace_{DateTime.Now.ToString("yyyyMMddHHmmss")}");
             LogFileBaseName = logname;
@@ -71,7 +71,10 @@ namespace EDDiscovery
             // Redirect console to trace
             Console.SetOut(new TraceLogWriter());
             // Log first-chance exceptions to help diagnose errors
-            Register_FirstChanceException_Handler();
+            if (logfcexcept)
+            {
+                Register_FirstChanceException_Handler();
+            }
         }
 
         public static void WriteLine(string msg)
@@ -246,7 +249,7 @@ namespace EDDiscovery
             }
         }
 
-        // Log exceptions were they occur so we can try to  some
+        // Log exceptions were they occur so we can try to diagnose some
         // hard to debug issues.
         private static void CurrentDomain_FirstChanceException(object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e)
         {

--- a/EDDiscovery/TraceLog.cs
+++ b/EDDiscovery/TraceLog.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Reflection;
+using System.Net;
+
+namespace EDDiscovery
+{
+    public class TraceLog
+    {
+        public static event Action<Exception> LogFileWriterException;
+        public static long MaxLogDirSizeMB { get; set; } = 1024;
+        public static string LogFileName { get; private set; }
+        public static string LogFileBaseName { get; private set; }
+        private static Thread LogFileWriterThread;
+        private static BlockingCollection<string> LogLineQueue = new BlockingCollection<string>();
+        private static AutoResetEvent LogLineQueueEvent = new AutoResetEvent(false);
+
+        private class TraceLogWriter : TextWriter
+        {
+            private ThreadLocal<StringBuilder> logline = new ThreadLocal<StringBuilder>(() => new StringBuilder());
+
+            public override Encoding Encoding { get { return Encoding.UTF8; } }
+            public override IFormatProvider FormatProvider { get { return CultureInfo.InvariantCulture; } }
+
+            public override void Write(string value)
+            {
+                if (value != null)
+                {
+                    logline.Value.Append(value);
+                    string logval = logline.ToString();
+                    while (logval.Contains("\n"))
+                    {
+                        string[] lines = logval.Split(new[] { '\n' }, 2);
+                        TraceLog.WriteLine(lines[0]);
+                        logline.Value.Clear();
+                        logline.Value.Append(lines.Length == 2 ? lines[1] : "");
+                        logval = logline.ToString();
+                    }
+                }
+            }
+
+            public override void Write(char value) { Write(new string(new[] { value })); }
+            public override void WriteLine(string value) { Write((value ?? "") + "\n"); }
+            public override void WriteLine() { Write("\n"); }
+        }
+
+        public static void Init()
+        {
+            string logname = Path.Combine(Tools.GetAppDataDirectory(), "Log", $"Trace_{DateTime.Now.ToString("yyyyMMddHHmmss")}");
+            LogFileBaseName = logname;
+            LogFileWriterThread = new Thread(LogWriterThreadProc);
+            LogFileWriterThread.IsBackground = true;
+            LogFileWriterThread.Name = "Log Writer";
+            LogFileWriterThread.Start();
+            System.Diagnostics.Trace.AutoFlush = true;
+            // Log trace events to the above file
+            System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(new TraceLogWriter()));
+            // Log unhandled exceptions
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            // Log unhandled UI exceptions
+            Application.ThreadException += Application_ThreadException;
+            // Redirect console to trace
+            Console.SetOut(new TraceLogWriter());
+            // Log first-chance exceptions to help diagnose errors
+            Register_FirstChanceException_Handler();
+        }
+
+        public static void WriteLine(string msg)
+        {
+            LogLineQueue.Add(msg);
+        }
+
+        private static void LogWriterThreadProc()
+        {
+            int partnum = 0;
+            Dictionary<string, int> msgrepeats = new Dictionary<string, int>();
+            while (true)
+            {
+                try
+                {
+                    DeleteOldLogFiles();
+                    LogFileName = $"{LogFileBaseName}.{partnum}.log";
+                    using (TextWriter writer = new StreamWriter(LogFileName))
+                    {
+                        int linenum = 0;
+                        while (true)
+                        {
+                            string msg = null;
+                            if (msgrepeats.Count < 100 && !msgrepeats.Any(m => m.Value >= 10000) && LogLineQueue.TryTake(out msg, msgrepeats.Count > 1 ? 1000 : Timeout.Infinite))
+                            {
+                                if (msg == null)
+                                {
+                                    LogLineQueueEvent.Set();
+                                    return;
+                                }
+                                else if (msgrepeats.ContainsKey(msg))
+                                {
+                                    msgrepeats[msg]++;
+                                }
+                                else
+                                {
+                                    writer.WriteLine($"[{DateTime.Now.ToString("u")}] {msg}");
+                                    writer.Flush();
+                                    msgrepeats[msg] = 0;
+                                    linenum++;
+                                    if (linenum >= 100000)
+                                    {
+                                        partnum++;
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                foreach (KeyValuePair<string, int> rptkvp in msgrepeats)
+                                {
+                                    if (rptkvp.Value >= 1)
+                                    {
+                                        writer.WriteLine($"[{DateTime.Now.ToString("u")}] {rptkvp.Key}");
+                                        if (rptkvp.Value > 1)
+                                        {
+                                            writer.WriteLine($"[{DateTime.Now.ToString("u")}] Last message repeated {(rptkvp.Value)} times");
+                                        }
+                                    }
+                                }
+
+                                msgrepeats = new Dictionary<string, int>();
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LogFileWriterException?.Invoke(ex);
+                    Thread.Sleep(30000);
+                }
+            }
+        }
+
+        private static void DeleteOldLogFiles()
+        {
+            try
+            {
+                long totsize = 0;
+                // Create a reference to the Log directory.
+                DirectoryInfo dir = new DirectoryInfo(Path.Combine(Tools.GetAppDataDirectory(), "Log"));
+
+                Trace.WriteLine("Running logfile age check");
+                // Create an array representing the files in the current directory.
+                FileInfo[] files = dir.GetFiles("*.log").OrderByDescending(f => f.LastWriteTimeUtc).ToArray();
+
+                foreach (FileInfo fi in files)
+                {
+                    DateTime time = fi.CreationTime;
+
+                    TimeSpan maxage = new TimeSpan(30, 0, 0, 0);
+                    TimeSpan fileage = DateTime.Now - time;
+                    totsize += fi.Length;
+
+                    if (fileage > maxage)
+                    {
+                        WriteLine(String.Format("File {0} is older then maximum age. Removing file from Logs.", fi.Name));
+                        fi.Delete();
+                    }
+                    else if (totsize >= MaxLogDirSizeMB * 1048576)
+                    {
+                        WriteLine($"File {fi.Name} pushes total log directory size over limit of {MaxLogDirSizeMB}MB");
+                        fi.Delete();
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        // We can't prevent an unhandled exception from killing the application.
+        // See https://blog.codinghorror.com/improved-unhandled-exception-behavior-in-net-20/
+        // Log the exception info if we can, and ask the user to report it.
+        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions]
+        [System.Security.SecurityCritical]
+        [System.Runtime.ConstrainedExecution.ReliabilityContract(
+            System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState,
+            System.Runtime.ConstrainedExecution.Cer.Success)]
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            try
+            {
+                WriteLine($"\n==== UNHANDLED EXCEPTION ====\n{e.ExceptionObject.ToString()}\n==== cut ====");
+                WriteLine(null);
+                LogLineQueueEvent.WaitOne(100);
+                MessageBox.Show($"There was an unhandled exception.\nPlease report this at https://github.com/EDDiscovery/EDDiscovery/issues and attach {LogFileName}\nException: {e.ExceptionObject.ToString()}\n\nThis application must now close", "Unhandled Exception");
+            }
+            catch
+            {
+            }
+
+            Environment.Exit(1);
+        }
+
+        // Handling a ThreadException leaves the application in an undefined state.
+        // See https://msdn.microsoft.com/en-us/library/system.windows.forms.application.threadexception(v=vs.100).aspx
+        // Log the exception, ask the user to report it, and exit.
+        private static void Application_ThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            DialogResult res = DialogResult.Abort;
+
+            try
+            {
+                WriteLine($"\n==== UNHANDLED UI EXCEPTION ====\n{e.Exception.ToString()}\n==== cut ====");
+                res = MessageBox.Show($"There was an unhandled UI exception.\nPlease report this at https://github.com/EDDiscovery/EDDiscovery/issues and attach {LogFileName}\nException: {e.Exception.Message}\n{e.Exception.StackTrace}\n\nDo you wish to abort, or ignore the exception and try to continue?", "Unhandled Exception", MessageBoxButtons.AbortRetryIgnore);
+            }
+            catch
+            {
+            }
+
+            if (res == DialogResult.Abort)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        // Mono does not implement AppDomain.CurrentDomain.FirstChanceException
+        private static void Register_FirstChanceException_Handler()
+        {
+            try
+            {
+                Type adtype = AppDomain.CurrentDomain.GetType();
+                EventInfo fcexevent = adtype.GetEvent("FirstChanceException");
+                if (fcexevent != null)
+                {
+                    fcexevent.AddEventHandler(AppDomain.CurrentDomain, new EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>(CurrentDomain_FirstChanceException));
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        // Log exceptions were they occur so we can try to  some
+        // hard to debug issues.
+        private static void CurrentDomain_FirstChanceException(object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e)
+        {
+            // Ignore HTTP NotModified exceptions
+            if (e.Exception is System.Net.WebException)
+            {
+                var webex = (WebException)e.Exception;
+                if (webex.Response != null && webex.Response is HttpWebResponse)
+                {
+                    var resp = (HttpWebResponse)webex.Response;
+                    if (resp.StatusCode == HttpStatusCode.NotModified)
+                    {
+                        return;
+                    }
+                }
+            }
+            // Ignore DLL Not Found exceptions from OpenTK
+            else if (e.Exception is DllNotFoundException && e.Exception.Source == "OpenTK")
+            {
+                return;
+            }
+            else if (Thread.CurrentThread == LogFileWriterThread)
+            {
+                return;
+            }
+
+            var trace = new StackTrace(1, true);
+
+            // Ignore first-chance exceptions in threads outside our code
+            bool ourcode = false;
+            foreach (var frame in trace.GetFrames())
+            {
+                if (frame.GetMethod().DeclaringType.Assembly == Assembly.GetExecutingAssembly())
+                {
+                    ourcode = true;
+                    break;
+                }
+            }
+
+            if (ourcode)
+                WriteLine($"First chance exception: {e.Exception.Message}\n{trace.ToString()}");
+        }
+    }
+}


### PR DESCRIPTION
This splits the trace log on 100k lines, detects when a message has been logged multiple times in succession, and prevents the trace log directory from growing to greater than 1GB in size.

It also adds some options to enable logging while debugging, and to enable first-chance exception logging.