### PR TITLE
Avoid race resulting in duplicate entries

### DIFF
--- a/EliteDangerous/EDSM/EDSMClass.cs
+++ b/EliteDangerous/EDSM/EDSMClass.cs
@@ -499,7 +499,8 @@ namespace EliteDangerousCore.EDSM
                         ISystem sc = SystemClassDB.GetSystem(id, cn, SystemClassDB.SystemIDType.EdsmId);
                         if (sc == null)
                         {
-                            sc = GetSystemsByName(name).FirstOrDefault(s => s.id_edsm == id);
+                            if (DateTime.UtcNow.Subtract(etutc).TotalHours < 6) // Avoid running into the rate limit
+                                sc = GetSystemsByName(name)?.FirstOrDefault(s => s.id_edsm == id);
 
                             if (sc == null)
                             {

--- a/EliteDangerous/EDSM/EDSMLogFetcher.cs
+++ b/EliteDangerous/EDSM/EDSMLogFetcher.cs
@@ -83,9 +83,6 @@ namespace EliteDangerousCore.EDSM
                 waittime = (int)Math.Min(EDSMMaxLogAgeMinutes * 60000, Math.Min(BackoffInterval.TotalSeconds * 1000, EDSMRequestBackoffTime.Subtract(DateTime.UtcNow).TotalSeconds * 1000));
             }
 
-            // get them as of now.. since we are searching back in time it should be okay. On a refresh we would start again!
-            List<HistoryEntry> hlfsdlist = JournalEntry.GetAll(Commander.Nr).OfType<JournalLocOrJump>().OrderBy(je => je.EventTimeUTC).Select(je => HistoryEntry.FromJournalEntry(je, null, false, out jupdate)).ToList();
-
             while (!ExitRequested.WaitOne(waittime))
             {
                 EDSMClass edsm = new EDSMClass { apiKey = Commander.APIKey, commanderName = Commander.EdsmName };
@@ -135,6 +132,10 @@ namespace EliteDangerousCore.EDSM
 
                         if (logendtime > DateTime.UtcNow)
                             logendtime = DateTime.UtcNow;
+
+                        // Get all of the local entries now that we have the entries from EDSM
+                        // Moved here to avoid the race that could have been causing duplicate entries
+                        List<HistoryEntry> hlfsdlist = JournalEntry.GetAll(Commander.Nr).OfType<JournalLocOrJump>().OrderBy(je => je.EventTimeUTC).Select(je => HistoryEntry.FromJournalEntry(je, null, false, out jupdate)).ToList();
 
                         HistoryList hl = new HistoryList(hlfsdlist);
                         List<DateTime> hlfsdtimes = hlfsdlist.Select(he => he.EventTimeUTC).ToList();


### PR DESCRIPTION
Move the local history fetch to after retrieval of travel log from EDSM.  This should eliminate the race between the local history being fetched and the logs being fetched where new entries could be submitted and then retrieved.