### PR TITLE
This wasn't happy about not having an audio device available

### DIFF
--- a/Audio/AudioDriverCSCore.cs
+++ b/Audio/AudioDriverCSCore.cs
@@ -91,8 +91,7 @@ namespace AudioExtensions
         private void Output_Stopped(object sender, PlaybackStoppedEventArgs e)
         {
             //System.Diagnostics.Debug.WriteLine((Environment.TickCount % 10000).ToString("00000") + "Driver stopped");
-            if (AudioStoppedEvent != null)
-                AudioStoppedEvent();
+            AudioStoppedEvent?.Invoke();
         }
 
         public void Dispose()
@@ -110,6 +109,9 @@ namespace AudioExtensions
 
         public void Start(AudioData o, int vol)
         {
+            if (((DirectSoundOut)aout).Device == Guid.Empty)
+                return;
+
             int t = Environment.TickCount;
 
             IWaveSource current = o.data as IWaveSource;


### PR DESCRIPTION
Not having an available audio output device (such as when working via remote desktop/terminal services or when working in absolute silence) should not be fatal.

@robbyxp1, you're way more familiar with this code than I am. It looks like we need to fire off an `AudioStoppedEvent` immediately in order for `AudioQueue` to unqueue it and release handles? If so, should AudioDriverDummy also do this? This PR is merely the bare minimum in order to avoid the following, but I'm pretty sure that cleanup is lacking...

```
CSCore.DirectSound.DirectSoundException occurred
  HResult=0x88780078
  Message=DSInterop::DirectSoundCreate8 caused an error: 0x88780078, "Unknown HRESULT".
  Source=CSCore
  StackTrace:
   at CSCore.SoundOut.DirectSoundOut.InitializeInternal()
   at CSCore.SoundOut.DirectSoundOut.Initialize(IWaveSource source)
   at AudioExtensions.AudioDriverCSCore.Start(AudioData o, Int32 vol) in Audio\AudioDriverCSCore.cs:line 116
   at AudioExtensions.AudioQueue.Queue(AudioSample newdata, Priority p) in Audio\AudioQueue.cs:line 185
   at AudioExtensions.AudioQueue.Submit(AudioSample s, Int32 vol, Priority p) in Audio\AudioQueue.cs:line 265
   at ActionLanguage.ActionSay.ExecuteAction(ActionProgramRun ap) in ActionLanguage\ActionsCoreCmds\ActionSay.cs:line 271
   at ActionLanguage.ActionRun.DoExecute() in ActionLanguage\ActionsCore\ActionRun.cs:line 182
   at ActionLanguage.ActionRun.Execute() in ActionLanguage\ActionsCore\ActionRun.cs:line 71
   at EDDiscovery.Actions.ActionController.ActionRun(String triggername, String triggertype, HistoryEntry he, ConditionVariables additionalvars, String flagstart, Boolean now) in EDDiscovery\Actions\ActionController.cs:line 377
   at EDDiscovery.Actions.ActionController.onStartup() in EDDiscovery\Actions\ActionController.cs:line 401
   at EDDiscovery.EDDiscoveryForm.EDDiscoveryForm_Shown(Object sender, EventArgs e) in EDDiscovery\EDDiscoveryForm.cs:line 275
   at System.Windows.Forms.Form.OnShown(EventArgs e)
   at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme)
   at System.Windows.Forms.Control.InvokeMarshaledCallbacks()
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.Form.WndProc(Message& m)
   at ExtendedControls.DraggableForm.WndProc(Message& m) in ExtendedControls\Forms\DraggableForm.cs:line 158
   at System.Windows.Forms.NativeWindow.DebuggableCallback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   at System.Windows.Forms.UnsafeNativeMethods.DispatchMessageW(MSG& msg)
   at System.Windows.Forms.Application.ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr dwComponentID, Int32 reason, Int32 pvLoopData)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(Int32 reason, ApplicationContext context)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoop(Int32 reason, ApplicationContext context)
   at EDDiscovery.Program.Main() in EDDiscovery\Program.cs:line 47
```