### PR TITLE
Habzone ext

### DIFF
--- a/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
@@ -152,7 +152,7 @@ namespace EDDiscovery.UserControls
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckOnClick = true;
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Name = "showHabitationMinimumAndMaximumDistanceToolStripMenuItem";
-            this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+            this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(346, 44);
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Text = "Show Habitation Minimum and Maximum Distance";
             this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Click += new System.EventHandler(this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem_Click);
             // 

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -504,10 +504,10 @@ namespace EliteDangerousCore.JournalEvents
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {
                 StringBuilder habZone = new StringBuilder();
-                habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n", GetHabZoneStringLs(),
+                habZone.AppendFormat("Main Star Habitable Zone {0} ({1}-{2} AU)\n", GetHabZoneStringLs(),
                                                                                   (HabitableZoneInner.Value / 499).ToString("N2"), (HabitableZoneOuter.Value / 499).ToString("N2"));
                 if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
-                    habZone.AppendFormat(" (Star only, others not considered)\n");
+                    habZone.AppendFormat(" (Others stars not considered)\n");
 
                 return habZone.ToNullSafeString();
             }

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -504,7 +504,7 @@ namespace EliteDangerousCore.JournalEvents
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {
                 StringBuilder habZone = new StringBuilder();
-                habZone.AppendFormat("Main Star Habitable Zone {0} ({1}-{2} AU)\n", GetHabZoneStringLs(),
+                habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n", GetHabZoneStringLs(),
                                                                                   (HabitableZoneInner.Value / 499).ToString("N2"), (HabitableZoneOuter.Value / 499).ToString("N2"));
                 if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
                     habZone.AppendFormat(" (Others stars not considered)\n");


### PR DESCRIPTION
Fixes text overlap in SPanel habitable zone information.
Slight text changes.

Await for further improvements, like a new string for main star, and possibly including choices to display also Ammonia and Water World ranges, upon user preferences...

