### PR TITLE
Write version string to trace log on launch

### DIFF
--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -76,6 +76,8 @@ namespace EDDiscovery
         {
             InitializeConfig(noreposition);
 
+            Trace.WriteLine($"*** Elite Dangerous Discovery Initializing - {EDDConfig.Options.VersionDisplayString}, Platform: {Environment.OSVersion.Platform.ToString()}");
+
             return Task.Factory.StartNew(InitializeDatabases);
         }
 


### PR DESCRIPTION
This should aid in issue tracker troubleshooting. Outputs the following, as early as possible:

>[2017-03-22 15:59:30Z] *** Elite Dangerous Discovery - Version 6.2.0.0, OS: Win32NT

This PR addresses the issues from #850, and doesn't even bother trying to grab all of the extended information.