### PR TITLE
WM_MOVE all EM, HT, MF, and WM constants to Win32Constants.cs

### DIFF
--- a/EDDiscovery/Actions/ActionController.cs
+++ b/EDDiscovery/Actions/ActionController.cs
@@ -15,6 +15,7 @@
  */
 using EDDiscovery.DB;
 using EDDiscovery.Forms;
+using EDDiscovery.Win32Constants;
 using EDDiscovery2;
 using System;
 using System.Collections.Generic;
@@ -353,11 +354,6 @@ namespace EDDiscovery.Actions
                 return false;
         }
 
-
-        const int WM_KEYDOWN = 0x100;
-        const int WM_KEYCHAR = 0x102;
-        const int WM_SYSKEYDOWN = 0x104;
-
         private class ActionMessageFilter : IMessageFilter
         {
             EDDiscoveryForm discoveryform;
@@ -370,7 +366,7 @@ namespace EDDiscovery.Actions
 
             public bool PreFilterMessage(ref Message m)
             {
-                if ((m.Msg == WM_KEYDOWN || m.Msg == WM_SYSKEYDOWN) && discoveryform.CanFocus)
+                if ((m.Msg == WM.KEYDOWN || m.Msg == WM.SYSKEYDOWN) && discoveryform.CanFocus)
                 {
                     Keys k = (Keys)m.WParam;
                     if (k != Keys.ControlKey && k != Keys.ShiftKey && k != Keys.Menu)

--- a/EDDiscovery/Actions/ActionProgramForm.cs
+++ b/EDDiscovery/Actions/ActionProgramForm.cs
@@ -13,6 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -828,24 +829,6 @@ namespace EDDiscovery.Actions
 
         #region Window Control
 
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_LEFT = 0xA;
-        public const int HT_RIGHT = 0xB;
-        public const int HT_BOTTOM = 0xF;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
-
         // Mono compatibility
         private bool _window_dragging = false;
         private Point _window_dragMousePos = Point.Empty;
@@ -862,7 +845,7 @@ namespace EDDiscovery.Actions
         {
             bool windowsborder = this.FormBorderStyle == FormBorderStyle.Sizable;
             // Compatibility movement for Mono
-            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
+            if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -872,7 +855,7 @@ namespace EDDiscovery.Actions
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -882,7 +865,7 @@ namespace EDDiscovery.Actions
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -891,11 +874,11 @@ namespace EDDiscovery.Actions
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -903,23 +886,23 @@ namespace EDDiscovery.Actions
 
                     if (p.X > this.ClientSize.Width - statusStripCustom.Height && p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOM;
+                        m.Result = (IntPtr)HT.BOTTOM;
                     }
                     else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     {
-                        m.Result = (IntPtr)HT_RIGHT;
+                        m.Result = (IntPtr)HT.RIGHT;
                     }
                     else if (p.X < 5)
                     {
-                        m.Result = (IntPtr)HT_LEFT;
+                        m.Result = (IntPtr)HT.LEFT;
                     }
                     else if (!windowsborder)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
                 }
             }
@@ -932,7 +915,7 @@ namespace EDDiscovery.Actions
         private void label_index_MouseDown(object sender, MouseEventArgs e)
         {
             ((Control)sender).Capture = false;
-            SendMessage(WM_NCLBUTTONDOWN, (System.IntPtr)HT_CAPTION, (System.IntPtr)0);
+            SendMessage(WM.NCLBUTTONDOWN, (IntPtr)HT.CAPTION, IntPtr.Zero);
         }
 
         private void panel_minimize_Click(object sender, EventArgs e)

--- a/EDDiscovery/Conditions/ConditionFilterForm.cs
+++ b/EDDiscovery/Conditions/ConditionFilterForm.cs
@@ -16,6 +16,7 @@
 using EDDiscovery;
 using EDDiscovery.Actions;
 using EDDiscovery.DB;
+using EDDiscovery.Win32Constants;
 using EDDiscovery2;
 using System;
 using System.Collections.Generic;
@@ -1002,24 +1003,6 @@ namespace EDDiscovery2
 
 #region Window Control
 
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_LEFT = 0xA;
-        public const int HT_RIGHT = 0xB;
-        public const int HT_BOTTOM = 0xF;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
-
         // Mono compatibility
         private bool _window_dragging = false;
         private Point _window_dragMousePos = Point.Empty;
@@ -1036,7 +1019,7 @@ namespace EDDiscovery2
         {
             bool windowsborder = this.FormBorderStyle == FormBorderStyle.Sizable;
             // Compatibility movement for Mono
-            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
+            if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -1046,7 +1029,7 @@ namespace EDDiscovery2
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -1056,7 +1039,7 @@ namespace EDDiscovery2
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -1065,11 +1048,11 @@ namespace EDDiscovery2
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -1077,23 +1060,23 @@ namespace EDDiscovery2
 
                     if (p.X > this.ClientSize.Width - statusStripCustom.Height && p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOM;
+                        m.Result = (IntPtr)HT.BOTTOM;
                     }
                     else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     {
-                        m.Result = (IntPtr)HT_RIGHT;
+                        m.Result = (IntPtr)HT.RIGHT;
                     }
                     else if (p.X < 5)
                     {
-                        m.Result = (IntPtr)HT_LEFT;
+                        m.Result = (IntPtr)HT.LEFT;
                     }
                     else if (!windowsborder)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
                 }
             }
@@ -1106,7 +1089,7 @@ namespace EDDiscovery2
         private void label_index_MouseDown(object sender, MouseEventArgs e)
         {
             ((Control)sender).Capture = false;
-            SendMessage(WM_NCLBUTTONDOWN,(System.IntPtr)HT_CAPTION, (System.IntPtr)0);
+            SendMessage(WM.NCLBUTTONDOWN, (IntPtr)HT.CAPTION, IntPtr.Zero);
         }
 
         private void panel_minimize_Click(object sender, EventArgs e)

--- a/EDDiscovery/Conditions/ConditionVariablesForm.cs
+++ b/EDDiscovery/Conditions/ConditionVariablesForm.cs
@@ -13,6 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -254,24 +255,6 @@ namespace EDDiscovery
 
         #region Window Control
 
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_LEFT = 0xA;
-        public const int HT_RIGHT = 0xB;
-        public const int HT_BOTTOM = 0xF;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
-
         // Mono compatibility
         private bool _window_dragging = false;
         private Point _window_dragMousePos = Point.Empty;
@@ -288,7 +271,7 @@ namespace EDDiscovery
         {
             bool windowsborder = this.FormBorderStyle == FormBorderStyle.Sizable;
             // Compatibility movement for Mono
-            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
+            if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -298,7 +281,7 @@ namespace EDDiscovery
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -308,7 +291,7 @@ namespace EDDiscovery
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -317,11 +300,11 @@ namespace EDDiscovery
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -329,23 +312,23 @@ namespace EDDiscovery
 
                     if (p.X > this.ClientSize.Width - statusStripCustom.Height && p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOM;
+                        m.Result = (IntPtr)HT.BOTTOM;
                     }
                     else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     {
-                        m.Result = (IntPtr)HT_RIGHT;
+                        m.Result = (IntPtr)HT.RIGHT;
                     }
                     else if (p.X < 5)
                     {
-                        m.Result = (IntPtr)HT_LEFT;
+                        m.Result = (IntPtr)HT.LEFT;
                     }
                     else if (!windowsborder)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
                 }
             }
@@ -358,7 +341,7 @@ namespace EDDiscovery
         private void label_index_MouseDown(object sender, MouseEventArgs e)
         {
             ((Control)sender).Capture = false;
-            SendMessage(WM_NCLBUTTONDOWN, (System.IntPtr)HT_CAPTION, (System.IntPtr)0);
+            SendMessage(WM.NCLBUTTONDOWN, (IntPtr)HT.CAPTION, IntPtr.Zero);
         }
 
         private void panel_minimize_Click(object sender, EventArgs e)

--- a/EDDiscovery/Controls/RichTextBoxScroll.cs
+++ b/EDDiscovery/Controls/RichTextBoxScroll.cs
@@ -13,6 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -165,7 +166,7 @@ namespace ExtendedControls
             int textboxclienth = ClientRectangle.Height - bordersize * 2;       // border is within Client area
             int linesinbox = EstimateLinesInBox(textboxclienth);
 
-            int firstVisibleLine = unchecked((int)(long)TextBox.SendMessage(EM_GETFIRSTVISIBLELINE, (IntPtr)0, (IntPtr)0));
+            int firstVisibleLine = unchecked((int)(long)TextBox.SendMessage(EM.GETFIRSTVISIBLELINE, IntPtr.Zero, IntPtr.Zero));
             ScrollBar.SetValueMaximumLargeChange(firstVisibleLine, LineCount - 1, linesinbox);
 
             visibleonlayout = ScrollBar.IsScrollBarOn || DesignMode || !HideScrollBar;  // Hide must be on, or in design mode, or scroll bar is on due to values
@@ -187,7 +188,7 @@ namespace ExtendedControls
             int textboxclienth = ClientRectangle.Height - bordersize * 2;
             int linesinbox = EstimateLinesInBox(textboxclienth);
 
-            int firstVisibleLine = unchecked((int)(long)TextBox.SendMessage(EM_GETFIRSTVISIBLELINE, (IntPtr)0, (IntPtr)0));
+            int firstVisibleLine = unchecked((int)(long)TextBox.SendMessage(EM.GETFIRSTVISIBLELINE, IntPtr.Zero, IntPtr.Zero));
 
             //System.Diagnostics.Debug.WriteLine("Scroll State Lines: " + LineCount+ " FVL: " + firstVisibleLine + " textlines " + textboxlinesestimate);
 
@@ -222,10 +223,6 @@ namespace ExtendedControls
             return pixels;
         }
 
-        const int EM_GETFIRSTVISIBLELINE = 0x00CE;
-        const int EM_LINESCROLL = 0x00B6;
-        const int EM_GETLINECOUNT = 0x00BA;
-
         protected virtual void OnVscrollChanged(object sender, EventArgs e) // comes from TextBox, update scroll..
         {
             UpdateScrollBar();
@@ -244,14 +241,14 @@ namespace ExtendedControls
 
         private void ScrollToBar()              // from the scrollbar, scroll first line to value
         {
-            int firstVisibleLine = unchecked((int)(long)TextBox.SendMessage(EM_GETFIRSTVISIBLELINE, (IntPtr)0, (IntPtr)0));
+            int firstVisibleLine = unchecked((int)(long)TextBox.SendMessage(EM.GETFIRSTVISIBLELINE, IntPtr.Zero, IntPtr.Zero));
             int scrollvalue = ScrollBar.Value;
             int delta = scrollvalue - firstVisibleLine;
 
             //Console.WriteLine("Scroll Bar:" + scrollvalue + " FVL: " + firstVisibleLine + " delta " + delta);
             if (delta != 0)
             {
-                TextBox.SendMessage(EM_LINESCROLL, (IntPtr)0, (IntPtr)(scrollvalue - firstVisibleLine));
+                TextBox.SendMessage(EM.LINESCROLL, IntPtr.Zero, (IntPtr)(scrollvalue - firstVisibleLine));
             }
         }
 

--- a/EDDiscovery/Controls/StatusStripCustom.cs
+++ b/EDDiscovery/Controls/StatusStripCustom.cs
@@ -13,6 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,25 +25,18 @@ namespace ExtendedControls
 {
     public class StatusStripCustom : StatusStrip
     {
-        public const int WM_NCHITTEST = 0x84;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int HT_TRANSPARENT = -1;
-
         protected override void WndProc(ref Message m)
         {
             base.WndProc(ref m);
 
-            if (m.Msg == WM_NCHITTEST)
+            if (m.Msg == WM.NCHITTEST)
             {
-                if ((int)m.Result == HT_BOTTOMRIGHT)
+                if ((int)m.Result == HT.BOTTOMRIGHT)
                 {
                     // Tell the system to test the parent
-                    m.Result = (IntPtr)HT_TRANSPARENT;
+                    m.Result = (IntPtr)HT.TRANSPARENT;
                 }
-                else if ((int)m.Result == HT_CLIENT)
+                else if ((int)m.Result == HT.CLIENT)
                 {
                     // Work around the implementation returning HT_CLIENT instead of HT_BOTTOMRIGHT
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
@@ -52,7 +46,7 @@ namespace ExtendedControls
                     if (p.X >= this.ClientSize.Width - this.ClientSize.Height || p.Y >= this.ClientSize.Height - 5) // corner, or bottom strip
                     {
                         // Tell the system to test the parent
-                        m.Result = (IntPtr)HT_TRANSPARENT;
+                        m.Result = (IntPtr)HT.TRANSPARENT;
                     }
                 }
             }

--- a/EDDiscovery/Controls/TabControlCustom.cs
+++ b/EDDiscovery/Controls/TabControlCustom.cs
@@ -13,6 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -78,9 +79,6 @@ namespace ExtendedControls
             Invalidate();           // and repaint
         }
 
-        public const int WM_SETFONT = 0x30;
-        public const int WM_FONTCHANGE = 0x1d;
-
         private IntPtr SendMessage(int msg, IntPtr wparam, IntPtr lparam)
         {
             Message message = Message.Create(this.Handle, msg, wparam, lparam);
@@ -94,8 +92,8 @@ namespace ExtendedControls
                                 ControlStyles.Opaque | ControlStyles.ResizeRedraw, (fs != FlatStyle.System));
 
             // asking for a font set seems to make it set size better during start up
-            SendMessage(WM_SETFONT, (IntPtr)this.Font.ToHfont(), (IntPtr)(-1));
-            SendMessage(WM_FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
+            SendMessage(WM.SETFONT, (IntPtr)this.Font.ToHfont(), (IntPtr)(-1));
+            SendMessage(WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
 
             flatstyle = fs;
             CleanUp();              // start afresh

--- a/EDDiscovery/Controls/TextBoxBorder.cs
+++ b/EDDiscovery/Controls/TextBoxBorder.cs
@@ -13,6 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,13 +34,11 @@ namespace ExtendedControls
         {
         }
 
-        private const int WM_PAINT = 15;
-
         protected override void WndProc(ref Message m)
         {
             base.WndProc(ref m);
 
-            if (m.Msg == WM_PAINT)          // Stupid control does not have a OnPaint
+            if (m.Msg == WM.PAINT)          // Stupid control does not have a OnPaint
             {
                 if (BorderColor != Color.Transparent)
                 {

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -813,6 +813,7 @@
       <DependentUpon>UserControlTrippanel.cs</DependentUpon>
     </Compile>
     <Compile Include="Vector3.cs" />
+    <Compile Include="Win32Constants.cs" />
     <Content Include="AppConfigLocal.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -14,6 +14,13 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using EDDiscovery.DB;
+using EDDiscovery.EDDN;
+using EDDiscovery.EDSM;
+using EDDiscovery.EliteDangerous;
+using EDDiscovery.EliteDangerous.JournalEvents;
+using EDDiscovery.Forms;
+using EDDiscovery.HTTP;
+using EDDiscovery.Win32Constants;
 using EDDiscovery2;
 using EDDiscovery2.DB;
 using EDDiscovery2.EDSM;
@@ -21,6 +28,8 @@ using EDDiscovery2.Forms;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
@@ -30,44 +39,18 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Threading;
-using System.Windows.Forms;
 using System.Runtime.InteropServices;
-using System.Configuration;
-using EDDiscovery.EDSM;
-using System.Threading.Tasks;
 using System.Text;
-using System.ComponentModel;
 using System.Text.RegularExpressions;
-using EDDiscovery.HTTP;
-using EDDiscovery.Forms;
-using EDDiscovery.EliteDangerous;
-using EDDiscovery.EliteDangerous.JournalEvents;
-using EDDiscovery.EDDN;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace EDDiscovery
 {
     public partial class EDDiscoveryForm : Form, IDiscoveryController
     {
         #region Variables
-
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_LEFT = 0xA;
-        public const int HT_RIGHT = 0xB;
-        public const int HT_BOTTOM = 0xF;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
 
         // Mono compatibility
         private bool _window_dragging = false;
@@ -938,7 +921,7 @@ namespace EDDiscovery
         protected override void WndProc(ref Message m)
         {
             // Compatibility movement for Mono
-            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !theme.WindowsFrame)
+            if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !theme.WindowsFrame)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -948,7 +931,7 @@ namespace EDDiscovery
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -958,7 +941,7 @@ namespace EDDiscovery
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -967,12 +950,12 @@ namespace EDDiscovery
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
                 //System.Diagnostics.Debug.WriteLine( Environment.TickCount + " Res " + ((int)m.Result));
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -980,23 +963,23 @@ namespace EDDiscovery
 
                     if (p.X > this.ClientSize.Width - statusStrip1.Height && p.Y > this.ClientSize.Height - statusStrip1.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (p.Y > this.ClientSize.Height - statusStrip1.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOM;
+                        m.Result = (IntPtr)HT.BOTTOM;
                     }
                     else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     {
-                        m.Result = (IntPtr)HT_RIGHT;
+                        m.Result = (IntPtr)HT.RIGHT;
                     }
                     else if (p.X < 5)
                     {
-                        m.Result = (IntPtr)HT_LEFT;
+                        m.Result = (IntPtr)HT.LEFT;
                     }
                     else if (!theme.WindowsFrame)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
                 }
             }

--- a/EDDiscovery/Forms/DownloadManagerForm.cs
+++ b/EDDiscovery/Forms/DownloadManagerForm.cs
@@ -20,17 +20,18 @@
 #define GITHUBDOWNLOAD
 // turn this on only for releasing
 
+using EDDiscovery.HTTP;
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using EDDiscovery.HTTP;
-using System.IO;
 
 namespace EDDiscovery.Forms
 {
@@ -367,24 +368,6 @@ namespace EDDiscovery.Forms
 
 #region Window Control
 
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_LEFT = 0xA;
-        public const int HT_RIGHT = 0xB;
-        public const int HT_BOTTOM = 0xF;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
-
         // Mono compatibility
         private bool _window_dragging = false;
         private Point _window_dragMousePos = Point.Empty;
@@ -401,7 +384,7 @@ namespace EDDiscovery.Forms
         {
             bool windowsborder = this.FormBorderStyle == FormBorderStyle.Sizable;
             // Compatibility movement for Mono
-            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
+            if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -411,7 +394,7 @@ namespace EDDiscovery.Forms
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -421,7 +404,7 @@ namespace EDDiscovery.Forms
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -430,11 +413,11 @@ namespace EDDiscovery.Forms
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -442,23 +425,23 @@ namespace EDDiscovery.Forms
 
                     if (p.X > this.ClientSize.Width - statusStripCustom.Height && p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (p.Y > this.ClientSize.Height - statusStripCustom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOM;
+                        m.Result = (IntPtr)HT.BOTTOM;
                     }
                     else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     {
-                        m.Result = (IntPtr)HT_RIGHT;
+                        m.Result = (IntPtr)HT.RIGHT;
                     }
                     else if (p.X < 5)
                     {
-                        m.Result = (IntPtr)HT_LEFT;
+                        m.Result = (IntPtr)HT.LEFT;
                     }
                     else if (!windowsborder)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
                 }
             }
@@ -471,7 +454,7 @@ namespace EDDiscovery.Forms
         private void label_index_MouseDown(object sender, MouseEventArgs e)
         {
             ((Control)sender).Capture = false;
-            SendMessage(WM_NCLBUTTONDOWN, (System.IntPtr)HT_CAPTION, (System.IntPtr)0);
+            SendMessage(WM.NCLBUTTONDOWN, (IntPtr)HT.CAPTION, IntPtr.Zero);
         }
 
         private void panel_minimize_Click(object sender, EventArgs e)

--- a/EDDiscovery/Forms/TabControlForm.cs
+++ b/EDDiscovery/Forms/TabControlForm.cs
@@ -15,6 +15,7 @@
  */
 using EDDiscovery.DB;
 using EDDiscovery.UserControls;
+using EDDiscovery.Win32Constants;
 using ExtendedControls;
 using System;
 using System.Collections.Generic;
@@ -216,21 +217,6 @@ namespace EDDiscovery2
             }
         }
 
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
-
         private IntPtr SendMessage(int msg, IntPtr wparam, IntPtr lparam)
         {
             Message message = Message.Create(this.Handle, msg, wparam, lparam);
@@ -246,7 +232,7 @@ namespace EDDiscovery2
         protected override void WndProc(ref Message m)
         {
             // Compatibility movement for Mono
-            if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
+            if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !windowsborder)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -256,7 +242,7 @@ namespace EDDiscovery2
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -266,7 +252,7 @@ namespace EDDiscovery2
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -275,11 +261,11 @@ namespace EDDiscovery2
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -287,11 +273,11 @@ namespace EDDiscovery2
 
                     if (p.X > this.ClientSize.Width - statusStripCustom1.Height && p.Y > this.ClientSize.Height - statusStripCustom1.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (!windowsborder)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
                 }
             }

--- a/EDDiscovery/Forms/UserControlForm.cs
+++ b/EDDiscovery/Forms/UserControlForm.cs
@@ -15,6 +15,7 @@
  */
 using EDDiscovery.DB;
 using EDDiscovery.UserControls;
+using EDDiscovery.Win32Constants;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -385,16 +386,15 @@ namespace EDDiscovery.Forms
 
         #region Low level Wndproc
 
-        private const int MF_SEPARATOR = 0x800;
-        private const int MF_STRING = 0x0;
-        private int SYSMENU_ONTOP = 0x1;
-        private int SYSMENU_TRANSPARENT = 0x2;
-        private int SYSMENU_TASKBAR = 0x3;
-        private const int WM_SYSCOMMAND = 0x112;
+        private const int SYSMENU_ONTOP = 0x1;
+        private const int SYSMENU_TRANSPARENT = 0x2;
+        private const int SYSMENU_TASKBAR = 0x3;
 
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms647985(v=vs.85).aspx
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
 
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms647616(v=vs.85).aspx
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         private static extern bool AppendMenu(IntPtr hMenu, int uFlags, int uIDNewItem, string lpNewItem);
 
@@ -411,35 +411,18 @@ namespace EDDiscovery.Forms
             {
                 // Get a handle to a copy of this form's system (window) menu
                 IntPtr hSysMenu = GetSystemMenu(this.Handle, false);
+                if (hSysMenu != IntPtr.Zero)
+                {
+                    // Add a separator
+                    AppendMenu(hSysMenu, MF.SEPARATOR, 0, string.Empty);
 
-                // Add a separator
-                AppendMenu(hSysMenu, MF_SEPARATOR, 0, string.Empty);
-
-                // Add the About menu item
-                AppendMenu(hSysMenu, MF_STRING, SYSMENU_ONTOP, "&On Top");
-                AppendMenu(hSysMenu, MF_STRING, SYSMENU_TRANSPARENT, "&Transparent");
-                AppendMenu(hSysMenu, MF_STRING, SYSMENU_TASKBAR, "Show icon in Task&Bar for window");
+                    // Add the About menu item
+                    AppendMenu(hSysMenu, MF.STRING, SYSMENU_ONTOP, "&On Top");
+                    AppendMenu(hSysMenu, MF.STRING, SYSMENU_TRANSPARENT, "&Transparent");
+                    AppendMenu(hSysMenu, MF.STRING, SYSMENU_TASKBAR, "Show icon in Task&Bar for window");
+                }
             }
         }
-
-
-        public const int WM_MOVE = 3;
-        public const int WM_SIZE = 5;
-        public const int WM_MOUSEMOVE = 0x200;
-        public const int WM_LBUTTONDOWN = 0x201;
-        public const int WM_LBUTTONUP = 0x202;
-        public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int WM_NCLBUTTONUP = 0xA2;
-        public const int WM_NCMOUSEMOVE = 0xA0;
-        public const int HT_CLIENT = 0x1;
-        public const int HT_CAPTION = 0x2;
-        public const int HT_LEFT = 0xA;
-        public const int HT_RIGHT = 0xB;
-        public const int HT_BOTTOM = 0xF;
-        public const int HT_BOTTOMRIGHT = 0x11;
-        public const int WM_NCL_RESIZE = 0x112;
-        public const int HT_RESIZE = 61448;
-        public const int WM_NCHITTEST = 0x84;
 
         private IntPtr SendMessage(int msg, IntPtr wparam, IntPtr lparam)
         {
@@ -456,7 +439,7 @@ namespace EDDiscovery.Forms
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == WM_SYSCOMMAND)
+            if (m.Msg == WM.SYSCOMMAND)
             {
                 int cmd = (int)m.WParam;
                 if (cmd == SYSMENU_ONTOP)
@@ -480,7 +463,7 @@ namespace EDDiscovery.Forms
                     base.WndProc(ref m);
             }
             // Compatibility movement for Mono
-            else if (m.Msg == WM_LBUTTONDOWN && (int)m.WParam == 1 && !curwindowsborder)
+            else if (m.Msg == WM.LBUTTONDOWN && (int)m.WParam == 1 && !curwindowsborder)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -490,7 +473,7 @@ namespace EDDiscovery.Forms
                 m.Result = IntPtr.Zero;
                 this.Capture = true;
             }
-            else if (m.Msg == WM_MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
+            else if (m.Msg == WM.MOUSEMOVE && (int)m.WParam == 1 && _window_dragging)
             {
                 int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                 int y = unchecked((short)((uint)m.LParam >> 16));
@@ -500,7 +483,7 @@ namespace EDDiscovery.Forms
                 this.Update();
                 m.Result = IntPtr.Zero;
             }
-            else if (m.Msg == WM_LBUTTONUP)
+            else if (m.Msg == WM.LBUTTONUP)
             {
                 _window_dragging = false;
                 _window_dragMousePos = Point.Empty;
@@ -509,11 +492,11 @@ namespace EDDiscovery.Forms
                 this.Capture = false;
             }
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM_NCHITTEST)
+            else if (m.Msg == WM.NCHITTEST)
             {
                 base.WndProc(ref m);
 
-                if ((int)m.Result == HT_CLIENT)
+                if ((int)m.Result == HT.CLIENT)
                 {
                     int x = unchecked((short)((uint)m.LParam & 0xFFFF));
                     int y = unchecked((short)((uint)m.LParam >> 16));
@@ -521,23 +504,23 @@ namespace EDDiscovery.Forms
 
                     if (p.X > this.ClientSize.Width - statusStripBottom.Height && p.Y > this.ClientSize.Height - statusStripBottom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOMRIGHT;
+                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
                     }
                     else if (p.Y > this.ClientSize.Height - statusStripBottom.Height)
                     {
-                        m.Result = (IntPtr)HT_BOTTOM;
+                        m.Result = (IntPtr)HT.BOTTOM;
                     }
                     else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     {
-                        m.Result = (IntPtr)HT_RIGHT;
+                        m.Result = (IntPtr)HT.RIGHT;
                     }
                     else if (p.X < 5)
                     {
-                        m.Result = (IntPtr)HT_LEFT;
+                        m.Result = (IntPtr)HT.LEFT;
                     }
                     else if (!curwindowsborder)
                     {
-                        m.Result = (IntPtr)HT_CAPTION;
+                        m.Result = (IntPtr)HT.CAPTION;
                     }
 
                 }
@@ -551,7 +534,7 @@ namespace EDDiscovery.Forms
         private void panelTop_MouseDown(object sender, MouseEventArgs e)
         {
             ((Control)sender).Capture = false;
-            SendMessage(WM_NCLBUTTONDOWN, (System.IntPtr)HT_CAPTION, (System.IntPtr)0);
+            SendMessage(WM.NCLBUTTONDOWN, (IntPtr)HT.CAPTION, IntPtr.Zero);
         }
 
         #endregion

--- a/EDDiscovery/Win32Constants.cs
+++ b/EDDiscovery/Win32Constants.cs
@@ -1,0 +1,245 @@
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+
+namespace EDDiscovery.Win32Constants
+{
+    /// <summary>
+    /// Edit control message constants, as defined in Winuser.h (via Windows.h).
+    /// </summary>
+    /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ff485923(v=vs.85).aspx"/>
+    public static class EM
+    {
+        /// <summary>
+        /// EM_LINESCROLL message: Scrolls the text in a multiline edit control.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb761615(v=vs.85).aspx"/>
+        public const int LINESCROLL = 0x00B6;
+
+        /// <summary>
+        /// EM_GETLINECOUNT message: Gets the number of lines in a multiline edit control.You can send this message
+        /// to either an edit control or a rich edit control.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb761586(v=vs.85).aspx"/>
+        public const int GETLINECOUNT = 0x00BA;
+
+        /// <summary>
+        /// EM_GETFIRSTVISIBLELINE message: Gets the zero-based index of the uppermost visible line in a multiline
+        /// edit control. You can send this message to either an edit control or a rich edit control.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb761574(v=vs.85).aspx"/>
+        public const int GETFIRSTVISIBLELINE = 0x00CE;
+    }
+
+    /// <summary>
+    /// <see cref="WM.NCHITTEST"/> message result constants, as defined in Winuser.h (via Windowsx.h).
+    /// </summary>
+    /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645618(v=vs.85).aspx"/>
+    /// <seealso href="http://www.pinvoke.net/default.aspx/Structures/HitTestValues.html"/>
+    public static class HT
+    {
+        /// <summary>
+        /// HTERROR means the coordinates are on the screen background or on a dividing line between windows (same as HTNOWHERE,
+        /// except that the DefWindowProc function produces a system beep to indicate an error).
+        /// </summary>
+        public const int ERROR = -2;
+
+        /// <summary>
+        /// HTTRANSPARENT means that the window is currently obscured by another window in the same thread. The message
+        /// will be sent to the underlying windows in the same thread until one returns a result other than HTTRANSPARENT.
+        /// </summary>
+        public const int TRANSPARENT = -1;
+
+        /// <summary>
+        /// HTNOWHERE means the coordinates are on the screen background or on a dividing line between windows.
+        /// </summary>
+        public const int NOWHERE = 0;
+
+        /// <summary>
+        /// HTCLIENT means the coordinates are in the client area.
+        /// </summary>
+        public const int CLIENT = 1;
+
+        /// <summary>
+        /// HTCAPTION means the coordinates are in a title bar.
+        /// </summary>
+        public const int CAPTION = 2;
+
+        /// <summary>
+        /// HTLEFT means the coordinates are in the left border of a resizable window.
+        /// </summary>
+        public const int LEFT = 10;
+
+        /// <summary>
+        /// HTRIGHT means the coordinates are in the right border of a resizable window.
+        /// </summary>
+        public const int RIGHT = 11;
+
+        /// <summary>
+        /// HTBOTTOM means the coordinates are in the lower-horizontal border of a resizable window.
+        /// </summary>
+        public const int BOTTOM = 15;
+
+        /// <summary>
+        /// HTBOTTOMRIGHT means the coordinates are in the lower-right corner of a border of a resizable window.
+        /// </summary>
+        public const int BOTTOMRIGHT = 17;
+    }
+
+    /// <summary>
+    /// Menu flag constants for use with AppendMenu, InsertMenuItem, etc. win32 calls, as defined in Winuser.h (via Windows.h).
+    /// </summary>
+    /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms647616(v=vs.85).aspx"/>
+    public static class MF
+    {
+        /// <summary>
+        /// MF_STRING: the menu item contains a string (conflicts with MF_BITMAP and/or MF_OWNERDRAW).
+        /// </summary>
+        public const int STRING = 0x00000000;
+
+        /// <summary>
+        /// MF_SEPARATOR: draws a horizontal dividing line. This flag is used only in a drop-down menu, submenu, or shortcut menu. The line cannot
+        /// be grayed, disabled, or highlighted.
+        /// </summary>
+        public const int SEPARATOR = 0x00000800;
+    }
+
+    /// <summary>
+    /// Windows message identifier constants, as defined in Winuser.h (via Windows.h) and as (mostly) implemented in Mono.
+    /// </summary>
+    /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms644927(v=vs.85).aspx"/>
+    /// <seealso href="http://www.pinvoke.net/default.aspx/Constants.WM"/>
+    public static class WM
+    {
+        /// <summary>
+        /// The WM_MOVE message is sent after a window has been moved.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms632631(v=vs.85).aspx"/>
+        public const int MOVE = 0x0003;
+
+        /// <summary>
+        /// The WM_SIZE message is sent to a window after its size has changed.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms632646(v=vs.85).aspx"/>
+        public const int SIZE = 0x0005;
+
+        /// <summary>
+        /// The WM_PAINT message is sent to a window or control when it needs to be repainted.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd145213(v=vs.85).aspx"/>
+        public const int PAINT = 0x000F;
+
+        /// <summary>
+        /// An application sends the WM_FONTCHANGE message to all top-level windows in the system after changing the
+        /// pool of font resources.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd145211(v=vs.85).aspx"/>
+        public const int FONTCHANGE = 0x001D;
+
+        /// <summary>
+        /// An application sends a WM_SETFONT message to specify the font that a control is to use when drawing text.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms632642(v=vs.85).aspx"/>
+        public const int SETFONT = 0x0030;
+
+        /// <summary>
+        /// The WM_NCHITTEST message is sent to a window when the cursor moves, or when a mouse button is pressed or
+        /// released. If the mouse is not captured, the message is sent to the window beneath the cursor. Otherwise,
+        /// the message is sent to the window that has captured the mouse.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645618(v=vs.85).aspx"/>
+        public const int NCHITTEST = 0x0084;
+
+        /// <summary>
+        /// The WM_NCMOUSEMOVE message is posted to a window when the cursor is moved within the nonclient area of the
+        /// window. This message is posted to the window that contains the cursor. If a window has captured the mouse,
+        /// this message is not posted.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645627(v=vs.85).aspx"/>
+        public const int NCMOUSEMOVE = 0x00A0;
+
+        /// <summary>
+        /// The WM_NCLBUTTONDOWN message is posted when the user presses the left mouse button while the cursor is
+        /// within the nonclient area of a window. This message is posted to the window that contains the cursor. If a
+        /// window has captured the mouse, this message is not posted.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645620(v=vs.85).aspx"/>
+        public const int NCLBUTTONDOWN = 0x00A1;
+
+        /// <summary>
+        /// The WM_NCLBUTTONUP message is posted when the user releases the left mouse button while the cursor is
+        /// within the nonclient area of a window. This message is posted to the window that contains the cursor.
+        /// If a window has captured the mouse, this message is not posted.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645621(v=vs.85).aspx"/>
+        public const int NCLBUTTONUP = 0x00A2;
+
+        /// <summary>
+        /// The WM_KEYDOWN message is posted to the window with the keyboard focus when a nonsystem key is pressed.
+        /// A nonsystem key is a key that is pressed when the ALT key is not pressed.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms646280(v=vs.85).aspx"/>
+        public const int KEYDOWN = 0x0100;
+
+        /// <summary>
+        /// The WM_CHAR message is posted to the window with the keyboard focus when a WM_KEYDOWN message is translated
+        /// by the TranslateMessage function. The WM_CHAR message contains the character code of the key that was pressed.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms646276(v=vs.85).aspx"/>
+        public const int CHAR = 0x0102;
+
+        /// <summary>
+        /// The WM_SYSKEYDOWN message is posted to the window with the keyboard focus when the user presses the F10
+        /// key (which activates the menu bar) or holds down the ALT key and then presses another key. It also occurs
+        /// when no window currently has the keyboard focus; in this case, the WM_SYSKEYDOWN message is sent to the
+        /// active window. The window that receives the message can distinguish between these two contexts by checking
+        /// the context code in the lParam parameter.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms646286(v=vs.85).aspx"/>
+        public const int SYSKEYDOWN = 0x0104;
+
+        /// <summary>
+        /// The WM_SYSCOMMAND message is posted to the window when the user chooses a command from the Window menu
+        /// (formerly known as the system or control menu) or when the user chooses the maximize button, minimize
+        /// button, restore button, or close button.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms646360(v=vs.85).aspx"/>
+        public const int SYSCOMMAND = 0x0112;
+
+        /// <summary>
+        /// The WM_MOUSEMOVE message is posted to a window when the cursor moves. If the mouse is not captured, the
+        /// message is posted to the window that contains the cursor. Otherwise, the message is posted to the window
+        /// that has captured the mouse.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645616(v=vs.85).aspx"/>
+        public const int MOUSEMOVE = 0x0200;
+
+        /// <summary>
+        /// The WM_LBUTTONDOWN message is posted when the user presses the left mouse button while the cursor is in the
+        /// client area of a window. If the mouse is not captured, the message is posted to the window beneath the
+        /// cursor. Otherwise, the message is posted to the window that has captured the mouse.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645607(v=vs.85).aspx"/>
+        public const int LBUTTONDOWN = 0x0201;
+
+        /// <summary>
+        /// The WM_LBUTTONUP message is posted when the user releases the left mouse button while the cursor is in the
+        /// client area of a window. If the mouse is not captured, the message is posted to the window beneath the
+        /// cursor. Otherwise, the message is posted to the window that has captured the mouse.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645608(v=vs.85).aspx"/>
+        public const int LBUTTONUP = 0x0202;
+    }
+}


### PR DESCRIPTION
This greatly cleans up a number of classes that all had this information duplicated, and it now even comes with documentation.

Numerous `(IntPtr)0` to `IntPtr.Zero` changes throughout to improve readability and save 4/8 bytes heap each time.

UserControlForm:
- Don't bother using `AppendMenu()` if `GetSystemMenu()` failed (such as when the theme has disabled the window frame).
- Make SYSMENU_ items const.

Hey look, I even got the copyright notice correct! :-)

Just for my record, the TabControlCustom MinimumTabWidth const is apparantly defined in CommCtrl.h:
```cpp
#define TCM_FIRST 0x1300
#define TCM_SETMINTABWIDTH (TCM_FIRST + 49)
```