### PR TITLE
Enhance Portable Zip Build and Cleanup Main csproj

### DIFF
--- a/EDDiscovery/App.Portable.config
+++ b/EDDiscovery/App.Portable.config
@@ -33,12 +33,6 @@
       </providers>
     </roleManager>
   </system.web>
-  <system.data>
-    <DbProviderFactories>
-      <remove invariant="System.Data.SQLite" />
-      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
-    </DbProviderFactories>
-  </system.data>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/EDDiscovery/App.config
+++ b/EDDiscovery/App.config
@@ -41,10 +41,6 @@
         <assemblyIdentity name="OpenTK" publicKeyToken="bad199fe84eb3df4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.104.0" newVersion="1.0.104.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -33,8 +33,14 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <ManifestCertificateThumbprint>6586052CF2C6A2D8348CC25AA17842FA028AED2F</ManifestCertificateThumbprint>
+    <ManifestKeyFile>EDDiscovery_TemporaryKey.pfx</ManifestKeyFile>
+    <GenerateManifests>true</GenerateManifests>
+    <SignManifests>false</SignManifests>
+    <ApplicationIcon>Resources\edlogo_3mo_icon.ico</ApplicationIcon>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -47,7 +53,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -57,28 +63,6 @@
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestCertificateThumbprint>6586052CF2C6A2D8348CC25AA17842FA028AED2F</ManifestCertificateThumbprint>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestKeyFile>EDDiscovery_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <GenerateManifests>true</GenerateManifests>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignManifests>false</SignManifests>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationIcon>Resources\edlogo_3mo_icon.ico</ApplicationIcon>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject>
-    </StartupObject>
-  </PropertyGroup>
-  <PropertyGroup>
-    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -607,6 +591,9 @@
     <EmbeddedResource Include="UserControls\UserControlTrippanel.resx">
       <DependentUpon>UserControlTrippanel.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="App.Portable.config">
       <SubType>Designer</SubType>
     </None>
@@ -756,11 +743,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">
       <Visible>False</Visible>
       <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
@@ -812,7 +794,6 @@
       <Name>ExtendedControls</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <UsingTask TaskName="Zip" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>
       <OutputFilename ParameterType="System.String" Required="true" />
@@ -848,16 +829,12 @@
     </Task>
   </UsingTask>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   -->
-  <Target Name="AfterBuild" Outputs="$(OutDir)EDDiscovery.Portable.zip" Condition=" '$(OS)' != 'Unix' ">
+  <Target Name="AfterBuild" Outputs="$(OutDir)EDDiscovery.Portable.zip" Condition="'$(OS)' != 'Unix'">
     <ItemGroup>
       <ZipFiles Include="$(TargetPath)" />
       <ZipFiles Include="$(OutDir)*.dll" />

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -857,27 +857,27 @@
   <Target Name="BeforeBuild">
   </Target>
   -->
-  <Target Name="AfterBuild" Condition=" '$(OS)' != 'Unix' ">
+  <Target Name="AfterBuild" Outputs="$(OutDir)EDDiscovery.Portable.zip" Condition=" '$(OS)' != 'Unix' ">
     <ItemGroup>
-      <ZipFiles Include="$(OutputPath)\EDDiscovery.exe" />
-      <ZipFiles Include="$(OutputPath)\EDDiscovery.pdb" />
-      <ZipFiles Include="$(OutputPath)\SharpDX.DirectInput.dll" />
-      <ZipFiles Include="$(OutputPath)\SharpDX.dll" />
-      <ZipFiles Include="$(ProjectDir)\App.Portable.config">
+      <ZipFiles Include="$(TargetPath)" />
+      <ZipFiles Include="$(OutDir)*.dll" />
+      <ZipFiles Include="$(OutDir)*.pdb" />
+      <ZipFiles Include="$(ProjectDir)App.Portable.config">
         <Name>EDDiscovery.exe.config</Name>
       </ZipFiles>
-      <ZipFiles Include="$(OutputPath)\CSCore.dll" />
-      <ZipFiles Include="$(OutputPath)\Newtonsoft.Json.dll" />
-      <ZipFiles Include="$(OutputPath)\OpenTK.GLControl.dll" />
-      <ZipFiles Include="$(OutputPath)\OpenTK.dll" />
-      <ZipFiles Include="$(OutputPath)\ActionLanguage.dll" />
-      <ZipFiles Include="$(OutputPath)\Audio.dll" />
-      <ZipFiles Include="$(OutputPath)\Conditions.dll" />
-      <ZipFiles Include="$(OutputPath)\DirectInput.dll" />
-      <ZipFiles Include="$(OutputPath)\ExtendedControls.dll" />
-      <ZipFiles Include="$(OutputPath)\General.dll" />
+      <Zipfiles Include="$(OutDir)x64\SQLite.Interop.dll">
+        <Name>x64\SQLite.Interop.dll</Name>
+      </Zipfiles>
+      <Zipfiles Include="$(OutDir)x86\SQLite.Interop.dll">
+        <Name>x86\SQLite.Interop.dll</Name>
+      </Zipfiles>
     </ItemGroup>
-    <Zip OutputFileName="$(OutputPath)\EDDiscovery.Portable.zip" Files="@(ZipFiles)" />
+    <Message Text="'@(ZipFiles)' -> '$(OutDir)EDDiscovery.Portable.zip'" />
+    <Zip OutputFileName="$(OutDir)EDDiscovery.Portable.zip" Files="@(ZipFiles)" />
+    <Error Condition="!Exists('$(OutDir)EDDiscovery.Portable.zip')" Importance="high" Text="Unknown error in BuildPortableZip." />
+  </Target>
+  <Target Name="CleanZipFile" AfterTargets="Clean">
+    <Delete Files="$(OutDir)EDDiscovery.Portable.zip" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/EliteDangerous/EliteDangerous.csproj
+++ b/EliteDangerous/EliteDangerous.csproj
@@ -14,6 +14,10 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <ContentSQLiteInteropFiles>True</ContentSQLiteInteropFiles>
+    <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+    <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+    <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Modification of @phroggster's #1148

* Delete EDDiscovery.portable.zip during a clean
* Use wildcards to pull in all .dll and .pdb files from build
* Use @(SQLiteInteropFiles) to reduce hard-coded paths
* Use OutDir instead of OutputPath, which includes the trailing slash
* Re-add SQLite interop

Should help guard against issues like #1136 in the future.