### PR TITLE
Add a notification area icon

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -54,7 +54,9 @@ namespace EDDiscovery2
         private bool _EDSMLog;
         readonly public string LogIndex;
         private bool _canSkipSlowUpdates = false;
+        private bool _useNotifyIcon = false;
         private bool _orderrowsinverted = false;
+        private bool _minimizeToNotifyIcon = false;
         private bool _focusOnNewSystem = false; /**< Whether to automatically focus on a new system in the TravelHistory */
         private bool _keepOnTop = false; /**< Whether to keep the windows on top or not */
         private bool _displayUTC = false;
@@ -92,6 +94,22 @@ namespace EDDiscovery2
             LogIndex = DateTime.Now.ToString("yyyyMMdd");
         }
 
+        /// <summary>
+        /// Controls whether or not a system notification area (systray) icon will be shown.
+        /// </summary>
+        public bool UseNotifyIcon
+        {
+            get
+            {
+                return _useNotifyIcon;
+            }
+            set
+            {
+                _useNotifyIcon = value;
+                SQLiteConnectionUser.PutSettingBool("UseNotifyIcon", value);
+            }
+        }
+
         public bool UseDistances
         {
             get
@@ -103,6 +121,24 @@ namespace EDDiscovery2
             {
                 _useDistances = value;
                 SQLiteConnectionUser.PutSettingBool("EDSMDistances", value);
+            }
+        }
+
+        /// <summary>
+        /// Controls whether or not the main window will be hidden to the
+        /// system notification area icon (systray) when minimized.
+        /// Has no effect if <see cref="UseNotifyIcon"/> is not enabled.
+        /// </summary>
+        public bool MinimizeToNotifyIcon
+        {
+            get
+            {
+                return _minimizeToNotifyIcon;
+            }
+            set
+            {
+                _minimizeToNotifyIcon = value;
+                SQLiteConnectionUser.PutSettingBool("MinimizeToNotifyIcon", value);
             }
         }
 
@@ -354,10 +390,12 @@ namespace EDDiscovery2
         {
             try
             {
+                _useNotifyIcon = SQLiteConnectionUser.GetSettingBool("UseNotifyIcon", false, conn);
                 _useDistances = SQLiteConnectionUser.GetSettingBool("EDSMDistances", false, conn);
                 _EDSMLog = SQLiteConnectionUser.GetSettingBool("EDSMLog", false, conn);
                 _canSkipSlowUpdates = SQLiteConnectionUser.GetSettingBool("CanSkipSlowUpdates", false, conn);
                 _orderrowsinverted = SQLiteConnectionUser.GetSettingBool("OrderRowsInverted", false, conn);
+                _minimizeToNotifyIcon = SQLiteConnectionUser.GetSettingBool("MinimizeToNotifyIcon", false, conn);
                 _focusOnNewSystem = SQLiteConnectionUser.GetSettingBool("FocusOnNewSystem", false, conn);
                 _keepOnTop = SQLiteConnectionUser.GetSettingBool("KeepOnTop", false, conn);
                 _displayUTC = SQLiteConnectionUser.GetSettingBool("DisplayUTC", false, conn);

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -93,6 +93,13 @@
             this.toolStripProgressBar1 = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.notifyIcon1 = new System.Windows.Forms.NotifyIcon();
+            this.notifyIconContextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip();
+            this.notifyIconMenu_Exit = new System.Windows.Forms.ToolStripMenuItem();
+            this.notifyIconMenu_Hide = new System.Windows.Forms.ToolStripMenuItem();
+            this.notifyIconMenu_Open = new System.Windows.Forms.ToolStripMenuItem();
+            this.notifyIconMenu_SyncEDDB = new System.Windows.Forms.ToolStripMenuItem();
+            this.notifyIconMenu_SyncEDSM = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.panelInfo.SuspendLayout();
             this.tabControl1.SuspendLayout();
@@ -105,6 +112,7 @@
             this.tabPageExport.SuspendLayout();
             this.tabPageSettings.SuspendLayout();
             this.statusStrip1.SuspendLayout();
+            this.notifyIconContextMenuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // menuStrip1
@@ -688,6 +696,60 @@
             this.clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem.Text = "Clear EDSM ID assigned to all records for current commander";
             this.clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem.Click += new System.EventHandler(this.clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem_Click);
             // 
+            // notifyIcon1
+            // 
+            this.notifyIcon1.ContextMenuStrip = this.notifyIconContextMenuStrip1;
+            this.notifyIcon1.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.notifyIcon1.Text = "EDDiscovery";
+            this.notifyIcon1.Visible = false;
+            this.notifyIcon1.DoubleClick += new System.EventHandler(this.notifyIcon1_DoubleClick);
+            // 
+            // notifyIconContextMenuStrip1
+            // 
+            this.notifyIconContextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.notifyIconMenu_Open,
+            this.notifyIconMenu_SyncEDDB,
+            this.notifyIconMenu_SyncEDSM,
+            this.notifyIconMenu_Hide,
+            this.notifyIconMenu_Exit});
+            this.notifyIconContextMenuStrip1.Name = "notifyIconContextMenuStrip1";
+            this.notifyIconContextMenuStrip1.Size = new System.Drawing.Size(160, 92);
+            // 
+            // notifyIconMenu_Exit
+            // 
+            this.notifyIconMenu_Exit.Name = "notifyIconMenu_Exit";
+            this.notifyIconMenu_Exit.Size = new System.Drawing.Size(159, 22);
+            this.notifyIconMenu_Exit.Text = "E&xit";
+            this.notifyIconMenu_Exit.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+            // 
+            // notifyIconMenu_Hide
+            // 
+            this.notifyIconMenu_Hide.Name = "notifyIconMenu_Hide";
+            this.notifyIconMenu_Hide.Size = new System.Drawing.Size(159, 22);
+            this.notifyIconMenu_Hide.Text = "&Hide Tray Icon";
+            this.notifyIconMenu_Hide.Click += new System.EventHandler(this.notifyIconMenu_Hide_Click);
+            // 
+            // notifyIconMenu_Open
+            // 
+            this.notifyIconMenu_Open.Name = "notifyIconMenu_Open";
+            this.notifyIconMenu_Open.Size = new System.Drawing.Size(159, 22);
+            this.notifyIconMenu_Open.Text = "&Open EDDiscovery";
+            this.notifyIconMenu_Open.Click += new System.EventHandler(this.notifyIconMenu_Open_Click);
+            // 
+            // notifyIconMenu_SyncEDDB
+            // 
+            this.notifyIconMenu_SyncEDDB.Name = "notifyIconMenu_SyncEDDB";
+            this.notifyIconMenu_SyncEDDB.Size = new System.Drawing.Size(159, 22);
+            this.notifyIconMenu_SyncEDDB.Text = "Sync with ED&DB";
+            this.notifyIconMenu_SyncEDDB.Click += new System.EventHandler(this.forceEDDBUpdateToolStripMenuItem_Click);
+            // 
+            // notifyIconMenu_SyncEDSM
+            // 
+            this.notifyIconMenu_SyncEDSM.Name = "notifyIconMenu_SyncEDSM";
+            this.notifyIconMenu_SyncEDSM.Size = new System.Drawing.Size(159, 22);
+            this.notifyIconMenu_SyncEDSM.Text = "Sync with ED&SM";
+            this.notifyIconMenu_SyncEDSM.Click += new System.EventHandler(this.syncEDSMSystemsToolStripMenuItem_Click);
+            // 
             // EDDiscoveryForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -710,6 +772,7 @@
             this.Activated += new System.EventHandler(this.EDDiscoveryForm_Activated);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.EDDiscoveryForm_FormClosing);
             this.Load += new System.EventHandler(this.EDDiscoveryForm_Load);
+            this.Resize += new System.EventHandler(this.EDDiscoveryForm_Resize);
             this.Shown += new System.EventHandler(this.EDDiscoveryForm_Shown);
             this.Layout += new System.Windows.Forms.LayoutEventHandler(this.EDDiscoveryForm_Layout);
             this.menuStrip1.ResumeLayout(false);
@@ -728,6 +791,7 @@
             this.tabPageSettings.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
+            this.notifyIconContextMenuStrip1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -796,5 +860,12 @@
         private System.Windows.Forms.ToolStripMenuItem showAllInTaskBarToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem turnOffAllTransparencyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem;
+        private System.Windows.Forms.NotifyIcon notifyIcon1;
+        private System.Windows.Forms.ContextMenuStrip notifyIconContextMenuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem notifyIconMenu_Exit;
+        private System.Windows.Forms.ToolStripMenuItem notifyIconMenu_Hide;
+        private System.Windows.Forms.ToolStripMenuItem notifyIconMenu_Open;
+        private System.Windows.Forms.ToolStripMenuItem notifyIconMenu_SyncEDDB;
+        private System.Windows.Forms.ToolStripMenuItem notifyIconMenu_SyncEDSM;
     }
 }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -114,6 +114,8 @@ namespace EDDiscovery
         EliteDangerous.EDJournalClass journalmonitor;
         GitHubRelease newRelease;
 
+        private bool _formMax;
+
         private bool CanSkipSlowUpdates()
         {
 #if DEBUG
@@ -197,6 +199,8 @@ namespace EDDiscovery
             ApplyTheme();
 
             DisplayedCommander = EDDiscoveryForm.EDDConfig.CurrentCommander.Nr;
+
+            notifyIcon1.Visible = EDDConfig.UseNotifyIcon;
         }
 
         private void Dbinitworker_DoWork(object sender, DoWorkEventArgs e)
@@ -438,8 +442,8 @@ namespace EDDiscovery
                 this.CreateParams.Y = this.Top;
                 this.StartPosition = FormStartPosition.Manual;
 
-                var Max = SQLiteDBClass.GetSettingBool("FormMax", false);
-                if (Max) this.WindowState = FormWindowState.Maximized;
+                _formMax = SQLiteDBClass.GetSettingBool("FormMax", false);
+                if (_formMax) this.WindowState = FormWindowState.Maximized;
             }
 
             travelHistoryControl1.LoadLayoutSettings();
@@ -1107,7 +1111,7 @@ namespace EDDiscovery
         {
             settings.SaveSettings();
 
-            SQLiteDBClass.PutSettingBool("FormMax", this.WindowState == FormWindowState.Maximized);
+            SQLiteDBClass.PutSettingBool("FormMax", _formMax);
             SQLiteDBClass.PutSettingInt("FormWidth", this.Width);
             SQLiteDBClass.PutSettingInt("FormHeight", this.Height);
             SQLiteDBClass.PutSettingInt("FormTop", this.Top);
@@ -1201,13 +1205,14 @@ namespace EDDiscovery
                 closeTimer.Stop();      // stop timer now. So it won't try to save it multiple times during close down if it takes a while - this caused a bug in saving some settings
                 SaveSettings();         // do close now
                 Close();
+                notifyIcon1.Visible = false;
                 Application.Exit();
             }
         }
 
 #endregion
 
-#region Buttons, Mouse, Menus
+#region Buttons, Mouse, Menus, NotifyIcon
 
         private void button_test_Click(object sender, EventArgs e)
         {
@@ -1315,6 +1320,17 @@ namespace EDDiscovery
         internal void keepOnTopChanged(bool keepOnTop)
         {
             this.TopMost = keepOnTop;
+        }
+
+        /// <summary>
+        /// The settings panel check box for 'Use notification area icon' has changed.
+        /// </summary>
+        /// <param name="useNotifyIcon">Whether or not the setting is enabled.</param>
+        internal void useNotifyIconChanged(bool useNotifyIcon)
+        {
+            notifyIcon1.Visible = useNotifyIcon;
+            if (!useNotifyIcon && !Visible)
+                Show();
         }
 
         private void panel_minimize_Click(object sender, EventArgs e)
@@ -1529,6 +1545,44 @@ namespace EDDiscovery
             frm.Show(this);
         }
 
+        private void notifyIcon1_DoubleClick(object sender, EventArgs e)
+        {
+            // Tray icon was double-clicked.
+            if (FormWindowState.Minimized == WindowState)
+            {
+                if (EDDConfig.MinimizeToNotifyIcon)
+                    Show();
+                if (_formMax)
+                    WindowState = FormWindowState.Maximized;
+                else
+                    WindowState = FormWindowState.Normal;
+            }
+            else
+                WindowState = FormWindowState.Minimized;
+        }
+
+        private void notifyIconMenu_Hide_Click(object sender, EventArgs e)
+        {
+            // Tray icon 'Hide Tray Icon' menu item was clicked.
+            settings.checkBoxUseNotifyIcon.Checked = false;
+        }
+
+        private void notifyIconMenu_Open_Click(object sender, EventArgs e)
+        {
+            // Tray icon 'Open EDDiscovery' menu item was clicked. Present the main window.
+            if (FormWindowState.Minimized == WindowState)
+            {
+                if (EDDConfig.UseNotifyIcon && EDDConfig.MinimizeToNotifyIcon)
+                    Show();
+                if (_formMax)
+                    WindowState = FormWindowState.Maximized;
+                else
+                    WindowState = FormWindowState.Normal;
+            }
+            else
+                Activate();
+        }
+
         #endregion
 
         #region Window Control
@@ -1602,6 +1656,22 @@ namespace EDDiscovery
             {
                 base.WndProc(ref m);
             }
+        }
+
+        private void EDDiscoveryForm_Resize(object sender, EventArgs e)
+        {
+            if (FormWindowState.Minimized == WindowState)
+            {
+                if (EDDConfig.UseNotifyIcon && EDDConfig.MinimizeToNotifyIcon)
+                    Hide();
+            }
+            else
+            {
+                if (EDDConfig.UseNotifyIcon && EDDConfig.MinimizeToNotifyIcon)
+                    Show();
+                _formMax = FormWindowState.Maximized == WindowState;
+            }
+            notifyIconMenu_Open.Enabled = FormWindowState.Minimized == WindowState;
         }
 
         #endregion
@@ -1790,7 +1860,7 @@ namespace EDDiscovery
             ReportProgress(e.ProgressPercentage, $"Processing log file {name}");
         }
 
-        // go thru the hisotry list and reworkout the materials ledge and the materials count, plus any other stuff..
+        // go through the history list and recalculate the materials ledger and the materials count, plus any other stuff..
         private void ProcessUserHistoryListEntries(List<HistoryEntry> hl, MaterialCommoditiesLedger ledger, StarScan scan)
         {
             using (SQLiteConnectionUser conn = new SQLiteConnectionUser())      // splitting the update into two, one using system, one using user helped

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -74,13 +74,15 @@
             this.buttonAddCommander = new ExtendedControls.ButtonExt();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
+            this.checkBoxUseNotifyIcon = new ExtendedControls.CheckBoxCustom();
+            this.checkBoxMinimizeToNotifyIcon = new ExtendedControls.CheckBoxCustom();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewCommanders)).BeginInit();
             this.groupBoxPopOuts.SuspendLayout();
             this.groupBoxTheme.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.dataViewScrollerPanel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewCommanders)).BeginInit();
             this.SuspendLayout();
             // 
             // toolTip
@@ -176,7 +178,7 @@
             this.groupBoxTheme.Controls.Add(this.button_edittheme);
             this.groupBoxTheme.Controls.Add(this.buttonSaveTheme);
             this.groupBoxTheme.FillClientAreaWithAlternateColor = false;
-            this.groupBoxTheme.Location = new System.Drawing.Point(3, 382);
+            this.groupBoxTheme.Location = new System.Drawing.Point(3, 405);
             this.groupBoxTheme.Name = "groupBoxTheme";
             this.groupBoxTheme.Size = new System.Drawing.Size(426, 108);
             this.groupBoxTheme.TabIndex = 18;
@@ -403,6 +405,8 @@
             this.groupBox3.BackColorScaling = 0.5F;
             this.groupBox3.BorderColor = System.Drawing.Color.LightGray;
             this.groupBox3.BorderColorScaling = 0.5F;
+            this.groupBox3.Controls.Add(this.checkBoxMinimizeToNotifyIcon);
+            this.groupBox3.Controls.Add(this.checkBoxUseNotifyIcon);
             this.groupBox3.Controls.Add(this.checkBoxFocusNewSystem);
             this.groupBox3.Controls.Add(this.checkBoxUTC);
             this.groupBox3.Controls.Add(this.checkBoxOrderRowsInverted);
@@ -411,7 +415,7 @@
             this.groupBox3.FillClientAreaWithAlternateColor = false;
             this.groupBox3.Location = new System.Drawing.Point(3, 254);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(426, 122);
+            this.groupBox3.Size = new System.Drawing.Size(426, 145);
             this.groupBox3.TabIndex = 16;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Options";
@@ -725,6 +729,42 @@
             this.label2.TabIndex = 1;
             this.label2.Text = "Get an EDSM API key from https://www.edsm.net in \"My account\" menu";
             // 
+            // checkBoxUseNotifyIcon
+            // 
+            this.checkBoxUseNotifyIcon.AutoSize = true;
+            this.checkBoxUseNotifyIcon.CheckBoxColor = System.Drawing.Color.Gray;
+            this.checkBoxUseNotifyIcon.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxUseNotifyIcon.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxUseNotifyIcon.FontNerfReduction = 0.5F;
+            this.checkBoxUseNotifyIcon.Location = new System.Drawing.Point(17, 115);
+            this.checkBoxUseNotifyIcon.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxUseNotifyIcon.Name = "checkBoxUseNotifyIcon";
+            this.checkBoxUseNotifyIcon.Size = new System.Drawing.Size(154, 17);
+            this.checkBoxUseNotifyIcon.TabIndex = 5;
+            this.checkBoxUseNotifyIcon.Text = "Show notification area icon";
+            this.checkBoxUseNotifyIcon.TickBoxReductionSize = 10;
+            this.toolTip.SetToolTip(this.checkBoxUseNotifyIcon, "Show a system notification area (system tray) icon for EDDiscovery.");
+            this.checkBoxUseNotifyIcon.UseVisualStyleBackColor = true;
+            this.checkBoxUseNotifyIcon.CheckedChanged += new System.EventHandler(this.checkBoxUseNotifyIcon_CheckedChanged);
+            // 
+            // checkBoxMinimizeToNotifyIcon
+            // 
+            this.checkBoxMinimizeToNotifyIcon.AutoSize = true;
+            this.checkBoxMinimizeToNotifyIcon.CheckBoxColor = System.Drawing.Color.Gray;
+            this.checkBoxMinimizeToNotifyIcon.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxMinimizeToNotifyIcon.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxMinimizeToNotifyIcon.FontNerfReduction = 0.5F;
+            this.checkBoxMinimizeToNotifyIcon.Location = new System.Drawing.Point(182, 115);
+            this.checkBoxMinimizeToNotifyIcon.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxMinimizeToNotifyIcon.Name = "checkBoxMinimizeToNotifyIcon";
+            this.checkBoxMinimizeToNotifyIcon.Size = new System.Drawing.Size(179, 17);
+            this.checkBoxMinimizeToNotifyIcon.TabIndex = 6;
+            this.checkBoxMinimizeToNotifyIcon.Text = "Minimize to notification area icon";
+            this.checkBoxMinimizeToNotifyIcon.TickBoxReductionSize = 10;
+            this.toolTip.SetToolTip(this.checkBoxMinimizeToNotifyIcon, "Minimize the main window to the system notification area (system tray) icon.");
+            this.checkBoxMinimizeToNotifyIcon.UseVisualStyleBackColor = true;
+            this.checkBoxMinimizeToNotifyIcon.CheckedChanged += new System.EventHandler(this.checkBoxMinimizeToNotifyIcon_CheckedChanged);
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -736,6 +776,7 @@
             this.Controls.Add(this.groupBox4);
             this.Name = "Settings";
             this.Size = new System.Drawing.Size(937, 725);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewCommanders)).EndInit();
             this.groupBoxPopOuts.ResumeLayout(false);
             this.groupBoxPopOuts.PerformLayout();
             this.groupBoxTheme.ResumeLayout(false);
@@ -747,7 +788,6 @@
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
             this.dataViewScrollerPanel1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewCommanders)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -798,5 +838,7 @@
         private ExtendedControls.ButtonExt buttonSaveSetup;
         private ExtendedControls.CheckBoxCustom checkBoxAutoSave;
         private ExtendedControls.CheckBoxCustom checkBoxAutoLoad;
+        private ExtendedControls.CheckBoxCustom checkBoxMinimizeToNotifyIcon;
+        internal ExtendedControls.CheckBoxCustom checkBoxUseNotifyIcon;
     }
 }

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -59,11 +59,15 @@ namespace EDDiscovery2
             checkBoxEDSMLog.Checked = EDDiscoveryForm.EDDConfig.EDSMLog;
             checkboxSkipSlowUpdates.Checked = EDDiscoveryForm.EDDConfig.CanSkipSlowUpdates;
             checkBoxOrderRowsInverted.Checked = EDDiscoveryForm.EDDConfig.OrderRowsInverted;
+            checkBoxMinimizeToNotifyIcon.Checked = EDDiscoveryForm.EDDConfig.MinimizeToNotifyIcon;
             checkBoxFocusNewSystem.Checked = EDDiscoveryForm.EDDConfig.FocusOnNewSystem;
             checkBoxKeepOnTop.Checked = EDDiscoveryForm.EDDConfig.KeepOnTop;
+            checkBoxUseNotifyIcon.Checked = EDDiscoveryForm.EDDConfig.UseNotifyIcon;
             checkBoxUTC.Checked = EDDiscoveryForm.EDDConfig.DisplayUTC;
             checkBoxAutoLoad.Checked = EDDiscoveryForm.EDDConfig.AutoLoadPopOuts;
             checkBoxAutoSave.Checked = EDDiscoveryForm.EDDConfig.AutoSavePopOuts;
+
+            checkBoxMinimizeToNotifyIcon.Enabled = EDDiscoveryForm.EDDConfig.UseNotifyIcon;
 
 #if DEBUG
             checkboxSkipSlowUpdates.Visible = true;
@@ -99,7 +103,9 @@ namespace EDDiscovery2
 
             EDDiscoveryForm.EDDConfig.EDSMLog = checkBoxEDSMLog.Checked;
             EDDiscoveryForm.EDDConfig.CanSkipSlowUpdates = checkboxSkipSlowUpdates.Checked;
+            EDDiscoveryForm.EDDConfig.UseNotifyIcon = checkBoxUseNotifyIcon.Checked;
             EDDiscoveryForm.EDDConfig.OrderRowsInverted = checkBoxOrderRowsInverted.Checked;
+            EDDiscoveryForm.EDDConfig.MinimizeToNotifyIcon = checkBoxMinimizeToNotifyIcon.Checked;
             EDDiscoveryForm.EDDConfig.FocusOnNewSystem = checkBoxFocusNewSystem.Checked;
             EDDiscoveryForm.EDDConfig.KeepOnTop = checkBoxKeepOnTop.Checked;
             EDDiscoveryForm.EDDConfig.DisplayUTC = checkBoxUTC.Checked;
@@ -271,6 +277,19 @@ namespace EDDiscovery2
             EDDConfig.Instance.KeepOnTop = checkBoxKeepOnTop.Checked;
             this.FindForm().TopMost = checkBoxKeepOnTop.Checked;
             _discoveryForm.keepOnTopChanged(checkBoxKeepOnTop.Checked);
+        }
+
+        private void checkBoxMinimizeToNotifyIcon_CheckedChanged(object sender, EventArgs e)
+        {
+            EDDiscoveryForm.EDDConfig.MinimizeToNotifyIcon = checkBoxMinimizeToNotifyIcon.Checked;
+        }
+
+        private void checkBoxUseNotifyIcon_CheckedChanged(object sender, EventArgs e)
+        {
+            bool chk = checkBoxUseNotifyIcon.Checked;
+            EDDiscoveryForm.EDDConfig.UseNotifyIcon = chk;
+            checkBoxMinimizeToNotifyIcon.Enabled = chk;
+            _discoveryForm.useNotifyIconChanged(chk);
         }
 
         private void checkBoxUTC_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Closes #417 (for real this time)

In what is commonly referred to as a system tray, the notification area will now show an EDD icon when enabled in the settings tab.

This was rewritten from the previous PR to follow desktop usability guidelines. These guidelines require a "hide icon" or similar menu item on the context menu.

I can't set the milestone, but this should target 5.3.