### PR TITLE
Using CellEnter would cause a UI crash if cursor keys held down

### DIFF
--- a/EDDiscovery/UserControls/UserControlTravelGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.Designer.cs
@@ -292,10 +292,10 @@ namespace EDDiscovery.UserControls
             this.dataGridViewTravel.TabIndex = 3;
             this.dataGridViewTravel.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewTravel_CellClick);
             this.dataGridViewTravel.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewTravel_CellDoubleClick);
-            this.dataGridViewTravel.CellEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewTravel_CellEnter);
             this.dataGridViewTravel.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewTravel_ColumnHeaderMouseClick);
             this.dataGridViewTravel.RowPostPaint += new System.Windows.Forms.DataGridViewRowPostPaintEventHandler(this.dataGridViewTravel_RowPostPaint);
             this.dataGridViewTravel.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridViewTravel_KeyDown);
+            this.dataGridViewTravel.KeyUp += new System.Windows.Forms.KeyEventHandler(this.dataGridViewTravel_KeyUp);
             this.dataGridViewTravel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewTravel_MouseDown);
             // 
             // ColumnTime

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -330,27 +330,36 @@ namespace EDDiscovery.UserControls
                 OnChangedSelection(e.RowIndex, e.ColumnIndex, false, e.ColumnIndex == TravelHistoryColumns.Note);
         }
 
+        int keyrepeatcount = 0;     // 1 is first down, 2 is second.  on 2+ we call the check selection to update the screen.  The final key up finished the job.
 
-        private void dataGridViewTravel_CellEnter(object sender, DataGridViewCellEventArgs e)
+        private void dataGridViewTravel_KeyDown(object sender, KeyEventArgs e)
         {
-            //System.Diagnostics.Debug.WriteLine("Cell Enter");
+            //System.Diagnostics.Debug.WriteLine("Key down " + e.KeyCode + " " + dataGridViewTravel.CurrentCell.RowIndex + ":" + dataGridViewTravel.CurrentCell.ColumnIndex);
+            keyrepeatcount++;
+
+            if (keyrepeatcount > 1)
+                CheckForSelection(e.KeyCode);
+        }
+
+        private void dataGridViewTravel_KeyUp(object sender, KeyEventArgs e)
+        {
+            //System.Diagnostics.Debug.WriteLine("Key up " + e.KeyCode + " " + dataGridViewTravel.CurrentCell.RowIndex + ":" + dataGridViewTravel.CurrentCell.ColumnIndex);
+            CheckForSelection(e.KeyCode);
+            keyrepeatcount = 0;
+        }
+
+        void CheckForSelection(Keys code)
+        { 
+            bool cursorkeydown = (code == Keys.Up || code == Keys.Down || code == Keys.PageDown || code == Keys.PageUp || code == Keys.Left || code == Keys.Right);
 
             if (cursorkeydown)
             {
-                cursorkeydown = false;
-                currentGridRow = e.RowIndex;
+                currentGridRow = dataGridViewTravel.CurrentCell.RowIndex;
                 if (OnChangedSelection != null)
-                    OnChangedSelection(e.RowIndex, e.ColumnIndex, false, e.ColumnIndex == TravelHistoryColumns.Note);
+                    OnChangedSelection(dataGridViewTravel.CurrentCell.RowIndex, dataGridViewTravel.CurrentCell.ColumnIndex, false, dataGridViewTravel.CurrentCell.ColumnIndex == TravelHistoryColumns.Note);
             }
-
         }
 
-        bool cursorkeydown = false;
-        private void dataGridViewTravel_KeyDown(object sender, KeyEventArgs e)
-        {
-            //System.Diagnostics.Debug.WriteLine("Key down " + e.KeyCode);
-            cursorkeydown = (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down || e.KeyCode == Keys.PageDown || e.KeyCode == Keys.PageUp);
-        }
 
         public void UpdateCurrentNote(string s)
         {
@@ -395,6 +404,8 @@ namespace EDDiscovery.UserControls
                                              int totalentries, HistoryEntry he,
                                              int hpos, int colwidth, bool showfsdmapcolour)
         {
+            System.Diagnostics.Debug.Assert(he != null);
+
             string rowIdx;
 
             if (discoveryform.settings.OrderRowsInverted)


### PR DESCRIPTION
Due to cell enter being called by the underlying system when the grid
row was filled, and the tag not being set up yet.

So, don't use cell enter (it was a clodge anyway to get the cursor keys
working).  Instead use key down/up and use that to decide when to
update.