### PR TITLE
Limit history fetch in EDSM log fetcher

### DIFF
--- a/EliteDangerous/EDSM/EDSMLogFetcher.cs
+++ b/EliteDangerous/EDSM/EDSMLogFetcher.cs
@@ -132,10 +132,12 @@ namespace EliteDangerousCore.EDSM
 
                         if (logendtime > DateTime.UtcNow)
                             logendtime = DateTime.UtcNow;
+                        if (logstarttime < DateTime.MinValue.AddDays(1))
+                            logstarttime = DateTime.MinValue.AddDays(1);
 
                         // Get all of the local entries now that we have the entries from EDSM
                         // Moved here to avoid the race that could have been causing duplicate entries
-                        List<HistoryEntry> hlfsdlist = JournalEntry.GetAll(Commander.Nr).OfType<JournalLocOrJump>().OrderBy(je => je.EventTimeUTC).Select(je => HistoryEntry.FromJournalEntry(je, null, false, out jupdate)).ToList();
+                        List<HistoryEntry> hlfsdlist = JournalEntry.GetAll(Commander.Nr, logstarttime.AddDays(-1), logendtime.AddDays(1)).OfType<JournalLocOrJump>().OrderBy(je => je.EventTimeUTC).Select(je => HistoryEntry.FromJournalEntry(je, null, false, out jupdate)).ToList();
 
                         HistoryList hl = new HistoryList(hlfsdlist);
                         List<DateTime> hlfsdtimes = hlfsdlist.Select(he => he.EventTimeUTC).ToList();

--- a/EliteDangerous/EliteDangerous/JournalEntry.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntry.cs
@@ -745,7 +745,7 @@ namespace EliteDangerousCore
             }
         }
 
-        static public List<JournalEntry> GetAll(int commander = -999)
+        static public List<JournalEntry> GetAll(int commander = -999, DateTime? after = null, DateTime? before = null)
         {
             Dictionary<long, TravelLogUnit> tlus = TravelLogUnit.GetAll().ToDictionary(t => t.id);
 
@@ -753,12 +753,14 @@ namespace EliteDangerousCore
 
             using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
             {
-                using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where CommanderID=@commander Order by EventTime ASC"))
+                using (DbCommand cmd = cn.CreateCommand("select * from JournalEntries where CommanderID=@commander and EventTime >= @after and EventTime <= @before Order by EventTime ASC"))
                 {
                     if (commander == -999)
-                        cmd.CommandText = "select * from JournalEntries Order by EventTime ";
+                        cmd.CommandText = "select * from JournalEntries where EventTime >= @after and EventTime <= @before Order by EventTime ";
 
                     cmd.AddParameterWithValue("@commander", commander);
+                    cmd.AddParameterWithValue("@before", before ?? DateTime.MaxValue);
+                    cmd.AddParameterWithValue("@after", after ?? DateTime.MinValue);
 
                     DataSet ds = SQLiteDBClass.SQLQueryText(cn, cmd);
 


### PR DESCRIPTION
This should reduce the CPU load of the EDSM log fetcher, especially with large histories.