### PR TITLE
Don't save window size if minimized

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -788,6 +788,7 @@ namespace EDDiscovery
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.EDDiscoveryForm_FormClosing);
             this.Load += new System.EventHandler(this.EDDiscoveryForm_Load);
             this.Resize += new System.EventHandler(this.EDDiscoveryForm_Resize);
+            this.ResizeEnd += new System.EventHandler(this.EDDiscoveryForm_ResizeEnd);
             this.Shown += new System.EventHandler(this.EDDiscoveryForm_Shown);
             this.Layout += new System.Windows.Forms.LayoutEventHandler(this.EDDiscoveryForm_Layout);
             this.menuStrip1.ResumeLayout(false);

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1682,13 +1682,13 @@ namespace EDDiscovery
 
         private void RecordPosition()
         {
-            _formMax = FormWindowState.Maximized == WindowState;
             if (FormWindowState.Minimized != WindowState)
             {
                 _formLeft = this.Left;
                 _formTop = this.Top;
                 _formWidth = this.Width;
                 _formHeight = this.Height;
+                _formMax = FormWindowState.Maximized == WindowState;
             }
         }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -129,6 +129,10 @@ namespace EDDiscovery
         GitHubRelease newRelease;
 
         private bool _formMax;
+        private int _formWidth;
+        private int _formHeight;
+        private int _formTop;
+        private int _formLeft;
 
         private bool CanSkipSlowUpdates()
         {
@@ -1126,13 +1130,10 @@ namespace EDDiscovery
             settings.SaveSettings();
 
             SQLiteDBClass.PutSettingBool("FormMax", _formMax);
-            if (FormWindowState.Minimized != this.WindowState)
-            {
-                SQLiteDBClass.PutSettingInt("FormWidth", this.Width);
-                SQLiteDBClass.PutSettingInt("FormHeight", this.Height);
-            }
-            SQLiteDBClass.PutSettingInt("FormTop", this.Top);
-            SQLiteDBClass.PutSettingInt("FormLeft", this.Left);
+            SQLiteDBClass.PutSettingInt("FormWidth", _formWidth);
+            SQLiteDBClass.PutSettingInt("FormHeight", _formHeight);
+            SQLiteDBClass.PutSettingInt("FormTop", _formTop);
+            SQLiteDBClass.PutSettingInt("FormLeft", _formLeft);
             routeControl1.SaveSettings();
             theme.SaveSettings(null);
             travelHistoryControl1.SaveSettings();
@@ -1687,6 +1688,10 @@ namespace EDDiscovery
                 if (EDDConfig.UseNotifyIcon && EDDConfig.MinimizeToNotifyIcon)
                     Show();
                 _formMax = FormWindowState.Maximized == WindowState;
+                _formLeft = this.Left;
+                _formTop = this.Top;
+                _formWidth = this.Width;
+                _formHeight = this.Height;
             }
             notifyIconMenu_Open.Enabled = FormWindowState.Minimized == WindowState;
         }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -463,6 +463,10 @@ namespace EDDiscovery
                 _formMax = SQLiteDBClass.GetSettingBool("FormMax", false);
                 if (_formMax) this.WindowState = FormWindowState.Maximized;
             }
+            _formLeft = Left;
+            _formTop = Top;
+            _formHeight = Height;
+            _formWidth = Width;
 
             travelHistoryControl1.LoadLayoutSettings();
             journalViewControl1.LoadLayoutSettings();

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1680,6 +1680,18 @@ namespace EDDiscovery
             }
         }
 
+        private void RecordPosition()
+        {
+            _formMax = FormWindowState.Maximized == WindowState;
+            if (FormWindowState.Minimized != WindowState)
+            {
+                _formLeft = this.Left;
+                _formTop = this.Top;
+                _formWidth = this.Width;
+                _formHeight = this.Height;
+            }
+        }
+
         private void EDDiscoveryForm_Resize(object sender, EventArgs e)
         {
             if (FormWindowState.Minimized == WindowState)
@@ -1691,13 +1703,14 @@ namespace EDDiscovery
             {
                 if (EDDConfig.UseNotifyIcon && EDDConfig.MinimizeToNotifyIcon)
                     Show();
-                _formMax = FormWindowState.Maximized == WindowState;
-                _formLeft = this.Left;
-                _formTop = this.Top;
-                _formWidth = this.Width;
-                _formHeight = this.Height;
             }
+            RecordPosition();
             notifyIconMenu_Open.Enabled = FormWindowState.Minimized == WindowState;
+        }
+
+        private void EDDiscoveryForm_ResizeEnd(object sender, EventArgs e)
+        {
+            RecordPosition();
         }
 
         #endregion

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1126,8 +1126,11 @@ namespace EDDiscovery
             settings.SaveSettings();
 
             SQLiteDBClass.PutSettingBool("FormMax", _formMax);
-            SQLiteDBClass.PutSettingInt("FormWidth", this.Width);
-            SQLiteDBClass.PutSettingInt("FormHeight", this.Height);
+            if (FormWindowState.Minimized != this.WindowState)
+            {
+                SQLiteDBClass.PutSettingInt("FormWidth", this.Width);
+                SQLiteDBClass.PutSettingInt("FormHeight", this.Height);
+            }
             SQLiteDBClass.PutSettingInt("FormTop", this.Top);
             SQLiteDBClass.PutSettingInt("FormLeft", this.Left);
             routeControl1.SaveSettings();


### PR DESCRIPTION
This should hopefully address the unusable small windows that require -NoRepositionWindow or database hacking.

For example, see [this image](http://i.imgur.com/LEEFXB7.jpg).