### PR TITLE
Cache nuget packages on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,3 +10,5 @@ after_build:
   - cmd: copy EDDiscovery\bin\Release\EDDiscovery.Portable.zip EDDiscovery.Portable.zip
 artifacts:
   - path: EDDiscovery.Portable.zip
+cache:
+  - packages -> **\package.config


### PR DESCRIPTION
A few AppVeyor builds have been failing due to the failure to restore
NuGet packages due to timeouts