### PR TITLE
Fix #715 (give SavedRouteExpeditionControl some tweaks)

### DIFF
--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -453,6 +453,12 @@ namespace EDDiscovery
         {
             UpdateRouteInfo(_currentRoute);
 
+            if (String.IsNullOrEmpty(_currentRoute.Name))
+            {
+                var result = MessageBox.Show(_discoveryForm, "Please specify a name for the route.", "Unsaved route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                textBoxRouteName.Select();
+                return;
+            }
             if (_currentRoute.Id == -1)
             {
                 _currentRoute.Add();

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -457,12 +457,13 @@ namespace EDDiscovery
             {
                 _currentRoute.Add();
                 _savedRoutes.Add(_currentRoute);
-                UpdateComboBox();
             }
             else
             {
                 _currentRoute.Update();
             }
+            UpdateComboBox();
+            toolStripComboBoxRouteSelection.Text = _currentRoute.Name;
         }
 
         private void toolStripButtonNew_Click(object sender, EventArgs e)


### PR DESCRIPTION
Update the combobox when renaming a saved route.
Select the new entry in the combo box automatically when saving it.
Lastly, don't allow an unnamed route to be saved, to prevent the new route button from recalling that saved route.