### PR TITLE
Plug an Image leak from PictureBoxHotspot

### DIFF
--- a/EDDiscovery/Controls/PictureBoxHotspot.cs
+++ b/EDDiscovery/Controls/PictureBoxHotspot.cs
@@ -206,7 +206,15 @@ namespace ExtendedControls
 
         public void ClearImageList()        // clears the element list, not the image.  call render to do this
         {
-            elements.Clear();
+            if (elements != null && elements.Count >= 1)
+            {
+                foreach (var e in elements)
+                {
+                    e.img?.Dispose();
+                    e.altimg?.Dispose();
+                }
+                elements.Clear();
+            }
         }
 
         public Size DisplaySize()
@@ -227,7 +235,7 @@ namespace ExtendedControls
         public void Render( bool resizecontrol = true , Size? minsize = null , Size? margin = null )          
         {
             Size max = DisplaySize();
-
+            Image?.Dispose();
             if (max.Width > 0 && max.Height > 0 ) // will be zero if no elements
             {
                 elementin = null;
@@ -289,6 +297,21 @@ namespace ExtendedControls
         }
 
         #endregion
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                EnterElement = LeaveElement = ClickElement = null;
+                ClearImageList();
+                elements = null;
+                ClearHoverTip();
+                hovertimer.Dispose();
+                hovertimer = null;
+            }
+            
+            base.Dispose(disposing);
+        }
 
         protected override void OnMouseMove(MouseEventArgs eventargs)
         {

--- a/EDDiscovery/Controls/PictureBoxHotspot.cs
+++ b/EDDiscovery/Controls/PictureBoxHotspot.cs
@@ -212,6 +212,7 @@ namespace ExtendedControls
                 {
                     e.img?.Dispose();
                     e.altimg?.Dispose();
+                    e.tag = null;
                 }
                 elements.Clear();
             }

--- a/EDDiscovery/ImageHandler.cs
+++ b/EDDiscovery/ImageHandler.cs
@@ -733,6 +733,7 @@ namespace EDDiscovery2.ImageHandler
             {
                 SQLiteDBClass.PutSettingBool("ImageHandlerPreview", checkBoxPreview.Checked);
             }
+            pictureBox.Image?.Dispose();
             pictureBox.Image = null;
         }
 


### PR DESCRIPTION
That occured every time a different history entry was selected. Also plug a smaller leak with the mouseover timer (only when closing PBHS panels/exiting), and elsewhere (ImageHandler.cs) when the preview setting gets toggled and an image is already being displayed.