### PR TITLE
More AboutForm Updates

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -688,9 +688,9 @@ namespace EDDiscovery
             }
         }
 
-#endregion
+        #endregion
 
-#region Buttons, Mouse, Menus, NotifyIcon
+        #region Buttons, Mouse, Menus, NotifyIcon
 
         private void buttonReloadActions_Click(object sender, EventArgs e)
         {
@@ -821,17 +821,16 @@ namespace EDDiscovery
             Close();
         }
 
-        private void AboutBox()
+        public void AboutBox(Form parent = null)
         {
             AboutForm frm = new AboutForm();
-            frm.labelVersion.Text = this.Text;
-            frm.TopMost = EDDiscoveryForm.EDDConfig.KeepOnTop;
-            frm.ShowDialog(this);
+            frm.TopMost = parent?.TopMost ?? this.TopMost;
+            frm.ShowDialog(parent ?? this);
         }
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AboutBox();
+            AboutBox(this);
         }
 
         private void eDDiscoveryChatDiscordToolStripMenuItem_Click(object sender, EventArgs e)
@@ -869,7 +868,7 @@ namespace EDDiscovery
 
         private void paneleddiscovery_Click(object sender, EventArgs e)
         {
-            AboutBox();
+            AboutBox(this);
         }
 
         private void panel_close_Click(object sender, EventArgs e)

--- a/EDDiscovery/Forms/AboutForm.Designer.cs
+++ b/EDDiscovery/Forms/AboutForm.Designer.cs
@@ -43,13 +43,12 @@ namespace EDDiscovery.Forms
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutForm));
-            this.panelLogo = new System.Windows.Forms.Panel();
             this.labelVersion = new System.Windows.Forms.Label();
             this.labelDevelopersEnum = new System.Windows.Forms.Label();
             this.buttonOK = new System.Windows.Forms.Button();
             this.textBoxLicense = new System.Windows.Forms.TextBox();
-            this.labelNoAffiliation = new System.Windows.Forms.Label();
             this.panelLinks = new System.Windows.Forms.Panel();
             this.linkLabelDeveloperChat = new System.Windows.Forms.LinkLabel();
             this.linkLabelHelp = new System.Windows.Forms.LinkLabel();
@@ -62,20 +61,14 @@ namespace EDDiscovery.Forms
             this.linkLabelEliteDangerous = new System.Windows.Forms.LinkLabel();
             this.labelLinks = new System.Windows.Forms.Label();
             this.labelDevelopers = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelNoAffiliation = new System.Windows.Forms.Label();
+            this.panelLogo = new System.Windows.Forms.PictureBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.panelLinks.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.panelLogo)).BeginInit();
             this.SuspendLayout();
-            // 
-            // panelLogo
-            // 
-            this.panelLogo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.panelLogo.BackColor = System.Drawing.Color.Transparent;
-            this.panelLogo.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("panelLogo.BackgroundImage")));
-            this.panelLogo.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.panelLogo.Location = new System.Drawing.Point(67, 210);
-            this.panelLogo.Name = "panelLogo";
-            this.panelLogo.Size = new System.Drawing.Size(325, 212);
-            this.panelLogo.TabIndex = 4;
-            this.panelLogo.Click += new System.EventHandler(this.panelLogo_Click);
             // 
             // labelVersion
             // 
@@ -83,25 +76,25 @@ namespace EDDiscovery.Forms
             this.labelVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelVersion.Location = new System.Drawing.Point(12, 19);
             this.labelVersion.Name = "labelVersion";
-            this.labelVersion.Size = new System.Drawing.Size(132, 24);
+            this.labelVersion.Size = new System.Drawing.Size(187, 24);
             this.labelVersion.TabIndex = 0;
-            this.labelVersion.Text = "EDDiscovery v";
+            this.labelVersion.Text = "EDDiscovery v4.3.2.1";
             // 
             // labelDevelopersEnum
             // 
             this.labelDevelopersEnum.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.labelDevelopersEnum.BackColor = System.Drawing.Color.Transparent;
-            this.labelDevelopersEnum.Location = new System.Drawing.Point(453, 57);
+            this.labelDevelopersEnum.Location = new System.Drawing.Point(437, 57);
             this.labelDevelopersEnum.Name = "labelDevelopersEnum";
-            this.labelDevelopersEnum.Size = new System.Drawing.Size(203, 162);
+            this.labelDevelopersEnum.Size = new System.Drawing.Size(203, 159);
             this.labelDevelopersEnum.TabIndex = 3;
             this.labelDevelopersEnum.Text = resources.GetString("labelDevelopersEnum.Text");
             // 
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.Location = new System.Drawing.Point(581, 399);
+            this.buttonOK.Location = new System.Drawing.Point(565, 396);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 6;
@@ -111,27 +104,22 @@ namespace EDDiscovery.Forms
             // 
             // textBoxLicense
             // 
+            this.textBoxLicense.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxLicense.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxLicense.Location = new System.Drawing.Point(12, 57);
             this.textBoxLicense.Multiline = true;
             this.textBoxLicense.Name = "textBoxLicense";
             this.textBoxLicense.ReadOnly = true;
             this.textBoxLicense.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBoxLicense.Size = new System.Drawing.Size(435, 134);
+            this.textBoxLicense.Size = new System.Drawing.Size(419, 156);
             this.textBoxLicense.TabIndex = 1;
             this.textBoxLicense.Text = resources.GetString("textBoxLicense.Text");
             // 
-            // labelNoAffiliation
-            // 
-            this.labelNoAffiliation.AutoSize = true;
-            this.labelNoAffiliation.Location = new System.Drawing.Point(85, 194);
-            this.labelNoAffiliation.Name = "labelNoAffiliation";
-            this.labelNoAffiliation.Size = new System.Drawing.Size(288, 13);
-            this.labelNoAffiliation.TabIndex = 2;
-            this.labelNoAffiliation.Text = "EDDiscovery is not affiliated with Frontier Developments plc.";
-            // 
             // panelLinks
             // 
+            this.panelLinks.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.panelLinks.Controls.Add(this.linkLabelDeveloperChat);
             this.panelLinks.Controls.Add(this.linkLabelHelp);
             this.panelLinks.Controls.Add(this.linkLabelLicense);
@@ -142,7 +130,7 @@ namespace EDDiscovery.Forms
             this.panelLinks.Controls.Add(this.linkLabelEDDB);
             this.panelLinks.Controls.Add(this.linkLabelEliteDangerous);
             this.panelLinks.Controls.Add(this.labelLinks);
-            this.panelLinks.Location = new System.Drawing.Point(446, 222);
+            this.panelLinks.Location = new System.Drawing.Point(430, 219);
             this.panelLinks.Name = "panelLinks";
             this.panelLinks.Size = new System.Drawing.Size(210, 171);
             this.panelLinks.TabIndex = 5;
@@ -156,7 +144,7 @@ namespace EDDiscovery.Forms
             this.linkLabelDeveloperChat.TabIndex = 2;
             this.linkLabelDeveloperChat.TabStop = true;
             this.linkLabelDeveloperChat.Text = "Developer Chat";
-            this.linkLabelDeveloperChat.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelDeveloperChat_LinkClicked);
+            this.linkLabelDeveloperChat.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelHelp
             // 
@@ -167,7 +155,7 @@ namespace EDDiscovery.Forms
             this.linkLabelHelp.TabIndex = 7;
             this.linkLabelHelp.TabStop = true;
             this.linkLabelHelp.Text = "Help";
-            this.linkLabelHelp.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelHelp_LinkClicked);
+            this.linkLabelHelp.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelLicense
             // 
@@ -179,7 +167,7 @@ namespace EDDiscovery.Forms
             this.linkLabelLicense.TabIndex = 8;
             this.linkLabelLicense.TabStop = true;
             this.linkLabelLicense.Text = "License";
-            this.linkLabelLicense.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelLicense_LinkClicked);
+            this.linkLabelLicense.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelFDForum
             // 
@@ -191,7 +179,7 @@ namespace EDDiscovery.Forms
             this.linkLabelFDForum.TabIndex = 5;
             this.linkLabelFDForum.TabStop = true;
             this.linkLabelFDForum.Text = "Frontier Forum";
-            this.linkLabelFDForum.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelFDForum_LinkClicked);
+            this.linkLabelFDForum.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelGitHubIssue
             // 
@@ -203,7 +191,7 @@ namespace EDDiscovery.Forms
             this.linkLabelGitHubIssue.TabIndex = 9;
             this.linkLabelGitHubIssue.TabStop = true;
             this.linkLabelGitHubIssue.Text = "Submit Feedback";
-            this.linkLabelGitHubIssue.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelGitHubIssue_LinkClicked);
+            this.linkLabelGitHubIssue.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelGitHub
             // 
@@ -215,7 +203,7 @@ namespace EDDiscovery.Forms
             this.linkLabelGitHub.TabIndex = 6;
             this.linkLabelGitHub.TabStop = true;
             this.linkLabelGitHub.Text = "GitHub";
-            this.linkLabelGitHub.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelGitHub_LinkClicked);
+            this.linkLabelGitHub.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelEDSM
             // 
@@ -227,7 +215,7 @@ namespace EDDiscovery.Forms
             this.linkLabelEDSM.TabIndex = 4;
             this.linkLabelEDSM.TabStop = true;
             this.linkLabelEDSM.Text = "EDSM";
-            this.linkLabelEDSM.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelEDSM_LinkClicked);
+            this.linkLabelEDSM.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelEDDB
             // 
@@ -239,7 +227,7 @@ namespace EDDiscovery.Forms
             this.linkLabelEDDB.TabIndex = 3;
             this.linkLabelEDDB.TabStop = true;
             this.linkLabelEDDB.Text = "EDDB";
-            this.linkLabelEDDB.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelEDDB_LinkClicked);
+            this.linkLabelEDDB.Click += new System.EventHandler(this.link_Click);
             // 
             // linkLabelEliteDangerous
             // 
@@ -251,7 +239,7 @@ namespace EDDiscovery.Forms
             this.linkLabelEliteDangerous.TabIndex = 1;
             this.linkLabelEliteDangerous.TabStop = true;
             this.linkLabelEliteDangerous.Text = "Elite Dangerous";
-            this.linkLabelEliteDangerous.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelEliteDangerous_LinkClicked);
+            this.linkLabelEliteDangerous.Click += new System.EventHandler(this.link_Click);
             // 
             // labelLinks
             // 
@@ -266,52 +254,90 @@ namespace EDDiscovery.Forms
             // 
             // labelDevelopers
             // 
+            this.labelDevelopers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.labelDevelopers.AutoSize = true;
             this.labelDevelopers.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelDevelopers.Location = new System.Drawing.Point(452, 19);
+            this.labelDevelopers.Location = new System.Drawing.Point(436, 19);
             this.labelDevelopers.Name = "labelDevelopers";
             this.labelDevelopers.Size = new System.Drawing.Size(106, 24);
             this.labelDevelopers.TabIndex = 7;
             this.labelDevelopers.Text = "Developers";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.labelNoAffiliation, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.panelLogo, 0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 220);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 170F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(401, 200);
+            this.tableLayoutPanel1.TabIndex = 9;
+            // 
+            // labelNoAffiliation
+            // 
+            this.labelNoAffiliation.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelNoAffiliation.Location = new System.Drawing.Point(3, 170);
+            this.labelNoAffiliation.Name = "labelNoAffiliation";
+            this.labelNoAffiliation.Size = new System.Drawing.Size(395, 30);
+            this.labelNoAffiliation.TabIndex = 12;
+            this.labelNoAffiliation.Text = "EDDiscovery is not affiliated with Frontier Developments plc.";
+            this.labelNoAffiliation.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // panelLogo
+            // 
+            this.panelLogo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelLogo.Image = ((System.Drawing.Image)(resources.GetObject("panelLogo.Image")));
+            this.panelLogo.Location = new System.Drawing.Point(3, 3);
+            this.panelLogo.Name = "panelLogo";
+            this.panelLogo.Padding = new System.Windows.Forms.Padding(1);
+            this.panelLogo.Size = new System.Drawing.Size(395, 164);
+            this.panelLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.panelLogo.TabIndex = 14;
+            this.panelLogo.TabStop = false;
+            this.panelLogo.Click += new System.EventHandler(this.link_Click);
             // 
             // AboutForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.ClientSize = new System.Drawing.Size(675, 434);
+            this.ClientSize = new System.Drawing.Size(659, 431);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.labelDevelopers);
             this.Controls.Add(this.panelLinks);
-            this.Controls.Add(this.labelNoAffiliation);
             this.Controls.Add(this.textBoxLicense);
             this.Controls.Add(this.labelVersion);
             this.Controls.Add(this.buttonOK);
-            this.Controls.Add(this.panelLogo);
             this.Controls.Add(this.labelDevelopersEnum);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(600, 420);
+            this.MinimumSize = new System.Drawing.Size(650, 470);
             this.Name = "AboutForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "About EDDiscovery";
             this.Load += new System.EventHandler(this.AboutForm_Load);
             this.panelLinks.ResumeLayout(false);
             this.panelLinks.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.panelLogo)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.Panel panelLogo;
         private System.Windows.Forms.Label labelDevelopersEnum;
         private System.Windows.Forms.Button buttonOK;
         internal System.Windows.Forms.Label labelVersion;
         private System.Windows.Forms.TextBox textBoxLicense;
-        private System.Windows.Forms.Label labelNoAffiliation;
         private System.Windows.Forms.Panel panelLinks;
         internal System.Windows.Forms.Label labelLinks;
         private System.Windows.Forms.LinkLabel linkLabelEliteDangerous;
@@ -324,5 +350,9 @@ namespace EDDiscovery.Forms
         private System.Windows.Forms.LinkLabel linkLabelLicense;
         private System.Windows.Forms.LinkLabel linkLabelGitHubIssue;
         internal System.Windows.Forms.Label labelDevelopers;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label labelNoAffiliation;
+        private System.Windows.Forms.PictureBox panelLogo;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/EDDiscovery/Forms/AboutForm.cs
+++ b/EDDiscovery/Forms/AboutForm.cs
@@ -31,6 +31,19 @@ namespace EDDiscovery.Forms
         public AboutForm()
         {
             InitializeComponent();
+            labelVersion.Text = "EDDiscovery v" + System.Reflection.Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+
+            SetTipAndTag(linkLabelDeveloperChat, Resources.URLProjectDiscord);
+            SetTipAndTag(linkLabelEDDB, Resources.URLeddb);
+            SetTipAndTag(linkLabelEDSM, Resources.URLedsm);
+            SetTipAndTag(linkLabelEliteDangerous, Resources.URLEDHomepage);
+            SetTipAndTag(linkLabelFDForum, Resources.URLProjectEDForumPost);
+            SetTipAndTag(linkLabelGitHub, Resources.URLProjectGithub);
+            SetTipAndTag(linkLabelGitHubIssue, Resources.URLProjectFeedback);
+            SetTipAndTag(linkLabelHelp, Resources.URLProjectWiki);
+            SetTipAndTag(linkLabelLicense, Resources.URLProjectLicense);
+
+            panelLogo.Tag = Resources.URLProjectGithub;
         }
 
         private void AboutForm_Load(object sender, EventArgs e)
@@ -43,54 +56,19 @@ namespace EDDiscovery.Forms
             Close();
         }
 
-        private void linkLabelEliteDangerous_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void SetTipAndTag(LinkLabel c, string text)
         {
-            Process.Start(Resources.URLEDHomepage);
+            toolTip1.SetToolTip(c, text);
+            c.Tag = text;
         }
 
-        private void linkLabelDeveloperChat_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void link_Click(object sender, EventArgs e)
         {
-            Process.Start(Resources.URLProjectDiscord);
-        }
-
-        private void linkLabelEDDB_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLeddb);
-        }
-
-        private void linkLabelEDSM_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLedsm);
-        }
-
-        private void linkLabelFDForum_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLProjectEDForumPost);
-        }
-
-        private void linkLabelGitHub_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLProjectGithub);
-        }
-
-        private void linkLabelHelp_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLProjectWiki);
-        }
-
-        private void linkLabelLicense_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLProjectLicense);
-        }
-
-        private void linkLabelGitHubIssue_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start(Resources.URLProjectFeedback);
-        }
-
-        private void panelLogo_Click(object sender, EventArgs e)
-        {
-            Process.Start(Resources.URLProjectGithub);
+            Control ctl = (Control)sender;
+            if (ctl != null && ctl.Tag != null)
+                Process.Start((string)ctl.Tag);
+            else
+                TraceLog.WriteLine($"AboutForm: Control and/or Tag is null: control {ctl?.Name ?? "(null)"}, tag {ctl?.Tag ?? "(null)"}.");   
         }
     }
 }

--- a/EDDiscovery/Forms/AboutForm.resx
+++ b/EDDiscovery/Forms/AboutForm.resx
@@ -117,8 +117,77 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="labelDevelopersEnum.Text" xml:space="preserve">
+    <value>Lead developer:
+  Cmdr Finwen  (Robert Wahlström )
+
+Main developers:
+  Robby
+  Bravada Cadelanne
+
+Additional developers:
+  Cruento Mucrone, Corbin Moran
+  Myshka, Zed
+  Marlon Blake, Majkl
+  Smacker, phroggie, Jason Thorpe</value>
+  </data>
+  <data name="textBoxLicense.Text" xml:space="preserve">
+    <value>Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="panelLogo.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="panelLogo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAABNkAAAKLCAYAAADLvl4hAAAABGdBTUEAALGPC/xhBQAA/8dJREFUeF7s
         3QWcHFXWNvAbT4i7JzMTF4K7+25wCba4hUBwd11gWWxhkQUiHZnJRIiH6GTibkRIcF1kYZGXxeG899yS
@@ -7648,75 +7717,9 @@
         AABJRU5ErkJggg==
 </value>
   </data>
-  <data name="labelDevelopersEnum.Text" xml:space="preserve">
-    <value>Lead developer:
-  Cmdr Finwen  (Robert Wahlström )
-
-Main developers:
-  Robby
-  Bravada Cadelanne
-
-Additional developers:
-  Cruento Mucrone, Corbin Moran
-  Myshka, Zed
-  Marlon Blake, Majkl
-  Smacker, phroggie, Jason Thorpe</value>
-  </data>
-  <data name="textBoxLicense.Text" xml:space="preserve">
-    <value>Apache License
-
-Version 2.0, January 2004
-
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-
-You must give any other recipients of the Work or Derivative Works a copy of this License; and
-You must cause any modified files to carry prominent notices stating that You changed the files; and
-You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
-
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS</value>
-  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAkAEBAAAAEAIABoBAAAlgAAABgYAAABACAAiAkAAP4EAAAgIAAAAQAgAKgQAACGDgAAMDAAAAEA


### PR DESCRIPTION
Add tooltips for the LinkLabels.
Anchor things appropriately to allow for prettier resizing.
Replace the longform version label (showing startup options) with the concise assembly version number.
Set reasonable minimum and default Form sizes.
Use a TableLayoutPanel to keep the logo and non-affiliation label centered.

[Before & after](http://imgur.com/a/QgmN7)