### PR TITLE
Figured out where all of my vRAM was going...

### DIFF
--- a/EDDiscovery/Program.cs
+++ b/EDDiscovery/Program.cs
@@ -35,7 +35,7 @@ namespace EDDiscovery
         [STAThread]
         static void Main()
         {
-            OpenTK.Toolkit.Init(new OpenTK.ToolkitOptions { EnableHighResolution = false });
+            var tk = OpenTK.Toolkit.Init(new OpenTK.ToolkitOptions { EnableHighResolution = false });
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
@@ -57,6 +57,7 @@ namespace EDDiscovery
                  * TODO: show a dialog and/or bring the current instance's window to the foreground.
                  */
             }
+            tk.Dispose();
         }
 
         static void Run()


### PR DESCRIPTION
OpenTK apparently expects to be disposed of, as it lacks context inside of the finalizer. Also, don't use the 3D map with a debug build of OpenTK or GLControl if you value your sanity.