### PR TITLE
A few more assembly name / version corrections

### DIFF
--- a/BaseUtils/HTTP/BrowserInfo.cs
+++ b/BaseUtils/HTTP/BrowserInfo.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -69,5 +70,7 @@ namespace BaseUtils
 
             return null;
         }
+
+        public static string UserAgent { get; } = Assembly.GetEntryAssembly().GetName().Name + " v" + Assembly.GetEntryAssembly().FullName.Split(',')[1].Split('=')[1];
     }
 }

--- a/BaseUtils/HTTP/DownloadFile.cs
+++ b/BaseUtils/HTTP/DownloadFile.cs
@@ -73,7 +73,7 @@ namespace BaseUtils
 
             BaseUtils.HttpCom.WriteLog("DownloadFile", url);
             var request = (HttpWebRequest)HttpWebRequest.Create(url);
-            request.UserAgent = "EDDiscovery v" + Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+            request.UserAgent = BrowserInfo.UserAgent;
             request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
 
             if (filename != null && File.Exists(etagFilename))

--- a/BaseUtils/HTTP/GitHubClass.cs
+++ b/BaseUtils/HTTP/GitHubClass.cs
@@ -43,7 +43,7 @@ namespace BaseUtils
             try
             {
                 HttpWebRequest request = WebRequest.Create("https://api.github.com/repos/EDDiscovery/EDDiscovery/releases") as HttpWebRequest;
-                request.UserAgent = "TestApp";
+                request.UserAgent = BrowserInfo.UserAgent;
                 using (HttpWebResponse response = request.GetResponse() as HttpWebResponse)
                 {
                     StreamReader reader = new StreamReader(response.GetResponseStream());
@@ -67,7 +67,7 @@ namespace BaseUtils
             try
             {
                 HttpWebRequest request = WebRequest.Create("https://api.github.com/repos/EDDiscovery/EDDiscovery/releases/latest") as HttpWebRequest;
-                request.UserAgent = "TestApp";
+                request.UserAgent = BrowserInfo.UserAgent;
                 using (HttpWebResponse response = request.GetResponse() as HttpWebResponse)
                 {
                     StreamReader reader = new StreamReader(response.GetResponseStream());
@@ -99,7 +99,7 @@ namespace BaseUtils
             try
             {
                 HttpWebRequest request = WebRequest.Create("https://api.github.com/repos/EDDiscovery/EDDiscoveryData/contents/" + gitdir) as HttpWebRequest;
-                request.UserAgent = "TestApp";
+                request.UserAgent = BrowserInfo.UserAgent;
                 using (HttpWebResponse response = request.GetResponse() as HttpWebResponse)
                 {
                     StreamReader reader = new StreamReader(response.GetResponseStream());

--- a/BaseUtils/Misc/TraceLog.cs
+++ b/BaseUtils/Misc/TraceLog.cs
@@ -295,7 +295,8 @@ namespace BaseUtils
             bool ourcode = false;
             foreach (var frame in trace.GetFrames())
             {
-                if (frame.GetMethod().DeclaringType.Assembly == Assembly.GetExecutingAssembly())
+                var a = frame.GetMethod().DeclaringType.Assembly;
+                if (a == Assembly.GetEntryAssembly() || a == Assembly.GetExecutingAssembly())
                 {
                     ourcode = true;
                     break;

--- a/EDDiscovery/EDDApplicationContext.cs
+++ b/EDDiscovery/EDDApplicationContext.cs
@@ -48,7 +48,18 @@ namespace EDDiscovery
         /// <summary>
         /// The concise version number of the EDDiscovery.exe assembly, in the form of "<c>3.14.15.926</c>".
         /// </summary>
-        public static string AssemblyVersionNumber { get; } = Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+        public static string AppVersion { get; } = Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+
+        /// <summary>
+        /// The friendly name of this assembly, i.e. "<c>EDDiscovery</c>".
+        /// </summary>
+        public static string FriendlyName { get; } = "EDDiscovery";
+
+        /// <summary>
+        /// The friendly name of this assembly combined with the version number, in the form of "<c>EDDiscovery v3.14.15.926</c>".
+        /// </summary>
+        public static string UserAgent { get; } = $"{FriendlyName} v{AppVersion}";
+
 
         /// <summary>
         /// The main <see cref="EDDiscoveryForm"/> of this application. If this is <c>null</c>, then you probably

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -407,7 +407,7 @@ namespace EDDiscovery
 
             private void SetVersionDisplayString()
             {
-                StringBuilder sb = new StringBuilder("Version " + EDDApplicationContext.AssemblyVersionNumber);
+                StringBuilder sb = new StringBuilder("Version " + EDDApplicationContext.AppVersion);
 
                 if (AppFolder != null)
                 {

--- a/EDDiscovery/Forms/AboutForm.cs
+++ b/EDDiscovery/Forms/AboutForm.cs
@@ -31,7 +31,7 @@ namespace EDDiscovery.Forms
         public AboutForm()
         {
             InitializeComponent();
-            labelVersion.Text = "EDDiscovery v" + System.Reflection.Assembly.GetExecutingAssembly().FullName.Split(',')[1].Split('=')[1];
+            labelVersion.Text = EDDApplicationContext.UserAgent;
 
             SetTipAndTag(linkLabelDeveloperChat, Resources.URLProjectDiscord);
             SetTipAndTag(linkLabelEDDB, Resources.URLeddb);

--- a/EDDiscovery/Forms/SplashForm.cs
+++ b/EDDiscovery/Forms/SplashForm.cs
@@ -33,7 +33,7 @@ namespace EDDiscovery.Forms
         public SplashForm()
         {
             InitializeComponent();
-            this.label_version.Text = $"EDDiscovery {EDDApplicationContext.AssemblyVersionNumber}";
+            this.label_version.Text = EDDApplicationContext.FriendlyName + " " + EDDApplicationContext.AppVersion;
         }
 
         public void SetLoadingText(string value)


### PR DESCRIPTION
Also, add a proper UserAgent for GitHub requests (was TestApp). See the [API docs](https://developer.github.com/v3/#user-agent-required).
Fix first chance exception handler missing out on exceptions
Reduce number of times that we process the version number/assembly name throughout, and just keep a few static strings.