### PR TITLE
Adding scrollbar to Stats Gridview

### DIFF
--- a/EDDiscovery/UserControls/UserControlStats.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStats.Designer.cs
@@ -225,7 +225,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewTravel.Location = new System.Drawing.Point(19, 46);
             this.dataGridViewTravel.Name = "dataGridViewTravel";
             this.dataGridViewTravel.RowHeadersVisible = false;
-            this.dataGridViewTravel.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewTravel.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.dataGridViewTravel.Size = new System.Drawing.Size(156, 336);
             this.dataGridViewTravel.TabIndex = 3;
             this.dataGridViewTravel.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dataGridViewTravel_ColumnHeaderMouseClick);


### PR DESCRIPTION
The accumulated scan values were hidden by default and the standard control sizes, and you had to find a hidden splitter to see the information. 

Issue #1115 prompted the discovery of this bug, and I've raised #1293 to cover this change.

This simply adds  a vertical scrollbar so it is immediately obvious there's more information available.

Let me know if there's anything else I need to do to get this merged.