### PR TITLE
V8.2 bugfixes

### DIFF
--- a/EliteDangerous/EliteDangerous/EDJournalReader.cs
+++ b/EliteDangerous/EliteDangerous/EDJournalReader.cs
@@ -121,12 +121,12 @@ namespace EliteDangerousCore
 
                 if (_commander == null )
                 {
-                    EDCommander onlyc = EDCommander.GetAll().FirstOrDefault();
-                    if (EDCommander.NumberOfCommanders == 1 && onlyc != null && onlyc.Name == "Jameson (Default)")
+                    _commander = EDCommander.GetAll().FirstOrDefault();
+                    if (EDCommander.NumberOfCommanders == 1 && _commander != null && _commander.Name == "Jameson (Default)")
                     {
-                        onlyc.Name = newname;
-                        onlyc.EdsmName = newname;
-                        EDCommander.Update(new List<EDCommander> { onlyc }, false);
+                        _commander.Name = newname;
+                        _commander.EdsmName = newname;
+                        EDCommander.Update(new List<EDCommander> { _commander }, false);
                     }
                     else
                         _commander = EDCommander.Create(newname, null, EDJournalClass.GetDefaultJournalDir().Equals(TravelLogUnit.Path) ? "" : TravelLogUnit.Path);

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -511,6 +511,8 @@ namespace EliteDangerousCore.JournalEvents
         {
             switch (ringClass)
             {
+                case null:
+                    return "Unknown";
                 case "eRingClass_Icy":
                     return "Icy";
                 case "eRingClass_Rocky":


### PR DESCRIPTION
* Fix null-reference exception on first startup (or, presumably, whenever a new Commander name is found in a log file).
* Protect against EDSM returning no ringclass


