### PR TITLE
Reprocess system scans if any unplaced stars found

### DIFF
--- a/EliteDangerous/EliteDangerous/StarScan.cs
+++ b/EliteDangerous/EliteDangerous/StarScan.cs
@@ -540,7 +540,7 @@ namespace EliteDangerousCore
                 }
 
                 // Reprocess if we've encountered the primary (A) star an we already have a "Main Star"
-                if (reprocessPrimary && elements.Count == 1 && elements[0].Equals("A", StringComparison.InvariantCultureIgnoreCase) && sn.starnodes.ContainsKey("Main Star"))
+                if (reprocessPrimary && elements.Count == 1 && elements[0].Equals("A", StringComparison.InvariantCultureIgnoreCase) && sn.starnodes.Any(n => n.Key.Length > 1 && n.Value.type == ScanNodeType.star))
                     ReProcess(sn);
 
                 return true;


### PR DESCRIPTION
PR #1256 broke the assumption that any unplaced bodies would create a "Main Star" star.
Fix that broken assumption - any unplaced bodies will now create a star with a designator 2 or more characters long at the top level (either "Main Star" or the unplaced body name)
This should fix the regression seen in #1216 after #1256 was applied.