### PR TITLE
Cleanup some easy analysis warnings

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -102,8 +102,6 @@ namespace EDDiscovery
         private int _formTop;
         private int _formLeft;
 
-        private HistoryEntry _uncommittedNoteHistoryEntry;
-
         #endregion
 
         #region Callbacks from us

--- a/EDDiscovery/TravelHistoryControl.cs
+++ b/EDDiscovery/TravelHistoryControl.cs
@@ -82,8 +82,6 @@ namespace EDDiscovery
                                                "Display System Information panel",
                                             };
 
-        HistoryEntry notedisplayedhe = null;            // remember the particulars of the note displayed, so we can save it later
-
         public HistoryEntry GetTravelHistoryCurrent {  get { return userControlTravelGrid.GetCurrentHistoryEntry; } }
         public TravelHistoryFilter GetPrimaryFilter { get { return userControlTravelGrid.GetHistoryFilter; } }  // some classes want to know out filter
 


### PR DESCRIPTION
| Code | Source File | Line Num | Message |
|--------|-------------------------|----------|------------------------------------------------------------------------------------------|
| CS0169 | EDDiscoveryForm.cs | 105 | The field 'EDDiscoveryForm._uncommittedNoteHistoryEntry' is never used |
| CS0414 | TravelHistoryControl.cs | 85 | The field 'TravelHistoryControl.notedisplayedhe' is assigned but its value is never used |