### PR TITLE
Show habitable zone in ls and AU

### DIFF
--- a/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EDDiscovery/EliteDangerous/JournalEvents/JournalScan.cs
@@ -420,7 +420,8 @@ namespace EDDiscovery.EliteDangerous.JournalEvents
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {
                 StringBuilder habZone = new StringBuilder();
-                habZone.AppendFormat("Habitable Zone Approx. {0}ls to {1}ls\n", HabitableZoneInner.Value.ToString("N0"), HabitableZoneOuter.Value.ToString("N0"));
+                habZone.AppendFormat("Habitable Zone Approx. {0}-{1}ls ({2}-{3} AU)\n", HabitableZoneInner.Value.ToString("N0"), HabitableZoneOuter.Value.ToString("N0"),
+                                                                                             (HabitableZoneInner.Value / 499).ToString("N2"), (HabitableZoneOuter.Value / 499).ToString("N2"));
                 if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
                     habZone.AppendFormat(" (This star only, others not considered)\n");
                 scanText.Append("\n" + habZone);


### PR DESCRIPTION
Saves dividing by 500 in your head when estimating for secondary stars where distance from entry point is not approximately distance from star.