### PR TITLE
Send ship info to EDSM

### DIFF
--- a/EDDiscovery/Actions/ActionVars.cs
+++ b/EDDiscovery/Actions/ActionVars.cs
@@ -72,7 +72,7 @@ namespace EDDiscovery.Actions
                 sv = si.SubVehicle.ToString();
                 fullinfo = si.ShipFullInfo;
                 shortname = si.ShipShortName;
-                fuel = si.FuelCapacity().ToString(System.Globalization.CultureInfo.InvariantCulture);
+                fuel = si.FuelCapacity.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 cargo = si.CargoCapacity().ToString(System.Globalization.CultureInfo.InvariantCulture);
             }
 

--- a/EDDiscovery/EDSM/EDSMClass.cs
+++ b/EDDiscovery/EDSM/EDSMClass.cs
@@ -835,7 +835,7 @@ namespace EDDiscovery2.EDSM
         }
 
 
-        public string CommanderUpdateShip(int shipId, string type)
+        public string CommanderUpdateShip(int shipId, string type, EDDiscovery.EliteDangerous.ShipInformation shipinfo = null, int cargoqty = -1)
         {
             if (!IsApiKeySet)
                 return null;
@@ -843,8 +843,31 @@ namespace EDDiscovery2.EDSM
             string query;
             query = "update-ship?commanderName=" + HttpUtility.UrlEncode(commanderName) + "&apiKey=" + apiKey;
             query = query + "&shipId=" + shipId.ToString();
-            query = query + "&type=" + type;
+            query = query + "&type=" + Uri.EscapeDataString(type);
 
+            if (shipinfo != null)
+            {
+                int cargocap = shipinfo.CargoCapacity();
+                if (cargocap != 0)
+                    query += "&cargoCapacity=" + cargocap.ToString();
+                if (cargoqty >= 0)
+                    query += "&cargoQty=" + cargoqty.ToString();
+                double fuelcap = shipinfo.FuelCapacity;
+                if (fuelcap != 0)
+                    query += "&fuelMainCapacity=" + fuelcap.ToString();
+                double fuellevel = shipinfo.FuelLevel;
+                if (fuellevel != 0)
+                    query += "&fuelMainLevel=" + fuellevel.ToString();
+                string ident = shipinfo.ShipUserIdent;
+                if (!string.IsNullOrWhiteSpace(ident))
+                    query += "&shipIdent=" + Uri.EscapeDataString(ident);
+                string name = shipinfo.ShipUserName;
+                if (!string.IsNullOrWhiteSpace(name))
+                    query += "&shipName=" + Uri.EscapeDataString(name);
+                string paintjob = shipinfo.Modules.ContainsKey("Paint Job") ? shipinfo.Modules["Paint Job"].ItemFD : null;
+                if (!string.IsNullOrWhiteSpace(paintjob))
+                    query += "&paintJob=" + Uri.EscapeDataString(paintjob);
+            }
 
             var response = RequestGet("api-commander-v1/" + query, handleException: true);
 

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalCargo.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalCargo.cs
@@ -73,6 +73,8 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
         public void MaterialList(MaterialCommoditiesList mc, DB.SQLiteConnectionUser conn)
         {
             //System.Diagnostics.Debug.WriteLine("Updated at " + this.EventTimeUTC.ToString());
+            mc.Clear(true);
+
             foreach (Cargo c in Inventory)
                 mc.Set(MaterialCommodities.CommodityCategory, c.Name, c.Count, 0, conn);
         }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -44,7 +44,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 
 
     [JournalEntryType(JournalTypeEnum.FSDJump)]
-    public class JournalFSDJump : JournalLocOrJump
+    public class JournalFSDJump : JournalLocOrJump, IShipInformation
     {
         public JournalFSDJump(JObject evt) : base(evt, JournalTypeEnum.FSDJump)
         {
@@ -115,5 +115,9 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 
         public override System.Drawing.Bitmap Icon { get { return EDDiscovery.Properties.Resources.hyperspace; } }
 
+        public void ShipInformation(ShipInformationList shp, DB.SQLiteConnectionUser conn)
+        {
+            shp.FSDJump(this);
+        }
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalFuelScope.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalFuelScope.cs
@@ -23,7 +23,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
     //•	Scooped: tons fuel scooped
     //•	Total: total fuel level after scooping
     [JournalEntryType(JournalTypeEnum.FuelScoop)]
-    public class JournalFuelScoop : JournalEntry
+    public class JournalFuelScoop : JournalEntry, IShipInformation
     {
         public JournalFuelScoop(JObject evt ) : base(evt, JournalTypeEnum.FuelScoop)
         {
@@ -40,6 +40,11 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             summary = EventTypeStr.SplitCapsWord();
             info = Tools.FieldBuilder(";t;0.0" , Scooped, "Total:;t;0.0" , Total);
             detailed = "";
+        }
+
+        public void ShipInformation(ShipInformationList shp, DB.SQLiteConnectionUser conn)
+        {
+            shp.FuelScoop(this);
         }
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalLoadGame.cs
@@ -79,7 +79,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 
         public void ShipInformation(ShipInformationList shp, DB.SQLiteConnectionUser conn)
         {
-            shp.LoadGame(ShipId, Ship, ShipFD, ShipName, ShipIdent);
+            shp.LoadGame(ShipId, Ship, ShipFD, ShipName, ShipIdent, FuelLevel, FuelCapacity);
         }
 
     }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterials.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalMaterials.cs
@@ -93,6 +93,8 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
         public void MaterialList(MaterialCommoditiesList mc, DB.SQLiteConnectionUser conn)
         {
             //System.Diagnostics.Debug.WriteLine("Updated at " + this.EventTimeUTC.ToString());
+            mc.Clear(false);
+
             if ( Raw != null )
                 foreach (Material m in Raw)
                     mc.Set(MaterialCommodities.MaterialRawCategory, m.Name, m.Count, 0, conn);

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelAll.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 
     //•	Security
     [JournalEntryType(JournalTypeEnum.RefuelAll)]
-    public class JournalRefuelAll : JournalEntry, ILedgerJournalEntry
+    public class JournalRefuelAll : JournalEntry, ILedgerJournalEntry, IShipInformation
     {
         public JournalRefuelAll(JObject evt ) : base(evt, JournalTypeEnum.RefuelAll)
         {
@@ -47,6 +47,11 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             summary = EventTypeStr.SplitCapsWord();
             info = Tools.FieldBuilder("Cost:; credits", Cost, "Fuel:; tons;0.0", Amount);
             detailed = "";
+        }
+
+        public void ShipInformation(ShipInformationList shp, DB.SQLiteConnectionUser conn)
+        {
+            shp.RefuelAll(this);
         }
     }
 }

--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
 
     //•	Security
     [JournalEntryType(JournalTypeEnum.RefuelPartial)]
-    public class JournalRefuelPartial : JournalEntry, ILedgerJournalEntry
+    public class JournalRefuelPartial : JournalEntry, ILedgerJournalEntry, IShipInformation
     {
         public JournalRefuelPartial(JObject evt ) : base(evt, JournalTypeEnum.RefuelPartial)
         {
@@ -46,6 +46,11 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             summary = EventTypeStr.SplitCapsWord();
             info = Tools.FieldBuilder("Cost:; credits", Cost, "Fuel:; tons;0.0", Amount);
             detailed = "";
+        }
+
+        public void ShipInformation(ShipInformationList shp, DB.SQLiteConnectionUser conn)
+        {
+            shp.RefuelPartial(this);
         }
     }
 }

--- a/EDDiscovery/EliteDangerous/MaterialCommoditiesList.cs
+++ b/EDDiscovery/EliteDangerous/MaterialCommoditiesList.cs
@@ -154,6 +154,19 @@ namespace EDDiscovery.EliteDangerous
             list[index] = mc;
         }
 
+        public void Clear(bool commodity)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                MaterialCommodities mc = list[i];
+                if (commodity == (mc.category == MaterialCommodities.CommodityCategory))
+                {
+                    mc.count = 0;
+                    list[i] = mc;
+                }
+            }
+        }
+
         static public MaterialCommoditiesList Process(JournalEntry je, MaterialCommoditiesList oldml, SQLiteConnectionUser conn,
                                                         bool clearzeromaterials, bool clearzerocommodities)
         {

--- a/EDDiscovery/EliteDangerous/ShipInformation.cs
+++ b/EDDiscovery/EliteDangerous/ShipInformation.cs
@@ -716,6 +716,29 @@ namespace EDDiscovery.EliteDangerous
             }
         }
 
+        public void RefuelAll(JournalRefuelAll e)
+        {
+            if (HaveCurrentShip)
+            {
+                Ships[currentid] = CurrentShip.SetFuelLevel(CurrentShip.FuelCapacity);
+            }
+        }
+
+        public void RefuelPartial(JournalRefuelPartial e)
+        {
+            if (HaveCurrentShip)
+            {
+                // Amount includes reserve
+                double level = CurrentShip.FuelLevel + e.Amount - 0.1;
+
+                // If amount refuelled is less than 10%, then the tank is full
+                if (e.Amount < CurrentShip.FuelCapacity / 10 || level > CurrentShip.FuelCapacity)
+                    level = CurrentShip.FuelCapacity;
+
+                Ships[currentid] = CurrentShip.SetFuelLevel(level);
+            }
+        }
+
         #region Helpers
 
         private ShipInformation EnsureShip(int id)      // ensure we have an ID of this type..


### PR DESCRIPTION
This sends the cargo capacity and quantity, main fuel capacity and level, ship name, ship ident, and paintjob to EDSM.  This should also work with pre-2.3 events.