### PR TITLE
AutoCompleteDGVColumn Solidification

### DIFF
--- a/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
+++ b/EDDiscovery/SavedRouteExpeditionControl.Designer.cs
@@ -68,7 +68,7 @@ namespace EDDiscovery
             this.textBoxRouteName = new ExtendedControls.TextBoxBorder();
             this.labelRouteName = new System.Windows.Forms.Label();
             this.dataGridViewRouteSystems = new System.Windows.Forms.DataGridView();
-            this.SystemName = new ExtendedControls.AutoCompleteSystemsColumn();
+            this.SystemName = new ExtendedControls.AutoCompleteDGVColumn();
             this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Note = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.contextMenuCopyPaste = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -471,7 +471,7 @@ namespace EDDiscovery
         private System.Windows.Forms.Label labelDateStart;
         private System.Windows.Forms.Label labelRouteName;
         private System.Windows.Forms.DataGridView dataGridViewRouteSystems;
-        private ExtendedControls.AutoCompleteSystemsColumn SystemName;
+        private ExtendedControls.AutoCompleteDGVColumn SystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
         private System.Windows.Forms.DataGridViewTextBoxColumn Note;
         private System.Windows.Forms.ToolStripButton toolStripButtonShowOn3DMap;

--- a/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
+++ b/EDDiscovery/Trilateration/TrilaterationControl.Designer.cs
@@ -82,7 +82,7 @@ namespace EDDiscovery
             this.dataViewScroller_Distances = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
             this.dataGridViewDistances = new System.Windows.Forms.DataGridView();
-            this.ColumnSystem = new ExtendedControls.AutoCompleteSystemsColumn();
+            this.ColumnSystem = new ExtendedControls.AutoCompleteDGVColumn();
             this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnCalculated = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -737,7 +737,7 @@ namespace EDDiscovery
         private System.Windows.Forms.ToolStripButton toolStripButtonRemoveUnused;
         private System.Windows.Forms.Panel panel_controls;
         private System.Windows.Forms.Label labelstpos;
-        private ExtendedControls.AutoCompleteSystemsColumn ColumnSystem;
+        private ExtendedControls.AutoCompleteDGVColumn ColumnSystem;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDistance;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnCalculated;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnStatus;

--- a/EDDiscovery/UserControls/UserControlExploration.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.Designer.cs
@@ -69,7 +69,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewExplore = new System.Windows.Forms.DataGridView();
             this.dataViewScrollerPanel1 = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
-            this.ColumnSystemName = new ExtendedControls.AutoCompleteSystemsColumn();
+            this.ColumnSystemName = new ExtendedControls.AutoCompleteDGVColumn();
             this.ColumnDist = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnX = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnY = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -467,7 +467,7 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.ToolStripButton tsbImportSphere;
         private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel1;
         private ExtendedControls.VScrollBarCustom vScrollBarCustom1;
-        private ExtendedControls.AutoCompleteSystemsColumn ColumnSystemName;
+        private ExtendedControls.AutoCompleteDGVColumn ColumnSystemName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDist;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnX;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnY;

--- a/ExtendedControls/ThemeStandardEditor.cs
+++ b/ExtendedControls/ThemeStandardEditor.cs
@@ -13,7 +13,6 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
-using EDDiscovery;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;


### PR DESCRIPTION
* An abstract AutoCompleteDGVColumn isn't effective if the inheriting classes are identical to base in all but type name. Remove the abstract qualifier from it, and remove the essentially identical child types.
  * The prior approach was great until EDDiscovery and ExtendedControls were separated, but it's not practical now. EDDiscovery could have classes added to extend from AutoCompleteDGVColumn if it's ever desired again.
* Cleanup some IDE0019 (Use pattern matching) messages in AutoCompleteDGVColumn.
* Remove a couple of `using EDDiscovery;` lines from types that can't possibly be linked to EDDiscovery, as EDDiscovery depends on them.