### PR TITLE
Avoid duplicate output in Star List Panel information summary.

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -266,13 +266,16 @@ namespace EDDiscovery.UserControls
                             {
                                 if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an earth like body", prefix);
-                                if (sc.PlanetTypeID == EDPlanet.Water_world)
+                                if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == false)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
+                                // Check and inform if a water planet is terraformable or not
+                                if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == true)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable water world", prefix); 
                                 if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia world", prefix);
 
                                 // Add information for terraformable planets
-                                if (sc.Terraformable == true)
+                                if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is terraformable", prefix);
                             }
                         }

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -266,17 +266,22 @@ namespace EDDiscovery.UserControls
                             {
                                 if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an earth like body", prefix);
+
+                                // Water Planets, not terraformable
                                 if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == false)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
-                                // Check and inform if a water planet is terraformable or not
+                                // Check and inform if a water planet is terraformable
                                 if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == true)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable water world", prefix); 
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable water world", prefix);
+                                
+                                // Add information for other terraformable planets
+                                if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is terraformable", prefix);
+                                
                                 if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia world", prefix);
 
-                                // Add information for terraformable planets
-                                if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is terraformable", prefix);
+                                
                             }
                         }
                     }


### PR DESCRIPTION
I added a check for water planet, so now the star list panel inform if the body is a "water planet" or a "terraformable water planet". Also, to avoid duplicate messages, the generic "terraformable" message apply only to all other bodies which are not water planet. It provide a cleaner display, especially for large star systems with lots of planets. 