### PR TITLE
Update About form, add license blobs, bump (c) year

### DIFF
--- a/EDDiscovery/2DMap/FGEImage.cs
+++ b/EDDiscovery/2DMap/FGEImage.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/EDDiscovery/2DMap/Form2DMap.Designer.cs
+++ b/EDDiscovery/2DMap/Form2DMap.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class FormSagCarinaMission
     {

--- a/EDDiscovery/2DMap/Form2DMap.cs
+++ b/EDDiscovery/2DMap/Form2DMap.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2.DB;
 using EMK.LightGeometry;

--- a/EDDiscovery/2DMap/ImageViewer.Designer.cs
+++ b/EDDiscovery/2DMap/ImageViewer.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2._2DMap
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2._2DMap
 {
     partial class ImageViewer
     {

--- a/EDDiscovery/2DMap/ImageViewer.cs
+++ b/EDDiscovery/2DMap/ImageViewer.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/3DMap/CameraDirectionMovement.cs
+++ b/EDDiscovery/3DMap/CameraDirectionMovement.cs
@@ -1,4 +1,19 @@
-﻿using OpenTK;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using OpenTK;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/3DMap/Data3DSetClass.cs
+++ b/EDDiscovery/3DMap/Data3DSetClass.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2.DB;
 

--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2.DB;
 using EDDiscovery2._3DMap;

--- a/EDDiscovery/3DMap/KeyboardActions.cs
+++ b/EDDiscovery/3DMap/KeyboardActions.cs
@@ -1,4 +1,19 @@
-﻿using OpenTK.Input;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using OpenTK.Input;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/3DMap/MapManager.cs
+++ b/EDDiscovery/3DMap/MapManager.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/3DMap/MapRecorder.cs
+++ b/EDDiscovery/3DMap/MapRecorder.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using Newtonsoft.Json.Linq;
 using OpenTK;
 using System;

--- a/EDDiscovery/3DMap/Polygon.cs
+++ b/EDDiscovery/3DMap/Polygon.cs
@@ -1,4 +1,19 @@
-﻿using OpenTK;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using OpenTK;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/EDDiscovery/3DMap/PositionDirection.cs
+++ b/EDDiscovery/3DMap/PositionDirection.cs
@@ -1,4 +1,19 @@
-﻿using OpenTK;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using OpenTK;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/EDDiscovery/3DMap/StarGrid.cs
+++ b/EDDiscovery/3DMap/StarGrid.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery2.DB;
 using OpenTK;
 using System;

--- a/EDDiscovery/3DMap/StarNamesList.cs
+++ b/EDDiscovery/3DMap/StarNamesList.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2._3DMap;
 using EDDiscovery2.DB;

--- a/EDDiscovery/3DMap/Zoom.cs
+++ b/EDDiscovery/3DMap/Zoom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/EDDiscovery/Controls/AutoCompleteTextBox.cs
+++ b/EDDiscovery/Controls/AutoCompleteTextBox.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/Controls/ButtonExt.cs
+++ b/EDDiscovery/Controls/ButtonExt.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Controls/CheckBoxCustom.cs
+++ b/EDDiscovery/Controls/CheckBoxCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/CheckedListControlCustom.cs
+++ b/EDDiscovery/Controls/CheckedListControlCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/Controls/ComboBoxCustom.cs
+++ b/EDDiscovery/Controls/ComboBoxCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;

--- a/EDDiscovery/Controls/ControlHelpers.cs
+++ b/EDDiscovery/Controls/ControlHelpers.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/Controls/CustomColourTable.cs
+++ b/EDDiscovery/Controls/CustomColourTable.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/Controls/DataGridViewExtensions.cs
+++ b/EDDiscovery/Controls/DataGridViewExtensions.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/Controls/DataViewScrollerPanel.cs
+++ b/EDDiscovery/Controls/DataViewScrollerPanel.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;

--- a/EDDiscovery/Controls/DrawnPanel.cs
+++ b/EDDiscovery/Controls/DrawnPanel.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;

--- a/EDDiscovery/Controls/GroupBoxCustom.cs
+++ b/EDDiscovery/Controls/GroupBoxCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/LabelExt.cs
+++ b/EDDiscovery/Controls/LabelExt.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/Controls/ListControlCustom.cs
+++ b/EDDiscovery/Controls/ListControlCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/Controls/NumericUpDownCustom.cs
+++ b/EDDiscovery/Controls/NumericUpDownCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/Controls/PanelVScroll.cs
+++ b/EDDiscovery/Controls/PanelVScroll.cs
@@ -1,4 +1,19 @@
-﻿using ExtendedControls;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using ExtendedControls;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/EDDiscovery/Controls/PictureBoxHotspot.cs
+++ b/EDDiscovery/Controls/PictureBoxHotspot.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Controls/RadioButtonCustom.cs
+++ b/EDDiscovery/Controls/RadioButtonCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/RichTextBoxBorder.cs
+++ b/EDDiscovery/Controls/RichTextBoxBorder.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Controls/RichTextBoxScroll.cs
+++ b/EDDiscovery/Controls/RichTextBoxScroll.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/SplitContainerCustom.cs
+++ b/EDDiscovery/Controls/SplitContainerCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/Controls/StatusStripCustom.cs
+++ b/EDDiscovery/Controls/StatusStripCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/Controls/TabControlCustom.cs
+++ b/EDDiscovery/Controls/TabControlCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/TabStrip.Designer.cs
+++ b/EDDiscovery/Controls/TabStrip.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Controls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Controls
 {
     partial class TabStrip
     {

--- a/EDDiscovery/Controls/TabStrip.cs
+++ b/EDDiscovery/Controls/TabStrip.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/Controls/TabStyleCustom.cs
+++ b/EDDiscovery/Controls/TabStyleCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/TextBoxBorder.cs
+++ b/EDDiscovery/Controls/TextBoxBorder.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/Controls/ToolStripComboBoxCustom.cs
+++ b/EDDiscovery/Controls/ToolStripComboBoxCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/Controls/UpDown.cs
+++ b/EDDiscovery/Controls/UpDown.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/Controls/VScrollCustom.cs
+++ b/EDDiscovery/Controls/VScrollCustom.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;

--- a/EDDiscovery/DB/BookmarkClass.cs
+++ b/EDDiscovery/DB/BookmarkClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/EDDiscovery/DB/ISystem.cs
+++ b/EDDiscovery/DB/ISystem.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/DB/IVisitedSystems.cs
+++ b/EDDiscovery/DB/IVisitedSystems.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 
 namespace EDDiscovery2.DB
 {

--- a/EDDiscovery/DB/InMemory/SystemClass.cs
+++ b/EDDiscovery/DB/InMemory/SystemClass.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 
 namespace EDDiscovery2.DB.InMemory
 {

--- a/EDDiscovery/DB/MaterialCommodities.cs
+++ b/EDDiscovery/DB/MaterialCommodities.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using System;

--- a/EDDiscovery/DB/RegisterEntry.cs
+++ b/EDDiscovery/DB/RegisterEntry.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;

--- a/EDDiscovery/DB/SQLiteCommandED.cs
+++ b/EDDiscovery/DB/SQLiteCommandED.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;

--- a/EDDiscovery/DB/SQLiteConnectionED.cs
+++ b/EDDiscovery/DB/SQLiteConnectionED.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;

--- a/EDDiscovery/DB/SQLiteConnectionSystem.cs
+++ b/EDDiscovery/DB/SQLiteConnectionSystem.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;

--- a/EDDiscovery/DB/SQLiteConnectionUser.cs
+++ b/EDDiscovery/DB/SQLiteConnectionUser.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;

--- a/EDDiscovery/DB/SQLiteDBClass.cs
+++ b/EDDiscovery/DB/SQLiteDBClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery2.DB;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2.DB;
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;

--- a/EDDiscovery/DB/SavedRouteClass.cs
+++ b/EDDiscovery/DB/SavedRouteClass.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;

--- a/EDDiscovery/DB/SqLiteDBSchema.cs
+++ b/EDDiscovery/DB/SqLiteDBSchema.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery2;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2;
 using EDDiscovery2.DB;
 using EMK.LightGeometry;
 using Newtonsoft.Json;

--- a/EDDiscovery/DB/SystemNoteClass.cs
+++ b/EDDiscovery/DB/SystemNoteClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/EDDiscovery/DB/TargetClass.cs
+++ b/EDDiscovery/DB/TargetClass.cs
@@ -1,4 +1,19 @@
-﻿using EMK.LightGeometry;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EMK.LightGeometry;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/DB/TravelLogUnit.cs
+++ b/EDDiscovery/DB/TravelLogUnit.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/DB/WantedSystemClass.cs
+++ b/EDDiscovery/DB/WantedSystemClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery2;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2;
 using EDDiscovery2.DB;
 using Newtonsoft.Json.Linq;
 using System;

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/EDDiscovery/EDDN/EDDNClass.cs
+++ b/EDDiscovery/EDDN/EDDNClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.EliteDangerous;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery2.HTTP;
 using Newtonsoft.Json.Linq;

--- a/EDDiscovery/EDDN/EDDNSync.cs
+++ b/EDDiscovery/EDDN/EDDNSync.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery.EDDN;
 using EDDiscovery.EliteDangerous;

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/EDDToolStripRenderer.cs
+++ b/EDDiscovery/EDDToolStripRenderer.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Windows.Forms;

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class EDDiscoveryForm
     {

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery2;
 using EDDiscovery2.DB;
 using EDDiscovery2.EDSM;

--- a/EDDiscovery/EDDiscoveryServer/EDDiscoveryServer.cs
+++ b/EDDiscovery/EDDiscoveryServer/EDDiscoveryServer.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery2.DB;

--- a/EDDiscovery/EDSM/EDSMSync.cs
+++ b/EDDiscovery/EDSM/EDSMSync.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2.DB;
 using Newtonsoft.Json.Linq;

--- a/EDDiscovery/EDSM/GalMapType.cs
+++ b/EDDiscovery/EDSM/GalMapType.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/EDSM/GalacticMapObject.cs
+++ b/EDDiscovery/EDSM/GalacticMapObject.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery2._3DMap;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2._3DMap;
 using Newtonsoft.Json.Linq;
 using OpenTK;
 using System;

--- a/EDDiscovery/EDSM/GalacticMapping.cs
+++ b/EDDiscovery/EDSM/GalacticMapping.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery2.EDSM;
 using EDDiscovery2.HTTP;
 using Newtonsoft.Json.Linq;

--- a/EDDiscovery/EliteDangerous/AppConfig.cs
+++ b/EDDiscovery/EliteDangerous/AppConfig.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/EliteDangerous/Bodies.cs
+++ b/EDDiscovery/EliteDangerous/Bodies.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/EDCommander.cs
+++ b/EDDiscovery/EliteDangerous/EDCommander.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/EDJournalClass.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery2;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2;
 using EDDiscovery2.DB;
 using EDDiscovery.DB;
 using System;

--- a/EDDiscovery/EliteDangerous/EDJournalReader.cs
+++ b/EDDiscovery/EliteDangerous/EDJournalReader.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery2;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2;
 using EDDiscovery2.DB;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/EliteDangerous/EliteDangerous.cs
+++ b/EDDiscovery/EliteDangerous/EliteDangerous.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/EDDiscovery/EliteDangerous/GameSettings.cs
+++ b/EDDiscovery/EliteDangerous/GameSettings.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery2;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalApproachSettlement.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalApproachSettlement.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBounty.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBounty.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyDrones.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyDrones.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCapShipBond.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCapShipBond.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalClearSavedGame.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalClearSavedGame.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCockpitBreached.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCockpitBreached.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCollectCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCollectCargo.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommitCrime.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommitCrime.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalDiscard.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalDiscard.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalJoin.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalJoin.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalContinued.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalContinued.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewAssign.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewAssign.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewFire.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewFire.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewHire.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewHire.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDataScanned.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDataScanned.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkScan.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkScan.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDied.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDied.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockFighter.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockFighter.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockSRV.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockSRV.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDocked.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDocked.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingCancelled.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingCancelled.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingDenied.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingDenied.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingGranted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingGranted.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingRequested.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingRequested.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingTimeout.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingTimeout.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEDDItemSet.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEDDItemSet.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEjectCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEjectCargo.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerApply.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerApply.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerCraft.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerCraft.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerProgress.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerProgress.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEscapeInterdiction.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEscapeInterdiction.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFileheader.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFileheader.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFuelScope.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFuelScope.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatDamage.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatDamage.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatWarning.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatWarning.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalHullDamage.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalHullDamage.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdicted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdicted.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdiction.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdiction.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeBoost.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeBoost.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeDamage.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeDamage.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchFighter.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchFighter.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchSRV.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchSRV.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLiftoff.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLiftoff.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLocOrJump.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLocOrJump.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using OpenTK;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLocation.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLocation.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketBuy.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketSell.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMassModuleStore.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMassModuleStore.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMiningRefined.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMiningRefined.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAbandoned.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAbandoned.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAccepted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAccepted.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Globalization;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionFailed.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionFailed.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleBuy.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSell.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleStore.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleStore.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSwap.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSwap.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalNewCommander.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalNewCommander.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPVPKill.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPVPKill.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPayFines.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPayFines.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayCollect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayCollect.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDefect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDefect.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDeliver.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDeliver.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayJoin.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayJoin.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayLeave.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayLeave.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVote.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVote.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVoucher.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalProgress.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalProgress.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPromotion.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPromotion.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRank.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRank.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRebootRepair.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRebootRepair.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalReceiveText.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalReceiveText.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRepair.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRepair.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRepairAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRepairAll.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalResurrect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalResurrect.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScientificResearch.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScientificResearch.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScreenshot.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScreenshot.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSelfDestruct.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSelfDestruct.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSellDrones.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSellDrones.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSendText.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSendText.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShieldState.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShieldState.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using Newtonsoft.Json.Linq;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardNew.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardNew.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSwap.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSwap.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSynthesis.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSynthesis.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalTouchdown.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalTouchdown.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalUSSDrop.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalUSSDrop.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalUndocked.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalUndocked.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalUnhandled.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalUnhandled.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalUnknown.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalUnknown.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalWingAdd.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalWingAdd.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalWingJoin.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalWingJoin.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalWingLeave.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalWingLeave.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents

--- a/EDDiscovery/EliteDangerous/LogReaderBase.cs
+++ b/EDDiscovery/EliteDangerous/LogReaderBase.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/EliteDangerous/Material.cs
+++ b/EDDiscovery/EliteDangerous/Material.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/NetLogClass.cs
+++ b/EDDiscovery/EliteDangerous/NetLogClass.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery.DB;

--- a/EDDiscovery/EliteDangerous/NetLogReader.cs
+++ b/EDDiscovery/EliteDangerous/NetLogReader.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/EliteDangerous/StarScan.cs
+++ b/EDDiscovery/EliteDangerous/StarScan.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.EliteDangerous.JournalEvents;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.EliteDangerous.JournalEvents;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/EliteDangerous/Synthesis.cs
+++ b/EDDiscovery/EliteDangerous/Synthesis.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/ExportImport/ExportBase.cs
+++ b/EDDiscovery/ExportImport/ExportBase.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.EliteDangerous;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.EliteDangerous;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;

--- a/EDDiscovery/ExportImport/ExportControl.Designer.cs
+++ b/EDDiscovery/ExportImport/ExportControl.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class ExportControl
     {

--- a/EDDiscovery/ExportImport/ExportControl.cs
+++ b/EDDiscovery/ExportImport/ExportControl.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/ExportImport/ExportExplorationData.cs
+++ b/EDDiscovery/ExportImport/ExportExplorationData.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/ExportImport/ExportFSDJump.cs
+++ b/EDDiscovery/ExportImport/ExportFSDJump.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.EliteDangerous;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/ExportImport/ExportFilteredSystems.cs
+++ b/EDDiscovery/ExportImport/ExportFilteredSystems.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;

--- a/EDDiscovery/ExportImport/ExportNotes.cs
+++ b/EDDiscovery/ExportImport/ExportNotes.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EMK.LightGeometry;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/ExportImport/ExportRoute.cs
+++ b/EDDiscovery/ExportImport/ExportRoute.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EMK.LightGeometry;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/ExportImport/ExportScan.cs
+++ b/EDDiscovery/ExportImport/ExportScan.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.EliteDangerous;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/ExportImport/ImportHistory.cs
+++ b/EDDiscovery/ExportImport/ImportHistory.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/Forms/AboutForm.Designer.cs
+++ b/EDDiscovery/Forms/AboutForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2.Forms
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2.Forms
 {
     partial class AboutForm
     {
@@ -29,30 +44,38 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutForm));
-            this.panel1 = new System.Windows.Forms.Panel();
+            this.panelLogo = new System.Windows.Forms.Panel();
             this.labelVersion = new System.Windows.Forms.Label();
-            this.textBox1 = new System.Windows.Forms.Label();
+            this.labelDevelopersEnum = new System.Windows.Forms.Label();
             this.buttonOK = new System.Windows.Forms.Button();
+            this.textBoxLicense = new System.Windows.Forms.TextBox();
+            this.labelNoAffiliation = new System.Windows.Forms.Label();
+            this.panelLinks = new System.Windows.Forms.Panel();
+            this.linkLabelDeveloperChat = new System.Windows.Forms.LinkLabel();
+            this.linkLabelHelp = new System.Windows.Forms.LinkLabel();
+            this.linkLabelLicense = new System.Windows.Forms.LinkLabel();
             this.linkLabelFDForum = new System.Windows.Forms.LinkLabel();
-            this.label1 = new System.Windows.Forms.Label();
+            this.linkLabelGitHubIssue = new System.Windows.Forms.LinkLabel();
             this.linkLabelGitHub = new System.Windows.Forms.LinkLabel();
             this.linkLabelEDSM = new System.Windows.Forms.LinkLabel();
-            this.linkLabelGitHubIssue = new System.Windows.Forms.LinkLabel();
             this.linkLabelEDDB = new System.Windows.Forms.LinkLabel();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.flowLayoutPanel1.SuspendLayout();
+            this.linkLabelEliteDangerous = new System.Windows.Forms.LinkLabel();
+            this.labelLinks = new System.Windows.Forms.Label();
+            this.labelDevelopers = new System.Windows.Forms.Label();
+            this.panelLinks.SuspendLayout();
             this.SuspendLayout();
             // 
-            // panel1
+            // panelLogo
             // 
-            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.panel1.BackColor = System.Drawing.Color.Transparent;
-            this.panel1.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("panel1.BackgroundImage")));
-            this.panel1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.panel1.Location = new System.Drawing.Point(331, 19);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(325, 212);
-            this.panel1.TabIndex = 2;
+            this.panelLogo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelLogo.BackColor = System.Drawing.Color.Transparent;
+            this.panelLogo.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("panelLogo.BackgroundImage")));
+            this.panelLogo.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.panelLogo.Location = new System.Drawing.Point(67, 210);
+            this.panelLogo.Name = "panelLogo";
+            this.panelLogo.Size = new System.Drawing.Size(325, 212);
+            this.panelLogo.TabIndex = 4;
+            this.panelLogo.Click += new System.EventHandler(this.panelLogo_Click);
             // 
             // labelVersion
             // 
@@ -61,18 +84,19 @@
             this.labelVersion.Location = new System.Drawing.Point(12, 19);
             this.labelVersion.Name = "labelVersion";
             this.labelVersion.Size = new System.Drawing.Size(132, 24);
-            this.labelVersion.TabIndex = 1;
+            this.labelVersion.TabIndex = 0;
             this.labelVersion.Text = "EDDiscovery v";
             // 
-            // textBox1
+            // labelDevelopersEnum
             // 
-            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.labelDevelopersEnum.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.textBox1.BackColor = System.Drawing.Color.Transparent;
-            this.textBox1.Location = new System.Drawing.Point(16, 46);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(309, 240);
-            this.textBox1.TabIndex = 1;
+            this.labelDevelopersEnum.BackColor = System.Drawing.Color.Transparent;
+            this.labelDevelopersEnum.Location = new System.Drawing.Point(453, 57);
+            this.labelDevelopersEnum.Name = "labelDevelopersEnum";
+            this.labelDevelopersEnum.Size = new System.Drawing.Size(203, 162);
+            this.labelDevelopersEnum.TabIndex = 3;
+            this.labelDevelopersEnum.Text = resources.GetString("labelDevelopersEnum.Text");
             // 
             // buttonOK
             // 
@@ -80,42 +104,115 @@
             this.buttonOK.Location = new System.Drawing.Point(581, 399);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 0;
+            this.buttonOK.TabIndex = 6;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
             // 
+            // textBoxLicense
+            // 
+            this.textBoxLicense.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBoxLicense.Location = new System.Drawing.Point(12, 57);
+            this.textBoxLicense.Multiline = true;
+            this.textBoxLicense.Name = "textBoxLicense";
+            this.textBoxLicense.ReadOnly = true;
+            this.textBoxLicense.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.textBoxLicense.Size = new System.Drawing.Size(435, 134);
+            this.textBoxLicense.TabIndex = 1;
+            this.textBoxLicense.Text = resources.GetString("textBoxLicense.Text");
+            // 
+            // labelNoAffiliation
+            // 
+            this.labelNoAffiliation.AutoSize = true;
+            this.labelNoAffiliation.Location = new System.Drawing.Point(85, 194);
+            this.labelNoAffiliation.Name = "labelNoAffiliation";
+            this.labelNoAffiliation.Size = new System.Drawing.Size(288, 13);
+            this.labelNoAffiliation.TabIndex = 2;
+            this.labelNoAffiliation.Text = "EDDiscovery is not affiliated with Fronter Developments plc.";
+            // 
+            // panelLinks
+            // 
+            this.panelLinks.Controls.Add(this.linkLabelDeveloperChat);
+            this.panelLinks.Controls.Add(this.linkLabelHelp);
+            this.panelLinks.Controls.Add(this.linkLabelLicense);
+            this.panelLinks.Controls.Add(this.linkLabelFDForum);
+            this.panelLinks.Controls.Add(this.linkLabelGitHubIssue);
+            this.panelLinks.Controls.Add(this.linkLabelGitHub);
+            this.panelLinks.Controls.Add(this.linkLabelEDSM);
+            this.panelLinks.Controls.Add(this.linkLabelEDDB);
+            this.panelLinks.Controls.Add(this.linkLabelEliteDangerous);
+            this.panelLinks.Controls.Add(this.labelLinks);
+            this.panelLinks.Location = new System.Drawing.Point(446, 222);
+            this.panelLinks.Name = "panelLinks";
+            this.panelLinks.Size = new System.Drawing.Size(210, 171);
+            this.panelLinks.TabIndex = 5;
+            // 
+            // linkLabelDeveloperChat
+            // 
+            this.linkLabelDeveloperChat.AutoSize = true;
+            this.linkLabelDeveloperChat.Location = new System.Drawing.Point(7, 41);
+            this.linkLabelDeveloperChat.Name = "linkLabelDeveloperChat";
+            this.linkLabelDeveloperChat.Size = new System.Drawing.Size(81, 13);
+            this.linkLabelDeveloperChat.TabIndex = 2;
+            this.linkLabelDeveloperChat.TabStop = true;
+            this.linkLabelDeveloperChat.Text = "Developer Chat";
+            this.linkLabelDeveloperChat.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelDeveloperChat_LinkClicked);
+            // 
+            // linkLabelHelp
+            // 
+            this.linkLabelHelp.AutoSize = true;
+            this.linkLabelHelp.Location = new System.Drawing.Point(7, 114);
+            this.linkLabelHelp.Name = "linkLabelHelp";
+            this.linkLabelHelp.Size = new System.Drawing.Size(29, 13);
+            this.linkLabelHelp.TabIndex = 7;
+            this.linkLabelHelp.TabStop = true;
+            this.linkLabelHelp.Text = "Help";
+            this.linkLabelHelp.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelHelp_LinkClicked);
+            // 
+            // linkLabelLicense
+            // 
+            this.linkLabelLicense.AutoSize = true;
+            this.linkLabelLicense.Location = new System.Drawing.Point(7, 128);
+            this.linkLabelLicense.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
+            this.linkLabelLicense.Name = "linkLabelLicense";
+            this.linkLabelLicense.Size = new System.Drawing.Size(44, 13);
+            this.linkLabelLicense.TabIndex = 8;
+            this.linkLabelLicense.TabStop = true;
+            this.linkLabelLicense.Text = "License";
+            this.linkLabelLicense.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelLicense_LinkClicked);
+            // 
             // linkLabelFDForum
             // 
             this.linkLabelFDForum.AutoSize = true;
-            this.linkLabelFDForum.Location = new System.Drawing.Point(45, 27);
+            this.linkLabelFDForum.Location = new System.Drawing.Point(7, 85);
             this.linkLabelFDForum.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
             this.linkLabelFDForum.Name = "linkLabelFDForum";
             this.linkLabelFDForum.Size = new System.Drawing.Size(74, 13);
-            this.linkLabelFDForum.TabIndex = 3;
+            this.linkLabelFDForum.TabIndex = 5;
             this.linkLabelFDForum.TabStop = true;
             this.linkLabelFDForum.Text = "Frontier Forum";
-            this.linkLabelFDForum.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelForum_LinkClicked);
+            this.linkLabelFDForum.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelFDForum_LinkClicked);
             // 
-            // label1
+            // linkLabelGitHubIssue
             // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(30, 1);
-            this.label1.Margin = new System.Windows.Forms.Padding(30, 1, 3, 1);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(53, 24);
-            this.label1.TabIndex = 4;
-            this.label1.Text = "Links";
+            this.linkLabelGitHubIssue.AutoSize = true;
+            this.linkLabelGitHubIssue.Location = new System.Drawing.Point(7, 143);
+            this.linkLabelGitHubIssue.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
+            this.linkLabelGitHubIssue.Name = "linkLabelGitHubIssue";
+            this.linkLabelGitHubIssue.Size = new System.Drawing.Size(87, 13);
+            this.linkLabelGitHubIssue.TabIndex = 9;
+            this.linkLabelGitHubIssue.TabStop = true;
+            this.linkLabelGitHubIssue.Text = "Submit Feedback";
+            this.linkLabelGitHubIssue.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelGitHubIssue_LinkClicked);
             // 
             // linkLabelGitHub
             // 
             this.linkLabelGitHub.AutoSize = true;
-            this.linkLabelGitHub.Location = new System.Drawing.Point(45, 42);
+            this.linkLabelGitHub.Location = new System.Drawing.Point(7, 100);
             this.linkLabelGitHub.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
             this.linkLabelGitHub.Name = "linkLabelGitHub";
             this.linkLabelGitHub.Size = new System.Drawing.Size(40, 13);
-            this.linkLabelGitHub.TabIndex = 5;
+            this.linkLabelGitHub.TabIndex = 6;
             this.linkLabelGitHub.TabStop = true;
             this.linkLabelGitHub.Text = "GitHub";
             this.linkLabelGitHub.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelGitHub_LinkClicked);
@@ -123,54 +220,59 @@
             // linkLabelEDSM
             // 
             this.linkLabelEDSM.AutoSize = true;
-            this.linkLabelEDSM.Location = new System.Drawing.Point(45, 72);
+            this.linkLabelEDSM.Location = new System.Drawing.Point(7, 70);
             this.linkLabelEDSM.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
             this.linkLabelEDSM.Name = "linkLabelEDSM";
             this.linkLabelEDSM.Size = new System.Drawing.Size(38, 13);
-            this.linkLabelEDSM.TabIndex = 6;
+            this.linkLabelEDSM.TabIndex = 4;
             this.linkLabelEDSM.TabStop = true;
             this.linkLabelEDSM.Text = "EDSM";
             this.linkLabelEDSM.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelEDSM_LinkClicked);
             // 
-            // linkLabelGitHubIssue
-            // 
-            this.linkLabelGitHubIssue.AutoSize = true;
-            this.linkLabelGitHubIssue.Location = new System.Drawing.Point(45, 57);
-            this.linkLabelGitHubIssue.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
-            this.linkLabelGitHubIssue.Name = "linkLabelGitHubIssue";
-            this.linkLabelGitHubIssue.Size = new System.Drawing.Size(139, 13);
-            this.linkLabelGitHubIssue.TabIndex = 7;
-            this.linkLabelGitHubIssue.TabStop = true;
-            this.linkLabelGitHubIssue.Text = "GitHub - Report idea / issue";
-            this.linkLabelGitHubIssue.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelGitHubIssue_LinkClicked);
-            // 
             // linkLabelEDDB
             // 
             this.linkLabelEDDB.AutoSize = true;
-            this.linkLabelEDDB.Location = new System.Drawing.Point(45, 87);
+            this.linkLabelEDDB.Location = new System.Drawing.Point(7, 55);
             this.linkLabelEDDB.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
             this.linkLabelEDDB.Name = "linkLabelEDDB";
             this.linkLabelEDDB.Size = new System.Drawing.Size(37, 13);
-            this.linkLabelEDDB.TabIndex = 8;
+            this.linkLabelEDDB.TabIndex = 3;
             this.linkLabelEDDB.TabStop = true;
             this.linkLabelEDDB.Text = "EDDB";
             this.linkLabelEDDB.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelEDDB_LinkClicked);
             // 
-            // flowLayoutPanel1
+            // linkLabelEliteDangerous
             // 
-            this.flowLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.flowLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
-            this.flowLayoutPanel1.Controls.Add(this.label1);
-            this.flowLayoutPanel1.Controls.Add(this.linkLabelFDForum);
-            this.flowLayoutPanel1.Controls.Add(this.linkLabelGitHub);
-            this.flowLayoutPanel1.Controls.Add(this.linkLabelGitHubIssue);
-            this.flowLayoutPanel1.Controls.Add(this.linkLabelEDSM);
-            this.flowLayoutPanel1.Controls.Add(this.linkLabelEDDB);
-            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(13, 289);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(312, 133);
-            this.flowLayoutPanel1.TabIndex = 9;
+            this.linkLabelEliteDangerous.AutoSize = true;
+            this.linkLabelEliteDangerous.Location = new System.Drawing.Point(7, 27);
+            this.linkLabelEliteDangerous.Margin = new System.Windows.Forms.Padding(45, 1, 3, 1);
+            this.linkLabelEliteDangerous.Name = "linkLabelEliteDangerous";
+            this.linkLabelEliteDangerous.Size = new System.Drawing.Size(82, 13);
+            this.linkLabelEliteDangerous.TabIndex = 1;
+            this.linkLabelEliteDangerous.TabStop = true;
+            this.linkLabelEliteDangerous.Text = "Elite Dangerous";
+            this.linkLabelEliteDangerous.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelEliteDangerous_LinkClicked);
+            // 
+            // labelLinks
+            // 
+            this.labelLinks.AutoSize = true;
+            this.labelLinks.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelLinks.Location = new System.Drawing.Point(6, 1);
+            this.labelLinks.Margin = new System.Windows.Forms.Padding(30, 1, 3, 1);
+            this.labelLinks.Name = "labelLinks";
+            this.labelLinks.Size = new System.Drawing.Size(53, 24);
+            this.labelLinks.TabIndex = 0;
+            this.labelLinks.Text = "Links";
+            // 
+            // labelDevelopers
+            // 
+            this.labelDevelopers.AutoSize = true;
+            this.labelDevelopers.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelDevelopers.Location = new System.Drawing.Point(452, 19);
+            this.labelDevelopers.Name = "labelDevelopers";
+            this.labelDevelopers.Size = new System.Drawing.Size(106, 24);
+            this.labelDevelopers.TabIndex = 7;
+            this.labelDevelopers.Text = "Developers";
             // 
             // AboutForm
             // 
@@ -178,11 +280,14 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.ClientSize = new System.Drawing.Size(675, 434);
+            this.Controls.Add(this.labelDevelopers);
+            this.Controls.Add(this.panelLinks);
+            this.Controls.Add(this.labelNoAffiliation);
+            this.Controls.Add(this.textBoxLicense);
             this.Controls.Add(this.labelVersion);
             this.Controls.Add(this.buttonOK);
-            this.Controls.Add(this.flowLayoutPanel1);
-            this.Controls.Add(this.panel1);
-            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.panelLogo);
+            this.Controls.Add(this.labelDevelopersEnum);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -192,8 +297,8 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "About EDDiscovery";
             this.Load += new System.EventHandler(this.AboutForm_Load);
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
+            this.panelLinks.ResumeLayout(false);
+            this.panelLinks.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -201,16 +306,23 @@
 
         #endregion
 
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Label textBox1;
+        private System.Windows.Forms.Panel panelLogo;
+        private System.Windows.Forms.Label labelDevelopersEnum;
         private System.Windows.Forms.Button buttonOK;
         internal System.Windows.Forms.Label labelVersion;
-        private System.Windows.Forms.LinkLabel linkLabelFDForum;
-        internal System.Windows.Forms.Label label1;
-        private System.Windows.Forms.LinkLabel linkLabelGitHub;
-        private System.Windows.Forms.LinkLabel linkLabelEDSM;
-        private System.Windows.Forms.LinkLabel linkLabelGitHubIssue;
+        private System.Windows.Forms.TextBox textBoxLicense;
+        private System.Windows.Forms.Label labelNoAffiliation;
+        private System.Windows.Forms.Panel panelLinks;
+        internal System.Windows.Forms.Label labelLinks;
+        private System.Windows.Forms.LinkLabel linkLabelEliteDangerous;
+        private System.Windows.Forms.LinkLabel linkLabelDeveloperChat;
         private System.Windows.Forms.LinkLabel linkLabelEDDB;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.LinkLabel linkLabelEDSM;
+        private System.Windows.Forms.LinkLabel linkLabelFDForum;
+        private System.Windows.Forms.LinkLabel linkLabelGitHub;
+        private System.Windows.Forms.LinkLabel linkLabelHelp;
+        private System.Windows.Forms.LinkLabel linkLabelLicense;
+        private System.Windows.Forms.LinkLabel linkLabelGitHubIssue;
+        internal System.Windows.Forms.Label labelDevelopers;
     }
 }

--- a/EDDiscovery/Forms/AboutForm.cs
+++ b/EDDiscovery/Forms/AboutForm.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -19,21 +34,7 @@ namespace EDDiscovery2.Forms
 
         private void AboutForm_Load(object sender, EventArgs e)
         {
-            textBox1.Text = "Lead developer:" + Environment.NewLine +
-            "Cmdr Finwen  (Robert Wahlström )" + Environment.NewLine + 
-            Environment.NewLine +
-            "Main developers:" + Environment.NewLine +
-            "Robby" + Environment.NewLine +
-            "Bravada Cadelanne" + Environment.NewLine +
-            Environment.NewLine +
-            "Additional developers:" + Environment.NewLine +
-            "Cruento Mucrone" +   ", Corbin Moran " + Environment.NewLine +
-            "Myshka , Zed" + Environment.NewLine+
-            "Marlon Blake, Majkl" + Environment.NewLine+
-            "Smacker" + Environment.NewLine;
-
             buttonOK.Select();
-
         }
 
         private void buttonOK_Click(object sender, EventArgs e)
@@ -41,7 +42,27 @@ namespace EDDiscovery2.Forms
             Close();
         }
 
-        private void linkLabelForum_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void linkLabelEliteDangerous_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("https://www.elitedangerous.com/");
+        }
+
+        private void linkLabelDeveloperChat_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("https://discordapp.com/invite/0qIqfCQbziTWzsQu");
+        }
+
+        private void linkLabelEDDB_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("https://eddb.io/");
+        }
+
+        private void linkLabelEDSM_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("https://www.edsm.net/");
+        }
+
+        private void linkLabelFDForum_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start("https://forums.frontier.co.uk/showthread.php?t=138155&p=2113535#post2113535");
         }
@@ -51,19 +72,24 @@ namespace EDDiscovery2.Forms
             Process.Start("https://github.com/EDDiscovery/EDDiscovery");
         }
 
+        private void linkLabelHelp_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("https://github.com/EDDiscovery/EDDiscovery/wiki");
+        }
+
+        private void linkLabelLicense_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("https://github.com/EDDiscovery/EDDiscovery/blob/master/LICENSE.md");
+        }
+
         private void linkLabelGitHubIssue_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start("https://github.com/EDDiscovery/EDDiscovery/issues");
         }
 
-        private void linkLabelEDSM_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void panelLogo_Click(object sender, EventArgs e)
         {
-            Process.Start("https://www.edsm.net/");
-        }
-
-        private void linkLabelEDDB_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start("https://eddb.io/");
+            Process.Start("https://github.com/EDDiscovery/EDDiscovery");
         }
     }
 }

--- a/EDDiscovery/Forms/AboutForm.resx
+++ b/EDDiscovery/Forms/AboutForm.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="panel1.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="panelLogo.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAABNkAAAKLCAYAAADLvl4hAAAABGdBTUEAALGPC/xhBQAA/8dJREFUeF7s
         3QWcHFXWNvAbT4i7JzMTF4K7+25wCba4hUBwd11gWWxhkQUiHZnJRIiH6GTibkRIcF1kYZGXxeG899yS
@@ -7647,6 +7647,75 @@
         /nP8kcp/3l9T+a/DSMbPNe+mfp+6hPot6lXUC6gfpr6NOpe6KxVBEARBEARpLK3W/wcALXyX4T6O/AAA
         AABJRU5ErkJggg==
 </value>
+  </data>
+  <data name="labelDevelopersEnum.Text" xml:space="preserve">
+    <value>Lead developer:
+  Cmdr Finwen  (Robert Wahlström )
+
+Main developers:
+  Robby
+  Bravada Cadelanne
+
+Additional developers:
+  Cruento Mucrone, Corbin Moran
+  Myshka, Zed
+  Marlon Blake, Majkl
+  Smacker, phroggie</value>
+  </data>
+  <data name="textBoxLicense.Text" xml:space="preserve">
+    <value>Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Forms
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Forms
 {
     partial class AssignTravelLogSystemForm
     {

--- a/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
+++ b/EDDiscovery/Forms/AssignTravelLogSystemForm.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Forms/BookmarkForm.Designer.cs
+++ b/EDDiscovery/Forms/BookmarkForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class BookmarkForm
     {

--- a/EDDiscovery/Forms/BookmarkForm.cs
+++ b/EDDiscovery/Forms/BookmarkForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery2.EDSM;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/Forms/FindMaterialsForm.Designer.cs
+++ b/EDDiscovery/Forms/FindMaterialsForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Forms
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Forms
 {
     partial class FindMaterialsForm
     {

--- a/EDDiscovery/Forms/FindMaterialsForm.cs
+++ b/EDDiscovery/Forms/FindMaterialsForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery2.DB;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/Forms/InfoForm.Designer.cs
+++ b/EDDiscovery/Forms/InfoForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 { 
     partial class InfoForm
     {

--- a/EDDiscovery/Forms/InfoForm.cs
+++ b/EDDiscovery/Forms/InfoForm.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Forms/JSONFiltersForm.Designer.cs
+++ b/EDDiscovery/Forms/JSONFiltersForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class JSONFiltersForm
     {

--- a/EDDiscovery/Forms/JSONFiltersForm.cs
+++ b/EDDiscovery/Forms/JSONFiltersForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using EDDiscovery2;
 using System;

--- a/EDDiscovery/Forms/MoveToCommander.Designer.cs
+++ b/EDDiscovery/Forms/MoveToCommander.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class MoveToCommander
     {

--- a/EDDiscovery/Forms/MoveToCommander.cs
+++ b/EDDiscovery/Forms/MoveToCommander.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Forms/NewReleaseForm.Designer.cs
+++ b/EDDiscovery/Forms/NewReleaseForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Forms
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Forms
 {
     partial class NewReleaseForm
     {

--- a/EDDiscovery/Forms/NewReleaseForm.cs
+++ b/EDDiscovery/Forms/NewReleaseForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.HTTP;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.HTTP;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/EDDiscovery/Forms/RecordStep.Designer.cs
+++ b/EDDiscovery/Forms/RecordStep.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class RecordStep
     {

--- a/EDDiscovery/Forms/RecordStep.cs
+++ b/EDDiscovery/Forms/RecordStep.cs
@@ -1,4 +1,19 @@
-﻿using OpenTK;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using OpenTK;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/EDDiscovery/Forms/ShipDetails.Designer.cs
+++ b/EDDiscovery/Forms/ShipDetails.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Forms
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Forms
 {
     partial class ShipDetails
     {

--- a/EDDiscovery/Forms/ShipDetails.cs
+++ b/EDDiscovery/Forms/ShipDetails.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/EDDiscovery/Forms/SplashForm.Designer.cs
+++ b/EDDiscovery/Forms/SplashForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Forms
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Forms
 {
     partial class SplashForm
     {

--- a/EDDiscovery/Forms/SplashForm.cs
+++ b/EDDiscovery/Forms/SplashForm.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Forms/SystemViewForm.Designer.cs
+++ b/EDDiscovery/Forms/SystemViewForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class SystemViewForm
     {

--- a/EDDiscovery/Forms/SystemViewForm.cs
+++ b/EDDiscovery/Forms/SystemViewForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery.DB;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/Forms/TabControlForm.Designer.cs
+++ b/EDDiscovery/Forms/TabControlForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class TabControlForm
     {

--- a/EDDiscovery/Forms/TabControlForm.cs
+++ b/EDDiscovery/Forms/TabControlForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery.UserControls;
 using ExtendedControls;
 using System;

--- a/EDDiscovery/Forms/TextBoxEntry.Designer.cs
+++ b/EDDiscovery/Forms/TextBoxEntry.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 { 
     partial class TextBoxEntry
     {

--- a/EDDiscovery/Forms/TextBoxEntry.cs
+++ b/EDDiscovery/Forms/TextBoxEntry.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Forms/ThemeEditor.Designer.cs
+++ b/EDDiscovery/Forms/ThemeEditor.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class ThemeEditor
     {

--- a/EDDiscovery/Forms/ThemeEditor.cs
+++ b/EDDiscovery/Forms/ThemeEditor.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/EDDiscovery/Forms/TimedMessage.Designer.cs
+++ b/EDDiscovery/Forms/TimedMessage.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class TimedMessage
     {

--- a/EDDiscovery/Forms/TimedMessage.cs
+++ b/EDDiscovery/Forms/TimedMessage.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Forms/UserControlForm.Designer.cs
+++ b/EDDiscovery/Forms/UserControlForm.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.Forms
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.Forms
 {
     partial class UserControlForm
     {

--- a/EDDiscovery/Forms/UserControlForm.cs
+++ b/EDDiscovery/Forms/UserControlForm.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery.UserControls;
 using System;
 using System.Collections.Generic;

--- a/EDDiscovery/HTTP/DownloadFile.cs
+++ b/EDDiscovery/HTTP/DownloadFile.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EDDiscovery/HTTP/EDMaterializerCom.cs
+++ b/EDDiscovery/HTTP/EDMaterializerCom.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;

--- a/EDDiscovery/HTTP/GitHubClass.cs
+++ b/EDDiscovery/HTTP/GitHubClass.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.EliteDangerous.JournalEvents;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery.HTTP;
 using EDDiscovery2.HTTP;
 using Newtonsoft.Json.Linq;

--- a/EDDiscovery/HTTP/GitHubRelease.cs
+++ b/EDDiscovery/HTTP/GitHubRelease.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/HTTP/HttpCom.cs
+++ b/EDDiscovery/HTTP/HttpCom.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using System;
 using System.Collections.Specialized;
 using System.IO;

--- a/EDDiscovery/HTTP/ResponseData.cs
+++ b/EDDiscovery/HTTP/ResponseData.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Specialized;
 using System.Net;

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery.DB;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery.DB;
 using EDDiscovery.EliteDangerous;
 using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery2;

--- a/EDDiscovery/ImageHandler.Designer.cs
+++ b/EDDiscovery/ImageHandler.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2.ImageHandler
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2.ImageHandler
 {
     partial class ImageHandler
     {

--- a/EDDiscovery/ImageHandler.cs
+++ b/EDDiscovery/ImageHandler.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/JSON/JSONFilter.cs
+++ b/EDDiscovery/JSON/JSONFilter.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/JSON/JSONHelper.cs
+++ b/EDDiscovery/JSON/JSONHelper.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/JSON/JSONPrettyPrint.cs
+++ b/EDDiscovery/JSON/JSONPrettyPrint.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/JournalViewControl.Designer.cs
+++ b/EDDiscovery/JournalViewControl.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class JournalViewControl
     {

--- a/EDDiscovery/JournalViewControl.cs
+++ b/EDDiscovery/JournalViewControl.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/ObjectExtensions.cs
+++ b/EDDiscovery/ObjectExtensions.cs
@@ -1,4 +1,19 @@
-﻿public static class ObjectExtensions
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+public static class ObjectExtensions
 {
     public static string ToNullSafeString(this object obj)
         {

--- a/EDDiscovery/Program.cs
+++ b/EDDiscovery/Program.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;                //Assembly

--- a/EDDiscovery/Properties/AssemblyInfo.cs
+++ b/EDDiscovery/Properties/AssemblyInfo.cs
@@ -1,4 +1,19 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("EDDiscovery")]
-[assembly: AssemblyCopyright("Copyright © Robert Wahlström 2016")]
+[assembly: AssemblyCopyright("Copyright © Robert Wahlström 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/EDDiscovery/RouteControl.Designer.cs
+++ b/EDDiscovery/RouteControl.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class RouteControl
     {

--- a/EDDiscovery/RouteControl.cs
+++ b/EDDiscovery/RouteControl.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/RoutingUtils.cs
+++ b/EDDiscovery/RoutingUtils.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Windows.Forms;
 using EDDiscovery.DB;
 using EDDiscovery2.DB;

--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class SavedRouteExpeditionControl
     {

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery2
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery2
 {
     partial class Settings
     {

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/Tools.cs
+++ b/EDDiscovery/Tools.cs
@@ -1,4 +1,19 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/EDDiscovery/TraceLog.cs
+++ b/EDDiscovery/TraceLog.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;

--- a/EDDiscovery/TravelHistoryControl.Designer.cs
+++ b/EDDiscovery/TravelHistoryControl.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class TravelHistoryControl
     {

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/Trilateration/DistanceParser.cs
+++ b/EDDiscovery/Trilateration/DistanceParser.cs
@@ -1,4 +1,19 @@
-﻿using System.Globalization;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace EDDiscovery

--- a/EDDiscovery/Trilateration/SysWarning.Designer.cs
+++ b/EDDiscovery/Trilateration/SysWarning.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class SysWarning
     {

--- a/EDDiscovery/Trilateration/SysWarning.cs
+++ b/EDDiscovery/Trilateration/SysWarning.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -1,4 +1,19 @@
-﻿using ExtendedControls;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using ExtendedControls;
 
 namespace EDDiscovery
 {

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/EDDiscovery/UserControls/DataGridViewSorter.cs
+++ b/EDDiscovery/UserControls/DataGridViewSorter.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/EDDiscovery/UserControls/TravelHistoryFilter.cs
+++ b/EDDiscovery/UserControls/TravelHistoryFilter.cs
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
 using EDDiscovery.DB;
 using EDDiscovery.EliteDangerous;
 using EDDiscovery2.DB;

--- a/EDDiscovery/UserControls/UserControlCommonBase.cs
+++ b/EDDiscovery/UserControls/UserControlCommonBase.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlExploration.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery
 {
     partial class UserControlExploration
     {

--- a/EDDiscovery/UserControls/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlJournalGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlJournalGrid
     {

--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlLedger.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlLedger.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlLedger
     {

--- a/EDDiscovery/UserControls/UserControlLedger.cs
+++ b/EDDiscovery/UserControls/UserControlLedger.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlLog.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlLog.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlLog
     {

--- a/EDDiscovery/UserControls/UserControlLog.cs
+++ b/EDDiscovery/UserControls/UserControlLog.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlMaterialCommodities
     {

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlNotePanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlNotePanel.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlNotePanel
     {

--- a/EDDiscovery/UserControls/UserControlNotePanel.cs
+++ b/EDDiscovery/UserControls/UserControlNotePanel.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlRouteTracker.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlRouteTracker.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlRouteTracker
     {

--- a/EDDiscovery/UserControls/UserControlRouteTracker.cs
+++ b/EDDiscovery/UserControls/UserControlRouteTracker.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlScan.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScan.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlScan
     {

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlScreenshot.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScreenshot.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlScreenshot
     {

--- a/EDDiscovery/UserControls/UserControlScreenshot.cs
+++ b/EDDiscovery/UserControls/UserControlScreenshot.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlSpanel
     {

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -1,4 +1,20 @@
-﻿// DEFINE this, allows you to click on an entry to make the scan change
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+
+// DEFINE this, allows you to click on an entry to make the scan change
 // #define TH 
 
 using System;

--- a/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlStarDistance
     {

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlStats.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStats.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlStats
     {

--- a/EDDiscovery/UserControls/UserControlStats.cs
+++ b/EDDiscovery/UserControls/UserControlStats.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlStatsTime.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStatsTime.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlStatsTime
     {

--- a/EDDiscovery/UserControls/UserControlStatsTime.cs
+++ b/EDDiscovery/UserControls/UserControlStatsTime.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlTravelGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlTravelGrid
     {

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscovery/UserControls/UserControlTrippanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlTrippanel.Designer.cs
@@ -1,4 +1,19 @@
-﻿namespace EDDiscovery.UserControls
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+namespace EDDiscovery.UserControls
 {
     partial class UserControlTrippanel
     {

--- a/EDDiscovery/UserControls/UserControlTrippanel.cs
+++ b/EDDiscovery/UserControls/UserControlTrippanel.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -1,4 +1,19 @@
-﻿using EDDiscovery;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery;
 using EDDiscovery2.DB;
 using EDDiscovery.DB;
 using EDDiscovery2._3DMap;

--- a/EDDiscoveryTests/DistanceParserTests.cs
+++ b/EDDiscoveryTests/DistanceParserTests.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Globalization;
 using EDDiscovery;
 using NFluent;

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using System;
 using System.Collections.Generic;
 using EDDiscovery;
 using NFluent;


### PR DESCRIPTION
AboutForm:
	Updated and rearranged to show license blurb.
	Added myself to developer list.
	Added some missing links.

AssemblyInfo:
	Bumped assembly copyright year to 2017.

Everything else:
	Added license blobs to all source files. This touches virtually every file, but will help to insulate us. I spent considerable time tracking down original creation dates and code block migration paths, but the sheer scope implies that I screwed up at least one copyright year.