### PR TITLE
Improve SplashForm + Process Initialization

### DIFF
--- a/EDDiscovery/EDDApplicationContext.cs
+++ b/EDDiscovery/EDDApplicationContext.cs
@@ -1,0 +1,127 @@
+﻿﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using EDDiscovery.Forms;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Reflection;                //Assembly
+using System.Runtime.InteropServices;   //GuidAttribute
+using System.Security.AccessControl;    //MutexAccessRule
+using System.Security.Principal;        //SecurityIdentifier
+using System.Threading;                 //Tasks and Mutex
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using Timer = System.Windows.Forms.Timer;
+
+namespace EDDiscovery
+{
+    // Class for managing application initialization, and proud owner of SplashScreen and EDDiscoveryForm. Singleton.
+    internal class EDDApplicationContext : ApplicationContext
+    {
+        public EDDApplicationContext() : base(new SplashForm())
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+                Timer timer = new Timer { Interval = 250, Enabled = true };
+                timer.Tick += initTimer_Tick;
+            }
+        }
+
+        #region Public static properties
+
+        /// <summary>
+        /// The concise version number of the EDDiscovery.exe assembly, in the form of "<c>3.14.15.926</c>".
+        /// </summary>
+        public static string AssemblyVersionNumber { get; } = Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+
+        /// <summary>
+        /// The main <see cref="EDDiscoveryForm"/> of this application. If this is <c>null</c>, then you probably
+        /// need to `<c>Application.Run(EDDApplicationContext.Instance);</c>` and check back later, because it is
+        /// still being initialized and is not yet in a valid state.
+        /// </summary>
+        public static EDDiscoveryForm EDDMainForm { get; private set; } = null;
+
+        /// <summary>
+        /// The <see cref="EDDApplicationContext"/> of this application process.
+        /// </summary>
+        public static EDDApplicationContext Instance { get; private set; } = null;
+
+        #endregion
+
+        #region Implementation
+
+        // methods
+
+        protected override void Dispose(bool disposing)
+        {   // EDDMainForm gets cleaned up elsewhere if it has been ctor'd but not assigned to MainForm.
+            if (disposing)
+            {
+                MainForm?.Dispose();
+            }
+            MainForm = null;
+            base.Dispose(disposing);
+        }
+
+        // Display a loading message on the SplashForm, if it is visible.
+        private void SetLoadingMsg(string msg)
+        {
+            if (MainForm != null && MainForm is SplashForm)
+            {
+                ((SplashForm)MainForm).SetLoadingText(msg ?? string.Empty);
+            }
+        }
+
+
+        // event handlers
+
+        // Initialize everything on the UI thread soon after the `Application` has been `.Run()`.
+        private void initTimer_Tick(object sender, EventArgs e)
+        {
+            ((Timer)sender)?.Stop();
+            ((Timer)sender)?.Dispose();
+
+            try
+            {
+                EDDMainForm = new EDDiscoveryForm();
+                SetLoadingMsg("Checking Ship Systems");
+                EDDiscoveryController.Initialize(Control.ModifierKeys.HasFlag(Keys.Shift), SetLoadingMsg);
+                EDDMainForm.Init(SetLoadingMsg);     // call the init function, which will initialize the eddiscovery form
+
+                SetLoadingMsg("Establishing Telepresence");
+                EDDMainForm.Show();
+            }
+            catch (Exception ex)
+            {   // There's so many ways that things could go wrong during init; let's fail for everything!
+                EDDMainForm.Dispose();
+                string msg = ex.Message ?? "(Unknown exception)";
+                string st = ex.StackTrace ?? "(Stack trace unavailable)";
+
+                MessageBox.Show(MainForm, $"Error initializing EDDiscovery. Please report this at {Properties.Resources.URLProjectFeedback}:\n\n{msg}\n{st}", "Error Initializing EDDiscovery");
+                ExitThread();
+                return;
+            }
+
+            var splashForm = MainForm;
+            MainForm = EDDMainForm; // Switch context
+            splashForm.Close();     // and cleanup
+        }
+
+        #endregion // Implementation
+    }
+}

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -405,9 +405,7 @@ namespace EDDiscovery
 
             private void SetVersionDisplayString()
             {
-                StringBuilder sb = new StringBuilder();
-                sb.Append("Version ");
-                sb.Append(Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1]);
+                StringBuilder sb = new StringBuilder("Version " + EDDApplicationContext.AssemblyVersionNumber);
 
                 if (AppFolder != null)
                 {

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -208,6 +208,7 @@
     <Compile Include="CompanionAPI\CSystem.cs" />
     <Compile Include="DB\BookmarkClass.cs" />
     <Compile Include="DB\TargetClassHelpers.cs" />
+    <Compile Include="EDDApplicationContext.cs" />
     <Compile Include="EGO\EGOClass.cs" />
     <Compile Include="EGO\EGOSync.cs" />
     <Compile Include="EliteDangerous\BindingsFile.cs" />

--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -88,13 +88,15 @@ namespace EDDiscovery
             InvokeAsyncOnUiThread = invokeAsyncOnUiThread;
         }
 
-        public static Task Initialize(bool noreposition)        // called from splash form to set up initial initialization of dbs and config
+        public static void Initialize(bool noreposition, Action<string> msg)    // called from EDDApplicationContext to initialize config and dbs
         {
+            msg.Invoke("Checking Config");
             InitializeConfig(noreposition);
 
             Trace.WriteLine($"*** Elite Dangerous Discovery Initializing - {EDDConfig.Options.VersionDisplayString}, Platform: {Environment.OSVersion.Platform.ToString()}");
 
-            return Task.Factory.StartNew(InitializeDatabases);
+            msg.Invoke("Scanning Memory Banks");
+            InitializeDatabases();
         }
 
         public void Init()

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -96,7 +96,6 @@ namespace EDDiscovery
         public PopOutControl PopOuts;
 
         private bool _shownOnce = false;
-        private bool _initialised = false;
         private bool _formMax;
         private int _formWidth;
         private int _formHeight;
@@ -174,9 +173,9 @@ namespace EDDiscovery
             Controller.OnSyncStarting += Controller_SyncStarting;
         }
 
-        public void Init()      // called from splash form .. continues on with the construction of the form, controlled by splash form sequencing
+        public void Init(Action<string> msg)    // called from EDDApplicationContext .. continues on with the construction of the form
         {
-            _initialised = true;
+            msg.Invoke("Modulating Shields");
             Controller.Init();
 
             // Some components require the controller to be initialized
@@ -195,6 +194,7 @@ namespace EDDiscovery
             PopOuts = new PopOutControl(this);
 
             ToolStripManager.Renderer = theme.toolstripRenderer;
+            msg.Invoke("Repairing Canopy");
             theme.LoadThemes();                                         // default themes and ones on disk loaded
             themeok = theme.RestoreSettings();                                    // theme, remember your saved settings
 
@@ -215,6 +215,7 @@ namespace EDDiscovery
             // Windows TTS (2000 and above). Speech *recognition* will be Version.Major >= 6 (Vista and above)
             if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version.Major >= 5)
             {
+                msg.Invoke("Activating Sensors");
                 audiodriverwave = new AudioExtensions.AudioDriverCSCore( EDDConfig.DefaultWaveDevice );
                 audiodriverspeech = new AudioExtensions.AudioDriverCSCore( EDDConfig.DefaultVoiceDevice );
                 speechsynth = new AudioExtensions.SpeechSynthesizer(new AudioExtensions.WindowsSpeechEngine());
@@ -251,11 +252,6 @@ namespace EDDiscovery
         {
             try
             {
-                if (!_initialised)      // paranoid, Bravada says ;-)
-                {
-                    Init();
-                }
-
                 EDDiscovery.EliteDangerous.MaterialCommodityDB.SetUpInitialTable();
                 Controller.PostInit_Loaded();
 

--- a/EDDiscovery/Forms/SplashForm.Designer.cs
+++ b/EDDiscovery/Forms/SplashForm.Designer.cs
@@ -68,7 +68,7 @@ namespace EDDiscovery.Forms
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(293, 33);
             this.label1.TabIndex = 20;
-            this.label1.Text = "Loading - Please Wait";
+            this.label1.Text = "Locating Ship";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // label_version


### PR DESCRIPTION
* Add EDDApplicationContext to manage startup, context switching
* Allow SplashForm to provide feedback (warning: divisive strings chosen)
* Fix the race condition resulting in an unpainted SplashForm
* Catch more init Exceptions and treat them with rabid hostility
* Change SingleGlobalInstance from using a per-machine lock to a per-user lock, and rename to SingleUserInstance.

Here's a looping preview at half-speed, with "Locating Ship" being the starting frame:
![newsplashform2](https://user-images.githubusercontent.com/14035789/28760638-1fb10d8c-756e-11e7-9a66-f3f9e48b6513.gif)
