### PR TITLE
Optimize a couple of expensive linq's

### DIFF
--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -646,11 +646,15 @@ namespace EDDiscovery
 
         public int GetVisitsCount(string name, long edsmid = 0)
         {
-            return historylist.Where(he => he.IsFSDJump && he.System.name.Equals(name, StringComparison.InvariantCultureIgnoreCase) && (edsmid <= 0 || he.System.id_edsm == edsmid)).Count();
+            return (from he in historylist.AsParallel()
+                   where (he.IsFSDJump && (edsmid <= 0 || he.System.id_edsm == edsmid) && he.System.name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                   select he).Count();
         }
         public List<JournalScan> GetScans(string name, long edsmid = 0)
         {
-            return (from s in historylist where (s.journalEntry.EventTypeID == JournalTypeEnum.Scan && s.System.name.Equals(name, StringComparison.InvariantCultureIgnoreCase) && (edsmid <= 0 || s.System.id_edsm == edsmid)) select s.journalEntry as JournalScan).ToList<JournalScan>();
+            return (from s in historylist.AsParallel()
+                    where (s.journalEntry.EventTypeID == JournalTypeEnum.Scan && (edsmid <= 0 || s.System.id_edsm == edsmid) && s.System.name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                    select s.journalEntry as JournalScan).ToList<JournalScan>();
         }
 
         public int GetFSDJumps( TimeSpan t )


### PR DESCRIPTION
Parallelize GetVisitsCount and GetScans queries, and move the long comparisons ahead of the string comparisons. This vastly speeds up these queries, albeit at the cost of multi-core CPU utilization.

On my 6700k, it would take roughly 60 seconds for the previous queries to complete, which is past the timeout resulting in incorrect data display. Now, it's done in under 30ms, and the initially displayed value is accurate to boot. I encourage testing to see if this cuts too far into ED resources on various other processors.

One item to do: cache the previous system ID in `ShowSystemInformation()` and don't bother running the queries again if the same system was selected.

>Delta 2-7 - Today at 4:20 PM
Hi there I'm trying to troubleshoot an issue I have regarding systems visited I'm using EDDiscovery as well as EDDI with voiceattack (EDDI tells me on hyperjumping that this is the first time I'm visiting a system when it is local and I have been here dozens of times and when I cross check EDDiscovery it informs me in the Log the correct number but the Vissits box is locked at either 1 or 2 (Attached screenshot on this occassion shows 2 in visit box but total 5 in Log I'd like to try resolve this so records are correct but dont know best course of action as I'd hate to loose the data so far collected.