### PR TITLE
UserControlEngineering touchups

### DIFF
--- a/EDDiscovery/UserControls/UserControlEngineering.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.Designer.cs
@@ -86,6 +86,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewEngineering.AllowDrop = true;
             this.dataGridViewEngineering.AllowUserToAddRows = false;
             this.dataGridViewEngineering.AllowUserToDeleteRows = false;
+            this.dataGridViewEngineering.AllowUserToOrderColumns = true;
             this.dataGridViewEngineering.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.dataGridViewEngineering.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridViewEngineering.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {


### PR DESCRIPTION
* Remove all hardcoded column numbers. This improves code readability, and allows column reordering to be enabled (albeit without persistence).
* Stop prematurely disposing of all Rows inside of `Init()`/`Display()` via `using(DataGridViewRow)`. This should clear up a couple of index out of range exceptions ([example](https://cdn.discordapp.com/attachments/151322154133225472/323095128090738688/unknown.png)), as well as some potential object disposed exceptions.
* Merge two back-to-back iterations of the same `Recipes` in `Display()`.