### PR TITLE
Moar designer for AutoCompleteDGVColumn

### DIFF
--- a/EDDiscovery/Controls/AutoCompleteDGV.cs
+++ b/EDDiscovery/Controls/AutoCompleteDGV.cs
@@ -14,6 +14,7 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using EDDiscovery;
+using EDDiscovery.DB;
 using System;
 using System.ComponentModel;
 using System.Windows.Forms;
@@ -21,25 +22,11 @@ using System.Windows.Forms;
 namespace ExtendedControls
 {
     /// <summary>
-    /// Represents a string-backed column capable of autocompletion during editing inside of a <see cref="DataGridView"/> control.
+    /// A string-backed <see cref="DataGridViewColumn"/> capable of autocompletion inside of a <see cref="DataGridView"/> control.
     /// </summary>
-    /// <remarks>Attach this column to your <see cref="DataGridView"/> inside of the editor, then attach an appropriate
-    /// delegate method to the <see cref="AutoCompleteGenerator"/> property during container initialization.</remarks>
-    /// <example><code>using EDDiscovery.ExtendedControls;
-    /// using EDDiscovery.DB;
-    /// using System.Windows.Forms;
-    /// 
-    /// namespace MyProject {
-    ///     public partial class TestForm : Form
-    ///     {
-    ///         public TestForm()
-    ///         {
-    ///             InitializeComponent();
-    ///             // Assuming a designer-generated DataGridView contains a column called autoCompleteDGVColumn, with ColumnType set to AutoCompleteDGVColumn.
-    ///             autoCompleteDGVColumn.AutoCompleteGenerator += SystemClass.ReturnSystemListForAutoComplete;
-    ///         }
-    ///     }</code></example>
-    public class AutoCompleteDGVColumn : DataGridViewColumn
+    /// <remarks>Use one of the specialized variants of this class, such as <see cref="AutoCompleteSystemsColumn"/>,
+    /// or create a new subclass for best results.</remarks>
+    public abstract class AutoCompleteDGVColumn : DataGridViewColumn
     {
         #region AutoCompleteDGVColumn
 
@@ -48,12 +35,13 @@ namespace ExtendedControls
         /// Signature is "<c>List&lt;string&gt; (string, TextBox as object)</c>".
         /// </summary>
         [Browsable(false)]
-        public AutoCompleteTextBox.PerformAutoComplete AutoCompleteGenerator { get; set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public AutoCompleteTextBox.PerformAutoComplete AutoCompleteGenerator { get; protected set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoCompleteDGVColumn"/> class to the default state.
         /// </summary>
-        public AutoCompleteDGVColumn() : base(new CellDisplayControl()) { }
+        protected AutoCompleteDGVColumn() : base(new CellDisplayControl()) { }
 
         /// <summary>
         /// Gets or sets the template used to create new cells.
@@ -72,15 +60,10 @@ namespace ExtendedControls
             }
         }
 
-        /// <summary>
-        /// Creates an exact copy of this <see cref="AutoCompleteDGVColumn"/>.
-        /// </summary>
-        /// <returns>An <see cref="object"/> that represents the cloned <see cref="AutoCompleteDGVColumn"/>.</returns>
-        public override object Clone()
+        protected override void Dispose(bool disposing)
         {
-            var clone = base.Clone() as AutoCompleteDGVColumn;
-            clone.AutoCompleteGenerator = AutoCompleteGenerator;
-            return clone;
+            AutoCompleteGenerator = null;
+            base.Dispose(disposing);
         }
 
         #endregion // AutoCompleteDGVColumn
@@ -276,4 +259,65 @@ namespace ExtendedControls
 
         #endregion // CellEditControl
     }
+
+    #region Specialized AutoCompleteDGVColumn classes
+
+    /// <summary>
+    /// An <see cref="AutoCompleteDGVColumn"/> specialized for interracting solely with system names.
+    /// </summary>
+    public class AutoCompleteSystemsColumn : AutoCompleteDGVColumn
+    {
+        /// <summary>
+        /// Constructs a new <see cref="AutoCompleteSystemsColumn"/> instance.
+        /// </summary>
+        public AutoCompleteSystemsColumn() : base()
+        {
+            AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
+        }
+
+        /// <summary>
+        /// Creates an exact copy of this <see cref="AutoCompleteSystemsColumn"/>.
+        /// </summary>
+        /// <returns>An <see cref="object"/> that represents the cloned <see cref="AutoCompleteSystemsColumn"/>.</returns>
+        public override object Clone()
+        {
+            return base.Clone() as AutoCompleteSystemsColumn;
+        }
+    }
+
+#if false // Nobody needs these now, but they may come in handy someday.
+    /// <summary>
+    /// An <see cref="AutoCompleteDGVColumn"/> specialized for interracting solely with GalMap objects.
+    /// </summary>
+    public class AutoCompleteGalMapColumn : AutoCompleteDGVColumn
+    {
+        public AutoCompleteGalMapColumn() : base()
+        {
+            AutoCompleteGenerator += SystemClass.ReturnOnlyGalMapListForAutoComplete;
+        }
+
+        public override object Clone()
+        {
+            return base.Clone() as AutoCompleteGalMapColumn;
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="AutoCompleteDGVColumn"/> specialized for interracting with both system names AND GalMap objects.
+    /// </summary>
+    public class AutoCompleteGalMapSysColumn : AutoCompleteDGVColumn
+    {
+        public AutoCompleteGalMapSysColumn() : base()
+        {
+            AutoCompleteGenerator += SystemClass.ReturnSystemListForAutoComplete;
+        }
+
+        public override object Clone()
+        {
+            return base.Clone() as AutoCompleteGalMapSysColumn;
+        }
+    }
+#endif
+
+    #endregion // Specialized AutoCompleteDGVColumn classes
 }

--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -70,7 +70,7 @@ namespace EDDiscovery
             this.textBoxRouteName = new ExtendedControls.TextBoxBorder();
             this.labelRouteName = new System.Windows.Forms.Label();
             this.dataGridViewRouteSystems = new System.Windows.Forms.DataGridView();
-            this.SystemName = new ExtendedControls.AutoCompleteDGVColumn();
+            this.SystemName = new ExtendedControls.AutoCompleteSystemsColumn();
             this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Note = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.contextMenuCopyPaste = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -481,7 +481,7 @@ namespace EDDiscovery
         private System.Windows.Forms.Label labelDateStart;
         private System.Windows.Forms.Label labelRouteName;
         private System.Windows.Forms.DataGridView dataGridViewRouteSystems;
-        private ExtendedControls.AutoCompleteDGVColumn SystemName;
+        private ExtendedControls.AutoCompleteSystemsColumn SystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
         private System.Windows.Forms.DataGridViewTextBoxColumn Note;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;

--- a/EDDiscovery/SavedRouteExpeditionControl.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.cs
@@ -129,7 +129,6 @@ namespace EDDiscovery
         {
             InitializeComponent();
             _currentRoute = new SavedRouteClass("");
-            SystemName.AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
         }
 
         public void InitControl(EDDiscoveryForm discoveryForm)

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -86,7 +86,7 @@ namespace EDDiscovery
             this.dataViewScroller_Distances = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
             this.dataGridViewDistances = new System.Windows.Forms.DataGridView();
-            this.ColumnSystem = new ExtendedControls.AutoCompleteDGVColumn();
+            this.ColumnSystem = new ExtendedControls.AutoCompleteSystemsColumn();
             this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnCalculated = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -549,7 +549,6 @@ namespace EDDiscovery
             // 
             // ColumnSystem
             // 
-            this.ColumnSystem.AutoCompleteGenerator = null;
             this.ColumnSystem.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ColumnSystem.FillWeight = 250F;
             this.ColumnSystem.HeaderText = "System";
@@ -745,7 +744,7 @@ namespace EDDiscovery
         private System.Windows.Forms.ToolStripButton toolStripButtonRemoveUnused;
         private System.Windows.Forms.Panel panel_controls;
         private System.Windows.Forms.Label labelstpos;
-        private ExtendedControls.AutoCompleteDGVColumn ColumnSystem;
+        private ExtendedControls.AutoCompleteSystemsColumn ColumnSystem;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDistance;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnCalculated;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnStatus;

--- a/EDDiscovery/Trilateration/TrilaterationControl.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.cs
@@ -42,7 +42,6 @@ namespace EDDiscovery
         public TrilaterationControl()
         {
             InitializeComponent();
-            ColumnSystem.AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
         }
 
         public void InitControl(EDDiscoveryForm discoveryForm)

--- a/EDDiscovery/UserControls/UserControlExploration.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.Designer.cs
@@ -69,7 +69,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewExplore = new System.Windows.Forms.DataGridView();
             this.dataViewScrollerPanel1 = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
-            this.ColumnSystemName = new ExtendedControls.AutoCompleteDGVColumn();
+            this.ColumnSystemName = new ExtendedControls.AutoCompleteSystemsColumn();
             this.ColumnDist = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnX = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnY = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -345,7 +345,6 @@ namespace EDDiscovery.UserControls
             // 
             // ColumnSystemName
             // 
-            this.ColumnSystemName.AutoCompleteGenerator = null;
             this.ColumnSystemName.FillWeight = 150F;
             this.ColumnSystemName.HeaderText = "System Name";
             this.ColumnSystemName.MinimumWidth = 50;
@@ -468,7 +467,7 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.ToolStripButton tsbImportSphere;
         private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel1;
         private ExtendedControls.VScrollBarCustom vScrollBarCustom1;
-        private ExtendedControls.AutoCompleteDGVColumn ColumnSystemName;
+        private ExtendedControls.AutoCompleteSystemsColumn ColumnSystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDist;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnX;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnY;

--- a/EDDiscovery/UserControls/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.cs
@@ -56,7 +56,6 @@ namespace EDDiscovery.UserControls
         {
             InitializeComponent();
             _currentExplorationSet = new ExplorationSetClass();
-            ColumnSystemName.AutoCompleteGenerator += SystemClass.ReturnOnlySystemsListForAutoComplete;
             Name = "Exploration";
         }
 


### PR DESCRIPTION
Extend designer capabilities by marking AutoCompleteDGVColumn abstract, and subclassing the manual labour of dealing with AutoCompleteGenerator.

AutoCompleteGenerator marked with DesignerSerializationVisibility attribute to stop Visual Studio from even trying to bother.