### PR TITLE
My apologies to Anthor (Branch_Release_5.2)

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -748,7 +748,7 @@
             this.notifyIconMenu_SyncEDSM.Name = "notifyIconMenu_SyncEDSM";
             this.notifyIconMenu_SyncEDSM.Size = new System.Drawing.Size(159, 22);
             this.notifyIconMenu_SyncEDSM.Text = "Sync with ED&SM";
-            this.notifyIconMenu_SyncEDSM.Click += new System.EventHandler(this.syncEDSMSystemsToolStripMenuItem_Click);
+            this.notifyIconMenu_SyncEDSM.Click += new System.EventHandler(this.notifyIconMenu_SyncEDSM_Click);
             // 
             // EDDiscoveryForm
             // 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1552,9 +1552,11 @@ namespace EDDiscovery
             frm.Show(this);
         }
 
+        /// <summary>
+        /// Handle system notification icon double-click event.
+        /// </summary>
         private void notifyIcon1_DoubleClick(object sender, EventArgs e)
         {
-            // Tray icon was double-clicked.
             if (FormWindowState.Minimized == WindowState)
             {
                 if (EDDConfig.MinimizeToNotifyIcon)
@@ -1568,12 +1570,17 @@ namespace EDDiscovery
                 WindowState = FormWindowState.Minimized;
         }
 
+        /// <summary>
+        /// Handle system notification icon context menu "Hide Tray Icon" click event.
+        /// </summary>
         private void notifyIconMenu_Hide_Click(object sender, EventArgs e)
         {
-            // Tray icon 'Hide Tray Icon' menu item was clicked.
             settings.checkBoxUseNotifyIcon.Checked = false;
         }
 
+        /// <summary>
+        /// Handle system notification icon context menu "Open EDDiscovery" click event.
+        /// </summary>
         private void notifyIconMenu_Open_Click(object sender, EventArgs e)
         {
             // Tray icon 'Open EDDiscovery' menu item was clicked. Present the main window.
@@ -1588,6 +1595,32 @@ namespace EDDiscovery
             }
             else
                 Activate();
+        }
+
+        /// <summary>
+        /// Handle system notification icon context menu "Sync with EDSM" click event.
+        /// </summary>
+        private void notifyIconMenu_SyncEDSM_Click(object sender, EventArgs e)
+        {
+            if (EDDConfig == null)
+                return;
+
+            EDSMClass edsm = new EDSMClass();
+
+            if (!edsm.IsApiKeySet)
+            {
+                MessageBox.Show("Please ensure a commander is selected and it has a EDSM API key set");
+                return;
+            }
+
+            try
+            {
+                EdsmSync.StartSync(edsm, EDDConfig.CurrentCommander.SyncToEdsm, EDDConfig.CurrentCommander.SyncFromEdsm, EDDConfig.DefaultMapColour);
+            }
+            catch (Exception ex)
+            {
+                LogLine($"EDSM Sync failed: {ex.Message}");
+            }
         }
 
         #endregion


### PR DESCRIPTION
The notification icon context menu "Sync with EDSM" got hooked up to the wrong method. Instead of syncing recent events, it was performing a full sync.

Added some commentary for the notifyicon events.

(cherry picked from commit aaa9bd0a2c3e69108a97bc330b28218ef77fa30a)