### PR TITLE
.gitignore Thumbs.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packages
 /Installer/EDDiscovery - Beta-cache
 /Installer/EDDiscovery - Beta.back.aip
 /Installer/EDDiscovery.back.aip
+Thumbs.db


### PR DESCRIPTION
Trivial addition of Thumbs.db to .gitignore, as my system wants to create it in several places every time I even think about looking at a control's `Image` property.