### PR TITLE
Fix material/commodity panel sorting/editing

### DIFF
--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.Designer.cs
@@ -108,6 +108,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewMC.Size = new System.Drawing.Size(684, 532);
             this.dataGridViewMC.TabIndex = 1;
             this.dataGridViewMC.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewMC_CellEndEdit);
+            this.dataGridViewMC.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewMC_SortCompare);
             // 
             // NameCol
             // 

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -316,57 +316,57 @@ namespace EDDiscovery.UserControls
 
             bool updateddb = false;
 
-            for (int i = 0; i < last_mc.Count; i++)
+            for (int i = 0; i < dataGridViewMC.Rows.Count; i++)
             {
+                MaterialCommodities mc = dataGridViewMC.Rows[i].Tag as MaterialCommodities;
                 string name = (string)dataGridViewMC.Rows[i].Cells[namecol].Value;
-                string abv = (abvcol >= 0) ? (string)dataGridViewMC.Rows[i].Cells[abvcol].Value : last_mc[i].shortname;
-                string cat = (catcol >= 0) ? (string)dataGridViewMC.Rows[i].Cells[catcol].Value : last_mc[i].category;
+                string abv = (abvcol >= 0) ? (string)dataGridViewMC.Rows[i].Cells[abvcol].Value : mc?.shortname ?? "";
+                string cat = (catcol >= 0) ? (string)dataGridViewMC.Rows[i].Cells[catcol].Value : mc?.category ?? (materials ? MaterialCommodities.MaterialRawCategory : MaterialCommodities.CommodityCategory);
                 string type = (string)dataGridViewMC.Rows[i].Cells[typecol].Value;
 
-                if (!last_mc[i].name.Equals(name) || !last_mc[i].shortname.Equals(abv) || !last_mc[i].category.Equals(cat)
-                    || !last_mc[i].type.Equals(type))
+                if (mc != null)
                 {
-                    //System.Diagnostics.Debug.WriteLine("Row " + i + " changed text");
-                    MaterialCommodities.ChangeDbText(last_mc[i].fdname, name, abv, cat, type);
-                    updateddb = true;
+                    if (mc.name != name || mc.shortname != abv || mc.category != cat || mc.type != type)
+                    {
+                        //System.Diagnostics.Debug.WriteLine("Row " + i + " changed text");
+                        MaterialCommodities.ChangeDbText(mc.fdname, name, abv, cat, type);
+                        updateddb = true;
+                    }
+
+                    int numvalue = 0;
+                    int.TryParse((string)dataGridViewMC.Rows[i].Cells[numcol].Value, out numvalue);
+
+                    double price = 0;
+                    bool pricechange = false;
+
+                    if (!materials)
+                    {
+                        double.TryParse((string)dataGridViewMC.Rows[i].Cells[pricecol].Value, out price);
+                        pricechange = Math.Abs(mc.price - price) >= 0.01;
+                    }
+
+                    if (mc.count != numvalue || pricechange)
+                    {
+                        mcchange.Add(new MaterialCommodities(0, mc.category, mc.name, mc.fdname, mc.type, mc.shortname, Color.Red, 0, numvalue, (pricechange) ? price : 0));
+                        //System.Diagnostics.Debug.WriteLine("Row " + i + " changed number");
+                    }
                 }
-
-                int numvalue = 0;
-                int.TryParse((string)dataGridViewMC.Rows[i].Cells[numcol].Value, out numvalue);
-
-                double price = 0;
-                bool pricechange = false;
-
-                if (!materials)
+                else
                 {
-                    double.TryParse((string)dataGridViewMC.Rows[i].Cells[pricecol].Value, out price);
-                    pricechange = Math.Abs(last_mc[i].price - price) >= 0.01;
-                }
+                    string fdname = Tools.FDName(name);
 
-                if (last_mc[i].count != numvalue || pricechange)
-                {
-                    mcchange.Add(new MaterialCommodities(0, last_mc[i].category, last_mc[i].name, last_mc[i].fdname, "", "", Color.Red, 0, numvalue, (pricechange) ? price : 0));
-                    //System.Diagnostics.Debug.WriteLine("Row " + i + " changed number");
-                }
-            }
+                    int numvalue = 0;
+                    bool numok = int.TryParse((string)dataGridViewMC.Rows[i].Cells[numcol].Value, out numvalue);
 
-            for (int i = last_mc.Count; i < dataGridViewMC.Rows.Count; i++)                // these have been added
-            {
-                string name = (string)dataGridViewMC.Rows[i].Cells[namecol].Value;
-                string cat = (materials) ? (string)dataGridViewMC.Rows[i].Cells[catcol].Value : MaterialCommodities.CommodityCategory;
-                string fdname = Tools.FDName(name);
+                    double price = 0;
 
-                int numvalue = 0;
-                bool numok = int.TryParse((string)dataGridViewMC.Rows[i].Cells[numcol].Value, out numvalue);
+                    if (!materials)
+                        double.TryParse((string)dataGridViewMC.Rows[i].Cells[pricecol].Value, out price);
 
-                double price = 0;
-
-                if (!materials)
-                    double.TryParse((string)dataGridViewMC.Rows[i].Cells[pricecol].Value, out price);
-
-                if ( numok && cat.Length > 0 && name.Length > 0)
-                {
-                    mcchange.Add(new MaterialCommodities(0, cat, name, fdname, "", "", Color.Red, 0, numvalue , price));
+                    if (numok && cat.Length > 0 && name.Length > 0)
+                    {
+                        mcchange.Add(new MaterialCommodities(0, cat, name, fdname, type, abv, Color.Red, 0, numvalue, price));
+                    }
                 }
             }
 

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -126,6 +126,11 @@ namespace EDDiscovery.UserControls
 
                     }
                 }
+
+                if (dataGridViewMC.SortedColumn != null && dataGridViewMC.SortOrder != SortOrder.None)
+                {
+                    dataGridViewMC.Sort(dataGridViewMC.SortedColumn, dataGridViewMC.SortOrder == SortOrder.Descending ? ListSortDirection.Descending : ListSortDirection.Ascending);
+                }
             }
             else
             {

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -114,17 +114,19 @@ namespace EDDiscovery.UserControls
 
                 foreach (MaterialCommodities m in mc)
                 {
+                    object[] rowobj;
+
                     if (materials)
                     {
-                        object[] rowobj = { m.name, m.shortname, m.category, m.type, m.count.ToString() };
-                        dataGridViewMC.Rows.Add(rowobj);
+                        rowobj = new[] { m.name, m.shortname, m.category, m.type, m.count.ToString() };
                     }
                     else
                     {
-                        object[] rowobj = { m.name, m.type, m.count.ToString(), m.price.ToString("0.#") };
-                        dataGridViewMC.Rows.Add(rowobj);
-
+                        rowobj = new[] { m.name, m.type, m.count.ToString(), m.price.ToString("0.#") };
                     }
+
+                    int idx = dataGridViewMC.Rows.Add(rowobj);
+                    dataGridViewMC.Rows[idx].Tag = m;
                 }
 
                 if (dataGridViewMC.SortedColumn != null && dataGridViewMC.SortOrder != SortOrder.None)
@@ -178,16 +180,19 @@ namespace EDDiscovery.UserControls
 
                 if (j == dataGridViewMC.Rows.Count)
                 {
+                    object[] rowobj;
+
                     if (materials)
                     {
-                        object[] rowobj = { mc.name, mc.shortname, mc.category, mc.type, "0" };
-                        dataGridViewMC.Rows.Add(rowobj);
+                        rowobj = new[] { mc.name, mc.shortname, mc.category, mc.type, "0" };
                     }
                     else
                     {
-                        object[] rowobj = { mc.name, mc.type, "0", "0" };
-                        dataGridViewMC.Rows.Add(rowobj);
+                        rowobj = new[] { mc.name, mc.type, "0", "0" };
                     }
+
+                    int idx = dataGridViewMC.Rows.Add(rowobj);
+                    dataGridViewMC.Rows[idx].Tag = mc;
 
                     labelNoItems.Visible = false;
                 }

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -224,6 +224,35 @@ namespace EDDiscovery.UserControls
             }
         }
 
+        private void dataGridViewMC_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
+        {
+            if ((materials && e.Column.Index == 4) || (!materials && (e.Column.Index == 2 || e.Column.Index == 3)))
+            {
+                double v1;
+                double v2;
+                bool v1hasval = Double.TryParse(e.CellValue1?.ToString(), out v1);
+                bool v2hasval = Double.TryParse(e.CellValue2?.ToString(), out v2);
+
+                if (v1hasval || v2hasval)
+                {
+                    if (!v1hasval)
+                    {
+                        e.SortResult = 1;
+                    }
+                    else if (!v2hasval)
+                    {
+                        e.SortResult = -1;
+                    }
+                    else
+                    {
+                        e.SortResult = v1.CompareTo(v2);
+                    }
+
+                    e.Handled = true;
+                }
+            }
+        }
+
         private void buttonExtModify_Click(object sender, EventArgs e)
         {
             if (buttonExtApply.Enabled)     // then its cancel


### PR DESCRIPTION
* Re-sort materials or commodities on re-display
* Sort numeric columns numerically instead of lexicographically
* Carry edits through refreshes