### PR TITLE
Fix Shoppinglist, Engineering and Synth behaviour

### DIFF
--- a/EDDiscovery/UserControls/UserControlEngineering.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.Designer.cs
@@ -46,6 +46,15 @@ namespace EDDiscovery.UserControls
             this.components = new System.ComponentModel.Container();
             this.dataViewScrollerPanel = new ExtendedControls.DataViewScrollerPanel();
             this.dataGridViewEngineering = new System.Windows.Forms.DataGridView();
+            this.vScrollBarCustomMC = new ExtendedControls.VScrollBarCustom();
+            this.panelButtons = new System.Windows.Forms.Panel();
+            this.buttonClear = new ExtendedControls.ButtonExt();
+            this.buttonFilterMaterial = new ExtendedControls.ButtonExt();
+            this.buttonFilterUpgrade = new ExtendedControls.ButtonExt();
+            this.buttonFilterLevel = new ExtendedControls.ButtonExt();
+            this.buttonFilterEngineer = new ExtendedControls.ButtonExt();
+            this.buttonFilterModule = new ExtendedControls.ButtonExt();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.UpgradeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Module = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -55,15 +64,6 @@ namespace EDDiscovery.UserControls
             this.Notes = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Recipe = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Engineers = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.vScrollBarCustomMC = new ExtendedControls.VScrollBarCustom();
-            this.panelButtons = new System.Windows.Forms.Panel();
-            this.buttonFilterMaterial = new ExtendedControls.ButtonExt();
-            this.buttonFilterUpgrade = new ExtendedControls.ButtonExt();
-            this.buttonFilterLevel = new ExtendedControls.ButtonExt();
-            this.buttonFilterEngineer = new ExtendedControls.ButtonExt();
-            this.buttonFilterModule = new ExtendedControls.ButtonExt();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.buttonClear = new ExtendedControls.ButtonExt();
             this.dataViewScrollerPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEngineering)).BeginInit();
             this.panelButtons.SuspendLayout();
@@ -113,80 +113,6 @@ namespace EDDiscovery.UserControls
             this.dataGridViewEngineering.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewEngineering_MouseDown);
             this.dataGridViewEngineering.MouseMove += new System.Windows.Forms.MouseEventHandler(this.dataGridViewEngineering_MouseMove);
             // 
-            // UpgradeCol
-            // 
-            this.UpgradeCol.HeaderText = "Upgrade/Mat";
-            this.UpgradeCol.MinimumWidth = 50;
-            this.UpgradeCol.Name = "UpgradeCol";
-            this.UpgradeCol.ReadOnly = true;
-            this.UpgradeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // Module
-            // 
-            this.Module.HeaderText = "Module";
-            this.Module.MinimumWidth = 50;
-            this.Module.Name = "Module";
-            this.Module.ReadOnly = true;
-            this.Module.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // Level
-            // 
-            this.Level.HeaderText = "Level";
-            this.Level.Name = "Level";
-            this.Level.ReadOnly = true;
-            this.Level.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // MaxCol
-            // 
-            this.MaxCol.FillWeight = 25F;
-            this.MaxCol.HeaderText = "Max";
-            this.MaxCol.MinimumWidth = 50;
-            this.MaxCol.Name = "MaxCol";
-            this.MaxCol.ReadOnly = true;
-            this.MaxCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // WantedCol
-            // 
-            this.WantedCol.FillWeight = 25F;
-            this.WantedCol.HeaderText = "Wanted";
-            this.WantedCol.MinimumWidth = 50;
-            this.WantedCol.Name = "WantedCol";
-            this.WantedCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // Available
-            // 
-            this.Available.FillWeight = 25F;
-            this.Available.HeaderText = "Avail.";
-            this.Available.MinimumWidth = 50;
-            this.Available.Name = "Available";
-            this.Available.ReadOnly = true;
-            this.Available.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // Notes
-            // 
-            this.Notes.FillWeight = 150F;
-            this.Notes.HeaderText = "Notes";
-            this.Notes.MinimumWidth = 50;
-            this.Notes.Name = "Notes";
-            this.Notes.ReadOnly = true;
-            this.Notes.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // Recipe
-            // 
-            this.Recipe.FillWeight = 50F;
-            this.Recipe.HeaderText = "Recipe";
-            this.Recipe.MinimumWidth = 15;
-            this.Recipe.Name = "Recipe";
-            this.Recipe.ReadOnly = true;
-            this.Recipe.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // Engineers
-            // 
-            this.Engineers.HeaderText = "Engineers";
-            this.Engineers.Name = "Engineers";
-            this.Engineers.ReadOnly = true;
-            this.Engineers.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
             // vScrollBarCustomMC
             // 
             this.vScrollBarCustomMC.ArrowBorderColor = System.Drawing.Color.LightBlue;
@@ -230,6 +156,21 @@ namespace EDDiscovery.UserControls
             this.panelButtons.Size = new System.Drawing.Size(800, 32);
             this.panelButtons.TabIndex = 2;
             this.toolTip1.SetToolTip(this.panelButtons, "Left click and drag on grid to reorder");
+            // 
+            // buttonClear
+            // 
+            this.buttonClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonClear.BorderColorScaling = 1.25F;
+            this.buttonClear.ButtonColorScaling = 0.5F;
+            this.buttonClear.ButtonDisabledScaling = 0.5F;
+            this.buttonClear.Location = new System.Drawing.Point(692, 4);
+            this.buttonClear.Name = "buttonClear";
+            this.buttonClear.Size = new System.Drawing.Size(88, 23);
+            this.buttonClear.TabIndex = 5;
+            this.buttonClear.Text = "Clear Wanted";
+            this.toolTip1.SetToolTip(this.buttonClear, "Set all wanted values to zero");
+            this.buttonClear.UseVisualStyleBackColor = true;
+            this.buttonClear.Click += new System.EventHandler(this.buttonClear_Click);
             // 
             // buttonFilterMaterial
             // 
@@ -305,20 +246,82 @@ namespace EDDiscovery.UserControls
             // 
             this.toolTip1.ShowAlways = true;
             // 
-            // buttonClear
+            // UpgradeCol
             // 
-            this.buttonClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClear.BorderColorScaling = 1.25F;
-            this.buttonClear.ButtonColorScaling = 0.5F;
-            this.buttonClear.ButtonDisabledScaling = 0.5F;
-            this.buttonClear.Location = new System.Drawing.Point(692, 4);
-            this.buttonClear.Name = "buttonClear";
-            this.buttonClear.Size = new System.Drawing.Size(88, 23);
-            this.buttonClear.TabIndex = 5;
-            this.buttonClear.Text = "Clear Wanted";
-            this.toolTip1.SetToolTip(this.buttonClear, "Set all wanted values to zero");
-            this.buttonClear.UseVisualStyleBackColor = true;
-            this.buttonClear.Click += new System.EventHandler(this.buttonClear_Click);
+            this.UpgradeCol.HeaderText = "Upgrade/Mat";
+            this.UpgradeCol.MinimumWidth = 50;
+            this.UpgradeCol.Name = "UpgradeCol";
+            this.UpgradeCol.ReadOnly = true;
+            this.UpgradeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // Module
+            // 
+            this.Module.HeaderText = "Module";
+            this.Module.MinimumWidth = 50;
+            this.Module.Name = "Module";
+            this.Module.ReadOnly = true;
+            this.Module.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // Level
+            // 
+            this.Level.FillWeight = 25F;
+            this.Level.HeaderText = "Level";
+            this.Level.MinimumWidth = 50;
+            this.Level.Name = "Level";
+            this.Level.ReadOnly = true;
+            this.Level.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // MaxCol
+            // 
+            this.MaxCol.FillWeight = 25F;
+            this.MaxCol.HeaderText = "Max";
+            this.MaxCol.MinimumWidth = 50;
+            this.MaxCol.Name = "MaxCol";
+            this.MaxCol.ReadOnly = true;
+            this.MaxCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // WantedCol
+            // 
+            this.WantedCol.FillWeight = 25F;
+            this.WantedCol.HeaderText = "Wanted";
+            this.WantedCol.MinimumWidth = 50;
+            this.WantedCol.Name = "WantedCol";
+            this.WantedCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // Available
+            // 
+            this.Available.FillWeight = 25F;
+            this.Available.HeaderText = "Avail.";
+            this.Available.MinimumWidth = 50;
+            this.Available.Name = "Available";
+            this.Available.ReadOnly = true;
+            this.Available.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // Notes
+            // 
+            this.Notes.FillWeight = 150F;
+            this.Notes.HeaderText = "Notes";
+            this.Notes.MinimumWidth = 50;
+            this.Notes.Name = "Notes";
+            this.Notes.ReadOnly = true;
+            this.Notes.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // Recipe
+            // 
+            this.Recipe.FillWeight = 50F;
+            this.Recipe.HeaderText = "Recipe";
+            this.Recipe.MinimumWidth = 15;
+            this.Recipe.Name = "Recipe";
+            this.Recipe.ReadOnly = true;
+            this.Recipe.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            // 
+            // Engineers
+            // 
+            this.Engineers.HeaderText = "Engineers";
+            this.Engineers.MinimumWidth = 50;
+            this.Engineers.Name = "Engineers";
+            this.Engineers.ReadOnly = true;
+            this.Engineers.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             // 
             // UserControlEngineering
             // 
@@ -346,6 +349,8 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ButtonExt buttonFilterEngineer;
         private ExtendedControls.ButtonExt buttonFilterModule;
         private ExtendedControls.ButtonExt buttonFilterUpgrade;
+        private ExtendedControls.ButtonExt buttonFilterMaterial;
+        private ExtendedControls.ButtonExt buttonClear;
         private System.Windows.Forms.DataGridViewTextBoxColumn UpgradeCol;
         private System.Windows.Forms.DataGridViewTextBoxColumn Module;
         private System.Windows.Forms.DataGridViewTextBoxColumn Level;
@@ -355,7 +360,5 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.DataGridViewTextBoxColumn Notes;
         private System.Windows.Forms.DataGridViewTextBoxColumn Recipe;
         private System.Windows.Forms.DataGridViewTextBoxColumn Engineers;
-        private ExtendedControls.ButtonExt buttonFilterMaterial;
-        private ExtendedControls.ButtonExt buttonClear;
     }
 }

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -237,7 +237,7 @@ namespace EDDiscovery.UserControls
                         dataGridViewEngineering[Notes.Index, i].Value = res.Item3;
 
                     }
-                    if (isEmbedded || Wanted[rno] > 0)      // embedded, need to 
+                    if (Wanted[rno] > 0 && (visible || isEmbedded))      // embedded, need to 
                     {
                         wantedList.Add(new Tuple<MaterialCommoditiesList.Recipe, int>(Recipes[rno], Wanted[rno]));
                     }

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -51,11 +51,9 @@ namespace EDDiscovery.UserControls
 
         int[] Order;        // order
         int[] Wanted;       // wanted, in order terms
-        internal bool isEmbedded = false;
-        private List<Tuple<MaterialCommoditiesList.Recipe, int>> wantedList;
 
-        public delegate void ChangedEngineeringWanted(List<Tuple<MaterialCommoditiesList.Recipe, int>> newWanted);
-        public event ChangedEngineeringWanted OnChangedEngineeringWanted;
+        internal bool isEmbedded = false;
+        public Action<List<Tuple<MaterialCommoditiesList.Recipe, int>>> OnDisplayComplete;  // called when display complete, for use by other UCs using this
 
         #region Init
 
@@ -141,7 +139,6 @@ namespace EDDiscovery.UserControls
         {
             last_he = uctg.GetCurrentHistoryEntry;
             Display();
-            if (OnChangedEngineeringWanted != null) OnChangedEngineeringWanted(wantedList);
         }
 
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)
@@ -163,6 +160,8 @@ namespace EDDiscovery.UserControls
             //DONT turn on sorting in the future, thats not how it works.  You click and drag to sort manually since it gives you
             // the order of recipies.
 
+            List<Tuple<MaterialCommoditiesList.Recipe, int>> wantedList = null;
+
             if (last_he != null)
             {
                 List<MaterialCommodities> mcl = last_he.MaterialCommodity.Sort(false);
@@ -170,6 +169,7 @@ namespace EDDiscovery.UserControls
                 int fdrow = dataGridViewEngineering.FirstDisplayedScrollingRowIndex;      // remember where we were displaying
 
                 MaterialCommoditiesList.ResetUsed(mcl);
+
                 wantedList = new List<Tuple<MaterialCommoditiesList.Recipe, int>>();
 
                 string engineers = SQLiteDBClass.GetSettingString(DbEngFilterSave, "All");
@@ -237,7 +237,7 @@ namespace EDDiscovery.UserControls
                         dataGridViewEngineering[Notes.Index, i].Value = res.Item3;
 
                     }
-                    if (isEmbedded && Wanted[rno] > 0)
+                    if (isEmbedded || Wanted[rno] > 0)      // embedded, need to 
                     {
                         wantedList.Add(new Tuple<MaterialCommoditiesList.Recipe, int>(Recipes[rno], Wanted[rno]));
                     }
@@ -271,6 +271,9 @@ namespace EDDiscovery.UserControls
                 if ( fdrow>=0 && dataGridViewEngineering.Rows[fdrow].Visible )        // better check visible, may have changed..
                     dataGridViewEngineering.FirstDisplayedScrollingRowIndex = fdrow;
             }
+
+            if (OnDisplayComplete != null)
+                OnDisplayComplete(wantedList);
         }
 
         #endregion
@@ -319,7 +322,6 @@ namespace EDDiscovery.UserControls
                     //System.Diagnostics.Debug.WriteLine("Set wanted {0} to {1}", rno, iv);
                     Wanted[rno] = iv;
                     Display();
-                    if (OnChangedEngineeringWanted != null) OnChangedEngineeringWanted(wantedList);
                 }
                 else
                     dataGridViewEngineering[WantedCol.Index, e.RowIndex].Value = Wanted[rno].ToStringInvariant();
@@ -1219,7 +1221,6 @@ namespace EDDiscovery.UserControls
                 Wanted[rno] = 0;
             }
             Display();
-            if (OnChangedEngineeringWanted != null) OnChangedEngineeringWanted(wantedList);
         }
     }
 }

--- a/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
@@ -45,69 +45,71 @@ namespace EDDiscovery.UserControls
         {
             this.components = new System.ComponentModel.Container();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.splitContainer1 = new ExtendedControls.SplitContainerCustom();
+            this.splitContainerVertical = new ExtendedControls.SplitContainerCustom();
             this.pictureBoxList = new ExtendedControls.PictureBoxHotspot();
-            this.splitContainer2 = new ExtendedControls.SplitContainerCustom();
+            this.splitContainerRightHorz = new ExtendedControls.SplitContainerCustom();
             this.userControlSynthesis = new EDDiscovery.UserControls.UserControlSynthesis();
             this.userControlEngineering = new EDDiscovery.UserControls.UserControlEngineering();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerVertical)).BeginInit();
+            this.splitContainerVertical.Panel1.SuspendLayout();
+            this.splitContainerVertical.Panel2.SuspendLayout();
+            this.splitContainerVertical.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxList)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
-            this.splitContainer2.Panel1.SuspendLayout();
-            this.splitContainer2.Panel2.SuspendLayout();
-            this.splitContainer2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerRightHorz)).BeginInit();
+            this.splitContainerRightHorz.Panel1.SuspendLayout();
+            this.splitContainerRightHorz.Panel2.SuspendLayout();
+            this.splitContainerRightHorz.SuspendLayout();
             this.SuspendLayout();
             // 
             // toolTip1
             // 
             this.toolTip1.ShowAlways = true;
             // 
-            // splitContainer1
+            // splitContainerVertical
             // 
-            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.splitContainerVertical.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainerVertical.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerVertical.Name = "splitContainerVertical";
             // 
-            // splitContainer1.Panel1
+            // splitContainerVertical.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.pictureBoxList);
+            this.splitContainerVertical.Panel1.Controls.Add(this.pictureBoxList);
+            this.splitContainerVertical.Panel1MinSize = 100;
             // 
-            // splitContainer1.Panel2
+            // splitContainerVertical.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
-            this.splitContainer1.Size = new System.Drawing.Size(971, 572);
-            this.splitContainer1.SplitterDistance = 323;
-            this.splitContainer1.TabIndex = 0;
+            this.splitContainerVertical.Panel2.Controls.Add(this.splitContainerRightHorz);
+            this.splitContainerVertical.Size = new System.Drawing.Size(971, 572);
+            this.splitContainerVertical.SplitterDistance = 120;
+            this.splitContainerVertical.TabIndex = 0;
             // 
             // pictureBoxList
             // 
+            this.pictureBoxList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pictureBoxList.Location = new System.Drawing.Point(0, 0);
             this.pictureBoxList.Name = "pictureBoxList";
-            this.pictureBoxList.Size = new System.Drawing.Size(320, 569);
+            this.pictureBoxList.Size = new System.Drawing.Size(120, 572);
             this.pictureBoxList.TabIndex = 0;
             // 
-            // splitContainer2
+            // splitContainerRightHorz
             // 
-            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Name = "splitContainer2";
-            this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.splitContainerRightHorz.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerRightHorz.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerRightHorz.Name = "splitContainerRightHorz";
+            this.splitContainerRightHorz.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
-            // splitContainer2.Panel1
+            // splitContainerRightHorz.Panel1
             // 
-            this.splitContainer2.Panel1.Controls.Add(this.userControlSynthesis);
+            this.splitContainerRightHorz.Panel1.Controls.Add(this.userControlSynthesis);
             // 
-            // splitContainer2.Panel2
+            // splitContainerRightHorz.Panel2
             // 
-            this.splitContainer2.Panel2.Controls.Add(this.userControlEngineering);
-            this.splitContainer2.Size = new System.Drawing.Size(644, 572);
-            this.splitContainer2.SplitterDistance = 214;
-            this.splitContainer2.TabIndex = 0;
+            this.splitContainerRightHorz.Panel2.Controls.Add(this.userControlEngineering);
+            this.splitContainerRightHorz.Size = new System.Drawing.Size(847, 572);
+            this.splitContainerRightHorz.SplitterDistance = 214;
+            this.splitContainerRightHorz.TabIndex = 0;
             // 
             // userControlSynthesis
             // 
@@ -116,7 +118,7 @@ namespace EDDiscovery.UserControls
             | System.Windows.Forms.AnchorStyles.Right)));
             this.userControlSynthesis.Location = new System.Drawing.Point(0, 0);
             this.userControlSynthesis.Name = "userControlSynthesis";
-            this.userControlSynthesis.Size = new System.Drawing.Size(641, 211);
+            this.userControlSynthesis.Size = new System.Drawing.Size(844, 211);
             this.userControlSynthesis.TabIndex = 0;
             // 
             // userControlEngineering
@@ -126,34 +128,34 @@ namespace EDDiscovery.UserControls
             | System.Windows.Forms.AnchorStyles.Right)));
             this.userControlEngineering.Location = new System.Drawing.Point(0, -1);
             this.userControlEngineering.Name = "userControlEngineering";
-            this.userControlEngineering.Size = new System.Drawing.Size(641, 352);
+            this.userControlEngineering.Size = new System.Drawing.Size(844, 352);
             this.userControlEngineering.TabIndex = 0;
             // 
             // UserControlShoppingList
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.splitContainerVertical);
             this.Name = "UserControlShoppingList";
             this.Size = new System.Drawing.Size(971, 572);
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
+            this.splitContainerVertical.Panel1.ResumeLayout(false);
+            this.splitContainerVertical.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerVertical)).EndInit();
+            this.splitContainerVertical.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxList)).EndInit();
-            this.splitContainer2.Panel1.ResumeLayout(false);
-            this.splitContainer2.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
-            this.splitContainer2.ResumeLayout(false);
+            this.splitContainerRightHorz.Panel1.ResumeLayout(false);
+            this.splitContainerRightHorz.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerRightHorz)).EndInit();
+            this.splitContainerRightHorz.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
 
         #endregion
         private System.Windows.Forms.ToolTip toolTip1;
-        private ExtendedControls.SplitContainerCustom splitContainer1;
+        private ExtendedControls.SplitContainerCustom splitContainerVertical;
         private ExtendedControls.PictureBoxHotspot pictureBoxList;
-        private ExtendedControls.SplitContainerCustom splitContainer2;
+        private ExtendedControls.SplitContainerCustom splitContainerRightHorz;
         private UserControlSynthesis userControlSynthesis;
         private UserControlEngineering userControlEngineering;
     }

--- a/ExtendedControls/Themes/ThemeStandard.cs
+++ b/ExtendedControls/Themes/ThemeStandard.cs
@@ -181,6 +181,8 @@ namespace ExtendedControls
             }
         }
 
+        public Font GetFontMaxSized(float size) { return new Font(currentsettings.fontname, Math.Min(currentsettings.fontsize,size)); }
+
         public Settings currentsettings;           // if name = custom, then its not a standard theme..
         public ThemeToolStripRenderer toolstripRenderer;
         protected List<Settings> themelist;


### PR DESCRIPTION
synth/ Engineering - changed to action callback on display finished
Engineering - incorrect code on wanted accumulation (240) therefore not
showing engineering materials list at bottom
Shopping list - now depends on displays of both sub controls.  when they
both complete, it computes the list.
Changed its visual behaviour so it does not jump around all over the
place. Now just makes sure its left panel has enough space for display
and keeps the user splitter distance