### PR TITLE
Fix slow note editing when 3dmap is open

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -879,13 +879,13 @@ namespace EDDiscovery
                     {
                         if (EDCommander.Current.SyncToEdsm && he.IsFSDJump)       // only send on FSD jumps
                             EDSMSync.SendComments(he.snc.Name, he.snc.Note, he.snc.EdsmId);
+
+                        Map.UpdateNote();
                     }
                     else
                     {
                         _uncommittedNoteHistoryEntry = he;
                     }
-
-                    Map.UpdateNote();
 
                     travelHistoryControl1.UpdateNoteJID(he.Journalid, txt);
                     PopOuts.UpdateNoteJID(he.Journalid, txt);


### PR DESCRIPTION
Move updating the Map Note from every keypress to only on exiting the control as otherwise it is unusably slow.