### PR TITLE
Add a system tray icon

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -57,6 +57,7 @@ namespace EDDiscovery2
         private bool _orderrowsinverted = false;
         private bool _focusOnNewSystem = false; /**< Whether to automatically focus on a new system in the TravelHistory */
         private bool _keepOnTop = false; /**< Whether to keep the windows on top or not */
+        private bool _useSystray = false; /**< Whether to utilize the system notification area icon */
         private bool _displayUTC = false;
         private bool _clearMaterials = false;
         private bool _clearCommodities = false;
@@ -210,6 +211,19 @@ namespace EDDiscovery2
             }
         }
 
+        public bool UseSystray
+        {
+            get
+            {
+                return _useSystray;
+            }
+            set
+            {
+                _useSystray = value;
+                SQLiteConnectionUser.PutSettingBool("UseSystray", value);
+            }
+        }
+
         public bool DisplayUTC
         {
             get
@@ -332,6 +346,7 @@ namespace EDDiscovery2
                 _orderrowsinverted = SQLiteConnectionUser.GetSettingBool("OrderRowsInverted", false, conn);
                 _focusOnNewSystem = SQLiteConnectionUser.GetSettingBool("FocusOnNewSystem", false, conn);
                 _keepOnTop = SQLiteConnectionUser.GetSettingBool("KeepOnTop", false, conn);
+                _useSystray = SQLiteConnectionUser.GetSettingBool("UseSystray", false, conn);
                 _displayUTC = SQLiteConnectionUser.GetSettingBool("DisplayUTC", false, conn);
                 _clearCommodities = SQLiteConnectionUser.GetSettingBool("ClearCommodities", false, conn);
                 _clearMaterials = SQLiteConnectionUser.GetSettingBool("ClearMaterials", false, conn);

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -69,6 +69,11 @@
             this._checkSystemsWorker = new System.ComponentModel.BackgroundWorker();
             this.edsmRefreshTimer = new System.Windows.Forms.Timer(this.components);
             this._refreshWorker = new System.ComponentModel.BackgroundWorker();
+            this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
+            this.notifyContextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.restoreContextStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.syncContextStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exitContextStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabControl1 = new ExtendedControls.TabControlCustom();
             this.tabPageTravelHistory = new System.Windows.Forms.TabPage();
             this.travelHistoryControl1 = new EDDiscovery.TravelHistoryControl();
@@ -95,6 +100,7 @@
             this.clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.panelInfo.SuspendLayout();
+            this.notifyContextMenuStrip1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPageTravelHistory.SuspendLayout();
             this.tabPageJournal.SuspendLayout();
@@ -424,6 +430,44 @@
             this._refreshWorker.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.RefreshHistoryWorkerProgressChanged);
             this._refreshWorker.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.RefreshHistoryWorkerCompleted);
             // 
+            // notifyIcon1
+            // 
+            this.notifyIcon1.ContextMenuStrip = this.notifyContextMenuStrip1;
+            this.notifyIcon1.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.notifyIcon1.Text = "EDDiscovery";
+            this.notifyIcon1.Visible = false;
+            this.notifyIcon1.DoubleClick += new System.EventHandler(this.notifyIcon1_DoubleClick);
+            // 
+            // notifyContextMenuStrip1
+            // 
+            this.notifyContextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.restoreContextStripMenuItem,
+            this.syncContextStripMenuItem,
+            this.exitContextStripMenuItem});
+            this.notifyContextMenuStrip1.Name = "contextMenuStrip1";
+            this.notifyContextMenuStrip1.Size = new System.Drawing.Size(160, 92);
+            // 
+            // restoreContextStripMenuItem
+            // 
+            this.restoreContextStripMenuItem.Name = "restoreContextStripMenuItem";
+            this.restoreContextStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.restoreContextStripMenuItem.Text = "&Restore";
+            this.restoreContextStripMenuItem.Click += new System.EventHandler(this.restoreContextStripMenuItem_Click);
+            // 
+            // syncContextStripMenuItem
+            // 
+            this.syncContextStripMenuItem.Name = "syncContextStripMenuItem";
+            this.syncContextStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.syncContextStripMenuItem.Text = "&Sync with EDSM";
+            this.syncContextStripMenuItem.Click += new System.EventHandler(this.syncContextStripMenuItem_Click);
+            // 
+            // exitContextStripMenuItem
+            // 
+            this.exitContextStripMenuItem.Name = "exitContextStripMenuItem";
+            this.exitContextStripMenuItem.Size = new System.Drawing.Size(159, 22);
+            this.exitContextStripMenuItem.Text = "E&xit";
+            this.exitContextStripMenuItem.Click += new System.EventHandler(this.exitContextStripMenuItem_Click);
+            // 
             // tabControl1
             // 
             this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -712,10 +756,12 @@
             this.Load += new System.EventHandler(this.EDDiscoveryForm_Load);
             this.Shown += new System.EventHandler(this.EDDiscoveryForm_Shown);
             this.Layout += new System.Windows.Forms.LayoutEventHandler(this.EDDiscoveryForm_Layout);
+            this.Resize += new System.EventHandler(this.EDDiscoveryForm_Resize);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.panelInfo.ResumeLayout(false);
             this.panelInfo.PerformLayout();
+            this.notifyContextMenuStrip1.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
             this.tabPageTravelHistory.ResumeLayout(false);
             this.tabPageJournal.ResumeLayout(false);
@@ -762,6 +808,11 @@
         private EDDiscovery2.ImageHandler.ImageHandler imageHandler1;
         private System.Windows.Forms.TabPage tabPageTriletaration;
         public TrilaterationControl trilaterationControl;
+        private System.Windows.Forms.NotifyIcon notifyIcon1;
+        private System.Windows.Forms.ContextMenuStrip notifyContextMenuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem restoreContextStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem syncContextStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exitContextStripMenuItem;
         private ExtendedControls.TabControlCustom tabControl1;
         private System.Windows.Forms.TabPage tabPageTravelHistory;
         private TravelHistoryControl travelHistoryControl1;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1554,6 +1554,18 @@ namespace EDDiscovery
             frm.Show(this);
         }
 
+        internal void useSystrayChanged(bool useSystray)
+        {
+            if (useSystray)
+            {
+                notifyIcon1.Visible = true;
+            }
+            else
+            {
+                notifyIcon1.Visible = false;
+            }
+        }
+
         private void exitContextStripMenuItem_Click(object sender, EventArgs e)
         {
             if (EDDConfig.UseSystray)

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -63,6 +63,8 @@ namespace EDDiscovery
         private Point _window_dragWindowPos = Point.Empty;
         public EDDTheme theme;
 
+        private FormWindowState _lastWindowState = FormWindowState.Normal;
+
         public string CommanderName { get; private set; }
         public int DisplayedCommander = 0;
 
@@ -197,6 +199,12 @@ namespace EDDiscovery
             ApplyTheme();
 
             DisplayedCommander = EDDiscoveryForm.EDDConfig.CurrentCommander.Nr;
+
+            if (EDDConfig.UseSystray)
+            {
+                notifyIcon1.Visible = true;
+                restoreContextStripMenuItem.Enabled = (WindowState == FormWindowState.Minimized);
+            }
         }
 
         private void Dbinitworker_DoWork(object sender, DoWorkEventArgs e)
@@ -328,6 +336,22 @@ namespace EDDiscovery
             catch (Exception ex)
             {
                 System.Windows.Forms.MessageBox.Show("EDDiscoveryForm_Load exception: " + ex.Message + "\n" + "Trace: " + ex.StackTrace);
+            }
+        }
+
+        private void EDDiscoveryForm_Resize(object sender, EventArgs e)
+        {
+            if (EDDConfig.UseSystray)
+            {
+                if (FormWindowState.Minimized == WindowState)
+                {
+                    Hide();
+                }
+                else
+                {
+                    _lastWindowState = WindowState;
+                }
+                restoreContextStripMenuItem.Enabled = (WindowState == FormWindowState.Minimized);
             }
         }
 
@@ -1199,7 +1223,7 @@ namespace EDDiscovery
 
 #endregion
 
-#region Buttons, Mouse, Menus
+#region Buttons, Mouse, Menus, Notification icon
 
         private void button_test_Click(object sender, EventArgs e)
         {
@@ -1311,7 +1335,16 @@ namespace EDDiscovery
 
         private void panel_minimize_Click(object sender, EventArgs e)
         {
-            this.WindowState = FormWindowState.Minimized;
+            if (EDDConfig.UseSystray)
+            {
+                _lastWindowState = WindowState;
+                restoreContextStripMenuItem.Enabled = true;
+            }
+            WindowState = FormWindowState.Minimized;
+            if (EDDConfig.UseSystray)
+            {
+                Hide();
+            }
         }
 
         private void changeMapColorToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1521,6 +1554,56 @@ namespace EDDiscovery
             frm.Show(this);
         }
 
+        private void exitContextStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (EDDConfig.UseSystray)
+            {
+                Close();
+            }
+        }
+
+        private void restoreContextStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (EDDConfig.UseSystray && WindowState == FormWindowState.Minimized)
+            {
+                Show();
+                WindowState = _lastWindowState;
+                restoreContextStripMenuItem.Enabled = false;
+            }
+        }
+
+        private void syncContextStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (EDDConfig.UseSystray)
+            {
+                if (!_syncWorker.IsBusy)      // we want it to have run, to completion, to allow another go..
+                {
+                    performedsmsync = true;
+                    AsyncPerformSync();
+                }
+                else
+                    MessageBox.Show("Synchronisation to databases is in operation or pending, please wait");
+            }
+        }
+
+        private void notifyIcon1_DoubleClick(object sender, EventArgs e)
+        {
+            if (EDDConfig.UseSystray)
+            {
+                if (WindowState == FormWindowState.Minimized)
+                {
+                    Show();
+                    WindowState = _lastWindowState;
+                }
+                else
+                {
+                    _lastWindowState = WindowState;
+                    WindowState = FormWindowState.Minimized;
+                    Hide();
+                }
+                restoreContextStripMenuItem.Enabled = (WindowState == FormWindowState.Minimized);
+            }
+        }
         #endregion
 
         #region Window Control

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -47,6 +47,7 @@
             this.panel_defaultmapcolor = new System.Windows.Forms.Panel();
             this.groupBox3 = new ExtendedControls.GroupBoxCustom();
             this.checkBoxFocusNewSystem = new ExtendedControls.CheckBoxCustom();
+            this.checkBoxUseSystray = new ExtendedControls.CheckBoxCustom();
             this.checkBoxUTC = new ExtendedControls.CheckBoxCustom();
             this.checkBoxOrderRowsInverted = new ExtendedControls.CheckBoxCustom();
             this.checkBoxEDSMLog = new ExtendedControls.CheckBoxCustom();
@@ -92,7 +93,7 @@
             this.groupBoxTheme.Controls.Add(this.button_edittheme);
             this.groupBoxTheme.Controls.Add(this.buttonSaveTheme);
             this.groupBoxTheme.FillClientAreaWithAlternateColor = false;
-            this.groupBoxTheme.Location = new System.Drawing.Point(3, 382);
+            this.groupBoxTheme.Location = new System.Drawing.Point(3, 405);
             this.groupBoxTheme.Name = "groupBoxTheme";
             this.groupBoxTheme.Size = new System.Drawing.Size(426, 108);
             this.groupBoxTheme.TabIndex = 18;
@@ -319,6 +320,7 @@
             this.groupBox3.BackColorScaling = 0.5F;
             this.groupBox3.BorderColor = System.Drawing.Color.LightGray;
             this.groupBox3.BorderColorScaling = 0.5F;
+            this.groupBox3.Controls.Add(this.checkBoxUseSystray);
             this.groupBox3.Controls.Add(this.checkBoxFocusNewSystem);
             this.groupBox3.Controls.Add(this.checkBoxUTC);
             this.groupBox3.Controls.Add(this.checkBoxOrderRowsInverted);
@@ -327,7 +329,7 @@
             this.groupBox3.FillClientAreaWithAlternateColor = false;
             this.groupBox3.Location = new System.Drawing.Point(3, 254);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(426, 122);
+            this.groupBox3.Size = new System.Drawing.Size(426, 145);
             this.groupBox3.TabIndex = 16;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Options";
@@ -345,12 +347,30 @@
             this.checkBoxFocusNewSystem.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBoxFocusNewSystem.Name = "checkBoxFocusNewSystem";
             this.checkBoxFocusNewSystem.Size = new System.Drawing.Size(253, 17);
-            this.checkBoxFocusNewSystem.TabIndex = 3;
+            this.checkBoxFocusNewSystem.TabIndex = 2;
             this.checkBoxFocusNewSystem.Text = "History cursor to new Journal Entry automatically";
             this.checkBoxFocusNewSystem.TickBoxReductionSize = 10;
             this.toolTip.SetToolTip(this.checkBoxFocusNewSystem, "Move the history cursor to the new journal entry automatically when its received");
             this.checkBoxFocusNewSystem.UseVisualStyleBackColor = true;
             this.checkBoxFocusNewSystem.CheckedChanged += new System.EventHandler(this.checkBoxFocusNewSystem_CheckedChanged);
+            // 
+            // checkBoxUseSystray
+            // 
+            this.checkBoxUseSystray.AutoSize = true;
+            this.checkBoxUseSystray.CheckBoxColor = System.Drawing.Color.Gray;
+            this.checkBoxUseSystray.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxUseSystray.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxUseSystray.FontNerfReduction = 0.5F;
+            this.checkBoxUseSystray.Location = new System.Drawing.Point(17, 115);
+            this.checkBoxUseSystray.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxUseSystray.Name = "checkBoxUseSystray";
+            this.checkBoxUseSystray.Size = new System.Drawing.Size(198, 17);
+            this.checkBoxUseSystray.TabIndex = 4;
+            this.checkBoxUseSystray.Text = "Use the system tray/notification area";
+            this.checkBoxUseSystray.TickBoxReductionSize = 10;
+            this.toolTip.SetToolTip(this.checkBoxUseSystray, "Maintain a system tray/notification area icon. Minimize program to this icon.");
+            this.checkBoxUseSystray.UseVisualStyleBackColor = true;
+            this.checkBoxUseSystray.CheckedChanged += new System.EventHandler(this.checkBoxUseSystray_CheckedChanged);
             // 
             // checkBoxUTC
             // 
@@ -363,7 +383,7 @@
             this.checkBoxUTC.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBoxUTC.Name = "checkBoxUTC";
             this.checkBoxUTC.Size = new System.Drawing.Size(209, 17);
-            this.checkBoxUTC.TabIndex = 0;
+            this.checkBoxUTC.TabIndex = 3;
             this.checkBoxUTC.Text = "Display Game time instead of local time";
             this.checkBoxUTC.TickBoxReductionSize = 10;
             this.toolTip.SetToolTip(this.checkBoxUTC, "Display game time (UTC) instead of your local time");
@@ -381,7 +401,7 @@
             this.checkBoxOrderRowsInverted.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBoxOrderRowsInverted.Name = "checkBoxOrderRowsInverted";
             this.checkBoxOrderRowsInverted.Size = new System.Drawing.Size(196, 17);
-            this.checkBoxOrderRowsInverted.TabIndex = 2;
+            this.checkBoxOrderRowsInverted.TabIndex = 1;
             this.checkBoxOrderRowsInverted.Text = "Number Rows Lastest Entry Highest";
             this.checkBoxOrderRowsInverted.TickBoxReductionSize = 10;
             this.toolTip.SetToolTip(this.checkBoxOrderRowsInverted, "Number oldest entry 1, latest entry highest");
@@ -398,7 +418,7 @@
             this.checkBoxEDSMLog.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBoxEDSMLog.Name = "checkBoxEDSMLog";
             this.checkBoxEDSMLog.Size = new System.Drawing.Size(121, 17);
-            this.checkBoxEDSMLog.TabIndex = 1;
+            this.checkBoxEDSMLog.TabIndex = 0;
             this.checkBoxEDSMLog.Text = "Log EDSM requests";
             this.checkBoxEDSMLog.TickBoxReductionSize = 10;
             this.toolTip.SetToolTip(this.checkBoxEDSMLog, "Store EDSM queries in a log file");
@@ -416,7 +436,7 @@
             this.checkboxSkipSlowUpdates.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkboxSkipSlowUpdates.Name = "checkboxSkipSlowUpdates";
             this.checkboxSkipSlowUpdates.Size = new System.Drawing.Size(238, 17);
-            this.checkboxSkipSlowUpdates.TabIndex = 4;
+            this.checkboxSkipSlowUpdates.TabIndex = 5;
             this.checkboxSkipSlowUpdates.Text = "DEBUG ONLY: Skip slow updates on startup";
             this.checkboxSkipSlowUpdates.TickBoxReductionSize = 10;
             this.checkboxSkipSlowUpdates.UseVisualStyleBackColor = false;
@@ -691,6 +711,7 @@
         private ExtendedControls.CheckBoxCustom checkBoxOrderRowsInverted;
         private ExtendedControls.CheckBoxCustom checkBoxFocusNewSystem;
         private ExtendedControls.CheckBoxCustom checkBoxKeepOnTop;
+        private ExtendedControls.CheckBoxCustom checkBoxUseSystray;
         private ExtendedControls.ButtonExt btnDeleteCommander;
         private System.Windows.Forms.Label label1;
         private ExtendedControls.CheckBoxCustom checkBoxUTC;

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -61,6 +61,7 @@ namespace EDDiscovery2
             checkBoxOrderRowsInverted.Checked = EDDiscoveryForm.EDDConfig.OrderRowsInverted;
             checkBoxFocusNewSystem.Checked = EDDiscoveryForm.EDDConfig.FocusOnNewSystem;
             checkBoxKeepOnTop.Checked = EDDiscoveryForm.EDDConfig.KeepOnTop;
+            checkBoxUseSystray.Checked = EDDiscoveryForm.EDDConfig.UseSystray;
             checkBoxUTC.Checked = EDDiscoveryForm.EDDConfig.DisplayUTC;
 
 #if DEBUG
@@ -100,6 +101,7 @@ namespace EDDiscovery2
             EDDiscoveryForm.EDDConfig.OrderRowsInverted = checkBoxOrderRowsInverted.Checked;
             EDDiscoveryForm.EDDConfig.FocusOnNewSystem = checkBoxFocusNewSystem.Checked;
             EDDiscoveryForm.EDDConfig.KeepOnTop = checkBoxKeepOnTop.Checked;
+            EDDiscoveryForm.EDDConfig.UseSystray = checkBoxUseSystray.Checked;
             EDDiscoveryForm.EDDConfig.DisplayUTC = checkBoxUTC.Checked;
         }
 
@@ -267,6 +269,11 @@ namespace EDDiscovery2
             EDDConfig.Instance.KeepOnTop = checkBoxKeepOnTop.Checked;
             this.FindForm().TopMost = checkBoxKeepOnTop.Checked;
             _discoveryForm.keepOnTopChanged(checkBoxKeepOnTop.Checked);
+        }
+
+        private void checkBoxUseSystray_CheckedChanged(object sender, EventArgs e)
+        {
+            EDDConfig.Instance.UseSystray = checkBoxUseSystray.Checked;
         }
 
         private void checkBoxUTC_CheckedChanged(object sender, EventArgs e)

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -274,6 +274,7 @@ namespace EDDiscovery2
         private void checkBoxUseSystray_CheckedChanged(object sender, EventArgs e)
         {
             EDDConfig.Instance.UseSystray = checkBoxUseSystray.Checked;
+            _discoveryForm.useSystrayChanged(checkBoxUseSystray.Checked);
         }
 
         private void checkBoxUTC_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Doesn't really add much, but it will be really nice once it's animated and hooked up to show the status of BackgroundWorkers.

The setting for "Use the system tray/notification area" is poorly worded. Technically, it's a notification area, but again, this is not yet wired up to provide notifications. Just a handy double-click to hide/restore and a context menu.