### PR TITLE
HomeSystem refactor; TravelHistoryControl tooltips

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -909,21 +909,7 @@ namespace EDDiscovery
 
         public ISystem GetHomeSystem()
         {
-            string homesysname = settings.MapHomeSystem;
-
-            ISystem homesys = ((homesysname != null) ? SystemClass.GetSystem(homesysname) : null);
-
-            if (homesys == null || !homesys.HasCoordinate)
-            {
-                homesys = SystemClass.GetSystem("Sol");
-
-                if (homesys == null)
-                {
-                    homesys = new SystemClass("Sol", 0, 0, 0);
-                }
-            }
-
-            return homesys;
+            return settings.HomeSystem;
         }
 
         public void Open3DMap(HistoryEntry he)

--- a/EDDiscovery/Settings.Designer.cs
+++ b/EDDiscovery/Settings.Designer.cs
@@ -394,6 +394,7 @@ namespace EDDiscovery
             this.textBoxHomeSystem.Size = new System.Drawing.Size(221, 20);
             this.textBoxHomeSystem.TabIndex = 0;
             this.toolTip.SetToolTip(this.textBoxHomeSystem, "Select home system for 3d Map");
+            this.textBoxHomeSystem.Validated += new System.EventHandler(this.textBoxHomeSystem_Validated);
             // 
             // panel_defaultmapcolor
             // 

--- a/EDDiscovery/Settings.cs
+++ b/EDDiscovery/Settings.cs
@@ -31,9 +31,24 @@ namespace EDDiscovery
     public partial class Settings : UserControl
     {
         private EDDiscoveryForm _discoveryForm;
+        private ISystem _homeSystem = new SystemClass("Sol", 0, 0, 0);
         private ThemeEditor themeeditor = null;
 
-        public string MapHomeSystem { get { return textBoxHomeSystem.Text; } }
+        public ISystem HomeSystem
+        {
+            get
+            {
+                return _homeSystem;
+            }
+            private set
+            {
+                if (value != null && value.HasCoordinate)
+                {
+                    _homeSystem = value;
+                    textBoxHomeSystem.Text = value.name;
+                }
+            }
+        }
         public float MapZoom { get { return float.Parse(textBoxDefaultZoom.Text); } }
         public bool MapCentreOnSelection { get { return radioButtonHistorySelection.Checked; } }
         public bool OrderRowsInverted { get { return checkBoxOrderRowsInverted.Checked; } }
@@ -89,7 +104,7 @@ namespace EDDiscovery
 #if DEBUG
             checkboxSkipSlowUpdates.Visible = true;
 #endif
-            textBoxHomeSystem.Text = SQLiteDBClass.GetSettingString("DefaultMapCenter", "Sol");
+            HomeSystem = SystemClass.GetSystem(SQLiteDBClass.GetSettingString("DefaultMapCenter", "Sol"));
 
             textBoxDefaultZoom.Text = SQLiteDBClass.GetSettingDouble("DefaultMapZoom", 1.0).ToString();
 
@@ -340,6 +355,13 @@ namespace EDDiscovery
             _discoveryForm.LoadSavedPopouts();
         }
 
+        private void textBoxHomeSystem_Validated(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(textBoxHomeSystem.Text))
+            {
+                HomeSystem = SystemClass.GetSystem(textBoxHomeSystem.Text);
+            }
+        }
     }
 }
 

--- a/EDDiscovery/TravelHistoryControl.Designer.cs
+++ b/EDDiscovery/TravelHistoryControl.Designer.cs
@@ -195,7 +195,7 @@ namespace EDDiscovery
             this.textBoxHomeDist.Size = new System.Drawing.Size(67, 20);
             this.textBoxHomeDist.TabIndex = 42;
             this.textBoxHomeDist.TabStop = false;
-            this.toolTipEddb.SetToolTip(this.textBoxHomeDist, "Distance to home planet");
+            this.toolTipEddb.SetToolTip(this.textBoxHomeDist, "Distance to home system");
             // 
             // buttonRoss
             // 
@@ -357,7 +357,7 @@ namespace EDDiscovery
             this.textBoxSolDist.Size = new System.Drawing.Size(67, 20);
             this.textBoxSolDist.TabIndex = 44;
             this.textBoxSolDist.TabStop = false;
-            this.toolTipEddb.SetToolTip(this.textBoxSolDist, "Distance to home planet");
+            this.toolTipEddb.SetToolTip(this.textBoxSolDist, "Distance to Sol");
             // 
             // splitContainerLeftRight
             // 

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -448,17 +448,9 @@ namespace EDDiscovery
 
                     ISystem homesys = _discoveryForm.GetHomeSystem();
 
-                    if (homesys == null || !homesys.HasCoordinate)
-                    {
-                        homesys = new SystemClass("Sol", 0, 0, 0);
-                    }
-
-                    double xdist = he.System.x - homesys.x;
-                    double ydist = he.System.y - homesys.y;
-                    double zdist = he.System.z - homesys.z;
-
-                    textBoxHomeDist.Text = Math.Sqrt(xdist * xdist + ydist * ydist + zdist * zdist).ToString("0.00");
-                    textBoxSolDist.Text = Math.Sqrt(he.System.x * he.System.x + he.System.y * he.System.y + he.System.z * he.System.z).ToString("0.00");
+                    toolTipEddb.SetToolTip(textBoxHomeDist, $"Distance to home system ({homesys.name})");
+                    textBoxHomeDist.Text = SystemClass.Distance(he.System, homesys).ToString(SingleCoordinateFormat);
+                    textBoxSolDist.Text = SystemClass.Distance(he.System, 0, 0, 0).ToString(SingleCoordinateFormat);
                 }
                 else
                 {


### PR DESCRIPTION
TravelHistoryControl:
* Distance tooltips are to systems, not planets.
* Show home system directly in the tooltip.
* Switch to `SystemClass.Distance(...)` for calculations.

Settings (+EDDiscoveryForm):
* `public ISystem HomeSystem{get;};` - Filtered only when privately `set` (instead of *every* `get`); guaranteed to supply a system with coordinates.