### PR TITLE
OpenTK.Toolkit.Init is supposed to be called early (v5.3.x)

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -315,7 +315,6 @@ namespace EDDiscovery2
             this.glControl.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.glControl_OnMouseWheel);
             this.glControlContainer.Controls.Add(this.glControl);
             this.glControlContainer.ResumeLayout();
-            OpenTK.Toolkit.Init();
         }
 
         private void FormMap_Load(object sender, EventArgs e)

--- a/EDDiscovery/Program.cs
+++ b/EDDiscovery/Program.cs
@@ -34,6 +34,7 @@ namespace EDDiscovery
         [STAThread]
         static void Main()
         {
+            OpenTK.Toolkit.Init(new OpenTK.ToolkitOptions { EnableHighResolution = false });
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 


### PR DESCRIPTION
OpenTK.Toolkit.Init is supposed to be called before the UI
has been initialized.  Pass a ToolkitOptions object with
EnableHighResolution=false to prevent it from overriding
the DpiAware setting in the manifest.

Pulling this into v5.3.x to try to fix #807 