### PR TITLE
Elite Dangerous re-uses filenames for screenshots (v5.3.x)

### DIFF
--- a/EDDiscovery/ImageHandler.cs
+++ b/EDDiscovery/ImageHandler.cs
@@ -393,6 +393,8 @@ namespace EDDiscovery2.ImageHandler
                 {
                     if (removeinputfile)         // if remove, delete original picture
                     {
+                        System.Threading.Timer timer;
+                        ScreenshotTimers.TryRemove(inputfile, out timer);
                         File.Delete(inputfile);
                     }
 


### PR DESCRIPTION
This should fix #780