### PR TITLE
Add AutoCompleteDGV* controls to ExtendedControls

### DIFF
--- a/EDDiscovery/Controls/AutoCompleteDGV.cs
+++ b/EDDiscovery/Controls/AutoCompleteDGV.cs
@@ -29,7 +29,7 @@ namespace ExtendedControls
             set
             {
                 if (value != null && !value.GetType().IsAssignableFrom(typeof(AutoCompleteDGVCell)))
-                    throw new InvalidCastException("value is not an AutoCompleteSystemsCell");
+                    throw new InvalidCastException("value is not an AutoCompleteDGVCell");
                 base.CellTemplate = value;
             }
         }
@@ -112,7 +112,6 @@ namespace ExtendedControls
                 SelectAll();
             else
                 SelectionStart = SelectionLength = 0;
-            selectAll = true;
         }
 
         protected override void OnTextChanged(EventArgs e)

--- a/EDDiscovery/Controls/AutoCompleteDGV.cs
+++ b/EDDiscovery/Controls/AutoCompleteDGV.cs
@@ -1,0 +1,125 @@
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2;
+using System;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class AutoCompleteDGVColumn : DataGridViewColumn
+    {
+        public AutoCompleteDGVColumn() : base(new AutoCompleteDGVCell()) { }
+
+        public override DataGridViewCell CellTemplate
+        {
+            get { return base.CellTemplate; }
+            set
+            {
+                if (value != null && !value.GetType().IsAssignableFrom(typeof(AutoCompleteDGVCell)))
+                    throw new InvalidCastException("value is not an AutoCompleteSystemsCell");
+                base.CellTemplate = value;
+            }
+        }
+    }
+
+    public class AutoCompleteDGVCell : DataGridViewTextBoxCell
+    {
+        public AutoCompleteDGVCell() : base() { }
+
+        public override object DefaultNewRowValue { get { return string.Empty; } }
+
+        public override Type EditType { get { return typeof(AutoCompleteDGVEditControl); } }
+
+        public override Type ValueType { get { return typeof(string); } }
+
+        public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
+        {
+            base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
+            var ctl = DataGridView.EditingControl as AutoCompleteDGVEditControl;
+            if (Value == null)
+                ctl.Text = (string)DefaultNewRowValue;
+            else
+                ctl.Text = (string)Value;
+        }
+    }
+
+    public class AutoCompleteDGVEditControl : AutoCompleteTextBox, IDataGridViewEditingControl
+    {
+        private DataGridView dataGridView;
+        private bool valueChanged = false;
+        private int rowIndex;
+
+        public AutoCompleteDGVEditControl() { }
+
+        #region IDataGridViewEditingControl properties
+
+        public DataGridView EditingControlDataGridView { get { return dataGridView; } set { dataGridView = value; } }
+
+        public object EditingControlFormattedValue
+        {
+            get { return Text; }
+            set
+            {
+                if (value == null || string.IsNullOrEmpty((string)value))
+                    Text = string.Empty;
+                else
+                    Text = ((string)value).Trim();
+            }
+        }
+
+        public int EditingControlRowIndex { get { return rowIndex; } set { rowIndex = value; } }
+
+        public bool EditingControlValueChanged { get { return valueChanged; } set { valueChanged = value; } }
+
+        public Cursor EditingPanelCursor { get { return base.Cursor; } }
+
+        public bool RepositionEditingControlOnValueChange { get { return false; } }
+
+        #endregion
+
+        public void ApplyCellStyleToEditingControl(DataGridViewCellStyle dgvStyle)
+        {
+            EDDTheme.Instance.ApplyToControls(Parent);
+        }
+
+        public object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
+        {
+            return EditingControlFormattedValue;
+        }
+
+        public bool EditingControlWantsInputKey(Keys key, bool dgvWantsInputKey)
+        {
+            // TODO: need to get these keys right to handle up/down and enter appropriately, along with the usual typing.
+            return !dgvWantsInputKey;
+        }
+
+        public void PrepareEditingControlForEdit(bool selectAll)
+        {
+            if (selectAll)
+                SelectAll();
+            else
+                SelectionStart = SelectionLength = 0;
+            selectAll = true;
+        }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            base.OnTextChanged(e);
+            valueChanged = true;
+            EditingControlDataGridView?.NotifyCurrentCellDirty(true);
+        }
+    }
+}

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -31,6 +31,18 @@ namespace EDDiscovery2
 {
     public class EDDTheme
     {
+        private static EDDTheme _instance;
+
+        public static EDDTheme Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new EDDTheme();
+                return _instance;
+            }
+        }
+
         public static readonly string[] ButtonStyles = "System Flat Gradient".Split();
         public static readonly string[] TextboxBorderStyles = "None FixedSingle Fixed3D Colour".Split();
 
@@ -735,7 +747,7 @@ namespace EDDiscovery2
 
                 myControl.Font = fnt;
 
-                if (myControl is AutoCompleteTextBox) // derived from text box
+                if (myControl is AutoCompleteTextBox || myControl is AutoCompleteDGVEditControl) // derived from text box
                 {
                     AutoCompleteTextBox actb = myControl as AutoCompleteTextBox;
                     actb.DropDownBackgroundColor = currentsettings.colors[Settings.CI.button_back];

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -226,6 +226,7 @@
       <DependentUpon>ConditionVariablesForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Conditions\ConditionVariables.cs" />
+    <Compile Include="Controls\AutoCompleteDGV.cs" />
     <Compile Include="Controls\CheckedListControlCustom.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -73,12 +73,12 @@ namespace EDDiscovery
         private bool _window_dragging = false;
         private Point _window_dragMousePos = Point.Empty;
         private Point _window_dragWindowPos = Point.Empty;
-        public EDDTheme theme;
 
         private EDDiscoveryController Controller;
         private Actions.ActionController actioncontroller;
 
         static public EDDConfig EDDConfig { get { return EDDConfig.Instance; } }
+        public EDDTheme theme { get { return EDDTheme.Instance; } }
 
         public TravelHistoryControl TravelControl { get { return travelHistoryControl1; } }
         public RouteControl RouteControl { get { return routeControl1; } }
@@ -167,8 +167,6 @@ namespace EDDiscovery
             InitializeComponent();
 
             label_version.Text = EDDConfig.Options.VersionDisplayString;
-
-            theme = new EDDTheme();
 
             PopOuts = new PopOutControl(this);
 

--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -70,7 +70,7 @@ namespace EDDiscovery
             this.textBoxRouteName = new ExtendedControls.TextBoxBorder();
             this.labelRouteName = new System.Windows.Forms.Label();
             this.dataGridViewRouteSystems = new System.Windows.Forms.DataGridView();
-            this.SystemName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SystemName = new ExtendedControls.AutoCompleteDGVColumn();
             this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Note = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.contextMenuCopyPaste = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -482,7 +482,7 @@ namespace EDDiscovery
         private System.Windows.Forms.Label labelDateStart;
         private System.Windows.Forms.Label labelRouteName;
         private System.Windows.Forms.DataGridView dataGridViewRouteSystems;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SystemName;
+        private ExtendedControls.AutoCompleteDGVColumn SystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
         private System.Windows.Forms.DataGridViewTextBoxColumn Note;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -28,6 +28,7 @@ using System.IO;
 using EMK.LightGeometry;
 using EDDiscovery.EDSM;
 using EDDiscovery2;
+using ExtendedControls;
 
 namespace EDDiscovery
 {
@@ -557,14 +558,12 @@ namespace EDDiscovery
 
         private void dataGridViewRouteSystems_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
         {
-            var textbox = (TextBox)e.Control;
-            if (dataGridViewRouteSystems.CurrentCell.ColumnIndex != 0)
-            {
-                textbox.AutoCompleteMode = AutoCompleteMode.None;
+            if (dataGridViewRouteSystems.CurrentCell.ColumnIndex != 0 || e.Control == null)
                 return;
-            }
 
-            //TBD this used to have an autocomplete, but now we don't have systemnames we are lacking it
+            AutoCompleteDGVEditControl ctl = (AutoCompleteDGVEditControl)e.Control;
+            if (ctl != null)
+                ctl.SetAutoCompletor(SystemClass.ReturnSystemListForAutoComplete);
         }
 
         private void dataGridViewRouteSystems_MouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
This inherits vastly from AutoCompleteTextBox and still has some rough.edges, but is mostly usable.
Wired SavedRouteExpeditionControl up to use this new control.
*Enhanced* EDDTheme to allow for single-instancing, similar to EDDConfig.

Eyeballs will be appreciated here, particularly with EDDTheme change (and updating *some* things to use it if appropriate).