### PR TITLE
Routing information should be read-only

### DIFF
--- a/EDDiscovery/RouteControl.cs
+++ b/EDDiscovery/RouteControl.cs
@@ -44,6 +44,7 @@ namespace EDDiscovery
             InitializeComponent();
             button_Route.Enabled = false;
             cmd3DMap.Enabled = false;
+			richTextBox_routeresult.TextBox.ReadOnly = true;
 
             for (int i = 0; i < metric_options.Length; i++)
                 comboBoxRoutingMetric.Items.Add(metric_options[i]);

--- a/EDDiscovery/UserControls/UserControlLog.cs
+++ b/EDDiscovery/UserControls/UserControlLog.cs
@@ -17,6 +17,7 @@ namespace EDDiscovery.UserControls
         public UserControlLog()
         {
             InitializeComponent();
+            richTextBox_History.TextBox.ReadOnly = true;
             Name = "Log";
         }
 


### PR DESCRIPTION
If only I could learn to stop trying to pilot my ship while I've got my next destination selected for copying in EDD. At least with this patch, the destination won't be aaadadddadaddadadwj.

[RichTextBoxScroll](https://github.com/EDDiscovery/EDDiscovery/blob/master/EDDiscovery/Controls/RichTextBoxScroll.cs#L37) has the following comment that may impact this:
`public RichTextBoxBack TextBox;  // Use these with caution`
Not sure where a problem could arise from using this, but I wanted to note it here. I'm also not very familiar with the EDD code base, so YMMV.