### PR TITLE
Detect and discard training systems and stations

### DIFF
--- a/EliteDangerous/EliteDangerous/EDJournalReader.cs
+++ b/EliteDangerous/EliteDangerous/EDJournalReader.cs
@@ -142,6 +142,11 @@ namespace EliteDangerousCore
                     System.Diagnostics.Trace.WriteLine(string.Format("TLU {0} updated with commander {1}", TravelLogUnit.Path, cmdrid));
                 }
             }
+            else if (je is ISystemStationEntry && ((ISystemStationEntry)je).IsTrainingEvent)
+            {
+                System.Diagnostics.Trace.WriteLine($"Training detected:\n{line}");
+                return null;
+            }
 
             je.TLUId = (int)TravelLogUnit.id;
             je.CommanderId = cmdrid;

--- a/EliteDangerous/EliteDangerous/JournalEntryInterfaces.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntryInterfaces.cs
@@ -42,4 +42,9 @@ namespace EliteDangerousCore
     {
         void UpdateMissions(MissionListAccumulator mlist, ISystem sys, string body, SQLiteConnectionUser conn);
     }
+
+    public interface ISystemStationEntry
+    {
+        bool IsTrainingEvent { get; }
+    }
 }

--- a/EliteDangerous/JournalEvents/JournalDocked.cs
+++ b/EliteDangerous/JournalEvents/JournalDocked.cs
@@ -50,7 +50,7 @@ namespace EliteDangerousCore.JournalEvents
     SearchAndRescue, 
      */
     [JournalEntryType(JournalTypeEnum.Docked)]
-    public class JournalDocked : JournalEntry
+    public class JournalDocked : JournalEntry, ISystemStationEntry
     {
         public JournalDocked(JObject evt ) : base(evt, JournalTypeEnum.Docked)
         {
@@ -71,6 +71,11 @@ namespace EliteDangerousCore.JournalEvents
             if (!evt["StationServices"].Empty())
                 StationServices = evt.Value<JArray>("StationServices").Values<string>().ToList();
 
+            // Government = None only happens in Training
+            if (Government == "$government_None;")
+            {
+                IsTrainingEvent = true;
+            }
         }
 
         public string StationName { get; set; }
@@ -85,6 +90,8 @@ namespace EliteDangerousCore.JournalEvents
         public string Government { get; set; }
         public string Government_Localised { get; set; }
         public List<string> StationServices { get; set; }
+
+        public bool IsTrainingEvent { get; private set; }
 
         public override System.Drawing.Bitmap Icon { get { return EliteDangerous.Properties.Resources.Stationenter; } }
 

--- a/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -106,7 +106,7 @@ Examples of trending states:
 
 
     [JournalEntryType(JournalTypeEnum.FSDJump)]
-    public class JournalFSDJump : JournalLocOrJump, IShipInformation
+    public class JournalFSDJump : JournalLocOrJump, IShipInformation, ISystemStationEntry
     {
         public JournalFSDJump(JObject evt) : base(evt, JournalTypeEnum.FSDJump)
         {
@@ -147,6 +147,12 @@ Examples of trending states:
             MapColor = jm.Int(EliteDangerousCore.EliteConfigInstance.InstanceConfig.DefaultMapColour);
             if (jm.Empty())
                 evt["EDDMapColor"] = EliteDangerousCore.EliteConfigInstance.InstanceConfig.DefaultMapColour;      // new entries get this default map colour if its not already there
+
+            // Allegiance without Faction only occurs in Training
+            if (!String.IsNullOrEmpty(Allegiance) && Faction == null)
+            {
+                IsTrainingEvent = true;
+            }
         }
 
         public class FactionInformation
@@ -181,6 +187,7 @@ Examples of trending states:
         public FactionInformation[] Factions;
         public int MapColor { get; set; }
         public bool RealJournalEvent { get; private set; } // True if real ED 2.2+ journal event and not pre 2.2 imported.
+        public bool IsTrainingEvent { get; private set; } // True if detected to be in training
 
         public override void FillInformation(out string summary, out string info, out string detailed)  //V
         {

--- a/EliteDangerous/JournalEvents/JournalLocation.cs
+++ b/EliteDangerous/JournalEvents/JournalLocation.cs
@@ -36,7 +36,7 @@ namespace EliteDangerousCore.JournalEvents
     //•	Government
     //•	Security
     [JournalEntryType(JournalTypeEnum.Location)]
-    public class JournalLocation : JournalLocOrJump
+    public class JournalLocation : JournalLocOrJump, ISystemStationEntry
     {
         public JournalLocation(JObject evt) : base(evt, JournalTypeEnum.Location)      // all have evidence 16/3/2017
         {
@@ -63,6 +63,12 @@ namespace EliteDangerousCore.JournalEvents
             PowerplayState = evt["PowerplayState"].Str();            // NO evidence
             if (!evt["Powers"].Empty())
                 Powers = evt.Value<JArray>("Powers").Values<string>().ToArray();
+
+            // Allegiance without Faction only occurs in Training
+            if (!String.IsNullOrEmpty(Allegiance) && Faction == null)
+            {
+                IsTrainingEvent = true;
+            }
         }
 
         public bool Docked { get; set; }
@@ -87,6 +93,8 @@ namespace EliteDangerousCore.JournalEvents
         public string[] Powers { get; set; }
 
         public FactionInfo[] Factions { get; set; }
+
+        public bool IsTrainingEvent { get; private set; } // True if detected to be in training
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {


### PR DESCRIPTION
* Training `FSDJump` and `Location` events have a non-empty `Allegiance` but no `Faction`
* Training `Docked` events have a Government of `None`
