### PR TITLE
Add a FatalExceptionForm : Form

### DIFF
--- a/EDDiscovery/EDDApplicationContext.cs
+++ b/EDDiscovery/EDDApplicationContext.cs
@@ -14,6 +14,7 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using EDDiscovery.Forms;
+using ExtendedControls;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -110,12 +111,7 @@ namespace EDDiscovery
             catch (Exception ex)
             {   // There's so many ways that things could go wrong during init; let's fail for everything!
                 EDDMainForm?.Dispose();
-                string msg = ex.Message ?? "(Unknown exception)";
-                string st = ex.StackTrace ?? "(Stack trace unavailable)";
-
-                MessageBox.Show(MainForm, $"Error initializing EDDiscovery. Please report this at {Properties.Resources.URLProjectFeedback}:\n\n{msg}\n{st}", "Error Initializing EDDiscovery");
-                ExitThread();
-                return;
+                FatalExceptionForm.ShowAndDie(MainForm, "Initializing", Properties.Resources.URLProjectFeedback, ex);
             }
 
             var splashForm = MainForm;

--- a/ExtendedControls/ExtendedControls.csproj
+++ b/ExtendedControls/ExtendedControls.csproj
@@ -61,6 +61,12 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="BitMapHelpers.cs" />
+    <Compile Include="FatalExceptionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="FatalExceptionForm.Designer.cs">
+      <DependentUpon>FatalExceptionForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="ThemeStandardEditor.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -165,6 +171,9 @@
   <ItemGroup>
     <EmbeddedResource Include="AutoCompleteTextBox.resx">
       <DependentUpon>AutoCompleteTextBox.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FatalExceptionForm.resx">
+      <DependentUpon>FatalExceptionForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="InfoForm.resx">
       <DependentUpon>InfoForm.cs</DependentUpon>

--- a/ExtendedControls/FatalExceptionForm.Designer.cs
+++ b/ExtendedControls/FatalExceptionForm.Designer.cs
@@ -1,0 +1,164 @@
+﻿namespace ExtendedControls
+{
+    partial class FatalExceptionForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                components?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FatalExceptionForm));
+            this.pnlIcon = new System.Windows.Forms.Panel();
+            this.pnlHeader = new System.Windows.Forms.Panel();
+            this.btnExit = new System.Windows.Forms.Button();
+            this.btnReport = new System.Windows.Forms.Button();
+            this.btnDetails = new System.Windows.Forms.Button();
+            this.lblHeader = new System.Windows.Forms.Label();
+            this.pnlDetails = new System.Windows.Forms.Panel();
+            this.tbDetails = new System.Windows.Forms.TextBox();
+            this.pnlHeader.SuspendLayout();
+            this.pnlDetails.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // pnlIcon
+            // 
+            this.pnlIcon.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.pnlIcon.Location = new System.Drawing.Point(3, 3);
+            this.pnlIcon.Name = "pnlIcon";
+            this.pnlIcon.Size = new System.Drawing.Size(48, 48);
+            this.pnlIcon.TabIndex = 0;
+            // 
+            // pnlHeader
+            // 
+            this.pnlHeader.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pnlHeader.Controls.Add(this.btnExit);
+            this.pnlHeader.Controls.Add(this.btnReport);
+            this.pnlHeader.Controls.Add(this.btnDetails);
+            this.pnlHeader.Controls.Add(this.lblHeader);
+            this.pnlHeader.Controls.Add(this.pnlIcon);
+            this.pnlHeader.Location = new System.Drawing.Point(12, 12);
+            this.pnlHeader.Name = "pnlHeader";
+            this.pnlHeader.Size = new System.Drawing.Size(363, 131);
+            this.pnlHeader.TabIndex = 1;
+            // 
+            // btnExit
+            // 
+            this.btnExit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnExit.Location = new System.Drawing.Point(259, 105);
+            this.btnExit.Name = "btnExit";
+            this.btnExit.Size = new System.Drawing.Size(101, 23);
+            this.btnExit.TabIndex = 4;
+            this.btnExit.Text = "E&xit";
+            this.btnExit.UseVisualStyleBackColor = true;
+            this.btnExit.Click += new System.EventHandler(this.btnExit_Click);
+            // 
+            // btnReport
+            // 
+            this.btnReport.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.btnReport.Location = new System.Drawing.Point(131, 105);
+            this.btnReport.Name = "btnReport";
+            this.btnReport.Size = new System.Drawing.Size(101, 23);
+            this.btnReport.TabIndex = 3;
+            this.btnReport.Text = "&Report An Issue";
+            this.btnReport.UseVisualStyleBackColor = true;
+            this.btnReport.Click += new System.EventHandler(this.btnReport_Click);
+            // 
+            // btnDetails
+            // 
+            this.btnDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnDetails.Location = new System.Drawing.Point(3, 105);
+            this.btnDetails.Name = "btnDetails";
+            this.btnDetails.Size = new System.Drawing.Size(101, 23);
+            this.btnDetails.TabIndex = 2;
+            this.btnDetails.Text = "▼   &Details     ";
+            this.btnDetails.UseVisualStyleBackColor = true;
+            this.btnDetails.Click += new System.EventHandler(this.btnDetails_Click);
+            // 
+            // lblHeader
+            // 
+            this.lblHeader.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblHeader.Location = new System.Drawing.Point(58, 3);
+            this.lblHeader.Name = "lblHeader";
+            this.lblHeader.Size = new System.Drawing.Size(302, 99);
+            this.lblHeader.TabIndex = 1;
+            this.lblHeader.Text = resources.GetString("lblHeader.Text");
+            // 
+            // pnlDetails
+            // 
+            this.pnlDetails.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.pnlDetails.Controls.Add(this.tbDetails);
+            this.pnlDetails.Location = new System.Drawing.Point(12, 149);
+            this.pnlDetails.Name = "pnlDetails";
+            this.pnlDetails.Size = new System.Drawing.Size(363, 192);
+            this.pnlDetails.TabIndex = 2;
+            // 
+            // tbDetails
+            // 
+            this.tbDetails.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tbDetails.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tbDetails.Location = new System.Drawing.Point(0, 0);
+            this.tbDetails.Multiline = true;
+            this.tbDetails.Name = "tbDetails";
+            this.tbDetails.ReadOnly = true;
+            this.tbDetails.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.tbDetails.Size = new System.Drawing.Size(359, 188);
+            this.tbDetails.TabIndex = 0;
+            this.tbDetails.WordWrap = false;
+            // 
+            // FatalExceptionForm
+            // 
+            this.AcceptButton = this.btnDetails;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnExit;
+            this.ClientSize = new System.Drawing.Size(387, 353);
+            this.Controls.Add(this.pnlDetails);
+            this.Controls.Add(this.pnlHeader);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "FatalExceptionForm";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.Text = "Fatal Error While ($DESCRIPTION)";
+            this.pnlHeader.ResumeLayout(false);
+            this.pnlDetails.ResumeLayout(false);
+            this.pnlDetails.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel pnlIcon;
+        private System.Windows.Forms.Panel pnlHeader;
+        private System.Windows.Forms.Button btnExit;
+        private System.Windows.Forms.Button btnReport;
+        private System.Windows.Forms.Button btnDetails;
+        private System.Windows.Forms.Label lblHeader;
+        private System.Windows.Forms.Panel pnlDetails;
+        private System.Windows.Forms.TextBox tbDetails;
+    }
+}

--- a/ExtendedControls/FatalExceptionForm.cs
+++ b/ExtendedControls/FatalExceptionForm.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public partial class FatalExceptionForm : Form
+    {
+        #region Public interfaces
+
+        public static void ShowAndDie(Form parent, string briefDesc, string reportIssueURL, Exception e)
+        {
+            FatalExceptionForm f = new FatalExceptionForm()
+            {
+                _Description = briefDesc,
+                _Exception = e,
+                _ReportURL = reportIssueURL,
+                Owner = parent,
+                StartPosition = parent != null ? FormStartPosition.CenterParent : FormStartPosition.WindowsDefaultLocation
+            };
+            f.ShowDialog(parent);
+        }
+
+        #endregion
+
+        #region Implementation
+
+        private bool _IsExpanded = false;
+        private Image _icon = null;
+        private string _Description = string.Empty;
+        private Exception _Exception = null;
+        private string _ReportURL = null;
+
+        private string DetailBtnText { get { return (_IsExpanded ? "▲" : "▼") + "   &Details     "; } }
+
+        private FatalExceptionForm()
+        {
+            InitializeComponent();
+            pnlDetails.Visible = _IsExpanded;
+            Height += (_IsExpanded ? (pnlDetails.Height + 12) : -(pnlDetails.Height + 12));
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            Environment.Exit(1);
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            base.OnClosing(e);
+
+            _icon?.Dispose();
+
+            _Description = null;
+            _Exception = null;
+            _icon = null;
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            Text = $"Fatal Error While {_Description}";
+            lblHeader.Text =
+                $"A fatal exception was encountered while {_Description}.{Environment.NewLine}{Environment.NewLine}" +
+                $"Click the \"Report An Issue\" button to copy diagnostic information to your clipboard, and provide this info to help us make {Assembly.GetEntryAssembly().GetName().Name} better, or click \"Exit\" to end the program.";
+            tbDetails.Text =
+                $"Fatal exception while {_Description}.{Environment.NewLine}{Environment.NewLine}" +
+                "==== BEGIN ====" + Environment.NewLine +
+                _Exception.ToString() + Environment.NewLine +
+                "===== END =====";
+
+            _icon = SystemIcons.Error.ToBitmap();
+            pnlIcon.BackgroundImage = _icon;
+        }
+
+        private void ToggleDetails()
+        {
+            _IsExpanded = !_IsExpanded;
+
+            btnDetails.Text = DetailBtnText;
+            pnlDetails.Visible = _IsExpanded;
+            Height += (_IsExpanded ? (pnlDetails.Height + 12) : -(pnlDetails.Height + 12));
+        }
+
+
+        private void btnDetails_Click(object sender, EventArgs e)
+        {
+            ToggleDetails();
+        }
+
+        private void btnExit_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void btnReport_Click(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(_ReportURL))
+            {
+                string mdText = tbDetails.Text
+                    .Replace("==== BEGIN", "```" + Environment.NewLine + "==== BEGIN")
+                    .Replace("END =====", "END =====" + Environment.NewLine + "```" + Environment.NewLine);
+
+                try { Clipboard.SetText(mdText); }
+                catch {}
+                try { Process.Start(_ReportURL); }
+                catch {}
+            }
+            else
+            {
+                MessageBox.Show("You forget to give me the URL/executable path. Bad developer.");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/ExtendedControls/FatalExceptionForm.resx
+++ b/ExtendedControls/FatalExceptionForm.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="lblHeader.Text" xml:space="preserve">
+    <value>A fatal exception was encountered while ($DESCRIPTION).
+
+Click the "Report An Issue" button to copy diagnostic information to your clipboard, and provide this info to help us make ($PRODUCT) better, or click "Exit" to end the program.
+PADDING1 PADDING2 PADDING3 PADDING4 PADDING5 PADDING6 PADDING7 PADDING8 PADDING9 PADDING0</value>
+  </data>
+</root>


### PR DESCRIPTION
Displays an exception similar to the debug unhandled exception dialog.
Provides a one-click copy details to clipboard and open github/issues button.

Migrate EDDApplicationContext init routine to use this dialog, which...
Fixes the old dialog not showing line numbers or InnerExceptions.

Several other places could probably use this dialog, as well as a non-fatal variant. Will have to see where else to recycle this...

Screenshots of some random exception that I threw in for testing:
![01](https://user-images.githubusercontent.com/14035789/29234155-b0649f7e-7eba-11e7-8e68-22988b043005.png)
![02](https://user-images.githubusercontent.com/14035789/29234003-d3c88792-7eb9-11e7-88a4-de05cd053f35.png)
![03](https://user-images.githubusercontent.com/14035789/29234041-0852a68c-7eba-11e7-8ae4-c5beafcd97c3.png)
