### PR TITLE
Create a README.md to point users to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+
+EDDiscovery is a captain's log and 2D/3D map for Elite Dangerous players. Find more information in the [EDDiscovery's wiki](https://github.com/EDDiscovery/EDDiscovery/wiki)


### PR DESCRIPTION
I'm used to read READMEs of repos instead of wiki, and I felt slightly confused when looking at this repo. A very short README should point users visiting `https://github.com/EDDiscovery/EDDiscovery` to the right place.