### PR TITLE
Engineering/Synthesis/Shopping list overlays only respond to MaterialCommodity journals

### DIFF
--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -141,6 +141,7 @@ namespace EDDiscovery.UserControls
         {
             last_he = uctg.GetCurrentHistoryEntry;
             Display();
+            if (OnChangedEngineeringWanted != null) OnChangedEngineeringWanted(wantedList);
         }
 
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -146,7 +146,8 @@ namespace EDDiscovery.UserControls
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)
         {
             last_he = he;
-            Display();
+            if (he.journalEntry is IMaterialCommodityJournalEntry)
+                Display();
         }
 
         HistoryEntry last_he = null;
@@ -268,8 +269,6 @@ namespace EDDiscovery.UserControls
 
                 if ( fdrow>=0 && dataGridViewEngineering.Rows[fdrow].Visible )        // better check visible, may have changed..
                     dataGridViewEngineering.FirstDisplayedScrollingRowIndex = fdrow;
-
-                if (OnChangedEngineeringWanted != null) OnChangedEngineeringWanted(wantedList);
             }
         }
 
@@ -319,6 +318,7 @@ namespace EDDiscovery.UserControls
                     //System.Diagnostics.Debug.WriteLine("Set wanted {0} to {1}", rno, iv);
                     Wanted[rno] = iv;
                     Display();
+                    if (OnChangedEngineeringWanted != null) OnChangedEngineeringWanted(wantedList);
                 }
                 else
                     dataGridViewEngineering[WantedCol.Index, e.RowIndex].Value = Wanted[rno].ToStringInvariant();

--- a/EDDiscovery/UserControls/UserControlShoppingList.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.cs
@@ -106,7 +106,7 @@ namespace EDDiscovery.UserControls
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)
         {
             last_he = he;
-            if (he is IMaterialCommodityJournalEntry)
+            if (he.journalEntry is IMaterialCommodityJournalEntry)
                 Display();
         }
 

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -121,7 +121,8 @@ namespace EDDiscovery.UserControls
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)
         {
             last_he = he;
-            Display();
+            if (he.journalEntry is IMaterialCommodityJournalEntry)
+                Display();
         }
 
         HistoryEntry last_he = null;
@@ -201,8 +202,7 @@ namespace EDDiscovery.UserControls
 
                 if ( fdrow>=0 && dataGridViewSynthesis.Rows[fdrow].Visible )        // better check visible, may have changed..
                     dataGridViewSynthesis.FirstDisplayedScrollingRowIndex = fdrow;
-
-                if (OnChangedSynthesisWanted != null) OnChangedSynthesisWanted(wantedList);
+                
             }
         }
 
@@ -251,6 +251,7 @@ namespace EDDiscovery.UserControls
                     //System.Diagnostics.Debug.WriteLine("Set wanted {0} to {1}", rno, iv);
                     Wanted[rno] = iv;
                     Display();
+                    if (OnChangedSynthesisWanted != null) OnChangedSynthesisWanted(wantedList);
                 }
             }
             else

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -116,6 +116,7 @@ namespace EDDiscovery.UserControls
         {
             last_he = uctg.GetCurrentHistoryEntry;
             Display();
+            if (OnChangedSynthesisWanted != null) OnChangedSynthesisWanted(wantedList);
         }
 
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)

--- a/EliteDangerous/EliteDangerous/SystemClass.cs
+++ b/EliteDangerous/EliteDangerous/SystemClass.cs
@@ -26,9 +26,9 @@ namespace EliteDangerousCore
         public long id { get; set; }
         public long id_edsm { get; set; }
         public string name { get; set; }
-        public double x { get; set; }
-        public double y { get; set; }
-        public double z { get; set; }
+        public double x { get; set; } = double.NaN;
+        public double y { get; set; } = double.NaN;
+        public double z { get; set; } = double.NaN;
         public DateTime UpdateDate { get; set; }
         public int gridid { get; set; }
         public int randomid { get; set; }
@@ -63,9 +63,6 @@ namespace EliteDangerousCore
         {
             name = Name;
             status = DB.SystemStatusEnum.Unknown;
-            x = double.NaN;
-            y = double.NaN;
-            z = double.NaN;
         }
 
         public SystemClass(string Name, double vx, double vy, double vz)


### PR DESCRIPTION
The shopping list is no longer refreshed three times by each such journal
SystemClass.cs now always defaults coordinates to double.NaN again (zeros can cause the system to think it has a position in some places)