### PR TITLE
Added moon information to Star List Panel

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -264,24 +264,54 @@ namespace EDDiscovery.UserControls
                             }
                             else
                             {
-                                if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an earth like body", prefix);
+                                // Check if a non-star body is a moon or not. We want it to further refine our brief summary in the visited star list.
+                                // To avoid duplicates, we need to apply our filters before on the bodies recognized as a moon, than do the same for the other bodies that do not fulfill that criteria.
+                                                               
+                                if (sn.level >= 2 && sn.type == StarScan.ScanNodeType.body)
+                                
+                                // Tell us that that special body is a moon. After all, it can be quite an outstanding discovery...
+                                {
+                                    // Earth-like moon
+                                    if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an earth like moon", prefix);
 
-                                // Water Planets, not terraformable
-                                if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == false)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
-                                // Check and inform if a water planet is terraformable
-                                if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == true)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable water world", prefix);
-                                
-                                // Add information for other terraformable planets
-                                if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is terraformable", prefix);
-                                
-                                if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia world", prefix);
+                                    // Terraformable water moon
+                                    if (sc.Terraformable == true && sc.PlanetTypeID == EDPlanet.Water_world)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable water moon", prefix);
+                                    // Water moon
+                                    if (sc.Terraformable == false && sc.PlanetTypeID == EDPlanet.Water_world)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water moon", prefix);
 
-                                
+                                    // Terraformable moon
+                                    if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable moon", prefix);
+
+                                    // Ammonia moon
+                                    if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia moon", prefix);                                  
+                                }
+                                else
+                                // Now, tell us the special state of planets.
+                                {
+                                    // Earth Like planet
+                                    if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an earth like planet", prefix);
+
+                                    // Terraformable water world
+                                    if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == true)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable water world", prefix);
+                                    // Water world
+                                    if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == false)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
+                                    
+                                    // Terraformable planet
+                                    if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable planet", prefix);
+
+                                    // Ammonia world
+                                    if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia world", prefix);
+                                }
                             }
                         }
                     }

--- a/EliteDangerous/EliteDangerous/StarScan.cs
+++ b/EliteDangerous/EliteDangerous/StarScan.cs
@@ -69,6 +69,7 @@ namespace EliteDangerousCore
             public string ownname;                  // own name              
             public string customname;               // e.g. Earth
             public SortedList<string, ScanNode> children;         // kids
+            public int level;                       // level within SystemNode
 
             private JournalScan scandata;            // can be null if no scan, its a place holder.
             private JournalScan.StarPlanetRing beltdata;
@@ -428,7 +429,8 @@ namespace EliteDangerousCore
                         fullname = lvl == 0 ? (sys.name + (ownname.Contains("Main") ? "" : (" " + ownname))) : node.fullname + " " + ownname,
                         ScanData = null,
                         children = null,
-                        type = sublvtype
+                        type = sublvtype,
+                        level = lvl
                     };
 
                     cnodes.Add(ownname, sublv);
@@ -473,7 +475,8 @@ namespace EliteDangerousCore
                             ScanData = null,
                             BeltData = ring,
                             children = null,
-                            type = ScanNodeType.belt
+                            type = ScanNodeType.belt,
+                            level = 1
                         };
 
                         node.children.Add(beltname, belt);


### PR DESCRIPTION
Now, the visited Star List panel tell us if a special body is a moon. 

A level is generated from ScanNode, which tell us if a body is a moon; than, both moon and non-moon bodies passes though the filter which tell us if they are worth mentioning: terraformable, water world, terraformable water world, earth-like or ammonia. 

It should work for procedurally-generated names as well for human-made names... 