### PR TITLE
Make main form resizes / drags / hittests smarter

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -364,6 +364,12 @@ namespace EDDiscovery
 
         public class OptionsClass
         {
+            /// <summary>The version number of the assembly, formatted as: <c>"8.1.2.3"</c></summary>
+            /// <seealso cref="VersionDisplayString"/>
+            public string VersionNumberShort { get; } = Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+            /// <summary>The version number of the assembly, with (some) processed option details:
+            /// <c>"Version 8.1.2.3 (using /some/super/long/appfolder/path) (EDSM No server) (no BETA detect)"</c></summary>
+            /// <seealso cref="VersionNumberShort"/>
             public string VersionDisplayString { get; private set; }
             public string AppFolder { get; private set; }
             public string AppDataDirectory { get; private set; }
@@ -409,8 +415,7 @@ namespace EDDiscovery
             private void SetVersionDisplayString()
             {
                 StringBuilder sb = new StringBuilder();
-                sb.Append("Version ");
-                sb.Append(Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1]);
+                sb.Append($"Version {VersionNumberShort}");
 
                 if (AppFolder != null)
                 {

--- a/EDDiscovery/EDDTheme.cs
+++ b/EDDiscovery/EDDTheme.cs
@@ -870,7 +870,7 @@ namespace EDDiscovery
                 myControl.ForeColor = currentsettings.colors[Settings.CI.textbox_fore];
                 myControl.Font = fnt;
             }
-            else if (myControl is DrawnPanelNoTheme)        // ignore these..
+            else if (myControl is DrawnPanelNoTheme || parentcontroltype == typeof(DrawnPanelNoTheme))        // ignore these..
             {
             }
             else if (myControl is DrawnPanel)

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -83,9 +83,9 @@ namespace EDDiscovery
             this.reportIssueIdeasToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpMenuSeparatorBottom = new System.Windows.Forms.ToolStripSeparator();
             this.checkForNewReleaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.panelInfo = new System.Windows.Forms.Panel();
+            this.VersionNumMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.panelInfo = new ExtendedControls.DrawnPanelNoTheme();
             this.labelPanelText = new System.Windows.Forms.Label();
-            this.label_version = new System.Windows.Forms.Label();
             this.panel_eddiscovery = new System.Windows.Forms.Panel();
             this.edsmRefreshTimer = new System.Windows.Forms.Timer(this.components);
             this.tabControl1 = new ExtendedControls.TabControlCustom();
@@ -105,7 +105,6 @@ namespace EDDiscovery
             this.exportControl1 = new EDDiscovery.Export.ExportControl();
             this.tabPageSettings = new System.Windows.Forms.TabPage();
             this.settings = new EDDiscovery.Settings();
-            this.buttonReloadActions = new ExtendedControls.ButtonExt();
             this.panel_minimize = new ExtendedControls.DrawnPanel();
             this.panel_close = new ExtendedControls.DrawnPanel();
             this.statusStrip1 = new ExtendedControls.StatusStripCustom();
@@ -138,12 +137,14 @@ namespace EDDiscovery
             this.toolsToolStripMenuItem,
             this.adminToolStripMenuItem,
             this.addOnsToolStripMenuItem,
-            this.helpToolStripMenuItem});
+            this.helpToolStripMenuItem,
+            this.VersionNumMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(313, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(401, 24);
             this.menuStrip1.TabIndex = 16;
             this.menuStrip1.Text = "menuStrip1";
+            this.menuStrip1.Resize += new System.EventHandler(this.menuStrip1_Resize);
             // 
             // toolsToolStripMenuItem
             // 
@@ -446,36 +447,45 @@ namespace EDDiscovery
             this.checkForNewReleaseToolStripMenuItem.Text = "&Check for Updates";
             this.checkForNewReleaseToolStripMenuItem.Click += new System.EventHandler(this.checkForNewReleaseToolStripMenuItem_Click);
             // 
+            // VersionNumMenuItem
+            // 
+            this.VersionNumMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.VersionNumMenuItem.Name = "VersionNumMenuItem";
+            this.VersionNumMenuItem.ShowShortcutKeys = false;
+            this.VersionNumMenuItem.Size = new System.Drawing.Size(88, 20);
+            this.VersionNumMenuItem.Text = "Version Label";
+            // 
             // panelInfo
             // 
-            this.panelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panelInfo.BackColor = System.Drawing.Color.Salmon;
             this.panelInfo.Controls.Add(this.labelPanelText);
-            this.panelInfo.Location = new System.Drawing.Point(435, 1);
+            this.panelInfo.Location = new System.Drawing.Point(312, 1);
             this.panelInfo.Name = "panelInfo";
-            this.panelInfo.Size = new System.Drawing.Size(331, 23);
+            this.panelInfo.Size = new System.Drawing.Size(516, 24);
             this.panelInfo.TabIndex = 17;
             this.panelInfo.Click += new System.EventHandler(this.panelInfo_Click);
+            this.panelInfo.DoubleClick += new System.EventHandler(this.infoPanel_DoubleClick);
+            this.panelInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this.infoPanel_MouseDown);
+            this.panelInfo.MouseMove += new System.Windows.Forms.MouseEventHandler(this.infoPanel_MouseMove);
+            this.panelInfo.MouseUp += new System.Windows.Forms.MouseEventHandler(this.infoPanel_MouseUp);
             // 
             // labelPanelText
             // 
-            this.labelPanelText.AutoSize = true;
+            this.labelPanelText.Dock = System.Windows.Forms.DockStyle.Fill;
             this.labelPanelText.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelPanelText.Location = new System.Drawing.Point(3, -1);
+            this.labelPanelText.Location = new System.Drawing.Point(0, 0);
             this.labelPanelText.Name = "labelPanelText";
-            this.labelPanelText.Size = new System.Drawing.Size(158, 20);
+            this.labelPanelText.Size = new System.Drawing.Size(516, 24);
             this.labelPanelText.TabIndex = 0;
             this.labelPanelText.Text = "Loading. Please wait!";
+            this.labelPanelText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.labelPanelText.Click += new System.EventHandler(this.labelPanelText_Click);
-            // 
-            // label_version
-            // 
-            this.label_version.AutoSize = true;
-            this.label_version.Location = new System.Drawing.Point(296, 4);
-            this.label_version.Name = "label_version";
-            this.label_version.Size = new System.Drawing.Size(71, 13);
-            this.label_version.TabIndex = 21;
-            this.label_version.Text = "Version Label";
+            this.labelPanelText.DoubleClick += new System.EventHandler(this.infoPanel_DoubleClick);
+            this.labelPanelText.MouseDown += new System.Windows.Forms.MouseEventHandler(this.infoPanel_MouseDown);
+            this.labelPanelText.MouseMove += new System.Windows.Forms.MouseEventHandler(this.infoPanel_MouseMove);
+            this.labelPanelText.MouseUp += new System.Windows.Forms.MouseEventHandler(this.infoPanel_MouseUp);
             // 
             // panel_eddiscovery
             // 
@@ -483,7 +493,7 @@ namespace EDDiscovery
             this.panel_eddiscovery.BackColor = System.Drawing.SystemColors.Control;
             this.panel_eddiscovery.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("panel_eddiscovery.BackgroundImage")));
             this.panel_eddiscovery.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.panel_eddiscovery.Location = new System.Drawing.Point(818, 1);
+            this.panel_eddiscovery.Location = new System.Drawing.Point(834, 1);
             this.panel_eddiscovery.Name = "panel_eddiscovery";
             this.panel_eddiscovery.Size = new System.Drawing.Size(101, 46);
             this.panel_eddiscovery.TabIndex = 18;
@@ -679,20 +689,6 @@ namespace EDDiscovery
             this.settings.Size = new System.Drawing.Size(979, 665);
             this.settings.TabIndex = 0;
             // 
-            // buttonReloadActions
-            // 
-            this.buttonReloadActions.BorderColorScaling = 1.25F;
-            this.buttonReloadActions.ButtonColorScaling = 0.5F;
-            this.buttonReloadActions.ButtonDisabledScaling = 0.5F;
-            this.buttonReloadActions.Location = new System.Drawing.Point(752, 0);
-            this.buttonReloadActions.Name = "buttonReloadActions";
-            this.buttonReloadActions.Size = new System.Drawing.Size(71, 23);
-            this.buttonReloadActions.TabIndex = 1;
-            this.buttonReloadActions.Text = "Reload-A";
-            this.buttonReloadActions.UseVisualStyleBackColor = true;
-            this.buttonReloadActions.Visible = false;
-            this.buttonReloadActions.Click += new System.EventHandler(this.buttonReloadActions_Click);
-            // 
             // panel_minimize
             // 
             this.panel_minimize.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -794,11 +790,9 @@ namespace EDDiscovery
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(993, 744);
-            this.Controls.Add(this.label_version);
             this.Controls.Add(this.panel_eddiscovery);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.panelInfo);
-            this.Controls.Add(this.buttonReloadActions);
             this.Controls.Add(this.panel_minimize);
             this.Controls.Add(this.panel_close);
             this.Controls.Add(this.menuStrip1);
@@ -813,12 +807,10 @@ namespace EDDiscovery
             this.Load += new System.EventHandler(this.EDDiscoveryForm_Load);
             this.Shown += new System.EventHandler(this.EDDiscoveryForm_Shown);
             this.ResizeEnd += new System.EventHandler(this.EDDiscoveryForm_ResizeEnd);
-            this.Layout += new System.Windows.Forms.LayoutEventHandler(this.EDDiscoveryForm_Layout);
             this.Resize += new System.EventHandler(this.EDDiscoveryForm_Resize);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.panelInfo.ResumeLayout(false);
-            this.panelInfo.PerformLayout();
             this.tabControl1.ResumeLayout(false);
             this.tabPageTravelHistory.ResumeLayout(false);
             this.tabPageJournal.ResumeLayout(false);
@@ -838,13 +830,12 @@ namespace EDDiscovery
         }
 
         #endregion
-        private ExtendedControls.ButtonExt buttonReloadActions;
         private System.Windows.Forms.MenuStrip menuStrip1;
         private System.Windows.Forms.ToolStripMenuItem toolsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem eDDiscoveryHomepageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem frontierForumThreadToolStripMenuItem;
-        private System.Windows.Forms.Panel panelInfo;
+        private ExtendedControls.DrawnPanelNoTheme panelInfo;
         private System.Windows.Forms.Label labelPanelText;
         private System.Windows.Forms.ToolStripMenuItem show2DMapsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem adminToolStripMenuItem;
@@ -869,7 +860,6 @@ namespace EDDiscovery
         private ExtendedControls.TabControlCustom tabControl1;
         private System.Windows.Forms.TabPage tabPageTravelHistory;
         private TravelHistoryControl travelHistoryControl1;
-        private System.Windows.Forms.Label label_version;
         private System.Windows.Forms.ToolStripMenuItem changeMapColorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editThemeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
@@ -908,5 +898,6 @@ namespace EDDiscovery
         private System.Windows.Forms.ToolStripMenuItem stopCurrentlyRunningActionProgramToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator helpMenuSeparatorTop;
         private System.Windows.Forms.ToolStripSeparator helpMenuSeparatorBottom;
+        private System.Windows.Forms.ToolStripMenuItem VersionNumMenuItem;
     }
 }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1117,11 +1117,11 @@ namespace EDDiscovery
         }
 
 
-        protected override void OnDoubleClick(EventArgs e)
+        protected override void OnMouseDoubleClick(MouseEventArgs e)
         {
             base.OnDoubleClick(e);
 
-            if (((MouseEventArgs)e).Button == MouseButtons.Left && !theme.WindowsFrame)
+            if (e.Button == MouseButtons.Left && !theme.WindowsFrame)
             {
                 if (WindowState == FormWindowState.Maximized)
                     WindowState = FormWindowState.Normal;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -167,7 +167,7 @@ namespace EDDiscovery
             // Some components require the controller to be initialized
             InitializeComponent();
 
-            label_version.Text = EDDConfig.Options.VersionDisplayString;
+            this.Text = VersionNumMenuItem.Text = EDDConfig.Options.VersionDisplayString;
 
             PopOuts = new PopOutControl(this);
 
@@ -239,12 +239,6 @@ namespace EDDiscovery
                 settings.InitSettingsTab();
                 savedRouteExpeditionControl1.LoadControl();
                 travelHistoryControl1.LoadControl();
-
-                if (EDDConfig.Options.ActionButton)
-                {
-                    buttonReloadActions.Visible = true;
-                }
-
             }
             catch (Exception ex)
             {
@@ -326,6 +320,8 @@ namespace EDDiscovery
         private void PanelInfoNewRelease()
         {
             ShowInfoPanel("Download new release!", true, Color.Green);
+            labelPanelText.Click -= checkForNewReleaseToolStripMenuItem_Click;
+            labelPanelText.Click += checkForNewReleaseToolStripMenuItem_Click;
         }
 
 
@@ -387,9 +383,9 @@ namespace EDDiscovery
             ToolStripManager.Renderer = theme.toolstripRenderer;
             panel_close.Visible = !theme.WindowsFrame;
             panel_minimize.Visible = !theme.WindowsFrame;
-            label_version.Visible = !theme.WindowsFrame;
+            VersionNumMenuItem.Visible = !theme.WindowsFrame;
 
-            this.Text = "EDDiscovery " + label_version.Text;            // note in no border mode, this is not visible on the title bar but it is in the taskbar..
+            this.Text = "EDDiscovery " + VersionNumMenuItem.Text;   // note in no border mode, this is not visible on the title bar but it is in the taskbar..
 
             theme.ApplyToForm(this);
 
@@ -640,7 +636,13 @@ namespace EDDiscovery
         {
             labelPanelText.Text = message;
             panelInfo.Visible = visible;
-            if (backColour.HasValue) panelInfo.BackColor = backColour.Value;
+            if (backColour.HasValue)
+                panelInfo.BackColor = backColour.Value;
+            else
+                panelInfo.BackColor = Color.Salmon;
+
+            if (!visible || newRelease == null)
+                labelPanelText.Click -= checkForNewReleaseToolStripMenuItem_Click;
         }
 
         private void EDDiscoveryForm_FormClosing(object sender, FormClosingEventArgs e)
@@ -658,12 +660,6 @@ namespace EDDiscovery
 #endregion
 
 #region Buttons, Mouse, Menus, NotifyIcon
-
-        private void buttonReloadActions_Click(object sender, EventArgs e)
-        {
-            actioncontroller.ReLoad();
-            actioncontroller.ActionRun("onStartup", "ProgramEvent");
-        }
 
         private void addNewStarToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -791,8 +787,8 @@ namespace EDDiscovery
         private void AboutBox()
         {
             AboutForm frm = new AboutForm();
-            frm.labelVersion.Text = this.Text;
-            frm.TopMost = EDDiscoveryForm.EDDConfig.KeepOnTop;
+            frm.labelVersion.Text = $"EDDiscovery v{EDDConfig.Options.VersionNumberShort}";
+            frm.TopMost = EDDConfig.KeepOnTop;
             frm.ShowDialog(this);
         }
 
@@ -836,7 +832,13 @@ namespace EDDiscovery
 
         private void paneleddiscovery_Click(object sender, EventArgs e)
         {
-            AboutBox();
+            if (EDDConfig.Options.ActionButton)
+            {
+                actioncontroller.ReLoad();
+                actioncontroller.ActionRun("onStartup", "ProgramEvent");
+            }
+            else
+                AboutBox();
         }
 
         private void panel_close_Click(object sender, EventArgs e)
@@ -891,15 +893,12 @@ namespace EDDiscovery
 
         private void checkForNewReleaseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (CheckForNewinstaller() )
+            if (newRelease != null || (CheckForNewinstaller() && newRelease != null))
             {
-                if (newRelease != null)
-                {
-                    NewReleaseForm frm = new NewReleaseForm();
-                    frm.release = newRelease;
+                NewReleaseForm frm = new NewReleaseForm();
+                frm.release = newRelease;
 
-                    frm.ShowDialog(this);
-                }
+                frm.ShowDialog(this);
             }
             else
             {
@@ -1057,79 +1056,193 @@ namespace EDDiscovery
                 Activate();
         }
 
-#endregion
+        #endregion
 
-#region Window Control
+        #region Window Control
 
         protected override void WndProc(ref Message m)
         {
-            // Compatibility movement for Mono
-            if (m.Msg == WM.LBUTTONDOWN && m.WParam == (IntPtr)1 && !theme.WindowsFrame)
-            {
-                int x = unchecked((short)((uint)m.LParam & 0xFFFF));
-                int y = unchecked((short)((uint)m.LParam >> 16));
-                _window_dragMousePos = new Point(x, y);
-                _window_dragWindowPos = this.Location;
-                _window_dragging = true;
-                m.Result = IntPtr.Zero;
-                this.Capture = true;
-            }
-            else if (m.Msg == WM.MOUSEMOVE && m.WParam == (IntPtr)1 && _window_dragging)
-            {
-                int x = unchecked((short)((uint)m.LParam & 0xFFFF));
-                int y = unchecked((short)((uint)m.LParam >> 16));
-                Point delta = new Point(x - _window_dragMousePos.X, y - _window_dragMousePos.Y);
-                _window_dragWindowPos = new Point(_window_dragWindowPos.X + delta.X, _window_dragWindowPos.Y + delta.Y);
-                this.Location = _window_dragWindowPos;
-                this.Update();
-                m.Result = IntPtr.Zero;
-            }
-            else if (m.Msg == WM.LBUTTONUP)
-            {
-                _window_dragging = false;
-                _window_dragMousePos = Point.Empty;
-                _window_dragWindowPos = Point.Empty;
-                m.Result = IntPtr.Zero;
-                this.Capture = false;
-            }
+            base.WndProc(ref m);
+
             // Windows honours NCHITTEST; Mono does not
-            else if (m.Msg == WM.NCHITTEST)
+            if (m.Msg == WM.NCHITTEST)
             {
-                base.WndProc(ref m);
+                short x = (short)m.LParam.ToInt32();
+                short y = (short)(m.LParam.ToInt32() >> 16);
+                Point p = PointToClient(new Point(x, y));
+                Size sansStrip = new Size(ClientRectangle.Width - statusStrip1.Height, ClientRectangle.Height - statusStrip1.Height);
+
                 //System.Diagnostics.Debug.WriteLine( Environment.TickCount + " Res " + ((int)m.Result));
-
-                if (m.Result == (IntPtr)HT.CLIENT)
+                // Extra padding here regardless to effortlessly handle the size grip, even if border is shown.
+                if (p.Y >= sansStrip.Height && p.X >= sansStrip.Width)
                 {
-                    int x = unchecked((short)((uint)m.LParam & 0xFFFF));
-                    int y = unchecked((short)((uint)m.LParam >> 16));
-                    Point p = PointToClient(new Point(x, y));
-
-                    if (p.X > this.ClientSize.Width - statusStrip1.Height && p.Y > this.ClientSize.Height - statusStrip1.Height)
-                    {
-                        m.Result = (IntPtr)HT.BOTTOMRIGHT;
+                    m.Result = (IntPtr)HT.BOTTOMRIGHT;
+                }
+                else if (!theme.WindowsFrame && m.Result.ToInt32() == HT.CLIENT && WindowState == FormWindowState.Normal)
+                {   // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
+                    if (p.X <= 5)
+                    {   // Left
+                        if (p.Y <= 5)
+                            m.Result = (IntPtr)HT.TOPLEFT;
+                        else if (p.Y >= sansStrip.Height)
+                            m.Result = (IntPtr)HT.BOTTOMLEFT;
+                        else
+                            m.Result = (IntPtr)HT.LEFT;
                     }
-                    else if (p.Y > this.ClientSize.Height - statusStrip1.Height)
-                    {
-                        m.Result = (IntPtr)HT.BOTTOM;
+                    else if (p.X >= ClientRectangle.Width - 5)
+                    {   // Right
+                        if (p.Y <= 5)
+                            m.Result = (IntPtr)HT.TOPRIGHT;
+                        // BTMRIGHT is handled above.
+                        else
+                            m.Result = (IntPtr)HT.RIGHT;
                     }
-                    else if (p.X > this.ClientSize.Width - 5)       // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
-                    {
-                        m.Result = (IntPtr)HT.RIGHT;
-                    }
-                    else if (p.X < 5)
-                    {
-                        m.Result = (IntPtr)HT.LEFT;
-                    }
-                    else if (!theme.WindowsFrame)
-                    {
-                        m.Result = (IntPtr)HT.CAPTION;
+                    else
+                    {   // Center
+                        if (p.Y <= 5)
+                            m.Result = (IntPtr)HT.TOP;
+                        else if (p.Y >= sansStrip.Height)
+                            m.Result = (IntPtr)HT.BOTTOM;
                     }
                 }
+                else if (m.Result.ToInt32() == HT.MENU && p.Y < menuStrip1.Padding.Top)
+                {   // Hittest chose the menu; override if we're within the margin.
+                    if (p.X < 5)
+                        m.Result = (IntPtr)HT.TOPLEFT;
+                    else if (p.X > ClientRectangle.Width - 5)
+                        m.Result = (IntPtr)HT.TOPRIGHT;
+                    else
+                        m.Result = (IntPtr)HT.TOP;
+                }
             }
-            else
+        }
+
+
+        protected override void OnDoubleClick(EventArgs e)
+        {
+            base.OnDoubleClick(e);
+
+            if (((MouseEventArgs)e).Button == MouseButtons.Left && !theme.WindowsFrame)
             {
-                base.WndProc(ref m);
+                if (WindowState == FormWindowState.Maximized)
+                    WindowState = FormWindowState.Normal;
+                else if (WindowState == FormWindowState.Normal)
+                    WindowState = FormWindowState.Maximized;
             }
+        }
+
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            base.OnMouseDown(e);
+
+            if (!theme.WindowsFrame && e.Button == MouseButtons.Left && WindowState != FormWindowState.Minimized)
+            {
+                _window_dragMousePos = e.Location;
+                _window_dragWindowPos = Location;
+                _window_dragging = Capture = true;
+            }
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+
+            if (_window_dragging && e.Button == MouseButtons.Left)
+            {
+                var ptscn = PointToScreen(e.Location);
+                var delta = new Point(e.X - _window_dragMousePos.X, e.Y - _window_dragMousePos.Y);
+
+                if (WindowState == FormWindowState.Normal && ptscn.Y > 32)
+                {
+                    _window_dragWindowPos = new Point(_window_dragWindowPos.X + delta.X, _window_dragWindowPos.Y + delta.Y);
+                    Location = _window_dragWindowPos;
+                }
+                else if (WindowState == FormWindowState.Normal && ptscn.Y <= 32)
+                {
+                    WindowState = FormWindowState.Maximized;
+                }
+                else if (WindowState == FormWindowState.Maximized && ptscn.Y > 32)
+                {
+                    WindowState = FormWindowState.Normal;
+                }
+            }
+        }
+
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            base.OnMouseUp(e);
+
+            if (_window_dragging && e.Button == MouseButtons.Left)
+            {
+                _window_dragging = Capture = false;
+                _window_dragMousePos = _window_dragWindowPos = Point.Empty;
+            }
+        }
+
+
+        private void infoPanel_DoubleClick(object sender, EventArgs e)
+        {
+            if (((MouseEventArgs)e).Button == MouseButtons.Left && !theme.WindowsFrame)
+            {
+                if (WindowState == FormWindowState.Normal)
+                    WindowState = FormWindowState.Maximized;
+                else if (WindowState == FormWindowState.Maximized)
+                    WindowState = FormWindowState.Normal;
+            }
+        }
+
+        private void infoPanel_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (!theme.WindowsFrame && e.Button == MouseButtons.Left && WindowState != FormWindowState.Minimized)
+            {
+                var ctl = (Control)sender;
+                var ptscn = ctl.PointToScreen(e.Location);
+
+                _window_dragMousePos = ptscn;
+                _window_dragWindowPos = Location;
+                ctl.Capture = _window_dragging = true;
+            }
+        }
+
+        private void infoPanel_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (_window_dragging)
+            {
+                var ptscn = ((Control)sender).PointToScreen(e.Location);
+                var delta = new Point(ptscn.X - _window_dragMousePos.X, ptscn.Y - _window_dragMousePos.Y);
+
+                if (WindowState == FormWindowState.Normal && ptscn.Y > 32)
+                {
+                    _window_dragWindowPos = new Point(_window_dragWindowPos.X + delta.X, _window_dragWindowPos.Y + delta.Y);
+                    Location = _window_dragWindowPos;
+                }
+                else if (WindowState == FormWindowState.Normal && ptscn.Y <= 32)
+                {
+                    WindowState = FormWindowState.Maximized;
+                }
+                else if (WindowState == FormWindowState.Maximized && ptscn.Y > 32)
+                {
+                    WindowState = FormWindowState.Normal;
+                }
+
+                _window_dragMousePos = ptscn;
+            }
+        }
+
+        private void infoPanel_MouseUp(object sender, MouseEventArgs e)
+        {
+            if (_window_dragging && e.Button == MouseButtons.Left)
+            {
+                var ctl = (Control)sender;
+                ctl.Capture = _window_dragging = false;
+                _window_dragMousePos = _window_dragWindowPos = Point.Empty;
+            }
+        }
+
+        private void menuStrip1_Resize(object sender, EventArgs e)
+        {   // It's properly anchored, but there's no other way to really take peer size changes into account.
+            panelInfo.Left = menuStrip1.Width + panelInfo.Padding.Left + VersionNumMenuItem.Padding.Right;
+            panelInfo.Width = panel_eddiscovery.Left - panel_eddiscovery.Padding.Left - panelInfo.Padding.Right - panelInfo.Left;
         }
 
         private void RecordPosition()
@@ -1166,9 +1279,9 @@ namespace EDDiscovery
             RecordPosition();
         }
 
-#endregion
+        #endregion
 
-#region Targets
+        #region Targets
 
         public void NewTargetSet()
         {
@@ -1289,8 +1402,7 @@ namespace EDDiscovery
         public int ActionRun(string name, string triggertype, HistoryEntry he = null, ConditionVariables additionalvars = null, string flagstart = null, bool now = false)
         { return actioncontroller.ActionRun(name, triggertype,he,additionalvars,flagstart,now); }
 
-#endregion
-
+        #endregion
     }
 }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1067,18 +1067,17 @@ namespace EDDiscovery
             // Windows honours NCHITTEST; Mono does not
             if (m.Msg == WM.NCHITTEST)
             {
-                short x = (short)m.LParam.ToInt32();
-                short y = (short)(m.LParam.ToInt32() >> 16);
-                Point p = PointToClient(new Point(x, y));
+                int res = m.Result.ToInt32();
+                Point p = PointToClient(new Point(m.LParam.ToInt32()));
                 Size sansStrip = new Size(ClientRectangle.Width - statusStrip1.Height, ClientRectangle.Height - statusStrip1.Height);
 
                 //System.Diagnostics.Debug.WriteLine( Environment.TickCount + " Res " + ((int)m.Result));
-                // Extra padding here regardless to effortlessly handle the size grip, even if border is shown.
-                if (p.Y >= sansStrip.Height && p.X >= sansStrip.Width)
+                // Extra padding here regardless to effortlessly handle the size grip, even if frame is shown.
+                if (p.Y >= sansStrip.Height && p.X >= sansStrip.Width && WindowState == FormWindowState.Normal)
                 {
                     m.Result = (IntPtr)HT.BOTTOMRIGHT;
                 }
-                else if (!theme.WindowsFrame && m.Result.ToInt32() == HT.CLIENT && WindowState == FormWindowState.Normal)
+                else if (!theme.WindowsFrame && res == HT.CLIENT && WindowState == FormWindowState.Normal)
                 {   // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them
                     if (p.X <= 5)
                     {   // Left
@@ -1105,8 +1104,8 @@ namespace EDDiscovery
                             m.Result = (IntPtr)HT.BOTTOM;
                     }
                 }
-                else if (m.Result.ToInt32() == HT.MENU && p.Y < menuStrip1.Padding.Top)
-                {   // Hittest chose the menu; override if we're within the margin.
+                else if ((res == HT.MENU || res == HT.SYSMENU) && p.Y < menuStrip1.Padding.Top)
+                {   // Hittest chose the menu; override if we're within the margin. This will *maybe* get the top pixel, because menus are top-level special.
                     if (p.X < 5)
                         m.Result = (IntPtr)HT.TOPLEFT;
                     else if (p.X > ClientRectangle.Width - 5)
@@ -1150,18 +1149,19 @@ namespace EDDiscovery
             if (_window_dragging && e.Button == MouseButtons.Left)
             {
                 var ptscn = PointToScreen(e.Location);
+                var screen = Screen.FromPoint(ptscn);
                 var delta = new Point(e.X - _window_dragMousePos.X, e.Y - _window_dragMousePos.Y);
 
-                if (WindowState == FormWindowState.Normal && ptscn.Y > 32)
+                if (WindowState == FormWindowState.Normal && ptscn.Y > 32 + screen.Bounds.Top)
                 {
                     _window_dragWindowPos = new Point(_window_dragWindowPos.X + delta.X, _window_dragWindowPos.Y + delta.Y);
                     Location = _window_dragWindowPos;
                 }
-                else if (WindowState == FormWindowState.Normal && ptscn.Y <= 32)
+                else if (WindowState == FormWindowState.Normal && ptscn.Y <= 32 + screen.Bounds.Top)
                 {
                     WindowState = FormWindowState.Maximized;
                 }
-                else if (WindowState == FormWindowState.Maximized && ptscn.Y > 32)
+                else if (WindowState == FormWindowState.Maximized && ptscn.Y > 32 + screen.Bounds.Top)
                 {
                     WindowState = FormWindowState.Normal;
                 }
@@ -1209,18 +1209,19 @@ namespace EDDiscovery
             if (_window_dragging)
             {
                 var ptscn = ((Control)sender).PointToScreen(e.Location);
+                var screen = Screen.FromPoint(ptscn);
                 var delta = new Point(ptscn.X - _window_dragMousePos.X, ptscn.Y - _window_dragMousePos.Y);
 
-                if (WindowState == FormWindowState.Normal && ptscn.Y > 32)
+                if (WindowState == FormWindowState.Normal && ptscn.Y > 32 + screen.Bounds.Top)
                 {
                     _window_dragWindowPos = new Point(_window_dragWindowPos.X + delta.X, _window_dragWindowPos.Y + delta.Y);
                     Location = _window_dragWindowPos;
                 }
-                else if (WindowState == FormWindowState.Normal && ptscn.Y <= 32)
+                else if (WindowState == FormWindowState.Normal && ptscn.Y <= 32 + screen.Bounds.Top)
                 {
                     WindowState = FormWindowState.Maximized;
                 }
-                else if (WindowState == FormWindowState.Maximized && ptscn.Y > 32)
+                else if (WindowState == FormWindowState.Maximized && ptscn.Y > 32 + screen.Bounds.Top)
                 {
                     WindowState = FormWindowState.Normal;
                 }

--- a/EDDiscovery/Win32Constants.cs
+++ b/EDDiscovery/Win32Constants.cs
@@ -51,8 +51,8 @@ namespace EDDiscovery.Win32Constants
     public static class HT
     {
         /// <summary>
-        /// HTERROR means the coordinates are on the screen background or on a dividing line between windows (same as HTNOWHERE,
-        /// except that the DefWindowProc function produces a system beep to indicate an error).
+        /// HTERROR means the coordinates are on the screen background or on a dividing line between windows (same as
+        /// <see cref="HTNOWHERE"/>, except the DefWindowProc function produces a system beep to indicate an error).
         /// </summary>
         public const int ERROR = -2;
 
@@ -78,6 +78,26 @@ namespace EDDiscovery.Win32Constants
         public const int CAPTION = 2;
 
         /// <summary>
+        /// HTSYSMENU means the coordinates are in a window menu or in a Close button in a child window.
+        /// </summary>
+        public const int SYSMENU = 3;
+
+        /// <summary>
+        /// HTGROWBOX means the coordinates are in a size box (same as <see cref="SIZE"/>).
+        /// </summary>
+        public const int GROWBOX = 4;
+
+        /// <summary>
+        /// HTSIZE means the coordinates are in a size box (same as <see cref="GROWBOX"/>).
+        /// </summary>
+        public const int SIZE = GROWBOX;
+
+        /// <summary>
+        /// HTMENU means the coordinates are in a menu.
+        /// </summary>
+        public const int MENU = 5;
+
+        /// <summary>
         /// HTLEFT means the coordinates are in the left border of a resizable window.
         /// </summary>
         public const int LEFT = 10;
@@ -88,14 +108,39 @@ namespace EDDiscovery.Win32Constants
         public const int RIGHT = 11;
 
         /// <summary>
+        /// HTTOP means the coordinates are in the upper-horizontal border of a window.
+        /// </summary>
+        public const int TOP = 12;
+
+        /// <summary>
+        /// HTTOPLEFT means the coordinates are in the upper-left corner of a window border.
+        /// </summary>
+        public const int TOPLEFT = 13;
+
+        /// <summary>
+        /// HTTOPRIGHT means the coordinates are in the upper-right corner of a window border.
+        /// </summary>
+        public const int TOPRIGHT = 14;
+
+        /// <summary>
         /// HTBOTTOM means the coordinates are in the lower-horizontal border of a resizable window.
         /// </summary>
         public const int BOTTOM = 15;
 
         /// <summary>
+        /// HTBOTTOMLEFT means the coordinates are in the lower-left corner of a resizable window.
+        /// </summary>
+        public const int BOTTOMLEFT = 16;
+
+        /// <summary>
         /// HTBOTTOMRIGHT means the coordinates are in the lower-right corner of a border of a resizable window.
         /// </summary>
         public const int BOTTOMRIGHT = 17;
+
+        /// <summary>
+        /// HTBORDER means the coordinates are in the border of a window that does not have a sizing border.
+        /// </summary>
+        public const int BORDER = 18;
     }
 
     /// <summary>
@@ -185,6 +230,17 @@ namespace EDDiscovery.Win32Constants
         /// </summary>
         /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645621(v=vs.85).aspx"/>
         public const int NCLBUTTONUP = 0x00A2;
+
+        /// <summary>
+        /// The WM_NCLBUTTONDBLCLK is posted when the user double-clicks the left mouse button while the cursor is
+        /// within the nonclient area of a window. This message is posted to the window that contains the cursor.
+        /// If a window has captured the mouse, this message is not posted.
+        /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms645619(v=vs.85).aspx"/>
+        public const int NCLBUTTONDBLCLK = 0x00A3;
+
+        // A4 - A6: WM_NC R BUTTON down|up|dblclk
+        // A7 - A9: WM_NC M BUTTON down|up|dblclk
 
         /// <summary>
         /// The WM_KEYDOWN message is posted to the window with the keyboard focus when a nonsystem key is pressed.


### PR DESCRIPTION
* You can now resize appropriately by dragging additional window edges/corners.
  * Drag client (or the giant info label) to top of screen => `Maximize`.
  * Drag client (or the giant info label) from maximized top of screen, in downward direction => `Normal`.
  * BottomRight drag rect is a little larger.
* `ApplyTheme()` ignores `DrawnPanelNoTheme` **parents**.
* MainForm info panel is now a `DrawnPanelNoTheme` (yay, font is legible!)
* About dialog shows concise version number ("eddisco v8.1.0.0", TYVM).
* Removed `buttonReloadActions`, now using `paneleddiscovery_Click`.
* Removed `label_version`, now using `VersionNumMenuItem`.
* Clicking the info panel with update msg shows update form.
* Note the revised NCHITTEST code that can survive without `unsafe()` and won't throw IntPtr overflows, and works even in multi-monitor, negative X/Y-coordinate-land:
```CS
short x = (short)m.LParam.ToInt32();
short y = (short)(m.LParam.ToInt32() >> 16);
Point p = PointToClient(new Point(x, y));
```

Potential Pitfalls:
* Mono users (@klightspeed, you've got a Mac, right?) please review & test, but it **should** be smoother.
  * Everything here is now using C# native mouse handling, except for the hittests.
* The `WndProc` hittest can't seem to pull the top-left corner in the menu margin. Not sure how to address this one.

I really wish that we could use aerosnap with a true no border frame, but these changes should make it behave a little more sanely, and at least satisfy the maximize/de-maximize aspect.