### PR TITLE
Catch errors reading register from EDDUser.sqlite

### DIFF
--- a/EDDiscovery/DB/SQLiteConnectionED.cs
+++ b/EDDiscovery/DB/SQLiteConnectionED.cs
@@ -49,9 +49,16 @@ namespace EDDiscovery.DB
 
             if (File.Exists(GetSQLiteDBFile(EDDSqlDbSelection.EDDiscovery)))
             {
-                using (SQLiteConnectionOld conn = new SQLiteConnectionOld(true))
+                try
                 {
-                    conn.GetRegister(reg);
+                    using (SQLiteConnectionOld conn = new SQLiteConnectionOld(true))
+                    {
+                        conn.GetRegister(reg);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Trace.WriteLine($"Unable to read register table from old database\n{ex.ToString()}");
                 }
             }
 

--- a/EDDiscovery/DB/SQLiteConnectionUser.cs
+++ b/EDDiscovery/DB/SQLiteConnectionUser.cs
@@ -696,9 +696,16 @@ namespace EDDiscovery.DB
 
             if (File.Exists(GetSQLiteDBFile(EDDSqlDbSelection.EDDUser)))
             {
-                using (SQLiteConnectionUser conn = new SQLiteConnectionUser(true, true, EDDbAccessMode.Reader))
+                try
                 {
-                    conn.GetRegister(reg);
+                    using (SQLiteConnectionUser conn = new SQLiteConnectionUser(true, true, EDDbAccessMode.Reader))
+                    {
+                        conn.GetRegister(reg);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Trace.WriteLine($"Unable to read register table from EDDUser.sqlite\n{ex.ToString()}");
                 }
             }
             else


### PR DESCRIPTION
Don't error out when EDDUser.sqlite exists but has no data.  This should prevent a repeat of #1025.