### PR TITLE
Less taskbar overlap when unframed

### DIFF
--- a/BaseUtils/Misc/NativeMethods.cs
+++ b/BaseUtils/Misc/NativeMethods.cs
@@ -245,7 +245,18 @@ namespace BaseUtils.Win32
         public static extern uint AssocQueryString(AssocF flags, AssocStr str,
            string pszAssoc, string pszExtra, [Out] StringBuilder pszOut, ref uint
            pcchOut);
-   }
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms632605.aspx
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MINMAXINFO
+        {
+            public System.Drawing.Point ptReserved;
+            public System.Drawing.Point ptMaxSize;
+            public System.Drawing.Point ptMaxPosition;
+            public System.Drawing.Point ptMinTrackSize;
+            public System.Drawing.Point ptMaxTrackSize;
+        }
+    }
 
     public class SafeNativeMethods
     {

--- a/BaseUtils/Misc/Win32Constants.cs
+++ b/BaseUtils/Misc/Win32Constants.cs
@@ -559,6 +559,14 @@ namespace BaseUtils.Win32Constants
         public const int FONTCHANGE = 0x001D;
 
         /// <summary>
+        /// WM_GETMINMAXINFO message is sent to a window when the size or position of the window is about to change. An
+        /// application can use this message to override the window's default maximized size and position, or its
+        /// default minimum or maximum tracking size. wParam is not used, while lParam is a pointer to a
+        /// <see cref="Win32.UnsafeNativeMethods.MINMAXINFO"/> struct.
+        /// </summary>
+        public const int GETMINMAXINFO = 0x0024;
+
+        /// <summary>
         /// An application sends a WM_SETFONT message to specify the font that a control is to use when drawing text.
         /// </summary>
         /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms632642(v=vs.85).aspx"/>


### PR DESCRIPTION
DraggableForm now handles the `WM_GETMINMAXINFO` message to prevent overlapping the taskbar when maximizing.

TODO:
- [ ] This needs to be tested on an x86 (non-amd64) operating system. `POINTS` (which is what the official `MINMAXINFO` struct uses) is not always the same as `System.Drawing.Point`, but it *might* be ok?
- [X] Verify Mac compatibility.