### PR TITLE
Remove unneeded `using EDDiscovery.DB` from tests

### DIFF
--- a/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
+++ b/EDDiscoveryTests/3DMap/DatasetBuilderTests.cs
@@ -14,7 +14,6 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using EDDiscovery;
-using EDDiscovery.DB;
 using EDDiscovery2._3DMap;
 using System;
 using System.Collections.Generic;

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -14,7 +14,6 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using EDDiscovery;
-using EDDiscovery.DB;
 using EDDiscovery.UserControls;
 using EliteDangerous;
 using EliteDangerousCore;


### PR DESCRIPTION
`using EDDiscovery.DB` was causing compile failures on the EDDiscoveryTests project.