### PR TITLE
Add a couple platform checks

### DIFF
--- a/EDDiscovery/Forms/UserControlForm.cs
+++ b/EDDiscovery/Forms/UserControlForm.cs
@@ -398,23 +398,28 @@ namespace EDDiscovery.Forms
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern bool AppendMenu(IntPtr hMenu, int uFlags, int uIDNewItem, string lpNewItem);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern bool InsertMenu(IntPtr hMenu, int uPosition, int uFlags, int uIDNewItem, string lpNewItem);
+        // Unused. Any reason to keep this?
+        // [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        // private static extern bool InsertMenu(IntPtr hMenu, int uPosition, int uFlags, int uIDNewItem, string lpNewItem);
 
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
 
-            // Get a handle to a copy of this form's system (window) menu
-            IntPtr hSysMenu = GetSystemMenu(this.Handle, false);
+            // Windows title-bar context menu manipulation (2000 and above)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version.Major >= 5)
+            {
+                // Get a handle to a copy of this form's system (window) menu
+                IntPtr hSysMenu = GetSystemMenu(this.Handle, false);
 
-            // Add a separator
-            AppendMenu(hSysMenu, MF_SEPARATOR, 0, string.Empty);
+                // Add a separator
+                AppendMenu(hSysMenu, MF_SEPARATOR, 0, string.Empty);
 
-            // Add the About menu item
-            AppendMenu(hSysMenu, MF_STRING, SYSMENU_ONTOP, "&On Top");
-            AppendMenu(hSysMenu, MF_STRING, SYSMENU_TRANSPARENT, "&Transparent");
-            AppendMenu(hSysMenu, MF_STRING, SYSMENU_TASKBAR, "Show icon in Task&Bar for window");
+                // Add the About menu item
+                AppendMenu(hSysMenu, MF_STRING, SYSMENU_ONTOP, "&On Top");
+                AppendMenu(hSysMenu, MF_STRING, SYSMENU_TRANSPARENT, "&Transparent");
+                AppendMenu(hSysMenu, MF_STRING, SYSMENU_TASKBAR, "Show icon in Task&Bar for window");
+            }
         }
 
 

--- a/EDDiscovery/Speech/SpeechSynthesizer.cs
+++ b/EDDiscovery/Speech/SpeechSynthesizer.cs
@@ -106,10 +106,14 @@ namespace EDDiscovery.Speech
         public QueuedSynthesizer()
         {
             phrases = new List<Phrase>();
-#if __MonoCS__
-            speechengine = new DummySpeechEngine();
+#if !__MonoCS__
+            // Windows TTS (2000 and above). Speech *recognition* will be Version.Major >= 6 (Vista and above)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version.Major >= 5)
+                speechengine = new WindowsSpeechEngine();
+            else
+                speechengine = new DummySpeechEngine();
 #else
-            speechengine = new WindowsSpeechEngine();
+            speechengine = new DummySpeechEngine();
 #endif
             speechengine.SpeakingCompleted += Synth_SpeakCompleted;
         }


### PR DESCRIPTION
@robbyxp1 Eyeballs on the speech synthesis change. This should allow for compile-time detection as well as run-time detection. I also inverted the `#if` to match the exact format that was used around the class definition.

Speech synthesis is Windows 2000+. Recognition will require Vista+.
	http://stackoverflow.com/a/5861145

AppendMenu, GetSystemMenu are also 2000+.
	https://msdn.microsoft.com/en-us/library/windows/desktop/ms647616(v=vs.85).aspx
	https://msdn.microsoft.com/en-us/library/windows/desktop/ms647985(v=vs.85).aspx