### PR TITLE
CSCore.dll is required for 6.1, so include it in the portable zip

### DIFF
--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1324,6 +1324,7 @@
       <ZipFiles Include="$(ProjectDir)\App.Portable.config">
         <Name>EDDiscovery.exe.config</Name>
       </ZipFiles>
+      <ZipFiles Include="$(OutputPath)\CSCore.dll" />
       <ZipFiles Include="$(OutputPath)\fround.js" />
       <ZipFiles Include="$(OutputPath)\trilateration.js" />
       <ZipFiles Include="$(OutputPath)\Newtonsoft.Json.dll" />


### PR DESCRIPTION
Otherwise, running the portable build yields:

>==== UNHANDLED EXCEPTION ====
>System.IO.FileNotFoundException: Could not load file or assembly 'CSCore, Version=1.1.6245.30570, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea' or one of its dependencies. The system cannot find the file specified.
>File name: 'CSCore, Version=1.1.6245.30570, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea'
>   at EDDiscovery.Audio.AudioDriverCSCore..ctor(String devicestr)
>   at EDDiscovery.EDDiscoveryForm..ctor()
>   at EDDiscovery.Program.Main()
>
>WRN: Assembly binding logging is turned OFF.
>To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
>Note: There is some performance penalty associated with assembly bind failure logging.
>To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].
>
>==== cut ====
