### PR TITLE
History processing speedups

### DIFF
--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -395,7 +395,7 @@ namespace EDDiscovery.UserControls
                         labelvoff -= 15;
                     }
 
-                    endpoint = CreateImageLabel(pc, sc.GetStarTypeImage().Item1,
+                    endpoint = CreateImageLabel(pc, sc.GetStarTypeImage(),
                                                 new Point(curpos.X + offset, curpos.Y + alignv),      // WE are basing it on a 1/4 + 1 + 1/4 grid, this is not being made bigger, move off
                                                 size, starLabel, tip, alignv + labelvoff, sc.IsEDSMBody, false);          // and the label needs to be a quarter height below it..
 
@@ -431,7 +431,7 @@ namespace EDDiscovery.UserControls
                 {
                     bool indicatematerials = sc.HasMaterials && !checkBoxMaterials.Checked;
 
-                    Image nodeimage = sc.IsStar ? sc.GetStarTypeImage().Item1 : sc.GetPlanetClassImage();
+                    Image nodeimage = sc.IsStar ? sc.GetStarTypeImage() : sc.GetPlanetClassImage();
 
                     if (ImageRequiresAnOverlay(sc, indicatematerials))
                     {

--- a/EliteDangerous/EliteDangerous/Bodies.cs
+++ b/EliteDangerous/EliteDangerous/Bodies.cs
@@ -196,45 +196,55 @@ namespace EliteDangerousCore
 
     public class Bodies
     {
+        private static Dictionary<string, EDStar> StarStr2EnumLookup;
 
         public static EDStar StarStr2Enum(string star)
         {
             if (star == null)
                 return EDStar.Unknown;
 
+            if (StarStr2EnumLookup == null)
+            {
+                StarStr2EnumLookup = new Dictionary<string, EDStar>(StringComparer.InvariantCultureIgnoreCase);
+                foreach (EDStar atm in Enum.GetValues(typeof(EDStar)))
+                {
+                    StarStr2EnumLookup[atm.ToString().Replace("_", "")] = atm;
+                }
+            }
+
             var searchstr = star.Replace("_", "").Replace(" ", "").Replace("-", "").ToLower();
 
-
-            foreach (EDStar atm in Enum.GetValues(typeof(EDStar)))
-            {
-                string str = atm.ToString().Replace("_", "").ToLower();
-
-                if (searchstr.Equals(str))
-                    return atm;
-            }
+            if (StarStr2EnumLookup.ContainsKey(searchstr))
+                return StarStr2EnumLookup[searchstr];
 
             return EDStar.Unknown;
         }
+
+        private static Dictionary<string, EDPlanet> PlanetStr2EnumLookup;
 
         public static EDPlanet PlanetStr2Enum(string star)
         {
             if (star == null)
                 return EDPlanet.Unknown;
 
+            if (PlanetStr2EnumLookup == null)
+            {
+                PlanetStr2EnumLookup = new Dictionary<string, EDPlanet>(StringComparer.InvariantCultureIgnoreCase);
+                foreach (EDPlanet atm in Enum.GetValues(typeof(EDPlanet)))
+                {
+                    PlanetStr2EnumLookup[atm.ToString().Replace("_", "")] = atm;
+                }
+            }
+
             var searchstr = star.Replace("_", "").Replace(" ", "").Replace("-", "").ToLower();
 
-            foreach (EDPlanet atm in Enum.GetValues(typeof(EDPlanet)))
-            {
-                string str = atm.ToString().Replace("_", "").ToLower();
-
-                if (searchstr.Equals(str))
-                    return atm;
-            }
+            if (PlanetStr2EnumLookup.ContainsKey(searchstr))
+                return PlanetStr2EnumLookup[searchstr];
 
             return EDPlanet.Unknown;
         }
 
-
+        private static Dictionary<string, EDAtmosphereType> AtmosphereStr2EnumLookup;
 
         public static EDAtmosphereType AtmosphereStr2Enum(string v, out EDAtmosphereProperty atmprop)
         {
@@ -242,6 +252,15 @@ namespace EliteDangerousCore
 
             if (v == null)
                 return EDAtmosphereType.Unknown;
+
+            if (AtmosphereStr2EnumLookup == null)
+            {
+                AtmosphereStr2EnumLookup = new Dictionary<string, EDAtmosphereType>(StringComparer.InvariantCultureIgnoreCase);
+                foreach (EDAtmosphereType atm in Enum.GetValues(typeof(EDAtmosphereType)))
+                {
+                    AtmosphereStr2EnumLookup[atm.ToString().Replace("_", "")] = atm;
+                }
+            }
 
             var searchstr = v.ToLower().Replace("_", "").Replace(" ", "").Replace("-", "").Replace("atmosphere", "");
 
@@ -266,19 +285,15 @@ namespace EliteDangerousCore
                 searchstr = searchstr.Replace("hot", "");
             }
 
-
-            foreach (EDAtmosphereType atm in Enum.GetValues(typeof(EDAtmosphereType)))
-            {
-                string str = atm.ToString().Replace("_", "").ToLower();
-
-                if (searchstr.Equals(str))
-                    return atm;
-            }
+            if (AtmosphereStr2EnumLookup.ContainsKey(searchstr))
+                return AtmosphereStr2EnumLookup[searchstr];
 
            // System.Diagnostics.Trace.WriteLine("atm: " + v);
 
             return EDAtmosphereType.Unknown;
         }
+
+        private static Dictionary<string, EDVolcanism> VolcanismStr2EnumLookup;
 
         public static EDVolcanism VolcanismStr2Enum(string v, out EDVolcanismProperty vprop )
         {
@@ -288,7 +303,14 @@ namespace EliteDangerousCore
 
             string searchstr = v.ToLower().Replace("_", "").Replace(" ", "").Replace("-", "").Replace("volcanism", "");
 
-
+            if (VolcanismStr2EnumLookup == null)
+            {
+                VolcanismStr2EnumLookup = new Dictionary<string, EDVolcanism>(StringComparer.InvariantCultureIgnoreCase);
+                foreach (EDVolcanism atm in Enum.GetValues(typeof(EDVolcanism)))
+                {
+                    VolcanismStr2EnumLookup[atm.ToString().Replace("_", "")] = atm;
+                }
+            }
 
             if (searchstr.Contains("minor"))
             {
@@ -301,33 +323,32 @@ namespace EliteDangerousCore
                 searchstr = searchstr.Replace("major", "");
             }
 
-            foreach (EDVolcanism atm in Enum.GetValues(typeof(EDVolcanism)))
-            {
-                string str = atm.ToString().Replace("_", "").ToLower();
-
-                if (searchstr.Equals(str))
-                    return atm;
-            }
+            if (VolcanismStr2EnumLookup.ContainsKey(searchstr))
+                return VolcanismStr2EnumLookup[searchstr];
 
             return EDVolcanism.Unknown;
         }
 
+        private static Dictionary<string, EDReserve> ReserveStr2EnumLookup;
 
         public static EDReserve ReserveStr2Enum(string star)
         {
             if (star == null)
                 return EDReserve.None;
 
+            if (ReserveStr2EnumLookup == null)
+            {
+                ReserveStr2EnumLookup = new Dictionary<string, EDReserve>(StringComparer.InvariantCultureIgnoreCase);
+                foreach (EDReserve atm in Enum.GetValues(typeof(EDReserve)))
+                {
+                    ReserveStr2EnumLookup[atm.ToString().Replace("_", "")] = atm;
+                }
+            }
+
             var searchstr = star.Replace("_", "").Replace(" ", "").Replace("-", "").ToLower();
 
-
-            foreach (EDReserve atm in Enum.GetValues(typeof(EDReserve)))
-            {
-                string str = atm.ToString().Replace("_", "").ToLower();
-
-                if (searchstr.Equals(str))
-                    return atm;
-            }
+            if (ReserveStr2EnumLookup.ContainsKey(searchstr))
+                return ReserveStr2EnumLookup[searchstr];
 
             return EDReserve.None;
         }

--- a/EliteDangerous/EliteDangerous/JournalEntry.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntry.cs
@@ -1061,7 +1061,8 @@ namespace EliteDangerousCore
             if (Eventstr == null)  // Should normaly not happend unless corrupt string.
                 return new JournalUnknown(jo);      // MUST return something
 
-            Type jtype = TypeOfJournalEntry(Eventstr);
+            JournalTypeEnum jte = JournalTypeEnum.Unknown;
+            Type jtype = Enum.TryParse(Eventstr, out jte) ? TypeOfJournalEntry(jte) : TypeOfJournalEntry(Eventstr);
 
             if (jtype == null)
             {

--- a/EliteDangerous/EliteDangerous/SystemCache.cs
+++ b/EliteDangerous/EliteDangerous/SystemCache.cs
@@ -106,7 +106,7 @@ namespace EliteDangerousCore
             {
                 dbsys = DB.SystemClassDB.FindEDSM(sys, conn: conn, useedsm: false);
 
-                if (useedsm && dbsys == null && (sys.id_edsm <= 0 || !sys.HasCoordinate || DateTime.UtcNow.Subtract(sys.UpdateDate).TotalDays > 7))
+                if (false && useedsm && dbsys == null && (sys.id_edsm <= 0 || !sys.HasCoordinate || DateTime.UtcNow.Subtract(sys.UpdateDate).TotalDays > 7))
                 {
                     dbsys = DB.SystemClassDB.FindEDSM(sys, conn: conn, useedsm: true);
                 }

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -897,7 +897,8 @@ namespace EliteDangerousCore
                 else if (je.EventTypeID == JournalTypeEnum.Friends && prev.EventTypeID == JournalTypeEnum.Friends) // merge friends
                 {
                     EliteDangerousCore.JournalEvents.JournalFriends jfprev = prev as EliteDangerousCore.JournalEvents.JournalFriends;
-                    jfprev.AddFriend(je.GetJson());
+                    EliteDangerousCore.JournalEvents.JournalFriends jf = je as EliteDangerousCore.JournalEvents.JournalFriends;
+                    jfprev.AddFriend(jf);
                     //System.Diagnostics.Debug.WriteLine("Merge Friends " + jfprev.EventTimeUTC + " " + jfprev.NameList.Count);
                     return true;
                 }

--- a/EliteDangerous/JournalEvents/JournalFriends.cs
+++ b/EliteDangerous/JournalEvents/JournalFriends.cs
@@ -31,7 +31,7 @@ namespace EliteDangerousCore.JournalEvents
             OnlineCount = Status.Equals("online", System.StringComparison.InvariantCultureIgnoreCase) ? 1 : 0;
         }
 
-        public void AddFriend(JObject evt)
+        public void AddFriend(JournalFriends next)
         {
             if (StatusList == null)     // if first time we added, move to status list format
             {
@@ -40,10 +40,10 @@ namespace EliteDangerousCore.JournalEvents
                 Status = Name = string.Empty;
             }
 
-            string stat = evt["Status"].Str();
+            string stat = next.Status;
 
             StatusList.Add(stat);
-            NameList.Add(evt["Name"].Str());
+            NameList.Add(next.Name);
 
             OfflineCount += stat.Equals("offline", System.StringComparison.InvariantCultureIgnoreCase) ? 1 : 0;
             OnlineCount += stat.Equals("online", System.StringComparison.InvariantCultureIgnoreCase) ? 1 : 0;

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -77,7 +77,7 @@ namespace EliteDangerousCore.JournalEvents
         // STAR
         public string StarType { get; set; }                        // null if no StarType, direct from journal, K, A, B etc
         public EDStar StarTypeID { get; }                           // star type -> identifier
-        public string StarTypeText { get { return IsStar ? GetStarTypeImage().Item2 : ""; } }   // Long form star name, from StarTypeID
+        public string StarTypeText { get { return IsStar ? GetStarTypeName() : ""; } }   // Long form star name, from StarTypeID
         public double? nStellarMass { get; set; }                   // direct
         public double? nAbsoluteMagnitude { get; set; }             // direct
         public string Luminosity { get; set; }
@@ -308,7 +308,7 @@ namespace EliteDangerousCore.JournalEvents
                 if (r.HasValue)
                     r = r / solarRadius_m;
 
-                info = BaseUtils.FieldBuilder.Build("", GetStarTypeImage().Item2, "Mass:;SM;0.00", nStellarMass, "Age:;my;0.0", nAge, "Radius:;SR;0.00", r);
+                info = BaseUtils.FieldBuilder.Build("", GetStarTypeName(), "Mass:;SM;0.00", nStellarMass, "Age:;my;0.0", nAge, "Radius:;SR;0.00", r);
             }
             else
             {
@@ -346,7 +346,7 @@ namespace EliteDangerousCore.JournalEvents
 
                 if (IsStar)
                 {
-                    scanText.AppendFormat(GetStarTypeImage().Item2);
+                    scanText.AppendFormat(GetStarTypeName());
                 }
                 else if (PlanetClass != null)
                 {
@@ -553,52 +553,48 @@ namespace EliteDangerousCore.JournalEvents
             return ring.RingInformation(scale, scaletype, IsStar);
         }
 
-
-
-        public Tuple<System.Drawing.Image, string> GetStarTypeImage()           // give image and description to star class
+        public string GetStarTypeName()           // give description to star class
         {
-            System.Drawing.Image ret = EliteDangerous.Properties.Resources.Star_K1IV;
-
             switch (StarTypeID)       // see journal, section 11.2
             {
                 case EDStar.O:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.O, string.Format("Luminous Hot Main Sequence star", StarType));
+                    return string.Format("Luminous Hot Main Sequence star", StarType);
 
                 case EDStar.B:
                     // also have an B1V
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.B6V_Blueish, string.Format("Luminous Blue Main Sequence star", StarType));
+                    return string.Format("Luminous Blue Main Sequence star", StarType);
 
                 case EDStar.A:
                     // also have an A3V..
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.A9III_White, string.Format("Bluish-White Main Sequence star", StarType));
+                    return string.Format("Bluish-White Main Sequence star", StarType);
 
                 case EDStar.F:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.F5VAB, string.Format("White Main Sequence star", StarType));
+                    return string.Format("White Main Sequence star", StarType);
 
                 case EDStar.G:
                     // also have a G8V
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.G1IV, string.Format("Yellow Main Sequence star", StarType));
+                    return string.Format("Yellow Main Sequence star", StarType);
 
                 case EDStar.K:
                     // also have a K0V
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.Star_K1IV, string.Format("Orange Main Sequence {0} star", StarType));
+                    return string.Format("Orange Main Sequence {0} star", StarType);
                 case EDStar.M:
                     // also have a M1VA
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.M5V, string.Format("Red Main Sequence {0} star", StarType));
+                    return string.Format("Red Main Sequence {0} star", StarType);
 
                 // dwarfs
                 case EDStar.L:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.L3V, string.Format("Dark Red Non Main Sequence {0} star", StarType));
+                    return string.Format("Dark Red Non Main Sequence {0} star", StarType);
                 case EDStar.T:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.T4V, string.Format("Methane Dwarf star", StarType));
+                    return string.Format("Methane Dwarf star", StarType);
                 case EDStar.Y:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.Y2, string.Format("Brown Dwarf star", StarType));
+                    return string.Format("Brown Dwarf star", StarType);
 
                 // proto stars
                 case EDStar.AeBe:    // Herbig
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "Herbig Ae/Be");
+                    return "Herbig Ae/Be";
                 case EDStar.TTS:     // seen in logs
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "T Tauri");
+                    return "T Tauri";
 
                 // wolf rayet
                 case EDStar.W:
@@ -606,7 +602,7 @@ namespace EliteDangerousCore.JournalEvents
                 case EDStar.WNC:
                 case EDStar.WC:
                 case EDStar.WO:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, string.Format("Wolf-Rayet {0} star", StarType));
+                    return string.Format("Wolf-Rayet {0} star", StarType);
 
                 // Carbon
                 case EDStar.CS:
@@ -614,13 +610,13 @@ namespace EliteDangerousCore.JournalEvents
                 case EDStar.CN:
                 case EDStar.CJ:
                 case EDStar.CHd:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.C7III, string.Format("Carbon {0} star", StarType));
+                    return string.Format("Carbon {0} star", StarType);
 
                 case EDStar.MS: //seen in log https://en.wikipedia.org/wiki/S-type_star
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.M5V, string.Format("Intermediate low Zirconium Monoxide Type {0} star", StarType));
+                    return string.Format("Intermediate low Zirconium Monoxide Type {0} star", StarType);
 
                 case EDStar.S:   // seen in log, data from http://elite-dangerous.wikia.com/wiki/Stars
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, string.Format("Cool Giant Zirconium Monoxide rich Type {0} star", StarType));
+                    return string.Format("Cool Giant Zirconium Monoxide rich Type {0} star", StarType);
 
                 // white dwarf
                 case EDStar.D:
@@ -638,38 +634,156 @@ namespace EliteDangerousCore.JournalEvents
                 case EDStar.DC:
                 case EDStar.DCV:
                 case EDStar.DX:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DA6VII_White, string.Format("White Dwarf {0} star", StarType));
+                    return string.Format("White Dwarf {0} star", StarType);
 
                 case EDStar.N:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.Neutron_Star, "Neutron Star");
+                    return "Neutron Star";
 
                 case EDStar.H:
 
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.Black_Hole, "Black Hole");
+                    return "Black Hole";
 
                 case EDStar.X:
                     // currently speculative, not confirmed with actual data... in journal
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "Exotic");
+                    return "Exotic";
 
                 // Journal.. really?  need evidence these actually are formatted like this.
 
                 case EDStar.SuperMassiveBlackHole:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.Black_Hole, "Super Massive Black Hole");
+                    return "Super Massive Black Hole";
                 case EDStar.A_BlueWhiteSuperGiant:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.A9III_White, "Blue White Super Giant");
+                    return "Blue White Super Giant";
                 case EDStar.F_WhiteSuperGiant:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "F White Super Giant");
+                    return "F White Super Giant";
                 case EDStar.M_RedSuperGiant:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "M Red Super Giant");
+                    return "M Red Super Giant";
                 case EDStar.M_RedGiant:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "M Red Giant");
+                    return "M Red Giant";
                 case EDStar.K_OrangeGiant:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "K Orange Giant");
+                    return "K Orange Giant";
                 case EDStar.RoguePlanet:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, "Rouge Planet");
+                    return "Rouge Planet";
 
                 default:
-                    return new Tuple<System.Drawing.Image, string>(EliteDangerous.Properties.Resources.DefaultStar, string.Format("Class {0} star\n", StarType.Replace("_", " ")));
+                    return string.Format("Class {0} star\n", StarType.Replace("_", " "));
+            }
+        }
+
+        public System.Drawing.Image GetStarTypeImage()           // give image and description to star class
+        {
+            System.Drawing.Image ret = EliteDangerous.Properties.Resources.Star_K1IV;
+
+            switch (StarTypeID)       // see journal, section 11.2
+            {
+                case EDStar.O:
+                    return EliteDangerous.Properties.Resources.O;
+
+                case EDStar.B:
+                    // also have an B1V
+                    return EliteDangerous.Properties.Resources.B6V_Blueish;
+
+                case EDStar.A:
+                    // also have an A3V..
+                    return EliteDangerous.Properties.Resources.A9III_White;
+
+                case EDStar.F:
+                    return EliteDangerous.Properties.Resources.F5VAB;
+
+                case EDStar.G:
+                    // also have a G8V
+                    return EliteDangerous.Properties.Resources.G1IV;
+
+                case EDStar.K:
+                    // also have a K0V
+                    return EliteDangerous.Properties.Resources.Star_K1IV;
+                case EDStar.M:
+                    // also have a M1VA
+                    return EliteDangerous.Properties.Resources.M5V;
+
+                // dwarfs
+                case EDStar.L:
+                    return EliteDangerous.Properties.Resources.L3V;
+                case EDStar.T:
+                    return EliteDangerous.Properties.Resources.T4V;
+                case EDStar.Y:
+                    return EliteDangerous.Properties.Resources.Y2;
+
+                // proto stars
+                case EDStar.AeBe:    // Herbig
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+                case EDStar.TTS:     // seen in logs
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+
+                // wolf rayet
+                case EDStar.W:
+                case EDStar.WN:
+                case EDStar.WNC:
+                case EDStar.WC:
+                case EDStar.WO:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+
+                // Carbon
+                case EDStar.CS:
+                case EDStar.C:
+                case EDStar.CN:
+                case EDStar.CJ:
+                case EDStar.CHd:
+                    return EliteDangerous.Properties.Resources.C7III;
+
+                case EDStar.MS: //seen in log https://en.wikipedia.org/wiki/S-type_star
+                    return EliteDangerous.Properties.Resources.M5V;
+
+                case EDStar.S:   // seen in log, data from http://elite-dangerous.wikia.com/wiki/Stars
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+
+                // white dwarf
+                case EDStar.D:
+                case EDStar.DA:
+                case EDStar.DAB:
+                case EDStar.DAO:
+                case EDStar.DAZ:
+                case EDStar.DAV:
+                case EDStar.DB:
+                case EDStar.DBZ:
+                case EDStar.DBV:
+                case EDStar.DO:
+                case EDStar.DOV:
+                case EDStar.DQ:
+                case EDStar.DC:
+                case EDStar.DCV:
+                case EDStar.DX:
+                    return EliteDangerous.Properties.Resources.DA6VII_White;
+
+                case EDStar.N:
+                    return EliteDangerous.Properties.Resources.Neutron_Star;
+
+                case EDStar.H:
+
+                    return EliteDangerous.Properties.Resources.Black_Hole;
+
+                case EDStar.X:
+                    // currently speculative, not confirmed with actual data... in journal
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+
+                // Journal.. really?  need evidence these actually are formatted like this.
+
+                case EDStar.SuperMassiveBlackHole:
+                    return EliteDangerous.Properties.Resources.Black_Hole;
+                case EDStar.A_BlueWhiteSuperGiant:
+                    return EliteDangerous.Properties.Resources.A9III_White;
+                case EDStar.F_WhiteSuperGiant:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+                case EDStar.M_RedSuperGiant:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+                case EDStar.M_RedGiant:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+                case EDStar.K_OrangeGiant:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+                case EDStar.RoguePlanet:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
+
+                default:
+                    return EliteDangerous.Properties.Resources.DefaultStar;
             }
         }
 


### PR DESCRIPTION
* Cache name to type ID lookup (helps with larger scan histories)
* Split GetStarTypeImage into two functions (cuts about 1ms per star scan)
* Use TypeOfJournalEntry(JournalTypeEnum) when possible to get journal event type (cuts about 10ms per 1000 journal entries)
* Use the JournalFriends object and not its json (down to 2ms from 175ms)
* Disable EDSM fetch from FindEDSM