### PR TITLE
Fix display scaling bug

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -281,7 +281,6 @@ namespace EDDiscovery2
         public FormMap()
         {
             InitializeComponent();
-            OpenTK.Toolkit.Init();
             // 
             // glControl
             // 
@@ -301,6 +300,7 @@ namespace EDDiscovery2
             this.glControl.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.glControl_OnMouseWheel);
             this.glControlContainer.Controls.Add(this.glControl);
             this.glControlContainer.ResumeLayout();
+            OpenTK.Toolkit.Init();
         }
 
         private void FormMap_Load(object sender, EventArgs e)


### PR DESCRIPTION
For whatever reason, initializing the OpenTK toolkit before adding the GL control to the 3D map throws off display scaling.

Move OpenTK toolkit init to after the GL control is added to the 3D map.

Fixes dfa86bf Use placeholder panel for GL Control in designer

This should fix #675 and #677