### PR TITLE
Display planetary coordinates in degrees decimal

### DIFF
--- a/EDDiscovery/JSON/JSONPrettyPrint.cs
+++ b/EDDiscovery/JSON/JSONPrettyPrint.cs
@@ -153,7 +153,7 @@ namespace EDDiscovery
                             {
                                 string marker = (lv >= 0.0d) ? "(N)" : "(S)";   // presume lat
                                 if (converters[i].converttype == Types.TLong)
-                                    marker = (lv >= 0) ? "(E)" : "(W)";         // but handle long
+                                    marker = (lv >= 0.0d) ? "(E)" : "(W)";      // but handle long
                                 value = string.Format("{0:0.0000}° {1}", lv, marker);
                                 if (formatsplit.Length >= 2)
                                     value = formatsplit[0] + value + formatsplit[1];

--- a/EDDiscovery/JSON/JSONPrettyPrint.cs
+++ b/EDDiscovery/JSON/JSONPrettyPrint.cs
@@ -146,16 +146,15 @@ namespace EDDiscovery
 
                         case Types.TLat:
                         case Types.TLong:
+                            // {N,E,S,W} markings are never used with degrees decimal, but are added here to maximize clarity.
+                            // 4 decimals = 11.132m worst-case precision (0° Lat, radius 6371km) per Wikipedia's "Decimal_degrees"
                             double lv;
                             if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out lv))        // if it does parse, we can convert it
                             {
-                                long arcsec = (long)(lv * 60 * 60);          // convert to arc seconds
-
-                                string marker = (arcsec < 0) ? "S" : "N";       // presume lat
-                                if (converters[i].converttype == Types.TLong )
-                                    marker = (arcsec < 0) ? "W" : "E";       // presume lat
-                                arcsec = Math.Abs(arcsec);
-                                value = string.Format("{0}°{1} {2}'{3}\"", arcsec / 3600, marker, (arcsec / 60) % 60, arcsec % 60 );
+                                string marker = (lv >= 0.0d) ? "(N)" : "(S)";   // presume lat
+                                if (converters[i].converttype == Types.TLong)
+                                    marker = (lv >= 0) ? "(E)" : "(W)";         // but handle long
+                                value = string.Format("{0:0.0000}° {1}", lv, marker);
                                 if (formatsplit.Length >= 2)
                                     value = formatsplit[0] + value + formatsplit[1];
                             }


### PR DESCRIPTION
... instead of Degrees Minutes Seconds. This makes sharing and revisiting landing and POI locations easier, as it saves users from converting DMS into degrees decimal.

- Before: `Latitude:34°S 12'57", Longitude:77°W 41'34"`
- After:   `Latitude:-34.2159° (S), Longitude:-77.6928° (W)`

I'm open for comments and suggestions, especially with regards to the non-standard use of the `{N,E,S,W}` indicators and/or the non-standard use of the `°` symbol. If ED ever defaults to (or even supports) display of coordinates in DMS, I believe that this change should be reverted.