### PR TITLE
Fix issue #1327 (Branch_8_3)

### DIFF
--- a/ExtendedControls/Forms/DraggableForm.cs
+++ b/ExtendedControls/Forms/DraggableForm.cs
@@ -122,6 +122,9 @@ namespace ExtendedControls
                         {
                             base.WndProc(ref m);
 
+                            if (WindowState == FormWindowState.Minimized)
+                                return;
+
                             var p = PointToClient(new Point((int)m.LParam));
                             const int CaptionHeight = 32;
                             const int edgesz = 5;   // 5 is generous.. really only a few pixels gets thru before the subwindows grabs them


### PR DESCRIPTION
We shouldn't even bother with hittests when minimized. Windows already does this in a perfectly fine manner. When unframed, the clicks will be interpreted as HT.CAPTION, meaning it takes a double-click to restore.

(cherry picked from commit eece18884f9ad59c912baa63286b8229f3acfc91)