### PR TITLE
Add AutoCompleteDGV* controls to ExtendedControls (take 2)

### DIFF
--- a/EDDiscovery/Controls/AutoCompleteDGV.cs
+++ b/EDDiscovery/Controls/AutoCompleteDGV.cs
@@ -29,7 +29,7 @@ namespace ExtendedControls
             set
             {
                 if (value != null && !value.GetType().IsAssignableFrom(typeof(AutoCompleteDGVCell)))
-                    throw new InvalidCastException("value is not an AutoCompleteSystemsCell");
+                    throw new InvalidCastException("value is not an AutoCompleteDGVCell");
                 base.CellTemplate = value;
             }
         }
@@ -112,7 +112,6 @@ namespace ExtendedControls
                 SelectAll();
             else
                 SelectionStart = SelectionLength = 0;
-            selectAll = true;
         }
 
         protected override void OnTextChanged(EventArgs e)

--- a/EDDiscovery/Controls/AutoCompleteDGV.cs
+++ b/EDDiscovery/Controls/AutoCompleteDGV.cs
@@ -1,0 +1,125 @@
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Fronter Developments plc.
+ */
+using EDDiscovery2;
+using System;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public class AutoCompleteDGVColumn : DataGridViewColumn
+    {
+        public AutoCompleteDGVColumn() : base(new AutoCompleteDGVCell()) { }
+
+        public override DataGridViewCell CellTemplate
+        {
+            get { return base.CellTemplate; }
+            set
+            {
+                if (value != null && !value.GetType().IsAssignableFrom(typeof(AutoCompleteDGVCell)))
+                    throw new InvalidCastException("value is not an AutoCompleteSystemsCell");
+                base.CellTemplate = value;
+            }
+        }
+    }
+
+    public class AutoCompleteDGVCell : DataGridViewTextBoxCell
+    {
+        public AutoCompleteDGVCell() : base() { }
+
+        public override object DefaultNewRowValue { get { return string.Empty; } }
+
+        public override Type EditType { get { return typeof(AutoCompleteDGVEditControl); } }
+
+        public override Type ValueType { get { return typeof(string); } }
+
+        public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
+        {
+            base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
+            var ctl = DataGridView.EditingControl as AutoCompleteDGVEditControl;
+            if (Value == null)
+                ctl.Text = (string)DefaultNewRowValue;
+            else
+                ctl.Text = (string)Value;
+        }
+    }
+
+    public class AutoCompleteDGVEditControl : AutoCompleteTextBox, IDataGridViewEditingControl
+    {
+        private DataGridView dataGridView;
+        private bool valueChanged = false;
+        private int rowIndex;
+
+        public AutoCompleteDGVEditControl() { }
+
+        #region IDataGridViewEditingControl properties
+
+        public DataGridView EditingControlDataGridView { get { return dataGridView; } set { dataGridView = value; } }
+
+        public object EditingControlFormattedValue
+        {
+            get { return Text; }
+            set
+            {
+                if (value == null || string.IsNullOrEmpty((string)value))
+                    Text = string.Empty;
+                else
+                    Text = ((string)value).Trim();
+            }
+        }
+
+        public int EditingControlRowIndex { get { return rowIndex; } set { rowIndex = value; } }
+
+        public bool EditingControlValueChanged { get { return valueChanged; } set { valueChanged = value; } }
+
+        public Cursor EditingPanelCursor { get { return base.Cursor; } }
+
+        public bool RepositionEditingControlOnValueChange { get { return false; } }
+
+        #endregion
+
+        public void ApplyCellStyleToEditingControl(DataGridViewCellStyle dgvStyle)
+        {
+            EDDTheme.Instance.ApplyToControls(Parent);
+        }
+
+        public object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
+        {
+            return EditingControlFormattedValue;
+        }
+
+        public bool EditingControlWantsInputKey(Keys key, bool dgvWantsInputKey)
+        {
+            // TODO: need to get these keys right to handle up/down and enter appropriately, along with the usual typing.
+            return !dgvWantsInputKey;
+        }
+
+        public void PrepareEditingControlForEdit(bool selectAll)
+        {
+            if (selectAll)
+                SelectAll();
+            else
+                SelectionStart = SelectionLength = 0;
+            selectAll = true;
+        }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            base.OnTextChanged(e);
+            valueChanged = true;
+            EditingControlDataGridView?.NotifyCurrentCellDirty(true);
+        }
+    }
+}

--- a/EDDiscovery/Controls/AutoCompleteDGV.cs
+++ b/EDDiscovery/Controls/AutoCompleteDGV.cs
@@ -15,110 +15,265 @@
  */
 using EDDiscovery2;
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace ExtendedControls
 {
+    /// <summary>
+    /// Represents a string-backed column capable of autocompletion during editing inside of a <see cref="DataGridView"/> control.
+    /// </summary>
+    /// <remarks>Attach this column to your <see cref="DataGridView"/> inside of the editor, then attach an appropriate
+    /// delegate method to the <see cref="AutoCompleteGenerator"/> property during container initialization.</remarks>
+    /// <example><code>using EDDiscovery.ExtendedControls;
+    /// using EDDiscovery.DB;
+    /// using System.Windows.Forms;
+    /// 
+    /// namespace MyProject {
+    ///     public partial class TestForm : Form
+    ///     {
+    ///         public TestForm()
+    ///         {
+    ///             InitializeComponent();
+    ///             // Assuming a designer-generated DataGridView contains a column called autoCompleteDGVColumn, with ColumnType set to AutoCompleteDGVColumn.
+    ///             autoCompleteDGVColumn.AutoCompleteGenerator += SystemClass.ReturnSystemListForAutoComplete;
+    ///         }
+    ///     }</code></example>
     public class AutoCompleteDGVColumn : DataGridViewColumn
     {
-        public AutoCompleteDGVColumn() : base(new AutoCompleteDGVCell()) { }
+        #region AutoCompleteDGVColumn
 
+        /// <summary>
+        /// The method to use for generating available autocomplete options, such as <see cref="SystemClass.ReturnSystemListForAutoComplete"/>.
+        /// Signature is "<c>List&lt;string&gt; (string, TextBox as object)</c>".
+        /// </summary>
+        [Browsable(false)]
+        public AutoCompleteTextBox.PerformAutoComplete AutoCompleteGenerator { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoCompleteDGVColumn"/> class to the default state.
+        /// </summary>
+        public AutoCompleteDGVColumn() : base(new CellDisplayControl()) { }
+
+        /// <summary>
+        /// Gets or sets the template used to create new cells.
+        /// </summary>
+        /// <value>A <see cref="DataGridViewCell"/> that all other cells in the column are modeled after. The default is <c>null</c>.</value>
+        /// <exception cref="InvalidCastException">raised when <paramref name="CellTemplate"/> does not inherit from <see cref="CellDisplayControl"/>.</exception>
+        [Browsable(false)]
         public override DataGridViewCell CellTemplate
         {
             get { return base.CellTemplate; }
             set
             {
-                if (value != null && !value.GetType().IsAssignableFrom(typeof(AutoCompleteDGVCell)))
+                if (value != null && !value.GetType().IsAssignableFrom(typeof(CellDisplayControl)))
                     throw new InvalidCastException("value is not an AutoCompleteDGVCell");
                 base.CellTemplate = value;
             }
         }
-    }
 
-    public class AutoCompleteDGVCell : DataGridViewTextBoxCell
-    {
-        public AutoCompleteDGVCell() : base() { }
-
-        public override object DefaultNewRowValue { get { return string.Empty; } }
-
-        public override Type EditType { get { return typeof(AutoCompleteDGVEditControl); } }
-
-        public override Type ValueType { get { return typeof(string); } }
-
-        public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
+        /// <summary>
+        /// Creates an exact copy of this <see cref="AutoCompleteDGVColumn"/>.
+        /// </summary>
+        /// <returns>An <see cref="object"/> that represents the cloned <see cref="AutoCompleteDGVColumn"/>.</returns>
+        public override object Clone()
         {
-            base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
-            var ctl = DataGridView.EditingControl as AutoCompleteDGVEditControl;
-            if (Value == null)
-                ctl.Text = (string)DefaultNewRowValue;
-            else
-                ctl.Text = (string)Value;
+            var clone = base.Clone() as AutoCompleteDGVColumn;
+            clone.AutoCompleteGenerator = AutoCompleteGenerator;
+            return clone;
         }
-    }
 
-    public class AutoCompleteDGVEditControl : AutoCompleteTextBox, IDataGridViewEditingControl
-    {
-        private DataGridView dataGridView;
-        private bool valueChanged = false;
-        private int rowIndex;
+        #endregion // AutoCompleteDGVColumn
 
-        public AutoCompleteDGVEditControl() { }
+        #region CellDisplayControl
 
-        #region IDataGridViewEditingControl properties
-
-        public DataGridView EditingControlDataGridView { get { return dataGridView; } set { dataGridView = value; } }
-
-        public object EditingControlFormattedValue
+        /// <summary>
+        /// Displays editable text information in a <see cref="DataGridViewTextBoxCell"/> control
+        /// and provides autocompletion facilities for <see cref="CellEditControl"/>.
+        /// </summary>
+        private class CellDisplayControl : DataGridViewTextBoxCell
         {
-            get { return Text; }
-            set
+            private CellEditControl _ctl;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CellDisplayControl"/> class.
+            /// </summary>
+            public CellDisplayControl() : base() { }
+
+            /// <summary>
+            /// Gets the default value for a cell in the row for new records.
+            /// </summary>
+            public override object DefaultNewRowValue { get { return string.Empty; } }
+
+            /// <summary>
+            /// Gets the type of the cell's hosted editing control.
+            /// </summary>
+            public override Type EditType { get { return typeof(CellEditControl); } }
+
+            /// <summary>
+            /// Gets the data type of the values in the cell.
+            /// </summary>
+            public override Type ValueType { get { return typeof(string); } }
+
+            /// <summary>
+            /// Attaches and initializes the hosted editing control.
+            /// </summary>
+            /// <param name="rowIndex">The index of the row being edited.</param>
+            /// <param name="initialFormattedValue">The initial value to be displayed in the control.</param>
+            /// <param name="dataGridViewCellStyle">A cell style that is used to determine the appearance of the hosted control.</param>
+            public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
             {
-                if (value == null || string.IsNullOrEmpty((string)value))
-                    Text = string.Empty;
-                else
-                    Text = ((string)value).Trim();
+                base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
+                var ctl = DataGridView.EditingControl as CellEditControl;
+                if (ctl != null)    // This should not be needed, but just in case...
+                {
+                    _ctl = ctl;
+                    if (Value == null)
+                        ctl.Text = (string)DefaultNewRowValue;
+                    else
+                        ctl.Text = (string)Value;
+                    var col = OwningColumn as AutoCompleteDGVColumn;
+                    if (col != null && col.AutoCompleteGenerator != null)
+                        ctl.SetAutoCompletor(col.AutoCompleteGenerator);
+                }
+            }
+
+            /// <summary>
+            /// Removes the cell's editing control from the <see cref="DataGridView"/>.
+            /// </summary>
+            /// <remarks>The <see cref="DataGridView"/> calls this method when the current cell hosts an editing control and editing mode ends.
+            /// The method removes the <see cref="CellEditControl"/> from the <see cref="DataGridView.EditingPanel"/>, and then removes the
+            /// <see cref="DataGridView.EditingPanel"/> from the <see cref="Controls"/> collection of the <see cref="DataGridView"/>.</remarks>
+            public override void DetachEditingControl()
+            {
+                // The user can commit to a selection before AC can even generate results. If so, we need to
+                // abort it, otherwise the popup appears at a random location, and it is unbound from this DGV.
+                if (_ctl != null)
+                    _ctl.AbortAutoComplete();
+                base.DetachEditingControl();
             }
         }
 
-        public int EditingControlRowIndex { get { return rowIndex; } set { rowIndex = value; } }
+        #endregion // CellDisplay
 
-        public bool EditingControlValueChanged { get { return valueChanged; } set { valueChanged = value; } }
+        #region CellEditControl
 
-        public Cursor EditingPanelCursor { get { return base.Cursor; } }
-
-        public bool RepositionEditingControlOnValueChange { get { return false; } }
-
-        #endregion
-
-        public void ApplyCellStyleToEditingControl(DataGridViewCellStyle dgvStyle)
+        /// <summary>
+        /// Provides for autocompletion capabilities when editing data in an <see cref="AutoCompleteDGVColumn"/>.
+        /// </summary>
+        internal class CellEditControl : AutoCompleteTextBox, IDataGridViewEditingControl
         {
-            EDDTheme.Instance.ApplyToControls(Parent);
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CellEditControl"/> class.
+            /// </summary>
+            public CellEditControl() : base() { }
+
+            #region IDataGridViewEditingControl implementation
+
+            /// <summary>
+            /// Gets or sets the <see cref="DataGridView"/> that contains the cell.
+            /// </summary>
+            public DataGridView EditingControlDataGridView { get; set; }
+
+            /// <summary>
+            /// Gets or sets the formatted value of the cell being modified by the editor.
+            /// </summary>
+            public object EditingControlFormattedValue
+            {
+                get { return Text; }
+                set
+                {
+                    if (value == null || string.IsNullOrEmpty((string)value))
+                        Text = string.Empty;
+                    else
+                        Text = ((string)value).Trim();
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets the index of the hosting cell's parent row.
+            /// </summary>
+            public int EditingControlRowIndex { get; set; }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether the value of the the editing control differs form the value of the hosting cell.
+            /// </summary>
+            public bool EditingControlValueChanged { get; set; }
+
+            /// <summary>
+            /// Gets the cursor used when the mouse pointer is over the <see cref="DataGridView.EditingPanel"/>, but not over the editing control.
+            /// </summary>
+            public Cursor EditingPanelCursor { get { return base.Cursor; } }
+
+            /// <summary>
+            /// Gets a value indicating whether the cell contents need to be repositioned whenever the value changes.
+            /// </summary>
+            public bool RepositionEditingControlOnValueChange { get { return false; } }
+
+            /// <summary>
+            /// Changes the control's user interface to be consistent with the user's desired theme.
+            /// </summary>
+            /// <param name="dgvStyle">The <see cref="DataGridViewCellStyle"/> to use as the model for the UI.</param>
+            public void ApplyCellStyleToEditingControl(DataGridViewCellStyle dgvStyle)
+            {
+                EDDTheme.Instance.ApplyToControls(Parent);
+            }
+
+            /// <summary>
+            /// Determines whether the specified key is a regular input key that the editing control should process
+            /// or a special key that the parent <see cref="DataGridView"/> should process.
+            /// </summary>
+            /// <param name="key">A <see cref="Keys"/> item that represents the key that was pressed.</param>
+            /// <param name="dgvWantsInputKey"><c>true</c> when the <see cref="DataGridView"/> wants to process the keypress; <c>false</c> otherwise.</param>
+            /// <returns><c>true</c> if the specified key is a regular input key that the edit control should handle; <c>false</c> otherwise.</returns>
+            public bool EditingControlWantsInputKey(Keys key, bool dgvWantsInputKey)
+            {
+                // TODO: need to get these keys right to handle up/down and enter appropriately, along with the usual typing.
+                return !dgvWantsInputKey;
+            }
+
+            /// <summary>
+            /// Retrieves the formatted value of the cell.
+            /// </summary>
+            /// <param name="context">A bitwise combination of <see cref="DataGridViewDataErrorContexts"/> values that specifies the context in which the data is needed.</param>
+            /// <returns>An <see cref="object"/> that represents the formatted version of the cell contents.</returns>
+            public object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
+            {
+                return EditingControlFormattedValue;
+            }
+
+            /// <summary>
+            /// Prepares the currently selected cell for editing.
+            /// </summary>
+            /// <param name="selectAll"><c>true</c> to select all of the cell's content; <c>false</c> otherwise.</param>
+            public void PrepareEditingControlForEdit(bool selectAll)
+            {
+                // Don't draw the ExtendedControls.TextBoxBorder border
+                BorderColor = System.Drawing.Color.Transparent;
+                BorderOffset = 0;
+                // Don't draw the System.Windows.Forms.TextBox border
+                BorderStyle = BorderStyle.None;
+
+                if (selectAll)
+                    SelectAll();
+                else
+                    SelectionStart = SelectionLength = 0;
+            }
+
+            #endregion // IDataGridViewEditingControl implementation
+
+            /// <summary>
+            /// Raises the <see cref="Control.TextChanged"/> event.
+            /// </summary>
+            /// <param name="e">An <see cref="EventArgs"/> that contains the event data.</param>
+            protected override void OnTextChanged(EventArgs e)
+            {
+                base.OnTextChanged(e);
+                EditingControlValueChanged = true;
+                EditingControlDataGridView?.NotifyCurrentCellDirty(true);
+            }
         }
 
-        public object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
-        {
-            return EditingControlFormattedValue;
-        }
-
-        public bool EditingControlWantsInputKey(Keys key, bool dgvWantsInputKey)
-        {
-            // TODO: need to get these keys right to handle up/down and enter appropriately, along with the usual typing.
-            return !dgvWantsInputKey;
-        }
-
-        public void PrepareEditingControlForEdit(bool selectAll)
-        {
-            if (selectAll)
-                SelectAll();
-            else
-                SelectionStart = SelectionLength = 0;
-        }
-
-        protected override void OnTextChanged(EventArgs e)
-        {
-            base.OnTextChanged(e);
-            valueChanged = true;
-            EditingControlDataGridView?.NotifyCurrentCellDirty(true);
-        }
+        #endregion // CellEditControl
     }
 }

--- a/EDDiscovery/Controls/AutoCompleteTextBox.cs
+++ b/EDDiscovery/Controls/AutoCompleteTextBox.cs
@@ -62,6 +62,21 @@ namespace ExtendedControls
 
         }
 
+        // Sometimes, the user is quicker than the timer, and has commited to a selection before the results even come back.
+        public void AbortAutoComplete()
+        {
+            if (waitforautotimer.Enabled)
+            {
+                waitforautotimer.Stop();
+            }
+            else if (isActivated && _cbdropdown != null)
+            {
+                isActivated = false;
+                _cbdropdown.Close();
+                Invalidate(true);
+            }
+        }
+
         public void SetAutoCompletor(PerformAutoComplete p)
         {
             func = p;
@@ -81,7 +96,7 @@ namespace ExtendedControls
             }
         }
 
-        protected void TextChangeEventHandler(object sender, EventArgs e)
+        private void TextChangeEventHandler(object sender, EventArgs e)
         {
             if (func != null && !isActivated && !disableauto)
             {
@@ -101,7 +116,7 @@ namespace ExtendedControls
             }
         }
 
-        void TimeOutTick(object sender, EventArgs e)
+        private void TimeOutTick(object sender, EventArgs e)
         {
             waitforautotimer.Stop();
             inautocomplete = true;

--- a/EDDiscovery/DB/SystemClass.cs
+++ b/EDDiscovery/DB/SystemClass.cs
@@ -1987,8 +1987,16 @@ namespace EDDiscovery.DB
         public static List<string> ReturnSystemListForAutoComplete(string input, Object ctrl)
         {
             List<string> ret = new List<string>();
+            ret.AddRange(ReturnOnlyGalMapListForAutoComplete(input, ctrl));
+            ret.AddRange(ReturnOnlySystemsListForAutoComplete(input, ctrl));
+            return ret;
+        }
 
-            if (input.Length > 0)
+        public static List<string> ReturnOnlyGalMapListForAutoComplete(string input, Object ctrl)
+        {
+            List<string> ret = new List<string>();
+
+            if (input != null && input.Length > 0)
             {
                 lock (AutoCompleteAdditionalList)
                 {
@@ -1998,7 +2006,15 @@ namespace EDDiscovery.DB
                             ret.Add(other);
                     }
                 }
+            }
+            return ret;
+        }
 
+        public static List<string> ReturnOnlySystemsListForAutoComplete(string input, Object ctrl)
+        {
+            List<string> ret = new List<string>();
+            if (input != null && input.Length > 0)
+            {
                 using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem())
                 {
                     using (DbCommand cmd = cn.CreateCommand("SELECT Name,EdsmId FROM SystemNames WHERE Name>=@first AND Name<=@second LIMIT 1000"))
@@ -2016,7 +2032,6 @@ namespace EDDiscovery.DB
                     }
                 }
             }
-
             return ret;
         }
 

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -747,7 +747,7 @@ namespace EDDiscovery2
 
                 myControl.Font = fnt;
 
-                if (myControl is AutoCompleteTextBox || myControl is AutoCompleteDGVEditControl) // derived from text box
+                if (myControl is AutoCompleteTextBox || myControl is AutoCompleteDGVColumn.CellEditControl) // derived from text box
                 {
                     AutoCompleteTextBox actb = myControl as AutoCompleteTextBox;
                     actb.DropDownBackgroundColor = currentsettings.colors[Settings.CI.button_back];

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -279,7 +279,7 @@ namespace EDDiscovery2
         
         public EDDToolStripRenderer toolstripRenderer;
 
-        public EDDTheme()
+        private EDDTheme()
         {
             toolstripRenderer = new EDDToolStripRenderer();
             themelist = new List<Settings>();           // theme list in

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -31,6 +31,18 @@ namespace EDDiscovery2
 {
     public class EDDTheme
     {
+        private static EDDTheme _instance;
+
+        public static EDDTheme Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new EDDTheme();
+                return _instance;
+            }
+        }
+
         public static readonly string[] ButtonStyles = "System Flat Gradient".Split();
         public static readonly string[] TextboxBorderStyles = "None FixedSingle Fixed3D Colour".Split();
 
@@ -735,7 +747,7 @@ namespace EDDiscovery2
 
                 myControl.Font = fnt;
 
-                if (myControl is AutoCompleteTextBox) // derived from text box
+                if (myControl is AutoCompleteTextBox || myControl is AutoCompleteDGVEditControl) // derived from text box
                 {
                     AutoCompleteTextBox actb = myControl as AutoCompleteTextBox;
                     actb.DropDownBackgroundColor = currentsettings.colors[Settings.CI.button_back];

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -226,6 +226,7 @@
       <DependentUpon>ConditionVariablesForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Conditions\ConditionVariables.cs" />
+    <Compile Include="Controls\AutoCompleteDGV.cs" />
     <Compile Include="Controls\CheckedListControlCustom.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -73,12 +73,12 @@ namespace EDDiscovery
         private bool _window_dragging = false;
         private Point _window_dragMousePos = Point.Empty;
         private Point _window_dragWindowPos = Point.Empty;
-        public EDDTheme theme;
 
         private EDDiscoveryController Controller;
         private Actions.ActionController actioncontroller;
 
         static public EDDConfig EDDConfig { get { return EDDConfig.Instance; } }
+        public EDDTheme theme { get { return EDDTheme.Instance; } }
 
         public TravelHistoryControl TravelControl { get { return travelHistoryControl1; } }
         public RouteControl RouteControl { get { return routeControl1; } }
@@ -167,8 +167,6 @@ namespace EDDiscovery
             InitializeComponent();
 
             label_version.Text = EDDConfig.Options.VersionDisplayString;
-
-            theme = new EDDTheme();
 
             PopOuts = new PopOutControl(this);
 

--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -70,7 +70,7 @@ namespace EDDiscovery
             this.textBoxRouteName = new ExtendedControls.TextBoxBorder();
             this.labelRouteName = new System.Windows.Forms.Label();
             this.dataGridViewRouteSystems = new System.Windows.Forms.DataGridView();
-            this.SystemName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SystemName = new ExtendedControls.AutoCompleteDGVColumn();
             this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Note = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.contextMenuCopyPaste = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -482,7 +482,7 @@ namespace EDDiscovery
         private System.Windows.Forms.Label labelDateStart;
         private System.Windows.Forms.Label labelRouteName;
         private System.Windows.Forms.DataGridView dataGridViewRouteSystems;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SystemName;
+        private ExtendedControls.AutoCompleteDGVColumn SystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
         private System.Windows.Forms.DataGridViewTextBoxColumn Note;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;

--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -366,7 +366,6 @@ namespace EDDiscovery
             this.dataGridViewRouteSystems.TabIndex = 2;
             this.dataGridViewRouteSystems.CellValidated += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewRouteSystems_CellValidated);
             this.dataGridViewRouteSystems.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewRouteSystems_CellValidating);
-            this.dataGridViewRouteSystems.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewRouteSystems_EditingControlShowing);
             this.dataGridViewRouteSystems.RowPostPaint += new System.Windows.Forms.DataGridViewRowPostPaintEventHandler(this.dataGridViewRouteSystems_RowPostPaint);
             this.dataGridViewRouteSystems.DragDrop += new System.Windows.Forms.DragEventHandler(this.dataGridViewRouteSystems_DragDrop);
             this.dataGridViewRouteSystems.DragOver += new System.Windows.Forms.DragEventHandler(this.dataGridViewRouteSystems_DragOver);
@@ -403,7 +402,7 @@ namespace EDDiscovery
             this.setTargetToolStripMenuItem,
             this.editBookmarkToolStripMenuItem});
             this.contextMenuCopyPaste.Name = "contextMenuCopyPaste";
-            this.contextMenuCopyPaste.Size = new System.Drawing.Size(176, 158);
+            this.contextMenuCopyPaste.Size = new System.Drawing.Size(176, 136);
             this.contextMenuCopyPaste.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuCopyPaste_Opening);
             // 
             // copyToolStripMenuItem

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -131,6 +131,7 @@ namespace EDDiscovery
         {
             InitializeComponent();
             _currentRoute = new SavedRouteClass("");
+            SystemName.AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
         }
 
         public void InitControl(EDDiscoveryForm discoveryForm)
@@ -554,16 +555,6 @@ namespace EDDiscovery
                 //Force the totals to update
                 UpdateSystemRows();
             }
-        }
-
-        private void dataGridViewRouteSystems_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
-        {
-            if (dataGridViewRouteSystems.CurrentCell.ColumnIndex != 0 || e.Control == null)
-                return;
-
-            AutoCompleteDGVEditControl ctl = (AutoCompleteDGVEditControl)e.Control;
-            if (ctl != null)
-                ctl.SetAutoCompletor(SystemClass.ReturnSystemListForAutoComplete);
         }
 
         private void dataGridViewRouteSystems_MouseDown(object sender, MouseEventArgs e)

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -28,6 +28,7 @@ using System.IO;
 using EMK.LightGeometry;
 using EDDiscovery.EDSM;
 using EDDiscovery2;
+using ExtendedControls;
 
 namespace EDDiscovery
 {
@@ -557,14 +558,12 @@ namespace EDDiscovery
 
         private void dataGridViewRouteSystems_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
         {
-            var textbox = (TextBox)e.Control;
-            if (dataGridViewRouteSystems.CurrentCell.ColumnIndex != 0)
-            {
-                textbox.AutoCompleteMode = AutoCompleteMode.None;
+            if (dataGridViewRouteSystems.CurrentCell.ColumnIndex != 0 || e.Control == null)
                 return;
-            }
 
-            //TBD this used to have an autocomplete, but now we don't have systemnames we are lacking it
+            AutoCompleteDGVEditControl ctl = (AutoCompleteDGVEditControl)e.Control;
+            if (ctl != null)
+                ctl.SetAutoCompletor(SystemClass.ReturnSystemListForAutoComplete);
         }
 
         private void dataGridViewRouteSystems_MouseDown(object sender, MouseEventArgs e)

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -86,7 +86,7 @@ namespace EDDiscovery
             this.dataViewScroller_Distances = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
             this.dataGridViewDistances = new System.Windows.Forms.DataGridView();
-            this.ColumnSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnSystem = new ExtendedControls.AutoCompleteDGVColumn();
             this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnCalculated = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -735,7 +735,7 @@ namespace EDDiscovery
         private System.Windows.Forms.ToolStripButton toolStripButtonRemoveUnused;
         private System.Windows.Forms.Panel panel_controls;
         private System.Windows.Forms.Label labelstpos;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnSystem;
+        private ExtendedControls.AutoCompleteDGVColumn ColumnSystem;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDistance;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnCalculated;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnStatus;

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -542,7 +542,6 @@ namespace EDDiscovery
             this.dataGridViewDistances.CellLeave += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewDistances_CellLeave);
             this.dataGridViewDistances.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewDistances_CellValidating);
             this.dataGridViewDistances.CurrentCellChanged += new System.EventHandler(this.dataGridViewDistances_CurrentCellChanged);
-            this.dataGridViewDistances.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewDistances_EditingControlShowing);
             this.dataGridViewDistances.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridViewDistances_KeyDown);
             // 
             // ColumnSystem

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -22,6 +22,7 @@ using System.Windows.Forms;
 using EDDiscovery.DB;
 using EDDiscovery2.EDSM;
 using EDDiscovery2.DB;
+using ExtendedControls;
 
 namespace EDDiscovery
 {
@@ -110,26 +111,11 @@ namespace EDDiscovery
 
         private void dataGridViewDistances_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
         {
-            try
+            if (dataGridViewDistances.CurrentCell.ColumnIndex == 0 && e.Control != null)
             {
-                var textbox = (TextBox)e.Control;
-
-                if (dataGridViewDistances.CurrentCell.ColumnIndex != 0)
-                {
-                    textbox.AutoCompleteMode = AutoCompleteMode.None;
-                    return;
-                }
-
-                // TBD Used to be an autocomplete..
-            }
-            catch (Exception ex)
-            {
-                this.BeginInvoke(new MethodInvoker(() =>
-                {
-                    LogTextHighlight("ViewPushedSystems Exception:" + ex.Message);
-                    LogText(ex.StackTrace);
-                }));
-
+                AutoCompleteDGVEditControl ctl = (AutoCompleteDGVEditControl)e.Control;
+                if (ctl != null)
+                    ctl.SetAutoCompletor(SystemClass.ReturnSystemListForAutoComplete);
             }
         }
 

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -42,6 +42,7 @@ namespace EDDiscovery
         public TrilaterationControl()
         {
             InitializeComponent();
+            ColumnSystem.AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
         }
 
         public void InitControl(EDDiscoveryForm discoveryForm)
@@ -107,16 +108,6 @@ namespace EDDiscovery
                 }
             }
             return systems;
-        }
-
-        private void dataGridViewDistances_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
-        {
-            if (dataGridViewDistances.CurrentCell.ColumnIndex == 0 && e.Control != null)
-            {
-                AutoCompleteDGVEditControl ctl = (AutoCompleteDGVEditControl)e.Control;
-                if (ctl != null)
-                    ctl.SetAutoCompletor(SystemClass.ReturnSystemListForAutoComplete);
-            }
         }
 
         private void dataGridViewDistances_CellValidating(object sender, DataGridViewCellValidatingEventArgs e)

--- a/EDDiscovery/UserControls/UserControlExploration.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.Designer.cs
@@ -67,7 +67,7 @@ namespace EDDiscovery
             this.setTargetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editBookmarkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.dataGridViewExplore = new System.Windows.Forms.DataGridView();
-            this.ColumnSystemName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ColumnSystemName = new ExtendedControls.AutoCompleteDGVColumn();
             this.ColumnDist = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnX = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnY = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -422,7 +422,7 @@ namespace EDDiscovery
         private System.Windows.Forms.ToolStripButton toolStripButtonLoad;
         private ExtendedControls.TextBoxBorder textBoxFileName;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ColumnSystemName;
+        private ExtendedControls.AutoCompleteDGVColumn ColumnSystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDist;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnX;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnY;

--- a/EDDiscovery/UserControls/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.cs
@@ -58,6 +58,7 @@ namespace EDDiscovery
         {
             InitializeComponent();
             _currentExplorationSet = new ExplorationSetClass();
+            ColumnSystemName.AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
         }
 
         public override void Init(EDDiscoveryForm ed, int vn) //0=primary, 1 = first windowed version, etc


### PR DESCRIPTION
This inherits vastly from AutoCompleteTextBox and still has **only one** rough edge (up/down keys close the popup, selecting the first entry, but this is evident with a standard `AutoCompleteTextBox`), but it is very usable. Left the naming and specification of all controls open, so this could be used for anything from system names, GalMap objects, stations, factions, commodities, materials, etc.

*Summary:*
AutoCompleteTextBox thread can now be aborted in instances where the user commits to a system before it has finished gathering data. Previously, the popup would appear at desktop 0, 0 if the user pressed enter quick enough, as the parent control was already disposed.

AutoCompleteDGVColumn now serves up an `AutoCompleteGenerator` delegate property and automatically applies it to any edit controls that appear in the column.

EDDTheme can now be accessed statically using a similar model as EDDConfig (`private static EDDTheme _instance;` set once during construction; accessed via new `public static EDDConfig.Instance` property).

SystemClass now offers up three auto-complete sources, depending on the control/form designer's needs:
1. `ReturnSystemListForAutoComplete`: All GalMap entries and known systems combined.
2. `ReturnOnlyGalMapListForAutoComplete`: All GalMap entries.
3. `ReturnOnlySystemsListForAutoComplete`: All known systems.

SavedRouteExpeditionControl, TrilaterationControl, and UserControlExploration are all hooked up to this functionality, and it's a very easy process to add it to any additional controls that need it:
1. Update the DGV column type to be `AutoCompleteDGVColumn`
2. Remove the designer-generated changes that occur when changing a column type.
3. Set the `AutoCompleteGenerator` property to use the data source that is desired.

Eyeballs will be appreciated here, particularly with the EDDTheme changes in 97e38a4917f748c7dcf8943ddf5b937bf70aba06 and the `AbortAutoComplete()` method in ba7b0498d433f65d37ff9036f2cd51da55e75002 ([direct link](https://github.com/EDDiscovery/EDDiscovery/commit/ba7b0498d433f65d37ff9036f2cd51da55e75002#diff-697a3fd057c9f6a369adfa679784208bR66)).

No harm if this one waits until after a full 6.0 release.