### PR TITLE
Fix a couple Paint bugs

### DIFF
--- a/BaseUtils/WinForms/ControlHelpers.cs
+++ b/BaseUtils/WinForms/ControlHelpers.cs
@@ -125,13 +125,7 @@ public static class ControlHelpersStaticFunc
             var icontainers = (from f in memcc      // pick out a list of IContainers (should be only 1)
                                where f.FieldType.FullName == "System.ComponentModel.IContainer"
                                select f);
-
-            if (icontainers.Count() > 0)    // paranoia, should always be there
-            {
-                var item = (icontainers.ToArray())[0].GetValue(c);
-
-                return item as System.ComponentModel.IContainer;  // But IT may be null if no containers are on the form
-            }
+            return icontainers?.FirstOrDefault()?.GetValue(c) as System.ComponentModel.IContainer;  // But IT may be null if no containers are on the form
         }
 
         return null;

--- a/ExtendedControls/Controls/ComboBoxCustom.cs
+++ b/ExtendedControls/Controls/ComboBoxCustom.cs
@@ -243,10 +243,9 @@ namespace ExtendedControls
             {
                 System.ComponentModel.IContainer ic = this.GetParentContainerComponents();
 
-                if (ic != null)    // yes we have a container object
-                    ic.CopyToolTips(this, new Control[] { this, _cbsystem });
+                ic?.CopyToolTips(this, new Control[] { this, _cbsystem });
 
-                firstpaint = true;
+                firstpaint = false;
             }
 
             base.OnPaint(e);

--- a/ExtendedControls/Controls/TextBoxBorder.cs
+++ b/ExtendedControls/Controls/TextBoxBorder.cs
@@ -123,10 +123,9 @@ namespace ExtendedControls
             {
                 System.ComponentModel.IContainer ic = this.GetParentContainerComponents();
 
-                if (ic != null)    // yes we have a container object
-                    ic.CopyToolTips(this, new Control[] { textbox });
+                ic?.CopyToolTips(this, new Control[] { textbox });
 
-                firstpaint = true;
+                firstpaint = false;
             }
 
             using (Brush highlight = new SolidBrush(controlbackcolor))


### PR DESCRIPTION
* ComboBoxCustom:
  * Fix a bug that was reflecting for every Paint call.
* TextBoxBorder:
  * Fix a bug that was reflecting for every Paint call.
* ControlHelpers:
  * Avoid multiple `O(N)` Linq flattenings when one `O(1)` can do it.