### PR TITLE
Delete edsmsystems.json (~1.45 GB) after fullsync success

### DIFF
--- a/EliteDangerous/EDSM/SystemClassEDSM.cs
+++ b/EliteDangerous/EDSM/SystemClassEDSM.cs
@@ -191,21 +191,22 @@ namespace EliteDangerousCore.EDSM
                 }
             });
 
+            GC.Collect();
             if (!success)
             {
                 logLine("Failed to download EDSM system file from server, will check next time");
                 return false;
             }
-
-            // Stop if requested
-            if (cancelRequested())
+            else if (cancelRequested())
+            {   // Stop if requested
                 return false;
-
-            logLine("Local database updated with EDSM data, " + updates + " systems updated.");
-
-            GC.Collect();
-
-            return (updates > 0);
+            }
+            else
+            {
+                logLine("Local database updated with EDSM data, " + updates + " systems updated.");
+                File.Delete(edsmsystems);
+                return (updates > 0);
+            }
         }
 
 


### PR DESCRIPTION
I'm probably missing the motivation behind skipping it, but this seems like something that should have been done a while ago.

Of note, this won't delete the files that everyone has laying around, even if they're really outdated (`api-v1/systems` can keep us updated for ages without a full `/dump/systemsWithCoordinates.json` download, provided that EDDiscovery is run often enough).