### PR TITLE
Small fixes in Habitable Zone information in SPanel

### DIFF
--- a/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
@@ -152,7 +152,7 @@ namespace EDDiscovery.UserControls
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckOnClick = true;
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Name = "showHabitationMinimumAndMaximumDistanceToolStripMenuItem";
-            this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+            this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(346, 44);
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Text = "Show Habitation Minimum and Maximum Distance";
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Click += new System.EventHandler(this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem_Click);
             // 

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -504,10 +504,10 @@ namespace EliteDangerousCore.JournalEvents
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {
                 StringBuilder habZone = new StringBuilder();
-                habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n", GetHabZoneStringLs(),
+                habZone.AppendFormat("Main Star Habitable Zone {0} ({1}-{2} AU)\n", GetHabZoneStringLs(),
                                                                                   (HabitableZoneInner.Value / 499).ToString("N2"), (HabitableZoneOuter.Value / 499).ToString("N2"));
                 if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
-                    habZone.AppendFormat(" (Star only, others not considered)\n");
+                    habZone.AppendFormat(" (Others stars not considered)\n");
 
                 return habZone.ToNullSafeString();
             }


### PR DESCRIPTION
I doubled the row height of the habitable zone information. It fixes this:
![needfixforhabitablezone](https://user-images.githubusercontent.com/4296635/31586288-aa157032-b1ad-11e7-87e1-8828726ca3f4.PNG)

Also, I changed the text in "Main Star Habitable Zone etc..." and "Others stars not considered"
