### PR TITLE
Ignore scans for old names of renamed systems

### DIFF
--- a/EDDiscovery/EliteDangerous/BodyDesignations.cs
+++ b/EDDiscovery/EliteDangerous/BodyDesignations.cs
@@ -1899,8 +1899,8 @@ namespace EDDiscovery.EliteDangerous
                 { "PER - G8XBE", "Kepler-20 1" },
                 { "Maxine's World", "Kepler-20 3" },
             } },
-            { "MOA-2007-BGL-400L", new Dictionary<string, string> {
-                { "MOA-2007-BGL-400L b", "MOA-2007-BGL-400L 1" }
+            { "MOA-2007-BLG-400L", new Dictionary<string, string> {
+                { "MOA-2007-BLG-400L b", "MOA-2007-BLG-400L 1" }
             } },
         };
     }

--- a/EDDiscovery/EliteDangerous/StarScan.cs
+++ b/EDDiscovery/EliteDangerous/StarScan.cs
@@ -182,15 +182,37 @@ namespace EDDiscovery.EliteDangerous
 
         public bool AddScanToBestSystem(JournalScan je, int startindex, List<HistoryEntry> hl)
         {
+            HistoryEntry he;
+            JournalLocOrJump jl;
+            return AddScanToBestSystem(je, startindex, hl, out he, out jl);
+        }
+
+        public bool AddScanToBestSystem(JournalScan je, int startindex, List<HistoryEntry> hl, out HistoryEntry he, out JournalLocOrJump jl)
+        {
             for (int j = startindex; j >= 0; j--)
             {
-                string designation = GetBodyDesignation(je, hl[j].System.name);
-                if (je.IsStarNameRelated(hl[j].System.name, designation))       // if its part of the name, use it
+                he = hl[j];
+
+                if (he.IsLocOrJump)
                 {
-                    je.BodyDesignation = designation;
-                    return Process(je, hl[j].System);
+                    jl = (JournalLocOrJump)he.journalEntry;
+                    string designation = GetBodyDesignation(je, he.System.name);
+
+                    if (je.IsStarNameRelated(he.System.name, designation))       // if its part of the name, use it
+                    {
+                        je.BodyDesignation = designation;
+                        return Process(je, he.System);
+                    }
+                    else if (jl != null && je.IsStarNameRelated(jl.StarSystem, designation))
+                    {
+                        // Ignore scans where the system name has changed
+                        return false;
+                    }
                 }
             }
+
+            jl = null;
+            he = null;
 
             je.BodyDesignation = GetBodyDesignation(je, hl[startindex].System.name);
             return Process(je, hl[startindex].System);         // no relationship, add..

--- a/EDDiscovery/HistoryList.cs
+++ b/EDDiscovery/HistoryList.cs
@@ -1137,10 +1137,16 @@ namespace EDDiscovery
                 if (je.EventTypeID == JournalTypeEnum.Scan)
                 {
                     JournalScan js = je as JournalScan;
-                    if (!starscan.AddScanToBestSystem(js, Count - 1, EntryOrder))
+                    JournalLocOrJump jl;
+                    HistoryEntry jlhe;
+                    if (!starscan.AddScanToBestSystem(js, Count - 1, EntryOrder, out jlhe, out jl))
                     {
-                        logerror("Cannot add scan to system - alert the EDDiscovery developers using either discord or Github (see help)" + Environment.NewLine +
-                                         "Scan object " + js.BodyName + " in " + he.System.name);
+                        // Ignore scans where the system name has been changed
+                        if (jl == null || jl.StarSystem.Equals(jlhe.System.name, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            logerror("Cannot add scan to system - alert the EDDiscovery developers using either discord or Github (see help)" + Environment.NewLine +
+                                             "Scan object " + js.BodyName + " in " + he.System.name);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Ignore old scans of bodies named by their old system name in systems that have been renamed, and silence the error that is printed when such a scan cannot be assigned to a system.