### PR TITLE
Added terraformable information in visited star list panel.

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -270,6 +270,10 @@ namespace EDDiscovery.UserControls
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
                                 if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a ammonia world", prefix);
+
+                                // Add information for terraformable planets
+                                if (sc.Terraformable == true)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is terraformable", prefix);
                             }
                         }
                     }

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -265,11 +265,11 @@ namespace EDDiscovery.UserControls
                             else
                             {
                                 if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a earth like body", prefix);
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an earth like body", prefix);
                                 if (sc.PlanetTypeID == EDPlanet.Water_world)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
                                 if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a ammonia world", prefix);
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia world", prefix);
 
                                 // Add information for terraformable planets
                                 if (sc.Terraformable == true)


### PR DESCRIPTION
I would like to add "terraformable" as the body information in the Star List Panel. I found it quite useful, especially after the major buff on exploration payouts, which gave terraformable bodies a quite special status.

Did a couple of minor grammatical corrections, not sure if really necessary...