### PR TITLE
Route planning output textbox should be read-only

### DIFF
--- a/EDDiscovery/RouteControl.Designer.cs
+++ b/EDDiscovery/RouteControl.Designer.cs
@@ -93,6 +93,7 @@
             this.richTextBox_routeresult.HideScrollBar = true;
             this.richTextBox_routeresult.Location = new System.Drawing.Point(0, 137);
             this.richTextBox_routeresult.Name = "richTextBox_routeresult";
+            this.richTextBox_routeresult.ReadOnly = true;
             this.richTextBox_routeresult.ScrollBarWidth = 20;
             this.richTextBox_routeresult.ShowLineCount = false;
             this.richTextBox_routeresult.Size = new System.Drawing.Size(897, 292);

--- a/EDDiscovery/RouteControl.Designer.cs
+++ b/EDDiscovery/RouteControl.Designer.cs
@@ -93,7 +93,7 @@
             this.richTextBox_routeresult.HideScrollBar = true;
             this.richTextBox_routeresult.Location = new System.Drawing.Point(0, 137);
             this.richTextBox_routeresult.Name = "richTextBox_routeresult";
-            this.richTextBox_routeresult.ReadOnly = true;
+            this.richTextBox_routeresult.RichTextBoxBack.ReadOnly = true;
             this.richTextBox_routeresult.ScrollBarWidth = 20;
             this.richTextBox_routeresult.ShowLineCount = false;
             this.richTextBox_routeresult.Size = new System.Drawing.Size(897, 292);


### PR DESCRIPTION
Hopefully, I'll eventually quit trying to keyboard steer my ship while I have my next destination highlighted for copying. Barring that, I should at least not have to worry about overwriting the text telling me where to
go next.

Note that my C# 6+ compiler is presently out of order. You'll want to compile and test this before actually applying this change. Visual effects may also make it less legible, but I never did really care what usability experts thought.