### PR TITLE
`OnPaint()` cleanups

### DIFF
--- a/EDDiscovery/Controls/CustomDateTimePicker.cs
+++ b/EDDiscovery/Controls/CustomDateTimePicker.cs
@@ -236,11 +236,11 @@ namespace ExtendedControls
                 Color color1 = BorderColor;
                 Color color2 = BorderColor.Multiply(BorderColorScaling);
 
-                GraphicsPath g1 = RectCutCorners(1, 1, ClientRectangle.Width - 2, ClientRectangle.Height - 1, 1, 1);
+                using (GraphicsPath g1 = RectCutCorners(1, 1, ClientRectangle.Width - 2, ClientRectangle.Height - 1, 1, 1))
                 using (Pen pc1 = new Pen(color1, 1.0F))
                     e.Graphics.DrawPath(pc1, g1);
 
-                GraphicsPath g2 = RectCutCorners(0, 0, ClientRectangle.Width, ClientRectangle.Height - 1, 2, 2);
+                using (GraphicsPath g2 = RectCutCorners(0, 0, ClientRectangle.Width, ClientRectangle.Height - 1, 2, 2))
                 using (Pen pc2 = new Pen(color2, 1.0F))
                     e.Graphics.DrawPath(pc2, g2);
 

--- a/EDDiscovery/Controls/GroupBoxCustom.cs
+++ b/EDDiscovery/Controls/GroupBoxCustom.cs
@@ -91,11 +91,11 @@ namespace ExtendedControls
 
                     e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
 
-                    GraphicsPath g1 = RectCutCorners(1, topline+1, ClientRectangle.Width-2, ClientRectangle.Height - topline - 1, 1,1 , textstart- 1, textlength);
+                    using (GraphicsPath g1 = RectCutCorners(1, topline+1, ClientRectangle.Width-2, ClientRectangle.Height - topline - 1, 1,1 , textstart- 1, textlength))
                     using (Pen pc1 = new Pen(color1, 1.0F))
                         e.Graphics.DrawPath(pc1, g1);
 
-                    GraphicsPath g2 = RectCutCorners(0, topline, ClientRectangle.Width, ClientRectangle.Height - topline - 1, 2, 2 , textstart, textlength);
+                    using (GraphicsPath g2 = RectCutCorners(0, topline, ClientRectangle.Width, ClientRectangle.Height - topline - 1, 2, 2 , textstart, textlength))
                     using (Pen pc2 = new Pen(color2, 1.0F))
                         e.Graphics.DrawPath(pc2, g2);
 
@@ -108,8 +108,8 @@ namespace ExtendedControls
                         Rectangle textarea = new Rectangle(textstart, 0, twidth, DisplayRectangle.Y);
 
                         using (Brush textb = new SolidBrush(this.ForeColor))
+                        using (StringFormat fmt = new StringFormat())
                         {
-                            StringFormat fmt = new StringFormat();
                             fmt.Alignment = StringAlignment.Center;
                             fmt.LineAlignment = StringAlignment.Center;
 

--- a/EDDiscovery/Controls/LabelExt.cs
+++ b/EDDiscovery/Controls/LabelExt.cs
@@ -42,9 +42,8 @@ namespace ExtendedControls
             if (sz.Width > 0 && sz.Height>0 && this.Text.Length>0)
             {
                 using (Bitmap mp = new Bitmap(sz.Width, sz.Height))   // bitmaps .. drawing directly does not work due to aliasing
+                using (Graphics mpg = Graphics.FromImage(mp))
                 {
-                    Graphics mpg = Graphics.FromImage(mp);
-
                     if (!this.TextBackColor.IsFullyTransparent())
                     {
                         using (Brush b = new SolidBrush(this.TextBackColor))

--- a/EDDiscovery/Controls/NumericUpDownCustom.cs
+++ b/EDDiscovery/Controls/NumericUpDownCustom.cs
@@ -96,11 +96,11 @@ namespace ExtendedControls
                 Color color2 = BorderColor.Multiply(BorderColorScaling);
 
                 int hg = tb.Height + 6;
-                GraphicsPath g1 = RectCutCorners(1, 1, ClientRectangle.Width - 2, hg - 1, 1, 1);
+                using (GraphicsPath g1 = RectCutCorners(1, 1, ClientRectangle.Width - 2, hg - 1, 1, 1))
                 using (Pen pc1 = new Pen(color1, 1.0F))
                     e.Graphics.DrawPath(pc1, g1);
 
-                GraphicsPath g2 = RectCutCorners(0, 0, ClientRectangle.Width, hg - 1, 2, 2);
+                using (GraphicsPath g2 = RectCutCorners(0, 0, ClientRectangle.Width, hg - 1, 2, 2))
                 using (Pen pc2 = new Pen(color2, 1.0F))
                     e.Graphics.DrawPath(pc2, g2);
             }


### PR DESCRIPTION
Mostly `GraphicsPath` disposals, but `LabelExt` was being slightly more naughty.

These changes were spun off from #1085 / #1090 / extendedcontrols_isolation branch for rapid inclusion in master due to the GDI+ leaks.