### PR TITLE
Fix an error in CompareEpsilon when values are negative

### DIFF
--- a/EliteDangerous/EliteDangerous/StarScan.cs
+++ b/EliteDangerous/EliteDangerous/StarScan.cs
@@ -176,7 +176,7 @@ namespace EliteDangerousCore
             double _a = (double)a;
             double _b = fb == null ? (double)b : fb(b);
 
-            return _a == _b || (_a + _b > 0 && Math.Abs((_a - _b) / (_a + _b)) < epsilon);
+            return _a == _b || (_a + _b != 0 && Math.Sign(_a + _b) == Math.Sign(_a) && Math.Abs((_a - _b) / (_a + _b)) < epsilon);
         }
 
         public string GetBodyDesignation(JournalScan je, string system)


### PR DESCRIPTION
This should fix the display of any systems where the orbital inclination is negative (such as Fuelum).