### PR TITLE
Count the first material in the list when working out max available for recipes

### DIFF
--- a/EDDiscovery/EliteDangerous/MaterialCommoditiesList.cs
+++ b/EDDiscovery/EliteDangerous/MaterialCommoditiesList.cs
@@ -245,7 +245,7 @@ namespace EDDiscovery.EliteDangerous
                 string ingredient = r.ingredients[i];
 
                 int mi = list.FindIndex(x => x.shortname.Equals(ingredient));
-                int got = (mi > 0) ? list[mi].scratchpad : 0;
+                int got = (mi >= 0) ? list[mi].scratchpad : 0;
                 int sets = got / r.count[i];
 
                 max = Math.Min(max, sets);


### PR DESCRIPTION
or ASPA will never be seen