### PR TITLE
Fix System.Speech error in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - nuget restore EDDiscovery.sln
   - nuget install NUnit.ConsoleRunner -Version 3.2.1 -OutputDirectory testrunner
 script:
-  - xbuild /p:Configuration=Release EDDiscovery.sln
+  - xbuild /p:Configuration=Release EDDiscovery.sln /p:DefineConstants=NO_SYSTEM_SPEECH
   - mono ./testrunner/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./EDDiscoveryTests/bin/Release/EDDiscoveryTests.dll

--- a/EDDiscovery/Audio/SpeechSythesizerWindows.cs
+++ b/EDDiscovery/Audio/SpeechSythesizerWindows.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 
 namespace EDDiscovery.Audio
 {
-#if !__MonoCS__
+#if !NO_SYSTEM_SPEECH
     class WindowsSpeechEngine : ISpeechEngine
     {
         private System.Speech.Synthesis.SpeechSynthesizer synth;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -188,7 +188,7 @@ namespace EDDiscovery
 
             this.TopMost = EDDConfig.KeepOnTop;
 
-#if !__MonoCS__
+#if !NO_SYSTEM_SPEECH
             // Windows TTS (2000 and above). Speech *recognition* will be Version.Major >= 6 (Vista and above)
             if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version.Major >= 5)
             {


### PR DESCRIPTION
Travis now uses mono 5.x by default - this uses Roslyn's csc, which doesn't define `__MonoCS__`.

Use a compile-time `NO_SYSTEM_SPEECH` define instead to disable linking against `System.Speech` where it is unavailable at compile time.