### PR TITLE
Replace some reflection with interfaces and delegates

### DIFF
--- a/EDDiscovery/DB/MaterialCommodities.cs
+++ b/EDDiscovery/DB/MaterialCommodities.cs
@@ -587,17 +587,13 @@ namespace EDDiscovery2.DB
 
         public void Process(JournalEntry je, SQLiteConnectionUser conn )
         {
-            Type jtype = JournalEntry.TypeOfJournalEntry(je.EventTypeStr);
-
-            if (jtype != null)
+            if (je is ILedgerJournalEntry)
             {
-                System.Reflection.MethodInfo m = jtype.GetMethod("Ledger"); // see if the class defines this function..
-
-                if (m == null)
-                    m = jtype.GetMethod("LedgerNC"); // see if the class defines this function..
-
-                if (m!=null)
-                    m.Invoke(Convert.ChangeType(je, jtype), new Object[] { this, conn });
+                ((ILedgerJournalEntry)je).Ledger(this, conn);
+            }
+            else if (je is ILedgerNoCashJournalEntry)
+            {
+                ((ILedgerNoCashJournalEntry)je).LedgerNC(this, conn);
             }
         }
 

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -291,6 +291,7 @@
     <Compile Include="DB\SQLiteConnectionUser.cs" />
     <Compile Include="DB\TargetClass.cs" />
     <Compile Include="EDDiscoveryController.cs" />
+    <Compile Include="EliteDangerous\JournalEntryAttributes.cs" />
     <Compile Include="EliteDangerous\JournalEntryInterfaces.cs" />
     <Compile Include="ExportImport\ExportSphereSystems.cs" />
     <Compile Include="Forms\DownloadManagerForm.cs">

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -291,7 +291,7 @@
     <Compile Include="DB\SQLiteConnectionUser.cs" />
     <Compile Include="DB\TargetClass.cs" />
     <Compile Include="EDDiscoveryController.cs" />
-    <Compile Include="EliteDangerous\IMaterialCommodityJournalEvent.cs" />
+    <Compile Include="EliteDangerous\JournalEntryInterfaces.cs" />
     <Compile Include="ExportImport\ExportSphereSystems.cs" />
     <Compile Include="Forms\DownloadManagerForm.cs">
       <SubType>Form</SubType>

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -1002,6 +1002,11 @@ namespace EDDiscovery.EliteDangerous
                 return (JournalEntry)Activator.CreateInstance(jtype, jo);
         }
 
+        public virtual System.Drawing.Bitmap GetIcon()
+        {
+            return GetIcon(this.EventTypeID);
+        }
+
         static public System.Drawing.Bitmap GetIcon(JournalTypeEnum eventtype, string seltext = null)    // get ICON associated with the event type.
         {
             if (JournalTypeIcons.ContainsKey(eventtype))

--- a/EDDiscovery/EliteDangerous/JournalEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntry.cs
@@ -258,6 +258,7 @@ namespace EDDiscovery.EliteDangerous
     [DebuggerDisplay("Event {EventTypeStr} {EventTimeUTC} EdsmID {EdsmID} JID {Id} C {CommanderId}")]
     public abstract class JournalEntry
     {
+        #region Instance properties and fields
         public long Id;                          // this is the entry ID
         public long TLUId;                       // this ID of the journal tlu (aka TravelLogId)
         public int CommanderId;                 // commander Id of entry
@@ -279,6 +280,75 @@ namespace EDDiscovery.EliteDangerous
         public bool SyncedEDDN { get { return (Synced & (int)SyncFlags.EDDN) != 0; } }
         public bool StartMarker { get { return (Synced & (int)SyncFlags.StartMarker) != 0; } }
         public bool StopMarker { get { return (Synced & (int)SyncFlags.StopMarker) != 0; } }
+        #endregion
+
+        #region Static properties and fields
+        private static Dictionary<JournalTypeEnum, Func<string, System.Drawing.Bitmap>> JournalTypeIcons = GetJournalTypeIcons();
+        private static Dictionary<JournalTypeEnum, Type> JournalEntryTypes = GetJournalEntryTypes();
+        #endregion
+
+        /// <summary>
+        /// Gets all of the journal type icons
+        /// </summary>
+        /// <returns>Map of journal type icon accessors</returns>
+        private static Dictionary<JournalTypeEnum, Func<string, System.Drawing.Bitmap>> GetJournalTypeIcons()
+        {
+            Dictionary<JournalTypeEnum, Func<string, System.Drawing.Bitmap>> icons = new Dictionary<JournalTypeEnum, Func<string, System.Drawing.Bitmap>>();
+            var asm = System.Reflection.Assembly.GetExecutingAssembly();
+            var types = asm.GetTypes().Where(t => typeof(JournalEntry).IsAssignableFrom(t) && !t.IsAbstract).ToList();
+
+            foreach (Type type in types)
+            {
+                JournalEntryTypeAttribute typeattrib = type.GetCustomAttributes(false).OfType<JournalEntryTypeAttribute>().FirstOrDefault();
+                if (typeattrib != null)
+                {
+                    System.Drawing.Bitmap defbmp = EDDiscovery.Properties.Resources.genericevent;
+                    Func<string, System.Drawing.Bitmap> bmpfunc = (d) => defbmp;
+
+                    System.Reflection.MethodInfo mi = type.GetMethod("SelectIcon");
+                    if (mi != null)
+                    {
+                        var p = System.Linq.Expressions.Expression.Parameter(typeof(string));
+                        bmpfunc = System.Linq.Expressions.Expression.Lambda<Func<string, System.Drawing.Bitmap>>(System.Linq.Expressions.Expression.Call(mi, p), p).Compile();
+                    }
+                    else
+                    {
+                        System.Reflection.PropertyInfo pi = type.GetProperty("Icon");
+                        if (pi != null)
+                        {
+                            System.Drawing.Bitmap bmp = (System.Drawing.Bitmap)pi.GetValue(null);
+                            bmpfunc = (d) => bmp;
+                        }
+                    }
+
+                    icons[typeattrib.EntryType] = bmpfunc;
+                }
+            }
+
+            return icons;
+        }
+
+        /// <summary>
+        /// Gets the mapping of journal type value to JournalEntry type
+        /// </summary>
+        /// <returns>Map of type values to types</returns>
+        private static Dictionary<JournalTypeEnum, Type> GetJournalEntryTypes()
+        {
+            Dictionary<JournalTypeEnum, Type> typedict = new Dictionary<JournalTypeEnum, Type>();
+            var asm = System.Reflection.Assembly.GetExecutingAssembly();
+            var types = asm.GetTypes().Where(t => typeof(JournalEntry).IsAssignableFrom(t) && !t.IsAbstract).ToList();
+
+            foreach (Type type in types)
+            {
+                JournalEntryTypeAttribute typeattrib = type.GetCustomAttributes(false).OfType<JournalEntryTypeAttribute>().FirstOrDefault();
+                if (typeattrib != null)
+                {
+                    typedict[typeattrib.EntryType] = type;
+                }
+            }
+
+            return typedict;
+        }
 
         /// <summary>
         /// Normalize commodity names for MiningRefined, MissionAccepted, and MissionCompleted entries.
@@ -888,6 +958,18 @@ namespace EDDiscovery.EliteDangerous
             }
         }
 
+        static public Type TypeOfJournalEntry(JournalTypeEnum type)
+        {
+            if (JournalEntryTypes.ContainsKey(type))
+            {
+                return JournalEntryTypes[type];
+            }
+            else
+            {
+                return TypeOfJournalEntry(type.ToString());
+            }
+        }
+
         static public Type TypeOfJournalEntry(string text)
         {
             //foreach (JournalTypeEnum jte in Enum.GetValues(typeof(JournalTypeEnum))) // check code only to make sure names match
@@ -920,9 +1002,14 @@ namespace EDDiscovery.EliteDangerous
                 return (JournalEntry)Activator.CreateInstance(jtype, jo);
         }
 
-        static public System.Drawing.Bitmap GetIcon(string eventtypestr, string seltext = null)    // get ICON associated with the event type.
+        static public System.Drawing.Bitmap GetIcon(JournalTypeEnum eventtype, string seltext = null)    // get ICON associated with the event type.
         {
-            Type jtype = TypeOfJournalEntry(eventtypestr);
+            if (JournalTypeIcons.ContainsKey(eventtype))
+            {
+                return JournalTypeIcons[eventtype].Invoke(seltext);
+            }
+
+            Type jtype = TypeOfJournalEntry(eventtype);
 
             if (jtype == null)
             {
@@ -1134,7 +1221,7 @@ namespace EDDiscovery.EliteDangerous
                 }
                 else
                 {
-                    Type jtype = TypeOfJournalEntry(n);
+                    Type jtype = TypeOfJournalEntry(jte);
 
                     if (jtype != null)      // may be null, Unknown for instance
                     {

--- a/EDDiscovery/EliteDangerous/JournalEntryAttributes.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntryAttributes.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright © 2016 EDDiscovery development team
+ * Copyright © 2017 EDDiscovery development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at
@@ -13,24 +13,22 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
-using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace EDDiscovery.EliteDangerous.JournalEvents
+namespace EDDiscovery.EliteDangerous
 {
-    //When written: player was HullDamage by player or npc
-    //Parameters: 
-    [JournalEntryType(JournalTypeEnum.HullDamage)]
-    public class JournalHullDamage : JournalEntry
+    [AttributeUsage(AttributeTargets.Class)]
+    public class JournalEntryTypeAttribute : Attribute
     {
-        public JournalHullDamage(JObject evt ) : base(evt, JournalTypeEnum.HullDamage)
+        public JournalTypeEnum EntryType { get; set; }
+
+        public JournalEntryTypeAttribute(JournalTypeEnum entrytype)
         {
-            Health = JSONHelper.GetDouble(evt["Health"]);
-
+            EntryType = entrytype;
         }
-        public double Health { get; set; }
-
-        public static System.Drawing.Bitmap Icon { get { return EDDiscovery.Properties.Resources.damage; } }
-
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEntryInterfaces.cs
+++ b/EDDiscovery/EliteDangerous/JournalEntryInterfaces.cs
@@ -27,4 +27,14 @@ namespace EDDiscovery.EliteDangerous
     {
         void MaterialList(MaterialCommoditiesList mc, SQLiteConnectionUser conn);
     }
+
+    public interface ILedgerJournalEntry
+    {
+        void Ledger(MaterialCommoditiesLedger mcl, SQLiteConnectionUser conn);
+    }
+
+    public interface ILedgerNoCashJournalEntry
+    {
+        void LedgerNC(MaterialCommoditiesLedger mcl, SQLiteConnectionUser conn);
+    }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalApproachSettlement.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalApproachSettlement.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     // •	Name
 
+    [JournalEntryType(JournalTypeEnum.ApproachSettlement)]
     public class JournalApproachSettlement : JournalEntry
     {
         public JournalApproachSettlement(JObject evt) : base(evt, JournalTypeEnum.ApproachSettlement)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBounty.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBounty.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward: the reward value
     //•	VictimFaction: the victim’s faction
     //•	SharedWithOthers: whether shared with other players
-    public class JournalBounty : JournalEntry
+    public class JournalBounty : JournalEntry, ILedgerNoCashJournalEntry
     {
         public class BountyReward
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBounty.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBounty.cs
@@ -24,6 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward: the reward value
     //•	VictimFaction: the victim’s faction
     //•	SharedWithOthers: whether shared with other players
+    [JournalEntryType(JournalTypeEnum.Bounty)]
     public class JournalBounty : JournalEntry, ILedgerNoCashJournalEntry
     {
         public class BountyReward

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
@@ -21,7 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When Written: when purchasing ammunition
     //Parameters:
     //•	Cost
-    public class JournalBuyAmmo : JournalEntry
+    public class JournalBuyAmmo : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyAmmo(JObject evt ) : base(evt, JournalTypeEnum.BuyAmmo)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When Written: when purchasing ammunition
     //Parameters:
     //•	Cost
+    [JournalEntryType(JournalTypeEnum.BuyAmmo)]
     public class JournalBuyAmmo : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyAmmo(JObject evt ) : base(evt, JournalTypeEnum.BuyAmmo)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyDrones.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyDrones.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.BuyDrones)]
     public class JournalBuyDrones : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyDrones(JObject evt ) : base(evt, JournalTypeEnum.BuyDrones)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyDrones.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyDrones.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
-    public class JournalBuyDrones : JournalEntry
+    public class JournalBuyDrones : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyDrones(JObject evt ) : base(evt, JournalTypeEnum.BuyDrones)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	System
     //•	Cost
+    [JournalEntryType(JournalTypeEnum.BuyExplorationData)]
     public class JournalBuyExplorationData : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyExplorationData(JObject evt ) : base(evt, JournalTypeEnum.BuyExplorationData)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	System
     //•	Cost
-    public class JournalBuyExplorationData : JournalEntry
+    public class JournalBuyExplorationData : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyExplorationData(JObject evt ) : base(evt, JournalTypeEnum.BuyExplorationData)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.BuyTradeData)]
     public class JournalBuyTradeData : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyTradeData(JObject evt ) : base(evt, JournalTypeEnum.BuyTradeData)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
-    public class JournalBuyTradeData : JournalEntry
+    public class JournalBuyTradeData : JournalEntry, ILedgerJournalEntry
     {
         public JournalBuyTradeData(JObject evt ) : base(evt, JournalTypeEnum.BuyTradeData)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCapShipBond.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCapShipBond.cs
@@ -27,7 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	AwardingFaction
     //•	VictimFaction
 
-    public class JournalCapShipBond : JournalEntry
+    public class JournalCapShipBond : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalCapShipBond(JObject evt) : base(evt, JournalTypeEnum.CapShipBond)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCapShipBond.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCapShipBond.cs
@@ -26,7 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward: value of award
     //•	AwardingFaction
     //•	VictimFaction
-
+    [JournalEntryType(JournalTypeEnum.CapShipBond)]
     public class JournalCapShipBond : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalCapShipBond(JObject evt) : base(evt, JournalTypeEnum.CapShipBond)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalClearSavedGame.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalClearSavedGame.cs
@@ -21,7 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //    When written: If you should ever reset your game
     //    Parameters:
     //•	Name: commander name
-
+    [JournalEntryType(JournalTypeEnum.ClearSavedGame)]
     public class JournalClearSavedGame : JournalEntry
     {
         public JournalClearSavedGame(JObject evt) : base(evt, JournalTypeEnum.ClearSavedGame)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCockpitBreached.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCockpitBreached.cs
@@ -20,6 +20,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: when cockpit canopy is breached
     //Parameters: none
+    [JournalEntryType(JournalTypeEnum.CockpitBreached)]
     public class JournalCockpitBreached : JournalEntry
     {
         public JournalCockpitBreached(JObject evt ) : base(evt, JournalTypeEnum.CockpitBreached)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCollectCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCollectCargo.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Type: cargo type
     //•	Stolen: whether stolen goods
+    [JournalEntryType(JournalTypeEnum.CollectCargo)]
     public class JournalCollectCargo : JournalEntry, IMaterialCommodityJournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalCollectCargo(JObject evt ) : base(evt, JournalTypeEnum.CollectCargo)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCollectCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCollectCargo.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Type: cargo type
     //•	Stolen: whether stolen goods
-    public class JournalCollectCargo : JournalEntry, IMaterialCommodityJournalEntry
+    public class JournalCollectCargo : JournalEntry, IMaterialCommodityJournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalCollectCargo(JObject evt ) : base(evt, JournalTypeEnum.CollectCargo)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommitCrime.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommitCrime.cs
@@ -26,6 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Victim
     //•	Fine
     //•	Bounty
+    [JournalEntryType(JournalTypeEnum.CommitCrime)]
     public class JournalCommitCrime : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalCommitCrime(JObject evt ) : base(evt, JournalTypeEnum.CommitCrime)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommitCrime.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommitCrime.cs
@@ -26,7 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Victim
     //•	Fine
     //•	Bounty
-    public class JournalCommitCrime : JournalEntry
+    public class JournalCommitCrime : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalCommitCrime(JObject evt ) : base(evt, JournalTypeEnum.CommitCrime)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalDiscard.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalDiscard.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Name
     //•	System
+    [JournalEntryType(JournalTypeEnum.CommunityGoalDiscard)]
     public class JournalCommunityGoalDiscard : JournalEntry
     {
         public JournalCommunityGoalDiscard(JObject evt) : base(evt, JournalTypeEnum.CommunityGoalDiscard)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalJoin.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalJoin.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Name
     //•	System
+    [JournalEntryType(JournalTypeEnum.CommunityGoalJoin)]
     public class JournalCommunityGoalJoin : JournalEntry
     {
         public JournalCommunityGoalJoin(JObject evt ) : base(evt, JournalTypeEnum.CommunityGoalJoin)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Name
     //•	System
     //•	Reward
+    [JournalEntryType(JournalTypeEnum.CommunityGoalReward)]
     public class JournalCommunityGoalReward : JournalEntry, ILedgerJournalEntry
     {
         public JournalCommunityGoalReward(JObject evt ) : base(evt, JournalTypeEnum.CommunityGoalReward)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Name
     //•	System
     //•	Reward
-    public class JournalCommunityGoalReward : JournalEntry
+    public class JournalCommunityGoalReward : JournalEntry, ILedgerJournalEntry
     {
         public JournalCommunityGoalReward(JObject evt ) : base(evt, JournalTypeEnum.CommunityGoalReward)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalContinued.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalContinued.cs
@@ -21,7 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     // When written: if the journal file grows to 500k lines, we write this event, close the file, and start a new one
     // Parameters:
     // •	Part: next part number
-
+    [JournalEntryType(JournalTypeEnum.Continued)]
     public class JournalContinued : JournalEntry
     {
         public JournalContinued(JObject evt ) : base(evt, JournalTypeEnum.Continued)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewAssign.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewAssign.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Name
     //•	Role
-
+    [JournalEntryType(JournalTypeEnum.CrewAssign)]
     public class JournalCrewAssign : JournalEntry
     {
         public JournalCrewAssign(JObject evt) : base(evt, JournalTypeEnum.CrewAssign)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewFire.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewFire.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Count
     //•	SellPrice
     //•	TotalSale
-
+    [JournalEntryType(JournalTypeEnum.CrewFire)]
     public class JournalCrewFire : JournalEntry
     {
         public JournalCrewFire(JObject evt) : base(evt, JournalTypeEnum.CrewFire)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewHire.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewHire.cs
@@ -25,7 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Cost
     //•	CombatRank
 
-    public class JournalCrewHire : JournalEntry
+    public class JournalCrewHire : JournalEntry, ILedgerJournalEntry
     {
         public JournalCrewHire(JObject evt) : base(evt, JournalTypeEnum.CrewHire)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewHire.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCrewHire.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Faction
     //•	Cost
     //•	CombatRank
-
+    [JournalEntryType(JournalTypeEnum.CrewHire)]
     public class JournalCrewHire : JournalEntry, ILedgerJournalEntry
     {
         public JournalCrewHire(JObject evt) : base(evt, JournalTypeEnum.CrewHire)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDataScanned.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDataScanned.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Message: message from data link
     //•	MessageLocalised: message from data link
-
+    [JournalEntryType(JournalTypeEnum.DataScanned)]
     public class JournalDataScanned : JournalEntry
     {
         public JournalDataScanned(JObject evt) : base(evt, JournalTypeEnum.DataScanned)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkScan.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkScan.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when scanning a data link
     //Parameters:
     //•	Message: message from data link
+    [JournalEntryType(JournalTypeEnum.DatalinkScan)]
     public class JournalDatalinkScan : JournalEntry
     {
         public JournalDatalinkScan(JObject evt ) : base(evt, JournalTypeEnum.DatalinkScan)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	VictimFaction
 //•	PayeeFaction
 
-    public class JournalDatalinkVoucher : JournalEntry
+    public class JournalDatalinkVoucher : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalDatalinkVoucher(JObject evt) : base(evt, JournalTypeEnum.DatalinkVoucher)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	Reward: value in credits
 //•	VictimFaction
 //•	PayeeFaction
-
+    [JournalEntryType(JournalTypeEnum.DatalinkVoucher)]
     public class JournalDatalinkVoucher : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalDatalinkVoucher(JObject evt) : base(evt, JournalTypeEnum.DatalinkVoucher)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDied.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDied.cs
@@ -26,6 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: player was killed by a wing
     //Parameters:
     //•	Killers: a JSON array of objects containing player name, ship, and rank
+    [JournalEntryType(JournalTypeEnum.Died)]
     public class JournalDied : JournalEntry
     {
         public class Killer

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockFighter.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockFighter.cs
@@ -20,6 +20,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: when docking a fighter back with the mothership
     //Parameters: none
+    [JournalEntryType(JournalTypeEnum.DockFighter)]
     public class JournalDockFighter : JournalEntry
     {
         public JournalDockFighter(JObject evt ) : base(evt, JournalTypeEnum.DockFighter)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockSRV.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockSRV.cs
@@ -20,6 +20,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: when docking an SRV with the ship
     //Parameters: none
+    [JournalEntryType(JournalTypeEnum.DockSRV)]
     public class JournalDockSRV : JournalEntry
     {
         public JournalDockSRV(JObject evt ) : base(evt, JournalTypeEnum.DockSRV)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDocked.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDocked.cs
@@ -30,6 +30,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Economy
     //•	Government
     //•	Security
+    [JournalEntryType(JournalTypeEnum.Docked)]
     public class JournalDocked : JournalEntry
     {
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingCancelled.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingCancelled.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when the player cancels a docking request
     //Parameters:
     //•	StationName: name of station
+    [JournalEntryType(JournalTypeEnum.DockingCancelled)]
     public class JournalDockingCancelled : JournalEntry
     {
         public JournalDockingCancelled(JObject evt ) : base(evt, JournalTypeEnum.DockingCancelled)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingDenied.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingDenied.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reason: reason for denial
     //
     //Reasons include: NoSpace, TooLarge, Hostile, Offences, Distance, ActiveFighter, NoReason
-
+    [JournalEntryType(JournalTypeEnum.DockingDenied)]
     public class JournalDockingDenied : JournalEntry
     {
         public JournalDockingDenied(JObject evt ) : base(evt, JournalTypeEnum.DockingDenied)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingGranted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingGranted.cs
@@ -30,6 +30,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Economy
     //•	Government
     //•	Security
+    [JournalEntryType(JournalTypeEnum.DockingGranted)]
     public class JournalDockingGranted : JournalEntry
     {
         public JournalDockingGranted(JObject evt ) : base(evt, JournalTypeEnum.DockingGranted)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingRequested.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingRequested.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when the player requests docking at a station
     //Parameters:
     //•	StationName: name of station
+    [JournalEntryType(JournalTypeEnum.DockingRequested)]
     public class JournalDockingRequested : JournalEntry
     {
         public JournalDockingRequested(JObject evt ) : base(evt, JournalTypeEnum.DockingRequested)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingTimeout.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalDockingTimeout.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when a docking request has timed out
     //Parameters:
     //•	StationName: name of station
+    [JournalEntryType(JournalTypeEnum.DockingTimeout)]
     public class JournalDockingTimeout : JournalEntry
     {
         public JournalDockingTimeout(JObject evt ) : base(evt, JournalTypeEnum.DockingTimeout)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEDDItemSet.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEDDItemSet.cs
@@ -19,7 +19,7 @@ using System.Linq;
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: by EDD when a user manually sets an item count (material or commodity)
-
+    [JournalEntryType(JournalTypeEnum.EDDItemSet)]
     public class JournalEDDItemSet : JournalEntry, IMaterialCommodityJournalEntry
     {
         public JournalEDDItemSet(JObject evt) : base(evt, JournalTypeEnum.EDDItemSet)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEjectCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEjectCargo.cs
@@ -25,7 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Abandoned: whether ‘abandoned’
 //    If the cargo is related to powerplay:
 //•	PowerplayOrigin
-
+    [JournalEntryType(JournalTypeEnum.EjectCargo)]
     public class JournalEjectCargo : JournalEntry, IMaterialCommodityJournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalEjectCargo(JObject evt) : base(evt, JournalTypeEnum.EjectCargo)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEjectCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEjectCargo.cs
@@ -26,7 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //    If the cargo is related to powerplay:
 //•	PowerplayOrigin
 
-    public class JournalEjectCargo : JournalEntry, IMaterialCommodityJournalEntry
+    public class JournalEjectCargo : JournalEntry, IMaterialCommodityJournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalEjectCargo(JObject evt) : base(evt, JournalTypeEnum.EjectCargo)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerApply.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerApply.cs
@@ -24,6 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Blueprint: blueprint being applied
     //•	Level: crafting level
     //•	Override: whether overriding special effect
+    [JournalEntryType(JournalTypeEnum.EngineerApply)]
     public class JournalEngineerApply : JournalEntry
     {
         public JournalEngineerApply(JObject evt ) : base(evt, JournalTypeEnum.EngineerApply)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerCraft.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerCraft.cs
@@ -25,6 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Blueprint: name of blueprint
     //•	Level: crafting level
     //•	Ingredients: JSON object with names and quantities of materials required
+    [JournalEntryType(JournalTypeEnum.EngineerCraft)]
     public class JournalEngineerCraft : JournalEntry, IMaterialCommodityJournalEntry
     {
         public JournalEngineerCraft(JObject evt ) : base(evt, JournalTypeEnum.EngineerCraft)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerProgress.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEngineerProgress.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.EngineerProgress)]
     public class JournalEngineerProgress : JournalEntry
     {
         public JournalEngineerProgress(JObject evt ) : base(evt, JournalTypeEnum.EngineerProgress)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalEscapeInterdiction.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalEscapeInterdiction.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters: 
     //•	Interdictor: interdicting pilot name
     //•	IsPlayer: whether player or npc
+    [JournalEntryType(JournalTypeEnum.EscapeInterdiction)]
     public class JournalEscapeInterdiction : JournalEntry
     {
         public JournalEscapeInterdiction(JObject evt ) : base(evt, JournalTypeEnum.EscapeInterdiction)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -43,7 +43,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	PowerplayState: the system state – one of("InPrepareRadius", "Prepared", "Exploited", "Contested", "Controlled", "Turmoil", "HomeSystem")
 
 
-
+    [JournalEntryType(JournalTypeEnum.FSDJump)]
     public class JournalFSDJump : JournalLocOrJump
     {
         public JournalFSDJump(JObject evt ) : base(evt, JournalTypeEnum.FSDJump)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward
     //•	AwardingFaction
     //•	VictimFaction
-    public class JournalFactionKillBond : JournalEntry
+    public class JournalFactionKillBond : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalFactionKillBond(JObject evt ) : base(evt, JournalTypeEnum.FactionKillBond)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward
     //•	AwardingFaction
     //•	VictimFaction
+    [JournalEntryType(JournalTypeEnum.FactionKillBond)]
     public class JournalFactionKillBond : JournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalFactionKillBond(JObject evt ) : base(evt, JournalTypeEnum.FactionKillBond)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
@@ -25,7 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	TransferCost
 //•	Ship
 //•	ShipId
-
+    [JournalEntryType(JournalTypeEnum.FetchRemoteModule)]
     public class JournalFetchRemoteModule : JournalEntry, ILedgerJournalEntry
     {
         public JournalFetchRemoteModule(JObject evt) : base(evt, JournalTypeEnum.FetchRemoteModule)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
@@ -26,7 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	Ship
 //•	ShipId
 
-    public class JournalFetchRemoteModule : JournalEntry
+    public class JournalFetchRemoteModule : JournalEntry, ILedgerJournalEntry
     {
         public JournalFetchRemoteModule(JObject evt) : base(evt, JournalTypeEnum.FetchRemoteModule)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFileheader.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFileheader.cs
@@ -21,6 +21,7 @@ using System.Text;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
+    [JournalEntryType(JournalTypeEnum.Fileheader)]
     public class JournalFileheader : JournalEntry
     {
         public JournalFileheader(JObject evt ) : base(evt, JournalTypeEnum.Fileheader)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFuelScope.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFuelScope.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Scooped: tons fuel scooped
     //•	Total: total fuel level after scooping
+    [JournalEntryType(JournalTypeEnum.FuelScoop)]
     public class JournalFuelScoop : JournalEntry
     {
         public JournalFuelScoop(JObject evt ) : base(evt, JournalTypeEnum.FuelScoop)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatDamage.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatDamage.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward
     //•	AwardingFaction
     //•	VictimFaction
+    [JournalEntryType(JournalTypeEnum.HeatDamage)]
     public class JournalHeatDamage : JournalEntry
     {
         public JournalHeatDamage(JObject evt ) : base(evt, JournalTypeEnum.HeatDamage)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatWarning.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalHeatWarning.cs
@@ -20,6 +20,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: player was HeatWarning by player or npc
     //Parameters: 
+    [JournalEntryType(JournalTypeEnum.HeatWarning)]
     public class JournalHeatWarning : JournalEntry
     {
         public JournalHeatWarning(JObject evt ) : base(evt, JournalTypeEnum.HeatWarning)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdicted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdicted.cs
@@ -26,6 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	CombatRank: if player
     //•	Faction: if npc
     //•	Power: if npc working for a power
+    [JournalEntryType(JournalTypeEnum.Interdicted)]
     public class JournalInterdicted : JournalEntry
     {
         public JournalInterdicted(JObject evt ) : base(evt, JournalTypeEnum.Interdicted)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdiction.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalInterdiction.cs
@@ -26,6 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	CombatRank: if a player
     //•	Faction: if an npc
     //•	Power: if npc working for power
+    [JournalEntryType(JournalTypeEnum.Interdiction)]
     public class JournalInterdiction : JournalEntry
     {
         public JournalInterdiction(JObject evt ) : base(evt, JournalTypeEnum.Interdiction)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeBoost.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeBoost.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when enough material has been collected from a solar jet code (at a white dwarf or neutron star) for a jump boost
     //Parameters:
     //•	BoostValue
+    [JournalEntryType(JournalTypeEnum.JetConeBoost)]
     public class JournalJetConeBoost : JournalEntry
     {
         public JournalJetConeBoost(JObject evt ) : base(evt, JournalTypeEnum.JetConeBoost)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeDamage.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalJetConeDamage.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when passing through the jet code from a white dwarf or neutron star has caused damage to a ship module
     //Parameters:
     //•	Module: the name of the module that has taken some damage
+    [JournalEntryType(JournalTypeEnum.JetConeDamage)]
     public class JournalJetConeDamage : JournalEntry
     {
         public JournalJetConeDamage(JObject evt ) : base(evt, JournalTypeEnum.JetConeDamage)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchFighter.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchFighter.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Loadout
     //•	PlayerControlled: whether player is controlling the fighter from launch
+    [JournalEntryType(JournalTypeEnum.LaunchFighter)]
     public class JournalLaunchFighter : JournalEntry
     {
         public JournalLaunchFighter(JObject evt) : base(evt, JournalTypeEnum.LaunchFighter)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchSRV.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLaunchSRV.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: deploying the SRV from a ship onto planet surface
     //Parameters:
     //•	Loadout
+    [JournalEntryType(JournalTypeEnum.LaunchSRV)]
     public class JournalLaunchSRV : JournalEntry
     {
         public JournalLaunchSRV(JObject evt ) : base(evt, JournalTypeEnum.LaunchSRV)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLiftoff.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLiftoff.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Latitude
     //•	Longitude
+    [JournalEntryType(JournalTypeEnum.Liftoff)]
     public class JournalLiftoff : JournalEntry
     {
         public JournalLiftoff(JObject evt ) : base(evt, JournalTypeEnum.Liftoff)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
@@ -21,7 +21,7 @@ using System.Text;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
-    public class JournalLoadGame : JournalEntry
+    public class JournalLoadGame : JournalEntry, ILedgerJournalEntry
     {
         public JournalLoadGame(JObject evt ) : base(evt, JournalTypeEnum.LoadGame)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
@@ -21,6 +21,7 @@ using System.Text;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
+    [JournalEntryType(JournalTypeEnum.LoadGame)]
     public class JournalLoadGame : JournalEntry, ILedgerJournalEntry
     {
         public JournalLoadGame(JObject evt ) : base(evt, JournalTypeEnum.LoadGame)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLocation.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLocation.cs
@@ -35,6 +35,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Economy
     //•	Government
     //•	Security
+    [JournalEntryType(JournalTypeEnum.Location)]
     public class JournalLocation : JournalLocOrJump
     {
         public JournalLocation(JObject evt ) : base(evt, JournalTypeEnum.Location)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketBuy.cs
@@ -24,6 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Count: number of units
     //•	BuyPrice: cost per unit
     //•	TotalCost: total cost
+    [JournalEntryType(JournalTypeEnum.MarketBuy)]
     public class JournalMarketBuy : JournalEntry, IMaterialCommodityJournalEntry, ILedgerJournalEntry
     {
         public JournalMarketBuy(JObject evt ) : base(evt, JournalTypeEnum.MarketBuy)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketBuy.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Count: number of units
     //•	BuyPrice: cost per unit
     //•	TotalCost: total cost
-    public class JournalMarketBuy : JournalEntry, IMaterialCommodityJournalEntry
+    public class JournalMarketBuy : JournalEntry, IMaterialCommodityJournalEntry, ILedgerJournalEntry
     {
         public JournalMarketBuy(JObject evt ) : base(evt, JournalTypeEnum.MarketBuy)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketSell.cs
@@ -28,7 +28,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	IllegalGoods: (not always present) whether goods are illegal here
     //•	StolenGoods: (not always present) whether goods were stolen
     //•	BlackMarket: (not always present) whether selling in a black market
-    public class JournalMarketSell : JournalEntry, IMaterialCommodityJournalEntry
+    public class JournalMarketSell : JournalEntry, IMaterialCommodityJournalEntry, ILedgerJournalEntry
     {
         public JournalMarketSell(JObject evt ) : base(evt, JournalTypeEnum.MarketSell)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMarketSell.cs
@@ -28,6 +28,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	IllegalGoods: (not always present) whether goods are illegal here
     //•	StolenGoods: (not always present) whether goods were stolen
     //•	BlackMarket: (not always present) whether selling in a black market
+    [JournalEntryType(JournalTypeEnum.MarketSell)]
     public class JournalMarketSell : JournalEntry, IMaterialCommodityJournalEntry, ILedgerJournalEntry
     {
         public JournalMarketSell(JObject evt ) : base(evt, JournalTypeEnum.MarketSell)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMassModuleStore.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMassModuleStore.cs
@@ -27,7 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //o   Name
 //o   EngineerModifications(only present if modified)
 
-
+    [JournalEntryType(JournalTypeEnum.MassModuleStore)]
     public class JournalMassModuleStore : JournalEntry
     {
         public JournalMassModuleStore(JObject evt) : base(evt, JournalTypeEnum.MassModuleStore)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters: 
     //•	Category: type of material (Raw/Encoded/Manufactured)
     //•	Name: name of material
+    [JournalEntryType(JournalTypeEnum.MaterialCollected)]
     public class JournalMaterialCollected : JournalEntry, IMaterialCommodityJournalEntry
     {
         public JournalMaterialCollected(JObject evt ) : base(evt, JournalTypeEnum.MaterialCollected)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
-
+    [JournalEntryType(JournalTypeEnum.MaterialDiscarded)]
     public class JournalMaterialDiscarded : JournalEntry, IMaterialCommodityJournalEntry
     {
         public JournalMaterialDiscarded(JObject evt ) : base(evt, JournalTypeEnum.MaterialDiscarded)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.MaterialDiscovered)]
     public class JournalMaterialDiscovered : JournalEntry
     {
         public JournalMaterialDiscovered(JObject evt ) : base(evt, JournalTypeEnum.MaterialDiscovered)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMiningRefined.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMiningRefined.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Type: $cargo_name;
     //•	Type_Localised: cargo type
-    public class JournalMiningRefined : JournalEntry, IMaterialCommodityJournalEntry
+    public class JournalMiningRefined : JournalEntry, IMaterialCommodityJournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalMiningRefined(JObject evt ) : base(evt, JournalTypeEnum.MiningRefined)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMiningRefined.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMiningRefined.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Type: $cargo_name;
     //•	Type_Localised: cargo type
+    [JournalEntryType(JournalTypeEnum.MiningRefined)]
     public class JournalMiningRefined : JournalEntry, IMaterialCommodityJournalEntry, ILedgerNoCashJournalEntry
     {
         public JournalMiningRefined(JObject evt ) : base(evt, JournalTypeEnum.MiningRefined)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAbandoned.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAbandoned.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When Written: when a mission has been abandoned
     //Parameters:
     //•	Name: name of mission
+    [JournalEntryType(JournalTypeEnum.MissionAbandoned)]
     public class JournalMissionAbandoned : JournalEntry
     {
         public JournalMissionAbandoned(JObject evt ) : base(evt, JournalTypeEnum.MissionAbandoned)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAccepted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionAccepted.cs
@@ -40,7 +40,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	PassengerType: eg Tourist, Soldier, Explorer,...
 
 
-
+    [JournalEntryType(JournalTypeEnum.MissionAccepted)]
     public class JournalMissionAccepted : JournalEntry
     {
         public JournalMissionAccepted(JObject evt ) : base(evt, JournalTypeEnum.MissionAccepted)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
@@ -32,6 +32,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward: value of reward
     //•	Donation: donation offered (for altruism missions)
     //•	PermitsAwarded:[] (names of any permits awarded, as a JSON array)
+    [JournalEntryType(JournalTypeEnum.MissionCompleted)]
     public class JournalMissionCompleted : JournalEntry, IMaterialCommodityJournalEntry, ILedgerJournalEntry
     {
         public JournalMissionCompleted(JObject evt ) : base(evt, JournalTypeEnum.MissionCompleted)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
@@ -32,7 +32,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Reward: value of reward
     //•	Donation: donation offered (for altruism missions)
     //•	PermitsAwarded:[] (names of any permits awarded, as a JSON array)
-    public class JournalMissionCompleted : JournalEntry, IMaterialCommodityJournalEntry
+    public class JournalMissionCompleted : JournalEntry, IMaterialCommodityJournalEntry, ILedgerJournalEntry
     {
         public JournalMissionCompleted(JObject evt ) : base(evt, JournalTypeEnum.MissionCompleted)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionFailed.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMissionFailed.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When Written: when a mission has failed
     //Parameters:
     //•	Name: name of mission
+    [JournalEntryType(JournalTypeEnum.MissionFailed)]
     public class JournalMissionFailed : JournalEntry
     {
         public JournalMissionFailed(JObject evt ) : base(evt, JournalTypeEnum.MissionFailed)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleBuy.cs
@@ -27,6 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //If replacing an existing module:
     //•	SellItem: item being sold
     //•	SellPrice: sale price
+    [JournalEntryType(JournalTypeEnum.ModuleBuy)]
     public class JournalModuleBuy : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleBuy(JObject evt ) : base(evt, JournalTypeEnum.ModuleBuy)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleBuy.cs
@@ -27,7 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //If replacing an existing module:
     //•	SellItem: item being sold
     //•	SellPrice: sale price
-    public class JournalModuleBuy : JournalEntry
+    public class JournalModuleBuy : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleBuy(JObject evt ) : base(evt, JournalTypeEnum.ModuleBuy)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
@@ -27,6 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	EngineerModifications: name of modification blueprint, if any
     //•	SwapOutItem (if slot was not empty)
     //•	Cost
+    [JournalEntryType(JournalTypeEnum.ModuleRetrieve)]
     public class JournalModuleRetrieve : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleRetrieve(JObject evt) : base(evt, JournalTypeEnum.ModuleRetrieve)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
@@ -27,7 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	EngineerModifications: name of modification blueprint, if any
     //•	SwapOutItem (if slot was not empty)
     //•	Cost
-    public class JournalModuleRetrieve : JournalEntry
+    public class JournalModuleRetrieve : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleRetrieve(JObject evt) : base(evt, JournalTypeEnum.ModuleRetrieve)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSell.cs
@@ -24,6 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellItem
     //•	SellPrice
     //•	Ship
+    [JournalEntryType(JournalTypeEnum.ModuleSell)]
     public class JournalModuleSell : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleSell(JObject evt ) : base(evt, JournalTypeEnum.ModuleSell)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSell.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellItem
     //•	SellPrice
     //•	Ship
-    public class JournalModuleSell : JournalEntry
+    public class JournalModuleSell : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleSell(JObject evt ) : base(evt, JournalTypeEnum.ModuleSell)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellItem
     //•	SellPrice
     //•	Ship
+    [JournalEntryType(JournalTypeEnum.ModuleSellRemote)]
     public class JournalModuleSellRemote : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleSellRemote(JObject evt) : base(evt, JournalTypeEnum.ModuleSellRemote)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellItem
     //•	SellPrice
     //•	Ship
-    public class JournalModuleSellRemote : JournalEntry
+    public class JournalModuleSellRemote : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleSellRemote(JObject evt) : base(evt, JournalTypeEnum.ModuleSellRemote)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleStore.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleStore.cs
@@ -27,7 +27,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	EngineerModifications: name of modification blueprint, if any
 //•	ReplacementItem(if a core module)
 //•	Cost(if any)
-
+    [JournalEntryType(JournalTypeEnum.ModuleStore)]
     public class JournalModuleStore : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleStore(JObject evt) : base(evt, JournalTypeEnum.ModuleStore)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleStore.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleStore.cs
@@ -28,7 +28,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	ReplacementItem(if a core module)
 //•	Cost(if any)
 
-    public class JournalModuleStore : JournalEntry
+    public class JournalModuleStore : JournalEntry, ILedgerJournalEntry
     {
         public JournalModuleStore(JObject evt) : base(evt, JournalTypeEnum.ModuleStore)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSwap.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalModuleSwap.cs
@@ -25,6 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	FromItem
     //•	ToItem
     //•	Ship
+    [JournalEntryType(JournalTypeEnum.ModuleSwap)]
     public class JournalModuleSwap : JournalEntry
     {
         public JournalModuleSwap(JObject evt ) : base(evt, JournalTypeEnum.ModuleSwap)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalNewCommander.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalNewCommander.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Name: (new) commander name
     //•	Package: selected starter package
+    [JournalEntryType(JournalTypeEnum.NewCommander)]
     public class JournalNewCommander : JournalEntry
     {
         public JournalNewCommander(JObject evt ) : base(evt, JournalTypeEnum.NewCommander)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPVPKill.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPVPKill.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters: 
     //•	Victim: name of victim
     //•	CombatRank: victim’s rank in range 0..8
+    [JournalEntryType(JournalTypeEnum.PVPKill)]
     public class JournalPVPKill : JournalEntry
     {
         public JournalPVPKill(JObject evt) : base(evt, JournalTypeEnum.PVPKill)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPayFines.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPayFines.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //    Parameters:
 //•	Amount: (total amount paid , including any broker fee)
 //•	BrokerPercentage(present if paid via a Broker)
-
+    [JournalEntryType(JournalTypeEnum.PayFines)]
     public class JournalPayFines : JournalEntry, ILedgerJournalEntry
     {
         public JournalPayFines(JObject evt) : base(evt, JournalTypeEnum.PayFines)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPayFines.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPayFines.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	Amount: (total amount paid , including any broker fee)
 //•	BrokerPercentage(present if paid via a Broker)
 
-    public class JournalPayFines : JournalEntry
+    public class JournalPayFines : JournalEntry, ILedgerJournalEntry
     {
         public JournalPayFines(JObject evt) : base(evt, JournalTypeEnum.PayFines)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Amount: (total amount paid , including any broker fee)
     //•	BrokerPercentage(present if paid via a Broker)
 
-    public class JournalPayLegacyFines : JournalEntry
+    public class JournalPayLegacyFines : JournalEntry, ILedgerJournalEntry
     {
         public JournalPayLegacyFines(JObject evt) : base(evt, JournalTypeEnum.PayLegacyFines)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //    Parameters:
     //•	Amount: (total amount paid , including any broker fee)
     //•	BrokerPercentage(present if paid via a Broker)
-
+    [JournalEntryType(JournalTypeEnum.PayLegacyFines)]
     public class JournalPayLegacyFines : JournalEntry, ILedgerJournalEntry
     {
         public JournalPayLegacyFines(JObject evt) : base(evt, JournalTypeEnum.PayLegacyFines)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayCollect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayCollect.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Power: name of power
     //•	Type: type of commodity
     //•	Count: number of units
+    [JournalEntryType(JournalTypeEnum.PowerplayCollect)]
     public class JournalPowerplayCollect : JournalEntry
     {
         public JournalPowerplayCollect(JObject evt) : base(evt, JournalTypeEnum.PowerplayCollect)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDefect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDefect.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	FromPower
     //•	ToPower
+    [JournalEntryType(JournalTypeEnum.PowerplayDefect)]
     public class JournalPowerplayDefect : JournalEntry
     {
         public JournalPowerplayDefect(JObject evt) : base(evt, JournalTypeEnum.PowerplayDefect)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDeliver.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayDeliver.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Power
     //•	Type
     //•	Count
+    [JournalEntryType(JournalTypeEnum.PowerplayDeliver)]
     public class JournalPowerplayDeliver : JournalEntry
     {
         public JournalPowerplayDeliver(JObject evt) : base(evt, JournalTypeEnum.PowerplayDeliver)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Power
     //•	Cost
+    [JournalEntryType(JournalTypeEnum.PowerplayFastTrack)]
     public class JournalPowerplayFastTrack : JournalEntry, ILedgerJournalEntry
     {
         public JournalPowerplayFastTrack(JObject evt) : base(evt, JournalTypeEnum.PowerplayFastTrack)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Power
     //•	Cost
-    public class JournalPowerplayFastTrack : JournalEntry
+    public class JournalPowerplayFastTrack : JournalEntry, ILedgerJournalEntry
     {
         public JournalPowerplayFastTrack(JObject evt) : base(evt, JournalTypeEnum.PowerplayFastTrack)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayJoin.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayJoin.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when joining up with a power
     //Parameters:
     //•	Power
+    [JournalEntryType(JournalTypeEnum.PowerplayJoin)]
     public class JournalPowerplayJoin : JournalEntry
     {
         public JournalPowerplayJoin(JObject evt) : base(evt, JournalTypeEnum.PowerplayJoin)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayLeave.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayLeave.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when leaving a power
     //Parameters:
     //•	Power
+    [JournalEntryType(JournalTypeEnum.PowerplayLeave)]
     public class JournalPowerplayLeave : JournalEntry
     {
         public JournalPowerplayLeave(JObject evt) : base(evt, JournalTypeEnum.PowerplayLeave)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Power
     //•	Amount
+    [JournalEntryType(JournalTypeEnum.PowerplaySalary)]
     public class JournalPowerplaySalary : JournalEntry, ILedgerJournalEntry
     {
         public JournalPowerplaySalary(JObject evt) : base(evt, JournalTypeEnum.PowerplaySalary)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Power
     //•	Amount
-    public class JournalPowerplaySalary : JournalEntry
+    public class JournalPowerplaySalary : JournalEntry, ILedgerJournalEntry
     {
         public JournalPowerplaySalary(JObject evt) : base(evt, JournalTypeEnum.PowerplaySalary)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVote.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVote.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Power
     //•	Votes
     //•	System
+    [JournalEntryType(JournalTypeEnum.PowerplayVote)]
     public class JournalPowerplayVote : JournalEntry
     {
         public JournalPowerplayVote(JObject evt) : base(evt, JournalTypeEnum.PowerplayVote)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPowerplayVoucher.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Power
     //•	Systems:[name,name]
+    [JournalEntryType(JournalTypeEnum.PowerplayVoucher)]
     public class JournalPowerplayVoucher : JournalEntry
     {
         public JournalPowerplayVoucher(JObject evt) : base(evt, JournalTypeEnum.PowerplayVoucher)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalProgress.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalProgress.cs
@@ -26,7 +26,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Empire: 	“
     //•	Federation: 	“
     //•	CQC: 		“ ranks: 0=’Helpless’, 1=’Mostly Helpless’, 2=’Amateur’, 3=’Semi Professional’, 4=’Professional’, 5=’Champion’, 6=’Hero’, 7=’Legend’, 8=’Elite’
-
+    [JournalEntryType(JournalTypeEnum.Progress)]
     public class JournalProgress : JournalEntry
     {
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalPromotion.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalPromotion.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
-
+    [JournalEntryType(JournalTypeEnum.Promotion)]
     public class JournalPromotion : JournalEntry
     {
         //        When written: when the player’s rank increases

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRank.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRank.cs
@@ -34,7 +34,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Federation ranks: 0='None', 1='Recruit', 2='Cadet', 3='Midshipman', 4='Petty Officer', 5='Chief Petty Officer', 6='Warrant Officer', 7='Ensign', 8='Lieutenant', 9='Lt. Commander', 10='Post Commander', 11= 'Post Captain', 12= 'Rear Admiral', 13='Vice Admiral', 14=’Admiral’
     //Empire ranks: 0='None', 1='Outsider', 2='Serf', 3='Master', 4='Squire', 5='Knight', 6='Lord', 7='Baron',  8='Viscount ', 9=’Count', 10= 'Earl', 11='Marquis' 12='Duke', 13='Prince', 14=’King’
     //CQC ranks: 0=’Helpless’, 1=’Mostly Helpless’, 2=’Amateur’, 3=’Semi Professional’, 4=’Professional’, 5=’Champion’, 6=’Hero’, 7=’Legend’, 8=’Elite’
-
+    [JournalEntryType(JournalTypeEnum.Rank)]
     public class JournalRank : JournalEntry
     {
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRebootRepair.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRebootRepair.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //    Parameters:
 //•	Modules: JSON array of names of modules repaired
 
-
+    [JournalEntryType(JournalTypeEnum.RebootRepair)]
     public class JournalRebootRepair : JournalEntry
     {
         public JournalRebootRepair(JObject evt) : base(evt, JournalTypeEnum.RebootRepair)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalReceiveText.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalReceiveText.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	From
     //•	Message
 
-
+    [JournalEntryType(JournalTypeEnum.ReceiveText)]
     public class JournalReceiveText : JournalEntry
     {
         public JournalReceiveText(JObject evt) : base(evt, JournalTypeEnum.ReceiveText)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	Type
 //•	Amount: (Net amount received, after any broker fee)
 //•	BrokerPercenentage
-
+    [JournalEntryType(JournalTypeEnum.RedeemVoucher)]
     public class JournalRedeemVoucher : JournalEntry, ILedgerJournalEntry
     {
         public JournalRedeemVoucher(JObject evt) : base(evt, JournalTypeEnum.RedeemVoucher)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 //•	Amount: (Net amount received, after any broker fee)
 //•	BrokerPercenentage
 
-    public class JournalRedeemVoucher : JournalEntry
+    public class JournalRedeemVoucher : JournalEntry, ILedgerJournalEntry
     {
         public JournalRedeemVoucher(JObject evt) : base(evt, JournalTypeEnum.RedeemVoucher)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
-    public class JournalRefuelAll : JournalEntry
+    public class JournalRefuelAll : JournalEntry, ILedgerJournalEntry
     {
         public JournalRefuelAll(JObject evt ) : base(evt, JournalTypeEnum.RefuelAll)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.RefuelAll)]
     public class JournalRefuelAll : JournalEntry, ILedgerJournalEntry
     {
         public JournalRefuelAll(JObject evt ) : base(evt, JournalTypeEnum.RefuelAll)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
-    public class JournalRefuelPartial : JournalEntry
+    public class JournalRefuelPartial : JournalEntry, ILedgerJournalEntry
     {
         public JournalRefuelPartial(JObject evt ) : base(evt, JournalTypeEnum.RefuelPartial)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.RefuelPartial)]
     public class JournalRefuelPartial : JournalEntry, ILedgerJournalEntry
     {
         public JournalRefuelPartial(JObject evt ) : base(evt, JournalTypeEnum.RefuelPartial)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRepair.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRepair.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Item: all, wear, hull, paint, or name of module
     //•	Cost: cost of repair
+    [JournalEntryType(JournalTypeEnum.Repair)]
     public class JournalRepair : JournalEntry, ILedgerJournalEntry
     {
         public JournalRepair(JObject evt ) : base(evt, JournalTypeEnum.Repair)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRepair.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRepair.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Item: all, wear, hull, paint, or name of module
     //•	Cost: cost of repair
-    public class JournalRepair : JournalEntry
+    public class JournalRepair : JournalEntry, ILedgerJournalEntry
     {
         public JournalRepair(JObject evt ) : base(evt, JournalTypeEnum.Repair)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRepairAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRepairAll.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Item: all, wear, hull, paint, or name of module
     //•	Cost: cost of repair
-    public class JournalRepairAll : JournalEntry
+    public class JournalRepairAll : JournalEntry, ILedgerJournalEntry
     {
         public JournalRepairAll(JObject evt) : base(evt, JournalTypeEnum.RepairAll)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRepairAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRepairAll.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Item: all, wear, hull, paint, or name of module
     //•	Cost: cost of repair
+    [JournalEntryType(JournalTypeEnum.RepairAll)]
     public class JournalRepairAll : JournalEntry, ILedgerJournalEntry
     {
         public JournalRepairAll(JObject evt) : base(evt, JournalTypeEnum.RepairAll)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Loadout: variant
     //•	Cost: purchase cost
     //•	Count: number of vehicles purchased
-    public class JournalRestockVehicle : JournalEntry
+    public class JournalRestockVehicle : JournalEntry, ILedgerJournalEntry
     {
         public JournalRestockVehicle(JObject evt ) : base(evt, JournalTypeEnum.RestockVehicle)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
@@ -24,6 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Loadout: variant
     //•	Cost: purchase cost
     //•	Count: number of vehicles purchased
+    [JournalEntryType(JournalTypeEnum.RestockVehicle)]
     public class JournalRestockVehicle : JournalEntry, ILedgerJournalEntry
     {
         public JournalRestockVehicle(JObject evt ) : base(evt, JournalTypeEnum.RestockVehicle)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalResurrect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalResurrect.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Option: the option selected on the insurance rebuy screen
     //•	Cost: the price paid
     //•	Bankrupt: whether the commander declared bankruptcy
-    public class JournalResurrect : JournalEntry
+    public class JournalResurrect : JournalEntry, ILedgerJournalEntry
     {
         public JournalResurrect(JObject evt ) : base(evt, JournalTypeEnum.Resurrect)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalResurrect.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalResurrect.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Option: the option selected on the insurance rebuy screen
     //•	Cost: the price paid
     //•	Bankrupt: whether the commander declared bankruptcy
+    [JournalEntryType(JournalTypeEnum.Resurrect)]
     public class JournalResurrect : JournalEntry, ILedgerJournalEntry
     {
         public JournalResurrect(JObject evt ) : base(evt, JournalTypeEnum.Resurrect)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
@@ -59,6 +59,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	InnerRad
     //•	OuterRad
     //
+    [JournalEntryType(JournalTypeEnum.Scan)]
     public class JournalScan : JournalEntry
     {
         private const double solarRadius_m = 695700000;

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScientificResearch.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScientificResearch.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
-
+    [JournalEntryType(JournalTypeEnum.ScientificResearch)]
     public class JournalScientificResearch : JournalEntry
     {
         public JournalScientificResearch(JObject evt) : base(evt, JournalTypeEnum.ScientificResearch)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScreenshot.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScreenshot.cs
@@ -20,7 +20,7 @@ using System.Linq;
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: screenshot
-
+    [JournalEntryType(JournalTypeEnum.Screenshot)]
     public class JournalScreenshot : JournalEntry
     {
         public JournalScreenshot(JObject evt ) : base(evt, JournalTypeEnum.Screenshot)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSelfDestruct.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSelfDestruct.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.SelfDestruct)]
     public class JournalSelfDestruct: JournalEntry
     {
         public JournalSelfDestruct(JObject evt ) : base(evt,   JournalTypeEnum.SelfDestruct)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSellDrones.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSellDrones.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Count
     //•	SellPrice
     //•	TotalSale
-
+    [JournalEntryType(JournalTypeEnum.SellDrones)]
     public class JournalSellDrones : JournalEntry, ILedgerJournalEntry
     {
         public JournalSellDrones(JObject evt) : base(evt, JournalTypeEnum.SellDrones)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSellDrones.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSellDrones.cs
@@ -25,7 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellPrice
     //•	TotalSale
 
-    public class JournalSellDrones : JournalEntry
+    public class JournalSellDrones : JournalEntry, ILedgerJournalEntry
     {
         public JournalSellDrones(JObject evt) : base(evt, JournalTypeEnum.SellDrones)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
@@ -24,6 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Discovered: JSON array of discovered bodies
     //•	BaseValue: value of systems
     //•	Bonus: bonus for first discoveries
+    [JournalEntryType(JournalTypeEnum.SellExplorationData)]
     public class JournalSellExplorationData : JournalEntry, ILedgerJournalEntry
     {
         public JournalSellExplorationData(JObject evt ) : base(evt, JournalTypeEnum.SellExplorationData)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Discovered: JSON array of discovered bodies
     //•	BaseValue: value of systems
     //•	Bonus: bonus for first discoveries
-    public class JournalSellExplorationData : JournalEntry
+    public class JournalSellExplorationData : JournalEntry, ILedgerJournalEntry
     {
         public JournalSellExplorationData(JObject evt ) : base(evt, JournalTypeEnum.SellExplorationData)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSendText.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSendText.cs
@@ -22,7 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	To
     //•	Message
-
+    [JournalEntryType(JournalTypeEnum.SendText)]
     public class JournalSendText : JournalEntry
     {
         public JournalSendText(JObject evt) : base(evt, JournalTypeEnum.SendText)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShieldState.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShieldState.cs
@@ -40,5 +40,10 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             else
                 return EDDiscovery.Properties.Resources.shieldsup;
         }
+
+        public override System.Drawing.Bitmap GetIcon()
+        {
+            return ShieldsUp ? EDDiscovery.Properties.Resources.shieldsup : EDDiscovery.Properties.Resources.shieldsdown;
+        }
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShieldState.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShieldState.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.ShieldState)]
     public class JournalShieldState : JournalEntry
     {
         public JournalShieldState(JObject evt ) : base(evt, JournalTypeEnum.ShieldState)
@@ -39,6 +40,5 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             else
                 return EDDiscovery.Properties.Resources.shieldsup;
         }
-
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
@@ -32,7 +32,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellPrice: (if selling current ship) ship sale price
     //
     //Note: the new ship’s ShipID will be logged in a separate event after the purchase
-    public class JournalShipyardBuy : JournalEntry
+    public class JournalShipyardBuy : JournalEntry, ILedgerJournalEntry
     {
         public JournalShipyardBuy(JObject evt ) : base(evt, JournalTypeEnum.ShipyardBuy)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
@@ -32,6 +32,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	SellPrice: (if selling current ship) ship sale price
     //
     //Note: the new ship’s ShipID will be logged in a separate event after the purchase
+    [JournalEntryType(JournalTypeEnum.ShipyardBuy)]
     public class JournalShipyardBuy : JournalEntry, ILedgerJournalEntry
     {
         public JournalShipyardBuy(JObject evt ) : base(evt, JournalTypeEnum.ShipyardBuy)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardNew.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardNew.cs
@@ -25,6 +25,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	ShipType
     //•	ShipID
+    [JournalEntryType(JournalTypeEnum.ShipyardNew)]
     public class JournalShipyardNew : JournalEntry
     {
         public JournalShipyardNew(JObject evt ) : base(evt, JournalTypeEnum.ShipyardNew)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
@@ -30,6 +30,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
         //•	SellShipID
         //•	ShipPrice: sale price
         //•	System: (if ship is in another system) name of system
+        [JournalEntryType(JournalTypeEnum.ShipyardSell)]
         public JournalShipyardSell(JObject evt ) : base(evt, JournalTypeEnum.ShipyardSell)
         {
             ShipType = JournalEntry.GetBetterShipName(JSONHelper.GetStringDef(evt["ShipType"]));

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
@@ -22,7 +22,8 @@ using System.Text;
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
 
-  public class JournalShipyardSell : JournalEntry, ILedgerJournalEntry
+    [JournalEntryType(JournalTypeEnum.ShipyardSell)]
+    public class JournalShipyardSell : JournalEntry, ILedgerJournalEntry
     {
         //When Written: when selling a ship stored in the shipyard
         //Parameters:
@@ -30,7 +31,6 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
         //•	SellShipID
         //•	ShipPrice: sale price
         //•	System: (if ship is in another system) name of system
-        [JournalEntryType(JournalTypeEnum.ShipyardSell)]
         public JournalShipyardSell(JObject evt ) : base(evt, JournalTypeEnum.ShipyardSell)
         {
             ShipType = JournalEntry.GetBetterShipName(JSONHelper.GetStringDef(evt["ShipType"]));

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSell.cs
@@ -22,7 +22,7 @@ using System.Text;
 namespace EDDiscovery.EliteDangerous.JournalEvents
 {
 
-  public class JournalShipyardSell : JournalEntry
+  public class JournalShipyardSell : JournalEntry, ILedgerJournalEntry
     {
         //When Written: when selling a ship stored in the shipyard
         //Parameters:

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSwap.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardSwap.cs
@@ -29,6 +29,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StoreShipID
     //•	SellOldShip: (if selling old ship) type of ship being sold
     //•	SellShipID
+    [JournalEntryType(JournalTypeEnum.ShipyardSwap)]
     public class JournalShipyardSwap : JournalEntry
     {
         public JournalShipyardSwap(JObject evt ) : base(evt, JournalTypeEnum.ShipyardSwap)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
@@ -28,7 +28,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	System: where it is
     //•	Distance: how far away
     //•	TransferPrice: cost of transfer
-    public class JournalShipyardTransfer : JournalEntry
+    public class JournalShipyardTransfer : JournalEntry, ILedgerJournalEntry
     {
         public JournalShipyardTransfer(JObject evt ) : base(evt, JournalTypeEnum.ShipyardTransfer)
         {

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
@@ -28,6 +28,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	System: where it is
     //•	Distance: how far away
     //•	TransferPrice: cost of transfer
+    [JournalEntryType(JournalTypeEnum.ShipyardTransfer)]
     public class JournalShipyardTransfer : JournalEntry, ILedgerJournalEntry
     {
         public JournalShipyardTransfer(JObject evt ) : base(evt, JournalTypeEnum.ShipyardTransfer)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: entering supercruise from normal space
     //Parameters:
     //•	Starsystem
+    [JournalEntryType(JournalTypeEnum.SupercruiseEntry)]
     public class JournalSupercruiseEntry : JournalEntry
     {
         public JournalSupercruiseEntry(JObject evt ) : base(evt, JournalTypeEnum.SupercruiseEntry)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Starsystem
     //•	Body
+    [JournalEntryType(JournalTypeEnum.SupercruiseExit)]
     public class JournalSupercruiseExit : JournalEntry
     {
         public JournalSupercruiseExit(JObject evt ) : base(evt, JournalTypeEnum.SupercruiseExit)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalSynthesis.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalSynthesis.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Name: synthesis blueprint
     //•	Materials: JSON object listing materials used and quantities
+    [JournalEntryType(JournalTypeEnum.Synthesis)]
     public class JournalSynthesis : JournalEntry, IMaterialCommodityJournalEntry
     {
         public JournalSynthesis(JObject evt ) : base(evt, JournalTypeEnum.Synthesis)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalTouchdown.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalTouchdown.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	Latitude
     //•	Longitude
+    [JournalEntryType(JournalTypeEnum.Touchdown)]
     public class JournalTouchdown : JournalEntry
     {
         public JournalTouchdown(JObject evt ) : base(evt, JournalTypeEnum.Touchdown)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalUSSDrop.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalUSSDrop.cs
@@ -22,6 +22,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //Parameters:
     //•	USSType: description of USS
     //•	USSThreat: threat level
+    [JournalEntryType(JournalTypeEnum.USSDrop)]
     public class JournalUSSDrop : JournalEntry
     {
         public JournalUSSDrop(JObject evt ) : base(evt, JournalTypeEnum.USSDrop)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalUndocked.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalUndocked.cs
@@ -23,6 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	StationName: name of station
 
     //•	Security
+    [JournalEntryType(JournalTypeEnum.Undocked)]
     public class JournalUndocked : JournalEntry
     {
         public JournalUndocked(JObject evt ) : base(evt, JournalTypeEnum.Undocked)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
@@ -37,5 +37,13 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             else
                 return EDDiscovery.Properties.Resources.fighter;
         }
+
+        public override System.Drawing.Bitmap GetIcon()
+        {
+            if (To.Contains("Mothership"))
+                return EDDiscovery.Properties.Resources.mothership;
+            else
+                return EDDiscovery.Properties.Resources.fighter;
+        }
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: when switching control between the main ship and a fighter
     //Parameters:
     //•	To: ( Mothership/Fighter)
+    [JournalEntryType(JournalTypeEnum.VehicleSwitch)]
     public class JournalVehicleSwitch : JournalEntry
     {
         public JournalVehicleSwitch(JObject evt ) : base(evt, JournalTypeEnum.VehicleSwitch)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalWingAdd.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalWingAdd.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: another player has joined the wing
     //Parameters:
     //•	Name
+    [JournalEntryType(JournalTypeEnum.WingAdd)]
     public class JournalWingAdd : JournalEntry
     {
         public JournalWingAdd(JObject evt ) : base(evt, JournalTypeEnum.WingAdd)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalWingJoin.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalWingJoin.cs
@@ -21,6 +21,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //When written: this player has joined a wing
     //Parameters:
     //•	Others: JSON array of other player names already in wing
+    [JournalEntryType(JournalTypeEnum.WingJoin)]
     public class JournalWingJoin : JournalEntry
     {
         public JournalWingJoin(JObject evt ) : base(evt, JournalTypeEnum.WingJoin)

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalWingLeave.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalWingLeave.cs
@@ -20,6 +20,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 {
     //When written: this player has left a wing
     //Parameters: none
+    [JournalEntryType(JournalTypeEnum.WingLeave)]
     public class JournalWingLeave : JournalEntry
     {
         public JournalWingLeave(JObject evt ) : base(evt, JournalTypeEnum.WingLeave)

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -380,7 +380,7 @@ namespace EDDiscovery
         {
             get
             {
-                return EliteDangerous.JournalEntry.GetIcon(EntryType.ToString(),EventDescription);
+                return EliteDangerous.JournalEntry.GetIcon(EntryType, EventDescription);
             }
         }
 

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -380,7 +380,14 @@ namespace EDDiscovery
         {
             get
             {
-                return EliteDangerous.JournalEntry.GetIcon(EntryType, EventDescription);
+                if (journalEntry != null)
+                {
+                    return journalEntry.GetIcon();
+                }
+                else
+                {
+                    return EliteDangerous.JournalEntry.GetIcon(EntryType, EventDescription);
+                }
             }
         }
 

--- a/EDDiscovery/JSON/JSONPrettyPrint.cs
+++ b/EDDiscovery/JSON/JSONPrettyPrint.cs
@@ -268,15 +268,12 @@ namespace EDDiscovery
             }
         }
 
-        bool InDupList(JToken jt, string name)
+        bool InDupList(HashSet<string> names, string name)
         {
             foreach (string l in duplicatepostfixremove)
             {
-                foreach( JToken jc in jt.Children())
-                {
-                    if (jc.Path.Contains(name + l))
-                        return true;
-                }
+                if (names.Contains(name + l))
+                    return true;
             }
             return false;
         }
@@ -291,9 +288,12 @@ namespace EDDiscovery
                 JObject jo = JObject.Parse(json);  // Create a clone
                 int linelen = 0;
                 int nc = 1;
-                foreach (JToken jc in jo.Children())
+
+                HashSet<string> names = new HashSet<string>(jo.Properties().Select(p => p.Name));
+
+                foreach (JProperty jc in jo.Properties())
                 {
-                    if ( !InDupList(jo,jc.Path))
+                    if (!InDupList(names, jc.Name))
                         ExpandTokens(jc, ref outstr, ref linelen, nc, jo.Children().Count());
 
                     nc++;

--- a/EDDiscovery/ObjectExtensions.cs
+++ b/EDDiscovery/ObjectExtensions.cs
@@ -14,6 +14,7 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Text.RegularExpressions;
 
@@ -220,10 +221,36 @@ public static class ObjectExtensions
 
     public static string SplitCapsWord(this string capslower)
     {
-        string s = Regex.Replace(capslower, @"([A-Z]+)([A-Z][a-z])", "$1 $2"); //Upper(rep)UpperLower = Upper(rep) UpperLower
-        s = Regex.Replace(s, @"([a-z\d])([A-Z])", "$1 $2");     // lowerdecUpper split
-        s = Regex.Replace(s, @"[-\s]", " ");                    // -orwhitespace with spc
-        return s;
+        List<int> positions = new List<int>();
+        List<string> words = new List<string>();
+
+        int start = 0;
+
+        if (capslower[0] == '-' || char.IsWhiteSpace(capslower[0]))  // Remove leading dash or whitespace
+            start = 1;
+
+        for (int i = 1; i <= capslower.Length; i++)
+        {
+            char c0 = capslower[i - 1];
+            char c1 = i < capslower.Length ? capslower[i] : '\0';
+            char c2 = i < capslower.Length - 1 ? capslower[i + 1] : '\0';
+
+            if (i == capslower.Length || // End of string
+                (i < capslower.Length - 1 && c0 >= 'A' && c0 <= 'Z' && c1 >= 'A' && c1 <= 'Z' && c2 >= 'a' && c2 <= 'z') || // UpperUpperLower
+                (((c0 >= 'a' && c0 <= 'z') || (c0 >= '0' && c0 <= '9')) && c1 >= 'A' && c1 <= 'Z') || // LowerdigitUpper
+                (c1 == '-' || c1 == ' ' || c1 == '\t' || c1 == '\r')) // dash or whitespace
+            {
+                if (i > start)
+                    words.Add(capslower.Substring(start, i - start));
+
+                if (i < capslower.Length && (c1 == '-' || c1 == ' ' || c1 == '\t' || c1 == '\r'))
+                    start = i + 1;
+                else
+                    start = i;
+            }
+        }
+
+        return String.Join(" ", words);
     }
 
     public static bool Eval(this string ins, out string res)        // true, res = eval.  false, res = error


### PR DESCRIPTION
* Use interfaces for journal entries that implement `Ledger()` or `LedgerNC()`
* Decorate journal classes with `JournalEventType` attributes linking the journal class to the journal event it handles
* Cache a lookup table journal event types
* Cache a lookup table of icon accessors
* Add a virtual instance GetIcon() method to JournalEntry, and override that on classes that change their icon based on their state (JournalShieldState and JournalVehicleSwitch)