### PR TITLE
Fix the ability to design the user controls

### DIFF
--- a/EDDiscovery/App.Portable.config
+++ b/EDDiscovery/App.Portable.config
@@ -20,6 +20,7 @@
   </userSettings>
   <appSettings>
     <add key="StoreDataInProgramDirectory" value="true" />
+    <add key="EnableOptimizedDesignerReloading" value="false" />
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/EDDiscovery/App.config
+++ b/EDDiscovery/App.config
@@ -21,6 +21,7 @@
   <appSettings>
     <add key="StoreDataInProgramDirectory" value="" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="EnableOptimizedDesignerReloading" value="false" />
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -222,6 +222,7 @@
     <Compile Include="ScreenShots\ScreenShotConverter.cs" />
     <Compile Include="ScreenShots\ScreenShotDirectoryWatcher.cs" />
     <Compile Include="ScreenShots\ScreenShotImageConverter.cs" />
+    <Compile Include="UserControls\AbstractControlDescriptionProvider.cs" />
     <Compile Include="UserControls\UserControlContainerGrid.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/EDDiscovery/UserControls/AbstractControlDescriptionProvider.cs
+++ b/EDDiscovery/UserControls/AbstractControlDescriptionProvider.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EDDiscovery.UserControls
+{
+    // https://stackoverflow.com/questions/6817107/abstract-usercontrol-inheritance-in-visual-studio-designer#answer-17661386
+    public class AbstractControlDescriptionProvider<TAbstract, TBase> : TypeDescriptionProvider
+    {
+        public AbstractControlDescriptionProvider() : base(TypeDescriptor.GetProvider(typeof(TAbstract)))
+        {
+        }
+
+        public override Type GetReflectionType(Type objectType, object instance)
+        {
+            if (objectType == typeof(TAbstract))
+            {
+                return typeof(TBase);
+            }
+            else
+            {
+                return base.GetReflectionType(objectType, instance);
+            }
+        }
+
+        public override object CreateInstance(IServiceProvider provider, Type objectType, Type[] argTypes, object[] args)
+        {
+            if (objectType == typeof(TAbstract))
+            {
+                objectType = typeof(TBase);
+            }
+
+            return base.CreateInstance(provider, objectType, argTypes, args);
+        }
+    }
+}

--- a/EDDiscovery/UserControls/UserControlCommonBase.cs
+++ b/EDDiscovery/UserControls/UserControlCommonBase.cs
@@ -27,6 +27,7 @@ using EliteDangerousCore;
 
 namespace EDDiscovery.UserControls
 {
+    [TypeDescriptionProvider(typeof(AbstractControlDescriptionProvider<UserControlCommonBase, UserControl>))]
     public abstract class UserControlCommonBase : UserControl
     {
         // in calling order..


### PR DESCRIPTION
Note that a rebuild of the solution followed by a restart of Visual Studio may be required before being able to open user controls in the designer.