### PR TITLE
Fixup d396f353a8fca4281afa2d49e43a6d12417a2330

### DIFF
--- a/EDDiscovery/PopOutControl.cs
+++ b/EDDiscovery/PopOutControl.cs
@@ -51,7 +51,6 @@ namespace EDDiscovery.Forms
             ScreenShot,
             Statistics,
             Scan,
-            EstimatedValues,
             Modules,                
             Exploration,
             Synthesis,
@@ -64,6 +63,7 @@ namespace EDDiscovery.Forms
             NotePanel,
             RouteTracker,
             Grid,
+            EstimatedValues,
 
             EndList,                // Keep here, used to work out MaxTabButtons
         };


### PR DESCRIPTION
PopOuts are used numerically in places, so inserting into the middle changes panel layout.
My `SystemInformation` got replaced with a `MarketData`. Eww.