### PR TITLE
ImageHandler fixes

### DIFF
--- a/EDDiscovery/ImageHandler.cs
+++ b/EDDiscovery/ImageHandler.cs
@@ -754,22 +754,25 @@ namespace EDDiscovery.ImageHandler
                 }
             }
 
-            try
+            if (bmp == null)
             {
-                //Console.WriteLine("Trying " + inputfile);
-                using (testfile = File.Open(inputfile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))        // throws if can't open
+                try
                 {
-                    memstrm.SetLength(0);
-                    testfile.CopyTo(memstrm);
-                    memstrm.Seek(0, SeekOrigin.Begin);
-                    bmp = new Bitmap(memstrm);
+                    //Console.WriteLine("Trying " + inputfile);
+                    using (testfile = File.Open(inputfile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))        // throws if can't open
+                    {
+                        memstrm.SetLength(0);
+                        testfile.CopyTo(memstrm);
+                        memstrm.Seek(0, SeekOrigin.Begin);
+                        bmp = new Bitmap(memstrm);
+                    }
+                    //Console.WriteLine("Worked " + inputfile);
                 }
-                //Console.WriteLine("Worked " + inputfile);
-            }
-            catch (Exception ex)
-            {
-                Controller.LogLineHighlight($"Unable to open screenshot '{inputfile}': {ex.Message}");
-                throw;
+                catch (Exception ex)
+                {
+                    Controller.LogLineHighlight($"Unable to open screenshot '{inputfile}': {ex.Message}");
+                    throw;
+                }
             }
 
             try

--- a/EliteDangerous/JournalEvents/JournalScreenshot.cs
+++ b/EliteDangerous/JournalEvents/JournalScreenshot.cs
@@ -56,6 +56,15 @@ namespace EliteDangerousCore.JournalEvents
             UpdateJson(jo);
         }
 
+        public void GetConvertedFilename(out string input_filename, out string output_filename, out int width, out int height)
+        {
+            JObject jo = GetJson();
+            input_filename = jo["EDDInputFile"]?.ToString();
+            output_filename = jo["EDDOutputFile"]?.ToString();
+            width = jo["EDDOutputWidth"].Int();
+            height = jo["EDDOutputHeight"].Int();
+        }
+
         public static JournalScreenshot GetScreenshot(string filename, int width, int height, DateTime timestamp, string sysname, int cmdrid)
         {
             JournalScreenshot ss = null;


### PR DESCRIPTION
Handle a possible case where the JournalScreenShot event is logged before the screenshot has been written.  Also ensure the last-ditch read does not occur when the image has already been successfully read.