### PR TITLE
.gitignore VS2015r2+ IntelliSense SQLite DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ packages
 /Installer/EDDiscovery - Beta.back.aip
 /Installer/EDDiscovery.back.aip
 Thumbs.db
+#Visual Studio 2015r2+ IntelliSense SQLite db and lockfile
+/EDDiscovery.VC.db
+/EDDiscovery.VC.VC.opendb


### PR DESCRIPTION
Trivial tweak to ignore the IntelliSense database and lockfile. You'll get one of these generated if you look at Win32Constants.cs for too long.