### PR TITLE
Prevent belt bodies from showing on Scan panel

### DIFF
--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -188,7 +188,7 @@ namespace EDDiscovery.UserControls
 
                             //System.Diagnostics.Debug.WriteLine("Planet Node " + planetnode.ownname + " has scans " + nonedsmscans);
 
-                            if (nonedsmscans || checkBoxEDSM.Checked)
+                            if ((nonedsmscans || checkBoxEDSM.Checked) && planetnode.type != StarScan.ScanNodeType.belt)
                             {
                                 List<PictureBoxHotspot.ImageElement> pc = new List<PictureBoxHotspot.ImageElement>();
 


### PR DESCRIPTION
This should prevent the `belt` objects which were used to consume belt clusters from showing on the scan panel.