### PR TITLE
Make HistoryEntry constructor private

### DIFF
--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -497,8 +497,7 @@ namespace EDDiscovery2.EDSM
                                 id_edsm = id
                             };
 
-                        HistoryEntry he = new HistoryEntry();
-                        he.MakeVSEntry(sc, etutc, EDDConfig.Instance.DefaultMapColour, "", "", firstdiscover: firstdiscover);       // FSD jump entry
+                        HistoryEntry he = HistoryEntry.MakeVSEntry(sc, etutc, EDDConfig.Instance.DefaultMapColour, "", "", firstdiscover: firstdiscover);       // FSD jump entry
                         log.Add(he);
                     }
                 }

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -19,6 +19,7 @@ using EDDiscovery.EliteDangerous.JournalEvents;
 using EDDiscovery2;
 using EDDiscovery2.DB;
 using EDDiscovery2.EDSM;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -119,19 +120,27 @@ namespace EDDiscovery
 
         #region Constructors
 
-        public void MakeVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info, int journalid = 0, bool firstdiscover = false)
+        private HistoryEntry()
+        {
+
+        }
+
+        public static HistoryEntry MakeVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info, int journalid = 0, bool firstdiscover = false)
         {
             Debug.Assert(sys != null);
-            EntryType = EliteDangerous.JournalTypeEnum.FSDJump;
-            System = sys;
-            EventTimeUTC = eventt;
-            EventSummary = "Jump to " + System.name;
-            EventDescription = dist;
-            EventDetailedInfo = info;
-            MapColour = m;
-            Journalid = journalid;
-            IsEDSMFirstDiscover = firstdiscover;
-            EdsmSync = true; 
+            return new HistoryEntry
+            {
+                EntryType = EliteDangerous.JournalTypeEnum.FSDJump,
+                System = sys,
+                EventTimeUTC = eventt,
+                EventSummary = "Jump to " + sys.name,
+                EventDescription = dist,
+                EventDetailedInfo = info,
+                MapColour = m,
+                Journalid = journalid,
+                IsEDSMFirstDiscover = firstdiscover,
+                EdsmSync = true
+            };
         }
 
         public static HistoryEntry FromJournalEntry(EliteDangerous.JournalEntry je, HistoryEntry prev, bool checkedsm, out bool journalupdate, SQLiteConnectionSystem conn = null, EDCommander cmdr = null)

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -39,11 +39,19 @@ namespace EDDiscoveryTests
     [TestClass]
     public class TravelHistoryFilterTests
     {
+        private ISystem sol = new EDDiscovery2.DB.InMemory.SystemClass
+        {
+            name = "Sol",
+            x = 0,
+            y = 0,
+            z = 0
+        };
+
         [Test]
         [TestMethod]
         public void No_filter_does_not_filter_anything()
         {
-            var veryOldData = new HistoryEntry { EventTimeUTC = DateTime.UtcNow.Subtract(TimeSpan.FromDays(500000)) };
+            var veryOldData = HistoryEntry.MakeVSEntry(sol, DateTime.UtcNow.Subtract(TimeSpan.FromDays(500000)), 0, "", "");
             var input = new HistoryList { veryOldData };
 
             Check.That(TravelHistoryFilter.NoFilter.Filter(input)).ContainsExactly(veryOldData);
@@ -53,8 +61,8 @@ namespace EDDiscoveryTests
         [TestMethod]
         public void Data_age_filter_removes_data_older_than_the_limit_and_keeps_data_more_recent_than_the_limit()
         {
-            var now = new HistoryEntry { EventTimeUTC = DateTime.UtcNow };
-            var fourDaysAgo = new HistoryEntry { EventTimeUTC = DateTime.UtcNow.Subtract(TimeSpan.FromDays(4))};
+            var now = HistoryEntry.MakeVSEntry(sol, DateTime.UtcNow, 0, "", "");
+            var fourDaysAgo = HistoryEntry.MakeVSEntry(sol, DateTime.UtcNow.Subtract(TimeSpan.FromDays(4)), 0, "", "");
             var input = new HistoryList { fourDaysAgo, now };
 
             Check.That(TravelHistoryFilter.FromDays(2).Filter(input)).ContainsExactly(now);
@@ -64,9 +72,9 @@ namespace EDDiscoveryTests
         [TestMethod]
         public void Last_2_items_filter_returns_the_2_most_recent_items_sorted_by_most_recent_and_removes_the_older_items()
         {
-            var twentyDaysAgo = new HistoryEntry { EventTimeUTC = DateTime.UtcNow.Subtract(TimeSpan.FromDays(20)) };
-            var tenDaysAgo = new HistoryEntry { EventTimeUTC = DateTime.UtcNow.Subtract(TimeSpan.FromDays(10)) };
-            var thirtyDaysAgo = new HistoryEntry { EventTimeUTC = DateTime.UtcNow.Subtract(TimeSpan.FromDays(30)) };
+            var twentyDaysAgo = HistoryEntry.MakeVSEntry(sol, DateTime.UtcNow.Subtract(TimeSpan.FromDays(20)), 0, "", "");
+            var tenDaysAgo = HistoryEntry.MakeVSEntry(sol, DateTime.UtcNow.Subtract(TimeSpan.FromDays(10)), 0, "", "");
+            var thirtyDaysAgo = HistoryEntry.MakeVSEntry(sol, DateTime.UtcNow.Subtract(TimeSpan.FromDays(30)), 0, "", "");
             var input = new HistoryList { twentyDaysAgo, tenDaysAgo, thirtyDaysAgo };
 
             Check.That(TravelHistoryFilter.Last(2).Filter(input)).ContainsExactly(tenDaysAgo, twentyDaysAgo);


### PR DESCRIPTION
Enforce the requirement that a history entry must either be a FSDJump entry or come from a journal entry