### PR TITLE
Bump the forum link to the newer post

### DIFF
--- a/EDDiscovery/Properties/Resources.Designer.cs
+++ b/EDDiscovery/Properties/Resources.Designer.cs
@@ -2020,7 +2020,7 @@ namespace EDDiscovery.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://forums.frontier.co.uk/showthread.php?t=138155&amp;amp;p=2113535#post2113535.
+        ///   Looks up a localized string similar to https://forums.frontier.co.uk/showthread.php/t=329643-EDDiscovery-Windows-Mac-Journals-Exploration-Trading-Voice-Star-Maps?p=5154370&amp;viewfull=1#post5154370.
         /// </summary>
         internal static string URLProjectEDForumPost {
             get {

--- a/EDDiscovery/Properties/Resources.resx
+++ b/EDDiscovery/Properties/Resources.resx
@@ -707,7 +707,7 @@
     <value>https://discordapp.com/invite/0qIqfCQbziTWzsQu</value>
   </data>
   <data name="URLProjectEDForumPost" xml:space="preserve">
-    <value>https://forums.frontier.co.uk/showthread.php?t=138155&amp;amp;p=2113535#post2113535</value>
+    <value>https://forums.frontier.co.uk/showthread.php/t=329643-EDDiscovery-Windows-Mac-Journals-Exploration-Trading-Voice-Star-Maps?p=5154370&amp;viewfull=1#post5154370</value>
   </data>
   <data name="URLProjectFeedback" xml:space="preserve">
     <value>https://github.com/EDDiscovery/EDDiscovery/issues</value>


### PR DESCRIPTION
Update the `URLProjectEDForumPost` resource from [this (rather old) link](https://forums.frontier.co.uk/showthread.php?t=138155&amp;p=2113535#post2113535) to [this (fresh) link](https://forums.frontier.co.uk/showthread.php/t=329643-EDDiscovery-Windows-Mac-Journals-Exploration-Trading-Voice-Star-Maps?p=5154370&viewfull=1#post5154370).

If there's a different link that would be preferred, feel free to scrub this and use that instead.