### PR TITLE
Resize event was being recursive at first show

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -90,6 +90,7 @@ namespace EDDiscovery
 
         public PopOutControl PopOuts;
 
+        private bool _shownOnce = false;
         private bool _formMax;
         private int _formWidth;
         private int _formHeight;
@@ -260,6 +261,7 @@ namespace EDDiscovery
 
             actioncontroller.ActionRun("onStartup", "ProgramEvent");
             splashform.Hide();
+            _shownOnce = true;
         }
 
         private Task CheckForNewInstallerAsync()
@@ -993,13 +995,13 @@ namespace EDDiscovery
         private void EDDiscoveryForm_Resize(object sender, EventArgs e)
         {
             // We may be getting called by this.ResumeLayout() from InitializeComponent().
-            if (EDDConfig != null)
+            if (EDDConfig != null && _shownOnce)
             {
                 if (EDDConfig.UseNotifyIcon && EDDConfig.MinimizeToNotifyIcon)
                 {
                     if (FormWindowState.Minimized == WindowState)
                         Hide();
-                    else
+                    else if (!Visible)
                         Show();
                 }
                 RecordPosition();


### PR DESCRIPTION
At least when the theme is adjusting window manager chrome. This doesn't make the initial painting instantaneous, but it does clear up some of my dancing chrome issues.