### PR TITLE
Fix bug #1406

### DIFF
--- a/ActionLanguage/ActionEditing/ActionPackEditCondition.cs
+++ b/ActionLanguage/ActionEditing/ActionPackEditCondition.cs
@@ -125,7 +125,7 @@ namespace ActionLanguage
         {
             ExtendedControls.KeyForm kf = new ExtendedControls.KeyForm();
             kf.Init(this.Icon, false, ",", buttonKeys.Text.Equals("?") ? "" : buttonKeys.Text);
-            if ( kf.ShowDialog(this) == DialogResult.OK)
+            if ( kf.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 buttonKeys.Text = kf.KeyList;
                 cd.fields[0].matchstring = kf.KeyList;

--- a/ActionLanguage/ActionEditing/ActionPackEditProgram.cs
+++ b/ActionLanguage/ActionEditing/ActionPackEditProgram.cs
@@ -193,7 +193,7 @@ namespace ActionLanguage
 
             if (p != null && p.StoredInSubFile != null && shift)        // if we have a stored in sub file, but we shift hit, cancel it
             {
-                if (ExtendedControls.MessageBoxTheme.Show(this, "Do you want to bring the file back into the main file", "WARNING", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
+                if (ExtendedControls.MessageBoxTheme.Show(FindForm(), "Do you want to bring the file back into the main file", "WARNING", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
                 {
                     p.CancelSubFileStorage();
                     shift = false;
@@ -220,7 +220,7 @@ namespace ActionLanguage
                 apf.EditProgram += (s) =>
                 {
                     if (!actionfile.actionprogramlist.EditProgram(s, actionfile.name, actioncorecontroller, applicationfolder))
-                        ExtendedControls.MessageBoxTheme.Show(this, "Unknown program or not in this file " + s);
+                        ExtendedControls.MessageBoxTheme.Show(FindForm(), "Unknown program or not in this file " + s);
                 };
 
                 // we init with a variable list based on the field names of the group (normally the event field names got by SetFieldNames)
@@ -229,7 +229,7 @@ namespace ActionLanguage
                 apf.Init("Action program ", this.Icon, actioncorecontroller, applicationfolder, onAdditionalNames(), actionfile.name, p, 
                                 actionfile.actionprogramlist.GetActionProgramList(), suggestedname, ModifierKeys.HasFlag(Keys.Shift));
 
-                DialogResult res = apf.ShowDialog();
+                DialogResult res = apf.ShowDialog(FindForm());
 
                 if (res == DialogResult.OK)
                 {
@@ -259,7 +259,7 @@ namespace ActionLanguage
             ConditionVariablesForm avf = new ConditionVariablesForm();
             avf.Init("Input parameters and flags to pass to program on run", this.Icon, cond, showone: true, showrefresh: true, showrefreshstate: flag.Equals(ConditionVariables.flagRunAtRefresh));
 
-            if (avf.ShowDialog(this) == DialogResult.OK)
+            if (avf.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 cd.actiondata = paras.Text = avf.result.ToActionDataString(avf.result_refresh ? ConditionVariables.flagRunAtRefresh : "");
             }

--- a/ActionLanguage/ActionEditing/ActionPackEditorForm.cs
+++ b/ActionLanguage/ActionEditing/ActionPackEditorForm.cs
@@ -365,7 +365,7 @@ namespace ActionLanguage
                                 actionfile.name, p, 
                                 actionfile.actionprogramlist.GetActionProgramList(), "", ModifierKeys.HasFlag(Keys.Shift));
 
-                    DialogResult res = apf.ShowDialog();
+                    DialogResult res = apf.ShowDialog(this);
 
                     if (res == DialogResult.OK)
                     {

--- a/ActionLanguage/ActionEditing/ActionProgramEditForm.cs
+++ b/ActionLanguage/ActionEditing/ActionProgramEditForm.cs
@@ -602,7 +602,7 @@ namespace ActionLanguage
             dlg.AddExtension = true;
             dlg.Filter = "Action Text Files (*.atf)|*.atf|All files (*.*)|*.*";
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 using (System.IO.StreamReader sr = new System.IO.StreamReader(dlg.FileName))
                 {
@@ -648,7 +648,7 @@ namespace ActionLanguage
                 dlg.AddExtension = true;
                 dlg.Filter = "Action Text Files (*.atf)|*.atf|All files (*.*)|*.*";
 
-                if (dlg.ShowDialog() == DialogResult.OK)
+                if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     curprog.Rename(textBoxBorderName.Text.Trim());
                     if ( associate )

--- a/ActionLanguage/ActionsCoreCmds/ActionKey.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionKey.cs
@@ -64,7 +64,7 @@ namespace ActionLanguage
             return FromString(userdata, out saying, out vars) ? null : "Key command line not in correct format";
         }
 
-        static public string Menu(Control parent , System.Drawing.Icon ic, string userdata)
+        static public string Menu(Form parent, System.Drawing.Icon ic, string userdata)
         {
             ConditionVariables vars;
             string keys;

--- a/ActionLanguage/ActionsCoreCmds/ActionSay.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionSay.cs
@@ -99,7 +99,7 @@ namespace ActionLanguage
                         vars
                         );
 
-            if (cfg.ShowDialog(parent) == DialogResult.OK)
+            if (cfg.ShowDialog(parent.FindForm()) == DialogResult.OK)
             {
                 ConditionVariables cond = new ConditionVariables(cfg.Effects);// add on any effects variables (and may add in some previous variables, since we did not purge
                 cond.SetOrRemove(cfg.Wait, waitname, "1");

--- a/ActionLanguage/ActionsCoreCmds/ActionSet.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionSet.cs
@@ -48,7 +48,7 @@ namespace ActionLanguage
             ConditionVariablesForm avf = new ConditionVariablesForm();
             avf.Init("Define Variable:", cp.Icon, av, showone: true, allowadd: allowaddv, allownoexpand: allownoexpandv, altops:operations, allowmultiple:false);
 
-            if (avf.ShowDialog(parent.FindForm()) == DialogResult.OK)
+            if (avf.ShowDialog(parent) == DialogResult.OK)
             {
                 userdata = ToString(avf.result,avf.result_altops);
                 return true;

--- a/ActionLanguage/ActionsCoreCmds/ActionStructures.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionStructures.cs
@@ -42,8 +42,7 @@ namespace ActionLanguage
             ConditionFilterForm frm = new ConditionFilterForm();
             frm.InitCondition("Define condition", cp.Icon, eventvars, jf);
 
-            frm.TopMost = parent.FindForm().TopMost;
-            if (frm.ShowDialog(parent.FindForm()) == DialogResult.OK)
+            if (frm.ShowDialog(parent) == DialogResult.OK)
             {
                 jf = frm.result;
                 return true;
@@ -502,7 +501,7 @@ namespace ActionLanguage
                 ConditionVariablesForm avf = new ConditionVariablesForm();
                 avf.Init("Variables to pass into called program", cp.Icon, cond, showone: true, allownoexpand: true, altops: altops);
 
-                if (avf.ShowDialog(parent.FindForm()) == DialogResult.OK)
+                if (avf.ShowDialog(parent) == DialogResult.OK)
                 {
                     userdata = ToString(promptValue, avf.result, avf.result_altops);
                     return true;

--- a/ActionLanguage/ActionsCoreCmds/ActionUserInteraction.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionUserInteraction.cs
@@ -80,8 +80,6 @@ namespace ActionLanguage
 
                     DialogResult res = ExtendedControls.MessageBoxTheme.Show(ap.actioncontroller.Form, exp[0], caption, but, icon);
 
-                    // debug ExtendedControls.MessageBoxTheme.Show(exp[0], caption, but, icon);
-
                     ap["DialogResult"] = res.ToString();
                 }
                 else

--- a/Audio/WaveConfigureDialog.cs
+++ b/Audio/WaveConfigureDialog.cs
@@ -176,7 +176,7 @@ namespace AudioExtensions
             dlg.AddExtension = true;
             dlg.Filter = "MP3 Files (*.mp3)|*.mp3|WAV files (*.wav)|*.wav|Audio Files (*.mp3;*.wav)|*.mp3;*.wav|All files (*.*)|*.*";
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 textBoxBorderText.Text = dlg.FileName;
             }

--- a/EDDiscovery/2DMap/Form2DMap.cs
+++ b/EDDiscovery/2DMap/Form2DMap.cs
@@ -319,7 +319,7 @@ namespace EDDiscovery
 
         private void buttonSave_Click(object sender, EventArgs e)
         {
-            if (saveFileDialog1.ShowDialog() == DialogResult.OK)
+            if (saveFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 switch (saveFileDialog1.FilterIndex)
                 {

--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -775,12 +775,6 @@ namespace EDDiscovery
             this.Name = "FormMap";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "3D Star Map";
-            this.Activated += new System.EventHandler(this.FormMap_Activated);
-            this.Deactivate += new System.EventHandler(this.FormMap_Deactivate);
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMap_FormClosing);
-            this.Load += new System.EventHandler(this.FormMap_Load);
-            this.Shown += new System.EventHandler(this.FormMap_Shown);
-            this.Resize += new System.EventHandler(this.FormMap_Resize);
             this.toolStripShowAllStars.ResumeLayout(false);
             this.toolStripShowAllStars.PerformLayout();
             this.statusStrip.ResumeLayout(false);

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -118,13 +118,14 @@ namespace EDDiscovery
         private ToolStripMenuItem _toolstripToggleNamingButton;     // for picking up this option quickly
         private ToolStripMenuItem _toolstripToggleRegionColouringButton;     // for picking up this option quickly
         
-        MapRecorder maprecorder = new MapRecorder();        // the recorder 
+        MapRecorder maprecorder = null;                     // the recorder 
         TimedMessage mapmsg = null;                         // and msg
 
         KeyboardActions _kbdActions = new KeyboardActions();        // needed to be held because it remembers key downs
 
         bool _allowresizematrixchange = false;           // prevent resize causing matrix calc before paint
         private OpenTK.GLControl glControl;
+        private ExtendedControls.InfoForm helpDialog;
 
         #endregion
 
@@ -303,6 +304,7 @@ namespace EDDiscovery
         public FormMap()
         {
             InitializeComponent();
+            maprecorder = new MapRecorder(this);
             // 
             // glControl
             // 
@@ -324,8 +326,10 @@ namespace EDDiscovery
             this.glControlContainer.ResumeLayout();
         }
 
-        private void FormMap_Load(object sender, EventArgs e)
+        protected override void OnLoad(EventArgs e)
         {
+            base.OnLoad(e);
+
             var top = SQLiteDBClass.GetSettingInt("Map3DFormTop", -1);
 
             if (top >= 0 && noWindowReposition == false)
@@ -366,17 +370,18 @@ namespace EDDiscovery
             SetCenterSystemTo(_centerSystem);                   // move to this..
 
             textboxFrom.SetAutoCompletor(SystemClassDB.ReturnSystemListForAutoComplete);
-
         }
 
-        private void FormMap_Shown(object sender, EventArgs e)
+        protected override void OnShown(EventArgs e)
         {
-            Console.WriteLine("Shown");
+            base.OnShown(e);
+
+            Console.WriteLine($"{nameof(FormMap)}.{nameof(OnShown)}");
             int helpno = SQLiteDBClass.GetSettingInt("Map3DShownHelp", 0);                 // force up help, to make sure they know it exists
 
             if (helpno != HELP_VERSION)
             {
-                toolStripButtonHelp_Click(null, null);
+                toolStripButtonHelp_Click(toolStripButtonHelp, EventArgs.Empty);
                 SQLiteDBClass.PutSettingInt("Map3DShownHelp", HELP_VERSION);
             }
 
@@ -400,8 +405,10 @@ namespace EDDiscovery
             }
         }
 
-        private void FormMap_Resize(object sender, EventArgs e)         // resizes changes glcontrol width/height, so needs a new viewport
+        protected override void OnResize(EventArgs e)           // resizes changes glcontrol width/height, so needs a new viewport
         {
+            base.OnResize(e);
+
             if (_allowresizematrixchange)
             {
                 SetModelProjectionMatrix();
@@ -409,22 +416,28 @@ namespace EDDiscovery
             }
         }
 
-        private void FormMap_Activated(object sender, EventArgs e)
+        protected override void OnActivated(EventArgs e)
         {
+            base.OnActivated(e);
+
             _isActivated = true;
             StartSystemTimer();                     // in case Close, then open, only get activated
             RequestPaint();
             glControl.Focus();
         }
 
-        private void FormMap_Deactivate(object sender, EventArgs e)
+        protected override void OnDeactivate(EventArgs e)
         {
+            base.OnDeactivate(e);
+
             _isActivated = false;
             VideoMessage();
         }
 
-        private void FormMap_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            base.OnFormClosing(e);
+
             Console.WriteLine("{0} Close form" , Environment.TickCount);
 
             _systemtimer.Stop();
@@ -463,6 +476,29 @@ namespace EDDiscovery
 
             e.Cancel = true;
             this.Hide();
+        }
+
+        protected override void OnFormClosed(FormClosedEventArgs e)
+        {
+            base.OnFormClosed(e);
+
+            helpDialog?.Dispose();
+        }
+
+        protected override void OnTopMostChanged(EventArgs e)
+        {
+            base.OnTopMostChanged(e);
+
+            if (helpDialog != null)
+                helpDialog.TopMost = this.TopMost;
+        }
+
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+
+            if (helpDialog != null)
+                helpDialog.Visible = this.Visible;
         }
 
         private void glControl_Load(object sender, EventArgs e)
@@ -709,12 +745,12 @@ namespace EDDiscovery
             mapmsg?.Dispose();
             mapmsg = null;
 
-            if (msg != null && msg.Length > 0 && time > 0)
+            if (!string.IsNullOrEmpty(msg) && time > 0)
             {
                 TimedMessage newmsg = new TimedMessage();
                 newmsg.Init("", msg, time, true, 0.9F, Color.Black, Color.White, new Font("MS Sans Serif", 20.0F));
                 newmsg.Position(this, 0, 0, -1, -20, 0, 0);         // careful, it triggers a deactivate.. which tries to close it
-                newmsg.Show();
+                newmsg.Show(this);
                 mapmsg = newmsg;                                    // now we can set this.. if we did it above, we would end with a race condition on a null pointer of this object
                 glControl.Focus();
             }
@@ -1143,7 +1179,7 @@ namespace EDDiscovery
                     posdir.CameraLookAt(loc,zoomfov.Zoom, 2F);
             }
             else
-                ExtendedControls.MessageBoxTheme.Show("System or Object " + textboxFrom.Text + " not found");
+                ExtendedControls.MessageBoxTheme.Show(this, "System or Object " + textboxFrom.Text + " not found");
 
             glControl.Focus();
         }
@@ -1156,7 +1192,7 @@ namespace EDDiscovery
                 SetCenterSystemTo((he == null) ? _centerSystem.name : he.System.name);
             }
             else
-                ExtendedControls.MessageBoxTheme.Show("No travel history is available");
+                ExtendedControls.MessageBoxTheme.Show(this, "No travel history is available");
         }
 
         private void buttonHome_Click(object sender, EventArgs e)
@@ -1167,7 +1203,7 @@ namespace EDDiscovery
         private void buttonHistory_Click(object sender, EventArgs e)
         {
             if (_historySelection == null)
-                ExtendedControls.MessageBoxTheme.Show("No travel history is available");
+                ExtendedControls.MessageBoxTheme.Show(this, "No travel history is available");
             else
                 SetCenterSystemTo(_historySelection);
         }
@@ -1183,7 +1219,7 @@ namespace EDDiscovery
             }
             else
             {
-                ExtendedControls.MessageBoxTheme.Show("No target designated, create a bookmark or region mark, or use a Note mark, right click on it and set it as the target");
+                ExtendedControls.MessageBoxTheme.Show(this, "No target designated, create a bookmark or region mark, or use a Note mark, right click on it and set it as the target");
             }
         }
         
@@ -1195,7 +1231,7 @@ namespace EDDiscovery
                 SetCenterSystemTo((he == null) ? _centerSystem.name : he.System.name);
             }
             else
-                ExtendedControls.MessageBoxTheme.Show("No travel history is available");
+                ExtendedControls.MessageBoxTheme.Show(this, "No travel history is available");
         }
 
         private void toolStripButtonAutoForward_Click(object sender, EventArgs e)
@@ -1211,10 +1247,10 @@ namespace EDDiscovery
                 if (he != null )
                     SetCenterSystemTo(FindSystem(he.System.name));
                 else
-                    ExtendedControls.MessageBoxTheme.Show("No stars with defined co-ordinates available in travel history");
+                    ExtendedControls.MessageBoxTheme.Show(this, "No stars with defined co-ordinates available in travel history");
             }
             else
-                ExtendedControls.MessageBoxTheme.Show("No travel history is available");
+                ExtendedControls.MessageBoxTheme.Show(this, "No travel history is available");
         }
 
         private void drawLinesBetweenStarsWithPositionToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1327,7 +1363,7 @@ namespace EDDiscovery
             frm.InitialisePos(posdir.Position.X, posdir.Position.Y, posdir.Position.Z);
             DateTime tme = DateTime.Now;
             frm.RegionBookmark(tme.ToString());
-            DialogResult res = frm.ShowDialog();
+            DialogResult res = frm.ShowDialog(this);
 
             if (res == DialogResult.OK)
             {
@@ -1377,11 +1413,19 @@ namespace EDDiscovery
 
         private void toolStripButtonHelp_Click(object sender, EventArgs e)
         {
-            ExtendedControls.InfoForm dl = new ExtendedControls.InfoForm();
-            string text = EDDiscovery.Properties.Resources.maphelp3d;
-            dl.Info("3D Map Help", Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location), 
-                        text, new Font("Microsoft Sans Serif", 10), new int[] { 50, 200, 400 });
-            dl.Show();
+            if (helpDialog == null)
+            {
+                helpDialog = new ExtendedControls.InfoForm() { TopMost = this.TopMost };
+                helpDialog.Info("3D Map Help", Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location),
+                            Properties.Resources.maphelp3d, new Font("Microsoft Sans Serif", 10), new int[] { 50, 200, 400 });
+                helpDialog.Show();
+                helpDialog.Disposed += (s, ea) => helpDialog = null;
+            }
+            else
+            {
+                helpDialog.Activate();
+                helpDialog.BringToFront();
+            }
         }
 
         private void dropdownMapNames_DropDownItemClicked(object sender, EventArgs e)
@@ -1435,7 +1479,7 @@ namespace EDDiscovery
 
         private void toolStripMenuItemClearRecording_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show("Confirm you wish to clear the current recording", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
+            if (ExtendedControls.MessageBoxTheme.Show(this, "Confirm you wish to clear the current recording", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
                 maprecorder.Clear();
 
             SetDropDownRecordImage();
@@ -1511,7 +1555,7 @@ namespace EDDiscovery
             string file = (string)tmsi.Tag;
             if ( !maprecorder.ReadFromFile(file) )
             {
-                ExtendedControls.MessageBoxTheme.Show("Failed to load flight " + file + ". Check file path and file contents");
+                ExtendedControls.MessageBoxTheme.Show(this, "Failed to load flight " + file + ". Check file path and file contents");
             }
         }
 
@@ -1646,7 +1690,7 @@ namespace EDDiscovery
                     frm.Name = gmo.name;
                     frm.InitialisePos(gmo.points[0].X, gmo.points[0].Y, gmo.points[0].Z);
                     frm.GMO(gmo.name, gmo.description, targetid == gmo.id, gmo.galMapUrl);
-                    DialogResult res = frm.ShowDialog();
+                    DialogResult res = frm.ShowDialog(this);
 
                     if (res == DialogResult.OK)
                     {

--- a/EDDiscovery/3DMap/MapManager.cs
+++ b/EDDiscovery/3DMap/MapManager.cs
@@ -30,9 +30,13 @@ namespace EDDiscovery._3DMap
 
         public MapManager(bool nowindowreposition,EDDiscoveryForm frm)
         {
-            _formMap = new FormMap();
-            _formMap.discoveryForm = frm;
-            _formMap.noWindowReposition = nowindowreposition;
+            _formMap = new FormMap()
+            {
+                discoveryForm = frm,
+                noWindowReposition = nowindowreposition,
+                TopMost = frm.TopMost
+            };
+            frm.TopMostChanged += (s, e) => _formMap.TopMost = ((EDDiscoveryForm)s).TopMost;
         }
 
         public bool Is3DMapsRunning { get { return _formMap.Is3DMapsRunning; } }
@@ -64,7 +68,6 @@ namespace EDDiscovery._3DMap
 
         public void Show()
         {
-            _formMap.TopMost = EDDiscoveryForm.EDDConfig.KeepOnTop;
             // TODO: set Opacity to match EDDiscoveryForm
             _formMap.Show();
             _formMap.Focus();

--- a/EDDiscovery/3DMap/MapRecorder.cs
+++ b/EDDiscovery/3DMap/MapRecorder.cs
@@ -65,6 +65,7 @@ namespace EDDiscovery._3DMap
         }
 
         private List<FlightEntry> entries = null;
+        private FormMap owner = null;
 
         private bool record = false;
         private bool pause = false;
@@ -76,6 +77,11 @@ namespace EDDiscovery._3DMap
         private Stopwatch timer;
 
         int playbackpos = -1;
+
+        public MapRecorder(FormMap form)
+        {
+            owner = form;
+        }
 
         public void Clear()
         {
@@ -235,7 +241,7 @@ namespace EDDiscovery._3DMap
             {
                 RecordStep frm = new RecordStep();
                 frm.Init(pos, dir, zoom);
-                if (frm.ShowDialog() == DialogResult.OK)
+                if (frm.ShowDialog(owner) == DialogResult.OK)
                 {
                     RecordStep(frm.Pos, frm.Dir, frm.Zoom, frm.Elapsed, frm.FlyTime, frm.PanTime, frm.ZoomTime, frm.Msg, frm.MsgTime, frm.WaitForComplete, frm.DisplayMessageWhenComplete);
                 }
@@ -294,14 +300,14 @@ namespace EDDiscovery._3DMap
                 dlg.AddExtension = true;
                 dlg.Filter = "Flight files (*.flight)|*.flight|All files (*.*)|*.*";
 
-                if (dlg.ShowDialog() == DialogResult.OK)
+                if (dlg.ShowDialog(owner) == DialogResult.OK)
                 {
                     if ( !SaveToFile(dlg.FileName) )
-                        ExtendedControls.MessageBoxTheme.Show("Failed to save flight - check file path");
+                        ExtendedControls.MessageBoxTheme.Show(owner, "Failed to save flight - check file path");
                 }
             }
             else
-                ExtendedControls.MessageBoxTheme.Show("No flight recorded");
+                ExtendedControls.MessageBoxTheme.Show(owner, "No flight recorded");
         }
 
         public void LoadDialog()
@@ -320,10 +326,10 @@ namespace EDDiscovery._3DMap
 
             dlg.Filter = "Flight files (*.flight)|*.flight|All files (*.*)|*.*";
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(owner) == DialogResult.OK)
             {
                 if (!ReadFromFile(dlg.FileName))
-                    ExtendedControls.MessageBoxTheme.Show("Failed to load flight " + dlg.FileName + ". Check file path and file contents");
+                    ExtendedControls.MessageBoxTheme.Show(owner, "Failed to load flight " + dlg.FileName + ". Check file path and file contents");
             }
         }
 

--- a/EDDiscovery/Actions/ActionController.cs
+++ b/EDDiscovery/Actions/ActionController.cs
@@ -88,7 +88,7 @@ namespace EDDiscovery.Actions
 
             string errlist = actionfiles.LoadAllActionFiles(AppFolder);
             if (errlist.Length > 0)
-                ExtendedControls.MessageBoxTheme.Show("Failed to load files\r\n" + errlist, "WARNING!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                ExtendedControls.MessageBoxTheme.Show(discoveryform, "Failed to load files\r\n" + errlist, "WARNING!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
 
             actionrunasync = new ActionRun(this, actionfiles);        // this is the guy who runs programs asynchronously
             ActionConfigureKeys();
@@ -101,7 +101,7 @@ namespace EDDiscovery.Actions
             if (lasteditedpack.Length > 0 && EditActionFile(lasteditedpack))
                 return;
             else
-                ExtendedControls.MessageBoxTheme.Show("Action pack does not exist anymore or never set", "WARNING!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                ExtendedControls.MessageBoxTheme.Show(discoveryform, "Action pack does not exist anymore or never set", "WARNING!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
 
         private bool EditActionFile(string name)            // edit pack name
@@ -121,9 +121,8 @@ namespace EDDiscovery.Actions
             if (f != null)
             {
                 frm.Init("Edit pack " + name, this.Icon, this, AppFolder, f, eventlist);
-                frm.TopMost = discoveryform.FindForm().TopMost;
 
-                frm.ShowDialog(discoveryform.FindForm()); // don't care about the result, the form does all the saving
+                frm.ShowDialog(discoveryform); // don't care about the result, the form does all the saving
 
                 ActionConfigureKeys();
 
@@ -235,7 +234,7 @@ namespace EDDiscovery.Actions
             ConditionVariablesForm avf = new ConditionVariablesForm();
             avf.Init("Global User variables to pass to program on run", this.Icon, PersistentVariables, showone: true);
 
-            if (avf.ShowDialog(discoveryform.FindForm()) == DialogResult.OK)
+            if (avf.ShowDialog(discoveryform) == DialogResult.OK)
             {
                 LoadPeristentVariables(avf.result);
             }
@@ -243,7 +242,7 @@ namespace EDDiscovery.Actions
 
         private void Dmf_OnCreateActionFile()
         {
-            String r = ExtendedControls.PromptSingleLine.ShowDialog(discoveryform.FindForm(), "New name", "", "Create new action file" , this.Icon);
+            String r = ExtendedControls.PromptSingleLine.ShowDialog(discoveryform, "New name", "", "Create new action file" , this.Icon);
             if ( r != null && r.Length>0 )
             {
                 if (actionfiles.Get(r, StringComparison.InvariantCultureIgnoreCase) == null)
@@ -251,7 +250,7 @@ namespace EDDiscovery.Actions
                     actionfiles.CreateSet(r,AppFolder);
                 }
                 else
-                    ExtendedControls.MessageBoxTheme.Show(discoveryform.FindForm(), "Duplicate name", "Create Action File Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    ExtendedControls.MessageBoxTheme.Show(discoveryform, "Duplicate name", "Create Action File Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
         }
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -821,7 +821,7 @@ namespace EDDiscovery
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Show log files exception: " + ex.Message);
+                MessageBox.Show(this, "Show log files exception: " + ex.Message);
             }
         }
 
@@ -838,13 +838,13 @@ namespace EDDiscovery
         private void forceEDDBUpdateToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (!Controller.AsyncPerformSync(eddbsync: true))      // we want it to have run, to completion, to allow another go..
-                ExtendedControls.MessageBoxTheme.Show("Synchronisation to databases is in operation or pending, please wait");
+                ExtendedControls.MessageBoxTheme.Show(this, "Synchronisation to databases is in operation or pending, please wait");
         }
 
         private void syncEDSMSystemsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (!Controller.AsyncPerformSync(edsmsync: true))      // we want it to have run, to completion, to allow another go..
-                ExtendedControls.MessageBoxTheme.Show("Synchronisation to databases is in operation or pending, please wait");
+                ExtendedControls.MessageBoxTheme.Show(this, "Synchronisation to databases is in operation or pending, please wait");
         }
 
         private void gitHubToolStripMenuItem_Click(object sender, EventArgs e)
@@ -855,11 +855,6 @@ namespace EDDiscovery
         private void reportIssueIdeasToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Process.Start(Properties.Resources.URLProjectFeedback);
-        }
-
-        internal void keepOnTopChanged(bool keepOnTop)
-        {
-            this.TopMost = keepOnTop;
         }
 
         /// <summary>
@@ -891,7 +886,6 @@ namespace EDDiscovery
         public void AboutBox(Form parent = null)
         {
             AboutForm frm = new AboutForm();
-            frm.TopMost = parent?.TopMost ?? this.TopMost;
             frm.ShowDialog(parent ?? this);
         }
 
@@ -926,7 +920,7 @@ namespace EDDiscovery
 
         private void clearEDSMIDAssignedToAllRecordsForCurrentCommanderToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show("Confirm you wish to reset the assigned EDSM IDs to all the current commander history entries," +
+            if (ExtendedControls.MessageBoxTheme.Show(this, "Confirm you wish to reset the assigned EDSM IDs to all the current commander history entries," +
                                 " and clear all the assigned EDSM IDs in all your notes for all commanders\r\n\r\n" +
                                 "This will not change your history, but when you next refresh, it will try and reassign EDSM systems to " +
                                 "your history and notes.  Use only if you think that the assignment of EDSM systems to entries is grossly wrong," +
@@ -965,7 +959,7 @@ namespace EDDiscovery
                 if (cmdr != null)
                 {
                     FolderBrowserDialog dirdlg = new FolderBrowserDialog();
-                    DialogResult dlgResult = dirdlg.ShowDialog();
+                    DialogResult dlgResult = dirdlg.ShowDialog(this);
 
                     if (dlgResult == DialogResult.OK)
                     {
@@ -979,7 +973,7 @@ namespace EDDiscovery
 
         private void dEBUGResetAllHistoryToFirstCommandeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show("Confirm you wish to reset all history entries to the current commander", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
+            if (ExtendedControls.MessageBoxTheme.Show(this, "Confirm you wish to reset all history entries to the current commander", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
             {
                 JournalEntry.ResetCommanderID(-1, EDCommander.CurrentCmdrID);
                 Controller.RefreshHistoryAsync();
@@ -1012,7 +1006,7 @@ namespace EDDiscovery
 
         private void deleteDuplicateFSDJumpEntriesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show("Confirm you remove any duplicate FSD entries from the current commander", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
+            if (ExtendedControls.MessageBoxTheme.Show(this, "Confirm you remove any duplicate FSD entries from the current commander", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
             {
                 int n = JournalEntry.RemoveDuplicateFSDEntries(EDCommander.CurrentCmdrID);
                 Controller.LogLine("Removed " + n + " FSD entries");
@@ -1039,7 +1033,7 @@ namespace EDDiscovery
                 dlg.Title = "Could not find VisitedStarsCache.dat file, choose file";
                 dlg.FileName = "ImportStars.txt";
 
-                if (dlg.ShowDialog() != DialogResult.OK)
+                if (dlg.ShowDialog(this) != DialogResult.OK)
                     return;
                 exportfilename = dlg.FileName;
             }
@@ -1063,7 +1057,7 @@ namespace EDDiscovery
             }
             catch (IOException)
             {
-                ExtendedControls.MessageBoxTheme.Show("Error writing " + exportfilename, "Export visited stars", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ExtendedControls.MessageBoxTheme.Show(this, "Error writing " + exportfilename, "Export visited stars", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -1114,7 +1108,7 @@ namespace EDDiscovery
         {
             FindMaterialsForm frm = new FindMaterialsForm();
 
-            frm.Show(this);
+            frm.Show();
         }
 
         private void notifyIcon1_DoubleClick(object sender, EventArgs e)
@@ -1498,7 +1492,7 @@ namespace EDDiscovery
 
             if (!edsm.IsApiKeySet)
             {
-                ExtendedControls.MessageBoxTheme.Show("Please ensure a commander is selected and it has a EDSM API key set");
+                ExtendedControls.MessageBoxTheme.Show(this, "Please ensure a commander is selected and it has a EDSM API key set");
                 return;
             }
 

--- a/EDDiscovery/Forms/CommanderForm.cs
+++ b/EDDiscovery/Forms/CommanderForm.cs
@@ -167,7 +167,7 @@ namespace EDDiscovery.Forms
         {
             if (textBoxBorderCompanionLogin.Text.Length>0 || textBoxBorderCompanionPassword.Text.Length>0)
             {
-                if (ExtendedControls.MessageBoxTheme.Show("You have entered text in the CAPI login or password fields, do you want to abandon CAPI credential check?", "Warning CAPI Information", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.Cancel)
+                if (ExtendedControls.MessageBoxTheme.Show(this, "You have entered text in the CAPI login or password fields, do you want to abandon CAPI credential check?", "Warning CAPI Information", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.Cancel)
                     return;
             }
 

--- a/EDDiscovery/Forms/ExportForm.cs
+++ b/EDDiscovery/Forms/ExportForm.cs
@@ -83,7 +83,7 @@ namespace EDDiscovery.Forms
             dlg.Filter = "CSV export| *.csv";
             dlg.Title = "Export current History view to Excel (csv)";
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 Path = dlg.FileName;
                 DialogResult = DialogResult.OK;

--- a/EDDiscovery/Forms/ImportSphere.cs
+++ b/EDDiscovery/Forms/ImportSphere.cs
@@ -38,7 +38,7 @@ namespace EDDiscovery.Forms
             systemName =  prompt.txtExportVisited.Text;
             bool worked = Double.TryParse(prompt.txtsphereRadius.Text, out radius);
             if (!worked)
-                ExtendedControls.MessageBoxTheme.Show("Radius in wrong format", "Spehere error");
+                ExtendedControls.MessageBoxTheme.Show(owner ?? discoveryForm, "Radius in wrong format", "Sphere error");
 
             return (res == DialogResult.OK && worked);
         }

--- a/EDDiscovery/Forms/TimedMessage.cs
+++ b/EDDiscovery/Forms/TimedMessage.cs
@@ -98,9 +98,10 @@ namespace EDDiscovery.Forms
             labelMessage.Size = new Size(ClientRectangle.Width - 8, ClientRectangle.Height - 8);
         }
 
-        public new void Show()
+        protected override void OnShown(EventArgs e)
         {
-            base.Show();
+            base.OnShown(e);
+
             ontimer.Start();
         }
 

--- a/EDDiscovery/Forms/UserControlForm.cs
+++ b/EDDiscovery/Forms/UserControlForm.cs
@@ -453,7 +453,7 @@ namespace EDDiscovery.Forms
                 if (IsTransparencySupported)
                     panel_transparency_Click(panel_transparent, EventArgs.Empty);
                 else
-                    ExtendedControls.MessageBoxTheme.Show("This panel does not support transparency");
+                    ExtendedControls.MessageBoxTheme.Show(this, "This panel does not support transparency");
             }
             else
             {

--- a/EDDiscovery/ScreenShots/ScreenShotConfigureForm.cs
+++ b/EDDiscovery/ScreenShots/ScreenShotConfigureForm.cs
@@ -93,7 +93,7 @@ namespace EDDiscovery.ScreenShots
             dlg.Description = "Select ED screenshot folder";
             dlg.SelectedPath = textBoxScreenshotsDir.Text;
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 initialssfolder = textBoxScreenshotsDir.Text = dlg.SelectedPath;
             }
@@ -106,7 +106,7 @@ namespace EDDiscovery.ScreenShots
             dlg.Description = "Select converted screenshot folder";
             dlg.SelectedPath = textBoxOutputDir.Text;
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 textBoxOutputDir.Text = dlg.SelectedPath;
             }
@@ -121,7 +121,7 @@ namespace EDDiscovery.ScreenShots
         {
             if (!Directory.Exists(textBoxScreenshotsDir.Text))
             {
-                ExtendedControls.MessageBoxTheme.Show("Folder specified does not exist");
+                ExtendedControls.MessageBoxTheme.Show(this, "Folder specified does not exist");
                 textBoxScreenshotsDir.Text = initialssfolder;
             }
             else
@@ -144,7 +144,7 @@ namespace EDDiscovery.ScreenShots
                 Close();
             }
             else
-                ExtendedControls.MessageBoxTheme.Show("Folder specified for scanning does not exist, correct or cancel");
+                ExtendedControls.MessageBoxTheme.Show(this, "Folder specified for scanning does not exist, correct or cancel");
         }
 
         private void buttonExtCancel_Click(object sender, EventArgs e)

--- a/EDDiscovery/UserControls/TargetClassHelpers.cs
+++ b/EDDiscovery/UserControls/TargetClassHelpers.cs
@@ -36,11 +36,13 @@ namespace EDDiscovery.UserControls
         }
         public static void setTargetSystem(Object sender, EDDiscoveryForm _discoveryForm, String sn, Boolean prompt)
         {
+            Form senderForm = ((Control)sender)?.FindForm() ?? _discoveryForm;
+
             if (string.IsNullOrWhiteSpace(sn))
             {
                 if (prompt && TargetClass.IsTargetSet())      // if prompting, and target is set, ask for delete
                 {
-                    if (ExtendedControls.MessageBoxTheme.Show("Confirm deletion of target", "Delete a target", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
+                    if (ExtendedControls.MessageBoxTheme.Show(senderForm, "Confirm deletion of target", "Delete a target", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
                     {
                         TargetClass.ClearTarget();
                         _discoveryForm.NewTargetSet(sender);          // tells everyone who cares a new target was set
@@ -74,7 +76,7 @@ namespace EDDiscovery.UserControls
                     else
                     {
                         bool createbookmark = false;
-                        if ((prompt && ExtendedControls.MessageBoxTheme.Show("Make a bookmark on " + sc.name + " and set as target?", "Make Bookmark", MessageBoxButtons.OKCancel) == DialogResult.OK) || !prompt)
+                        if ((prompt && ExtendedControls.MessageBoxTheme.Show(senderForm, "Make a bookmark on " + sc.name + " and set as target?", "Make Bookmark", MessageBoxButtons.OKCancel) == DialogResult.OK) || !prompt)
                         {
                             createbookmark = true;
                         }
@@ -115,13 +117,15 @@ namespace EDDiscovery.UserControls
             _discoveryForm.NewTargetSet(sender);          // tells everyone who cares a new target was set
 
             if (msgboxtext != null && prompt)
-                ExtendedControls.MessageBoxTheme.Show(msgboxtext, "Create a target", MessageBoxButtons.OK);
+                ExtendedControls.MessageBoxTheme.Show(senderForm, msgboxtext, "Create a target", MessageBoxButtons.OK);
 
         }
 
         public static void showBookmarkForm(Object sender,
             EDDiscoveryForm discoveryForm, ISystem cursystem, BookmarkClass curbookmark, bool notedsystem)
         {
+            Form senderForm = ((Control)sender)?.FindForm() ?? discoveryForm;
+
             // try and find the associated bookmark..
             BookmarkClass bkmark = (curbookmark != null) ? curbookmark : BookmarkClass.bookmarks.Find(x => x.StarName != null && x.StarName.Equals(cursystem.name));
 
@@ -137,7 +141,7 @@ namespace EDDiscovery.UserControls
 
                 frm.InitialisePos(cursystem.x, cursystem.y, cursystem.z);
                 frm.NotedSystem(cursystem.name, note, noteid == targetid);       // note may be passed in null
-                frm.ShowDialog();
+                frm.ShowDialog(senderForm);
 
                 if ((frm.IsTarget && targetid != noteid) || (!frm.IsTarget && targetid == noteid)) // changed..
                 {
@@ -168,7 +172,7 @@ namespace EDDiscovery.UserControls
                     frm.Update(regionmarker ? bkmark.Heading : bkmark.StarName, note, bkmark.Note, tme.ToString(), regionmarker, targetid == bkmark.id);
                 }
 
-                DialogResult res = frm.ShowDialog();
+                DialogResult res = frm.ShowDialog(senderForm);
 
                 if (res == DialogResult.OK)
                 {

--- a/EDDiscovery/UserControls/UserControlEDSM.cs
+++ b/EDDiscovery/UserControls/UserControlEDSM.cs
@@ -101,14 +101,14 @@ namespace EDDiscovery.UserControls
         {
             if ( dataGridViewEDSM.Rows.Count == 0)
             {
-                ExtendedControls.MessageBoxTheme.Show("No data to export", "Export EDSM", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "No data to export", "Export EDSM", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
 
             Forms.ExportForm frm = new Forms.ExportForm();
             frm.Init(new string[] { "Export Current View" }, disablestartendtime:true);
 
-            if (frm.ShowDialog(this) == DialogResult.OK)
+            if (frm.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 if (frm.SelectedIndex == 0)
                 {
@@ -148,7 +148,7 @@ namespace EDDiscovery.UserControls
                             System.Diagnostics.Process.Start(frm.Path);
                     }
                     else
-                        ExtendedControls.MessageBoxTheme.Show("Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                        ExtendedControls.MessageBoxTheme.Show(FindForm(), "Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 }
             }
         }
@@ -160,7 +160,7 @@ namespace EDDiscovery.UserControls
             double radius = textBoxRadius.Text.InvariantParseDouble(20);
             if ( radius > 100 )
             {
-                if (ExtendedControls.MessageBoxTheme.Show("This is a large radius, it make take a long time or not work, are you sure?", "Warning - Large radius", MessageBoxButtons.OKCancel, MessageBoxIcon.Asterisk) == DialogResult.Cancel)
+                if (ExtendedControls.MessageBoxTheme.Show(FindForm(), "This is a large radius, it make take a long time or not work, are you sure?", "Warning - Large radius", MessageBoxButtons.OKCancel, MessageBoxIcon.Asterisk) == DialogResult.Cancel)
                     return;
             }
 
@@ -277,7 +277,7 @@ namespace EDDiscovery.UserControls
             }
 
             if (!edsm.ShowSystemInEDSM(rightclicksystem.name, id_edsm))
-                ExtendedControls.MessageBoxTheme.Show("System could not be found - has not been synched or EDSM is unavailable");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
 
             this.Cursor = Cursors.Default;
         }

--- a/EDDiscovery/UserControls/UserControlExpedition.cs
+++ b/EDDiscovery/UserControls/UserControlExpedition.cs
@@ -296,7 +296,7 @@ namespace EDDiscovery.UserControls
             }
             else
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, "No route set up. Please add at least two systems.", "No Route", MessageBoxButtons.OK);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "No route set up. Please add at least two systems.", "No Route", MessageBoxButtons.OK);
                 return;
             }
         }
@@ -311,7 +311,7 @@ namespace EDDiscovery.UserControls
 
         private void toolStripButtonDelete_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show(ParentForm, "Are you sure you want to delete this route?", "Delete Route", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            if (ExtendedControls.MessageBoxTheme.Show(FindForm(), "Are you sure you want to delete this route?", "Delete Route", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
                 if (currentroute.Id >= 0)
                 {
@@ -342,7 +342,7 @@ namespace EDDiscovery.UserControls
             ofd.Filter = "Text Files|*.txt";
             ofd.Title = "Select a route file";
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (ofd.ShowDialog(FindForm()) != System.Windows.Forms.DialogResult.OK)
                 return;
             string[] sysnames;
 
@@ -352,7 +352,7 @@ namespace EDDiscovery.UserControls
             }
             catch (IOException)
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, $"There was an error reading {ofd.FileName}",
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), $"There was an error reading {ofd.FileName}",
                     "Import route", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
@@ -371,7 +371,7 @@ namespace EDDiscovery.UserControls
             }
             if (systems.Count == 0)
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, "The imported file contains no known system names",
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "The imported file contains no known system names",
                     "Import route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
@@ -390,7 +390,7 @@ namespace EDDiscovery.UserControls
         {
             if (latestplottedroute == null || latestplottedroute.Count == 0)
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, "Please create a route on a route panel", "Import from route panel");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "Please create a route on a route panel", "Import from route panel");
                 return;
             }
             else if (!PromptAndSaveIfNeeded())
@@ -416,7 +416,7 @@ namespace EDDiscovery.UserControls
             {
                 if (rt.Systems.Count < 1)
                 {
-                    ExtendedControls.MessageBoxTheme.Show(ParentForm, "There is no route to export ",
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "There is no route to export ",
                         "Export route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                     return;
                 }
@@ -436,7 +436,7 @@ namespace EDDiscovery.UserControls
                 }
                 dlg.FileName = fileName;
 
-                if (dlg.ShowDialog() != DialogResult.OK)
+                if (dlg.ShowDialog(FindForm()) != DialogResult.OK)
                     return;
                 filename = dlg.FileName;
                 using (StreamWriter writer = new StreamWriter(filename, false))
@@ -447,11 +447,11 @@ namespace EDDiscovery.UserControls
                             writer.WriteLine(sysname);
                     }
                 }
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, $"Export completed to {filename}", "Export route");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), $"Export completed to {filename}", "Export route");
             }
             catch (IOException)
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, $"Problem exporting route. Is file {filename} already open?",
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), $"Problem exporting route. Is file {filename} already open?",
                     "Export route", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
@@ -671,7 +671,7 @@ namespace EDDiscovery.UserControls
             ISystem sc = SystemClassDB.GetSystem((string)obj);
             if (sc == null)
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, "Unknown system, system is without co-ordinates", "Edit bookmark", MessageBoxButtons.OK);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "Unknown system, system is without co-ordinates", "Edit bookmark", MessageBoxButtons.OK);
             }
             else
                 TargetHelpers.showBookmarkForm(this, discoveryform, sc, null, false);
@@ -768,7 +768,7 @@ namespace EDDiscovery.UserControls
                 return true;
             else
             {
-                var result = ExtendedControls.MessageBoxTheme.Show(ParentForm, "There are unsaved changes to the current route." + Environment.NewLine
+                var result = ExtendedControls.MessageBoxTheme.Show(FindForm(), "There are unsaved changes to the current route." + Environment.NewLine
                     + "Would you like to save the current route before proceeding?", "Unsaved route", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Exclamation);
                 switch (result)
                 {
@@ -797,12 +797,12 @@ namespace EDDiscovery.UserControls
 
             if (string.IsNullOrEmpty(newrtname))
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, "Please specify a name for the route.", "Unsaved Route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "Please specify a name for the route.", "Unsaved Route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 textBoxRouteName.Select();
             }
             else if (EDSMClass.Expeditions.Any(r => r.Name.Equals(newrtname)))
             {
-                ExtendedControls.MessageBoxTheme.Show(ParentForm, "The current route name conflicts with a well-known expedition." + Environment.NewLine
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "The current route name conflicts with a well-known expedition." + Environment.NewLine
                     + "Please specify a new name to save your changes.", "Unsaved Route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 textBoxRouteName.Select();
                 textBoxRouteName.SelectAll();
@@ -812,7 +812,7 @@ namespace EDDiscovery.UserControls
                 var overwriteroute = savedroute.Where(r => r.Name.Equals(newrtname) && r.Id != currentroute.Id).FirstOrDefault();
                 if (overwriteroute != null)
                 {
-                    if (MessageBoxTheme.Show(ParentForm, "Warning: route already exists. Would you like to overwrite it?", "Route Exists", MessageBoxButtons.YesNo) != DialogResult.Yes)
+                    if (MessageBoxTheme.Show(FindForm(), "Warning: route already exists. Would you like to overwrite it?", "Route Exists", MessageBoxButtons.YesNo) != DialogResult.Yes)
                         return false;
 
                     overwriteroute.Delete();

--- a/EDDiscovery/UserControls/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.cs
@@ -304,7 +304,7 @@ namespace EDDiscovery.UserControls
                 dlg.AddExtension = true;
                 dlg.Filter = "Explore file| *.json";
 
-                if (dlg.ShowDialog() == DialogResult.OK)
+                if (dlg.ShowDialog(FindForm()) == DialogResult.OK)
                 {
                     textBoxFileName.Text = dlg.FileName;
                 }
@@ -330,7 +330,7 @@ namespace EDDiscovery.UserControls
             dlg.AddExtension = true;
             dlg.Filter = "Explore file| *.json";
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 textBoxFileName.Text = dlg.FileName;
                 _currentExplorationSet.Clear();
@@ -361,7 +361,7 @@ namespace EDDiscovery.UserControls
             dlg.Filter = "Explore file| *.json";
 
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 textBoxFileName.Text = dlg.FileName;
                 UpdateExplorationInfo(_currentExplorationSet);
@@ -611,7 +611,7 @@ namespace EDDiscovery.UserControls
 
         private void toolStripButtonDelete_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show(_discoveryForm, "Are you sure you want to delete this route?", "Delete Route", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            if (ExtendedControls.MessageBoxTheme.Show(FindForm(), "Are you sure you want to delete this route?", "Delete Route", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
                 if (DeleteIsPermanent)
                 {
@@ -637,7 +637,7 @@ namespace EDDiscovery.UserControls
             ofd.Filter = "Text Files|*.txt";
             ofd.Title = "Select a exploration set file";
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (ofd.ShowDialog(FindForm()) != System.Windows.Forms.DialogResult.OK)
                 return;
 
             ClearExplorationSet();
@@ -652,7 +652,7 @@ namespace EDDiscovery.UserControls
             }
             catch (IOException)
             {
-                ExtendedControls.MessageBoxTheme.Show(String.Format("There has been an error openning file {0}", ofd.FileName), "Import file",
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), $"There was a problem opening file {ofd.FileName}", "Import file",
                       MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
@@ -680,9 +680,9 @@ namespace EDDiscovery.UserControls
             }
             if (systems.Count == 0)
             {
-                ExtendedControls.MessageBoxTheme.Show(_discoveryForm,
-                String.Format("There are no known system names in the file import", countunknown),
-                "Unsaved", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(),
+                    "The imported file contains no known system names",
+                    "Unsaved", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
 
@@ -705,7 +705,7 @@ namespace EDDiscovery.UserControls
                 if (dataGridViewExplore.Rows.Count == 0
                     || (dataGridViewExplore.Rows.Count == 1 && dataGridViewExplore[0, 0].Value == null))
                 {
-                    ExtendedControls.MessageBoxTheme.Show(_discoveryForm,
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(),
                     "There is no route to export ", "Export route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                     return;
                 }
@@ -725,7 +725,7 @@ namespace EDDiscovery.UserControls
                 }
                 dlg.FileName = fileName;
 
-                if (dlg.ShowDialog() != DialogResult.OK)
+                if (dlg.ShowDialog(FindForm()) != DialogResult.OK)
                     return;
                 filename = dlg.FileName;
                 using (StreamWriter writer = new StreamWriter(filename, false))
@@ -737,11 +737,11 @@ namespace EDDiscovery.UserControls
                             writer.WriteLine(sysname);
                     }
                 }
-                ExtendedControls.MessageBoxTheme.Show(String.Format("Export complete {0}", filename), "Export route");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), $"Export complete to {filename}", "Export route");
             }
             catch (IOException)
             {
-                ExtendedControls.MessageBoxTheme.Show(String.Format("Is file {0} open?", filename), "Export route",
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), $"Error exporting route. Is file {filename} open?", "Export route",
                       MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
@@ -773,7 +773,7 @@ namespace EDDiscovery.UserControls
             ISystem sc = SystemClassDB.GetSystem((string)obj);
             if (sc == null)
             {
-                ExtendedControls.MessageBoxTheme.Show("Unknown system, system is without co-ordinates", "Edit bookmark", MessageBoxButtons.OK);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "Unknown system, system is without co-ordinates", "Edit bookmark", MessageBoxButtons.OK);
             }
             else
                 TargetHelpers.showBookmarkForm(this,_discoveryForm, sc, null, false);
@@ -788,16 +788,16 @@ namespace EDDiscovery.UserControls
         {
             string systemName;
             double radius;
-            if (!ImportSphere.showDialog(_discoveryForm, out systemName, out radius, this.FindForm()))
+            if (!ImportSphere.showDialog(_discoveryForm, out systemName, out radius, FindForm()))
                 return;
             if (String.IsNullOrWhiteSpace(systemName))
             {
-                ExtendedControls.MessageBoxTheme.Show("System name not set");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System name not set");
                 return;
             }
 
             if (radius < 0 || radius > 1000.0) { 
-                ExtendedControls.MessageBoxTheme.Show("Radius should be a number 0.0 and 1000.0");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "Radius should be a number 0.0 and 1000.0");
                 return;
             }
 
@@ -832,9 +832,8 @@ namespace EDDiscovery.UserControls
             }
             if (systems.Count == 0)
             {
-                ExtendedControls.MessageBoxTheme.Show(_discoveryForm,
-                String.Format("There are no known system names in the import", countunknown),
-                "Unsaved", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "The imported file contains no known system names",
+                    "Unsaved", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
 

--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -284,7 +284,6 @@ namespace EDDiscovery.UserControls
                             JournalEntry.GetListOfEventsWithOptMethod(false) ,
                             (s) => { return BaseUtils.FieldNames.GetPropertyFieldNames(JournalEntry.TypeOfJournalEntry(s)); },
                             discoveryform.Globals.NameList, fieldfilter);
-            frm.TopMost = this.FindForm().TopMost;
             if (frm.ShowDialog(this.FindForm()) == DialogResult.OK)
             {
                 fieldfilter = frm.result;
@@ -369,7 +368,7 @@ namespace EDDiscovery.UserControls
             }
 
             if (!edsm.ShowSystemInEDSM(rightclicksystem.System.name, id_edsm))
-                ExtendedControls.MessageBoxTheme.Show("System could not be found - has not been synched or EDSM is unavailable");
+                ExtendedControls.MessageBoxTheme.Show(this.FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
 
             this.Cursor = Cursors.Default;
         }
@@ -452,7 +451,7 @@ namespace EDDiscovery.UserControls
             Forms.ExportForm frm = new Forms.ExportForm();
             frm.Init(new string[] { "Export Current View" });
 
-            if (frm.ShowDialog(this) == DialogResult.OK)
+            if (frm.ShowDialog(this.FindForm()) == DialogResult.OK)
             {
                 if (frm.SelectedIndex == 0)
                 {
@@ -489,7 +488,7 @@ namespace EDDiscovery.UserControls
                             System.Diagnostics.Process.Start(frm.Path);
                     }
                     else
-                        ExtendedControls.MessageBoxTheme.Show("Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                        ExtendedControls.MessageBoxTheme.Show(this.FindForm(), "Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 }
             }
         }

--- a/EDDiscovery/UserControls/UserControlModules.cs
+++ b/EDDiscovery/UserControls/UserControlModules.cs
@@ -249,7 +249,7 @@ namespace EDDiscovery.UserControls
                 string s = si.ToJSON(out errstr);
 
                 if (errstr.Length > 0)
-                    ExtendedControls.MessageBoxTheme.Show(this, errstr + Environment.NewLine + "This is probably a new or powerplay module" + Environment.NewLine + "Report to EDD Team by Github giving the full text above", "Unknown Module Type");
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), errstr + Environment.NewLine + "This is probably a new or powerplay module" + Environment.NewLine + "Report to EDD Team by Github giving the full text above", "Unknown Module Type");
 
                 string uri = null;
 
@@ -281,7 +281,7 @@ namespace EDDiscovery.UserControls
                                 }
                                 catch (Exception ex)
                                 {
-                                    ExtendedControls.MessageBoxTheme.Show(this, "Unable to launch browser" + ex.Message, "Browser Launch Error");
+                                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "Unable to launch browser" + ex.Message, "Browser Launch Error");
                                 }
                             }
                         }
@@ -292,7 +292,7 @@ namespace EDDiscovery.UserControls
                 ExtendedControls.InfoForm info = new ExtendedControls.InfoForm();
                 info.Info("Cannot launch browser, use this JSON for manual Coriolis import", Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location), 
                                 s, new Font("MS Sans Serif", 10), new int[] { 0, 100 });
-                info.ShowDialog(this);
+                info.ShowDialog(FindForm());
             }
         }
 

--- a/EDDiscovery/UserControls/UserControlRoute.cs
+++ b/EDDiscovery/UserControls/UserControlRoute.cs
@@ -244,7 +244,7 @@ namespace EDDiscovery.UserControls
 
             if (plotter.possiblejumps > 100)
             {
-                DialogResult res = ExtendedControls.MessageBoxTheme.Show(this, "This will result in a large number (" + plotter.possiblejumps.ToString("0") + ") of jumps" + Environment.NewLine + Environment.NewLine + "Confirm please", "Confirm you want to compute", MessageBoxButtons.YesNo);
+                DialogResult res = ExtendedControls.MessageBoxTheme.Show(FindForm(), "This will result in a large number (" + plotter.possiblejumps.ToString("0") + ") of jumps" + Environment.NewLine + Environment.NewLine + "Confirm please", "Confirm you want to compute", MessageBoxButtons.YesNo);
                 if (res != System.Windows.Forms.DialogResult.Yes)
                 {
                     ToggleButtons(true);
@@ -275,7 +275,7 @@ namespace EDDiscovery.UserControls
             }
             else
             {
-                ExtendedControls.MessageBoxTheme.Show("No route set up, retry", "No Route", MessageBoxButtons.OK);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "No route set up, retry", "No Route", MessageBoxButtons.OK);
                 return;
             }
         }
@@ -448,7 +448,7 @@ namespace EDDiscovery.UserControls
             if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                 Process.Start(url);
             else
-                ExtendedControls.MessageBoxTheme.Show("System unknown to EDSM");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System unknown to EDSM");
         }
 
 
@@ -610,7 +610,7 @@ namespace EDDiscovery.UserControls
             if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                 Process.Start(url);
             else
-                ExtendedControls.MessageBoxTheme.Show("System unknown to EDSM");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System unknown to EDSM");
 
         }
 
@@ -622,14 +622,14 @@ namespace EDDiscovery.UserControls
         {
             if ( dataGridViewRoute.Rows.Count == 0)
             {
-                ExtendedControls.MessageBoxTheme.Show("No Route Plotted", "Route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "No Route Plotted", "Route", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
 
             Forms.ExportForm frm = new Forms.ExportForm();
             frm.Init(new string[] { "All" }, disablestartendtime: true);
 
-            if (frm.ShowDialog(this) == DialogResult.OK)
+            if (frm.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 BaseUtils.CSVWriteGrid grd = new BaseUtils.CSVWriteGrid();
                 grd.SetCSVDelimiter(frm.Comma);
@@ -663,7 +663,7 @@ namespace EDDiscovery.UserControls
                         System.Diagnostics.Process.Start(frm.Path);
                 }
                 else
-                    ExtendedControls.MessageBoxTheme.Show("Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
         }
 
@@ -717,7 +717,7 @@ namespace EDDiscovery.UserControls
                 }
 
                 if (!edsm.ShowSystemInEDSM(sys.name, id_edsm))
-                    ExtendedControls.MessageBoxTheme.Show("System could not be found - has not been synched or EDSM is unavailable");
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
 
                 this.Cursor = Cursors.Default;
             }

--- a/EDDiscovery/UserControls/UserControlRouteTracker.cs
+++ b/EDDiscovery/UserControls/UserControlRouteTracker.cs
@@ -151,7 +151,7 @@ namespace EDDiscovery.UserControls
         {
             SavedRouteClass selectedRoute;
 
-            if (Prompt.ShowDialog(discoveryform, SavedRouteClass.GetAllSavedRoutes().Where(r => !r.Name.StartsWith("\x7F")).OrderBy(r => r.Name).ToList(),
+            if (Prompt.ShowDialog(FindForm(), SavedRouteClass.GetAllSavedRoutes().Where(r => !r.Name.StartsWith("\x7F")).OrderBy(r => r.Name).ToList(),
                 _currentRoute?.Name ?? string.Empty, "Select route", out selectedRoute))
             {
                 if (selectedRoute == null)

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -819,7 +819,7 @@ namespace EDDiscovery.UserControls
                                     "Sold Exploration Data", // 5
                                         });
 
-            if (frm.ShowDialog(this) == DialogResult.OK)
+            if (frm.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 BaseUtils.CSVWrite csv = new BaseUtils.CSVWrite();
                 csv.SetCSVDelimiter(frm.Comma);
@@ -897,7 +897,7 @@ namespace EDDiscovery.UserControls
 
                                 scans = new List<JournalScan>();
 
-                                if (dlg.ShowDialog() == DialogResult.OK)
+                                if (dlg.ShowDialog(FindForm()) == DialogResult.OK)
                                 {
 
                                     ExplorationSetClass _currentExplorationSet = new ExplorationSetClass();
@@ -1114,7 +1114,7 @@ namespace EDDiscovery.UserControls
                 }
                 catch
                 {
-                    ExtendedControls.MessageBoxTheme.Show("Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 }
             }
         }

--- a/EDDiscovery/UserControls/UserControlShoppingList.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.cs
@@ -193,7 +193,7 @@ namespace EDDiscovery.UserControls
                 if (IsTransparent)
                 {
                     RevertToNormalSize();
-                    int minWidth = Math.Max(((UserControlForm)this.ParentForm).TitleBarMinWidth(), displayList.img.Width) + 8;
+                    int minWidth = Math.Max(((UserControlForm)FindForm()).TitleBarMinWidth(), displayList.img.Width) + 8;
                     RequestTemporaryResize(new Size(minWidth, displayList.img.Height + 4));
                 }
                 else

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -564,7 +564,7 @@ namespace EDDiscovery.UserControls
                     if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                         System.Diagnostics.Process.Start(url);
                     else
-                        ExtendedControls.MessageBoxTheme.Show("System " + he.System.name + " unknown to EDSM");
+                        ExtendedControls.MessageBoxTheme.Show(FindForm(), "System " + he.System.name + " unknown to EDSM");
                 }
             }
         }
@@ -934,7 +934,6 @@ namespace EDDiscovery.UserControls
                             JournalEntry.GetListOfEventsWithOptMethod(false) ,
                             (s) => { return BaseUtils.FieldNames.GetPropertyFieldNames(JournalEntry.TypeOfJournalEntry(s)); },
                             discoveryform.Globals.NameList, fieldfilter);
-            frm.TopMost = this.FindForm().TopMost;
             if (frm.ShowDialog(this.FindForm()) == DialogResult.OK)
             {
                 fieldfilter = frm.result;

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -172,7 +172,7 @@ namespace EDDiscovery.UserControls
 
             if (!edsm.ShowSystemInEDSM(rightclicksystem.name, id_edsm))
             {
-                ExtendedControls.MessageBoxTheme.Show("System could not be found - has not been synched or EDSM is unavailable");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
             }
 
             this.Cursor = Cursors.Default;

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -536,7 +536,7 @@ namespace EDDiscovery.UserControls
             }
 
             if (!edsm.ShowSystemInEDSM(rightclicksystem.System.name, id_edsm))
-                ExtendedControls.MessageBoxTheme.Show("System could not be found - has not been synched or EDSM is unavailable");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
 
             this.Cursor = Cursors.Default;
         }
@@ -547,7 +547,7 @@ namespace EDDiscovery.UserControls
             {
                 using (Forms.SetNoteForm noteform = new Forms.SetNoteForm(rightclicksystem, discoveryform))
                 {
-                    if (noteform.ShowDialog(this) == DialogResult.OK)
+                    if (noteform.ShowDialog(FindForm()) == DialogResult.OK)
                     {
                         rightclicksystem.SetJournalSystemNoteText(noteform.NoteText, true, EDCommander.Current.SyncToEdsm);
 
@@ -566,7 +566,7 @@ namespace EDDiscovery.UserControls
             Forms.ExportForm frm = new Forms.ExportForm();
             frm.Init(new string[] { "Export Current View" });
 
-            if (frm.ShowDialog(this) == DialogResult.OK)
+            if (frm.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 if (frm.SelectedIndex == 0)
                 {
@@ -630,7 +630,7 @@ namespace EDDiscovery.UserControls
                             System.Diagnostics.Process.Start(frm.Path);
                     }
                     else
-                        ExtendedControls.MessageBoxTheme.Show("Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                        ExtendedControls.MessageBoxTheme.Show(FindForm(), "Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 
                 }
             }

--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -288,7 +288,7 @@ namespace EDDiscovery.UserControls
                         if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                             Process.Start(url);
                         else
-                            ExtendedControls.MessageBoxTheme.Show("System unknown to EDSM");
+                            ExtendedControls.MessageBoxTheme.Show(FindForm(), "System unknown to EDSM");
                     }
                 }
             }
@@ -337,7 +337,7 @@ namespace EDDiscovery.UserControls
             if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                 Process.Start(url);
             else
-                ExtendedControls.MessageBoxTheme.Show("System unknown to EDSM");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System unknown to EDSM");
 
         }
 

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -595,7 +595,7 @@ namespace EDDiscovery.UserControls
             HistoryEntry sp2 = (HistoryEntry)selectedRows.First().Cells[TravelHistoryColumns.HistoryTag].Tag;
             mapColorDialog.Color = Color.FromArgb(sp2.MapColour);
 
-            if (mapColorDialog.ShowDialog(this) == DialogResult.OK)
+            if (mapColorDialog.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 this.Cursor = Cursors.WaitCursor;
 
@@ -665,7 +665,7 @@ namespace EDDiscovery.UserControls
 
             movefrm.Init();
 
-            DialogResult red = movefrm.ShowDialog(this);
+            DialogResult red = movefrm.ShowDialog(FindForm());
             if (red == DialogResult.OK)
             {
                 foreach (HistoryEntry sp in listsyspos)
@@ -755,7 +755,7 @@ namespace EDDiscovery.UserControls
             }
 
             if (!edsm.ShowSystemInEDSM(rightclicksystem.System.name, id_edsm))
-                ExtendedControls.MessageBoxTheme.Show("System could not be found - has not been synched or EDSM is unavailable");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
 
             this.Cursor = Cursors.Default;
         }
@@ -810,13 +810,13 @@ namespace EDDiscovery.UserControls
 
             if (journalent == null)
             {
-                ExtendedControls.MessageBoxTheme.Show("Could not find Location or FSDJump entry associated with selected journal entry");
+                ExtendedControls.MessageBoxTheme.Show(FindForm(), "Could not find Location or FSDJump entry associated with selected journal entry");
                 return;
             }
 
             using (Forms.AssignTravelLogSystemForm form = new Forms.AssignTravelLogSystemForm(journalent))
             {
-                DialogResult result = form.ShowDialog();
+                DialogResult result = form.ShowDialog(FindForm());
                 if (result == DialogResult.OK)
                 {
                     foreach (var jent in jents)
@@ -841,7 +841,7 @@ namespace EDDiscovery.UserControls
 
         private void removeJournalEntryToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (ExtendedControls.MessageBoxTheme.Show("Confirm you wish to remove this entry" + Environment.NewLine + "It may reappear if the logs are rescanned", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
+            if (ExtendedControls.MessageBoxTheme.Show(FindForm(), "Confirm you wish to remove this entry" + Environment.NewLine + "It may reappear if the logs are rescanned", "WARNING", MessageBoxButtons.OKCancel) == DialogResult.OK)
             {
                 JournalEntry.Delete(rightclicksystem.Journalid);
                 discoveryform.RefreshHistoryAsync();
@@ -868,7 +868,7 @@ namespace EDDiscovery.UserControls
             {
                 using (Forms.SetNoteForm noteform = new Forms.SetNoteForm(rightclicksystem, discoveryform))
                 {
-                    if (noteform.ShowDialog(this) == DialogResult.OK)
+                    if (noteform.ShowDialog(FindForm()) == DialogResult.OK)
                     {
                         rightclicksystem.SetJournalSystemNoteText(noteform.NoteText, true , EDCommander.Current.SyncToEdsm);
 
@@ -924,7 +924,6 @@ namespace EDDiscovery.UserControls
                             JournalEntry.GetListOfEventsWithOptMethod(false),
                             (s) => { return BaseUtils.FieldNames.GetPropertyFieldNames(JournalEntry.TypeOfJournalEntry(s)); },
                             discoveryform.Globals.NameList, fieldfilter);
-            frm.TopMost = this.FindForm().TopMost;
             if (frm.ShowDialog(this.FindForm()) == DialogResult.OK)
             {
                 fieldfilter = frm.result;
@@ -942,7 +941,7 @@ namespace EDDiscovery.UserControls
             Forms.ExportForm frm = new Forms.ExportForm();
             frm.Init(new string[] { "View", "FSD Jumps only", "With Notes only" , "With Notes, no repeat"  });
 
-            if (frm.ShowDialog(this) == DialogResult.OK)
+            if (frm.ShowDialog(FindForm()) == DialogResult.OK)
             {
                 BaseUtils.CSVWriteGrid grd = new BaseUtils.CSVWriteGrid();
                 grd.SetCSVDelimiter(frm.Comma);
@@ -1060,7 +1059,7 @@ namespace EDDiscovery.UserControls
                         System.Diagnostics.Process.Start(frm.Path);
                 }
                 else
-                    ExtendedControls.MessageBoxTheme.Show("Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "Failed to write to " + frm.Path, "Export Failed", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
 
         }

--- a/EDDiscovery/UserControls/UserControlTrilateration.cs
+++ b/EDDiscovery/UserControls/UserControlTrilateration.cs
@@ -378,7 +378,7 @@ namespace EDDiscovery.UserControls
 
         private bool Query(string msg)
         {
-            return MessageBoxTheme.Show(this, msg, "Trilateration Panel", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes;
+            return MessageBoxTheme.Show(FindForm(), msg, "Trilateration Panel", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes;
         }
 
         private void toolStripButtonSubmitDistances_Click(object sender, EventArgs e)
@@ -625,7 +625,7 @@ namespace EDDiscovery.UserControls
                     {
                         this.BeginInvoke(new MethodInvoker(() =>
                         {
-                            ExtendedControls.MessageBoxTheme.Show("Please enter commander name before submitting the system!");
+                            ExtendedControls.MessageBoxTheme.Show(FindForm(), "Please enter commander name before submitting the system!");
                             UnfreezeTrilaterationUI();
                         }));
                         return;

--- a/EDDiscovery/UserControls/UserControlTrippanel.cs
+++ b/EDDiscovery/UserControls/UserControlTrippanel.cs
@@ -284,7 +284,7 @@ namespace EDDiscovery.UserControls
                     if (url.Length > 0)         // may pass back empty string if not known, this solves another exception
                         System.Diagnostics.Process.Start(url);
                     else
-                        ExtendedControls.MessageBoxTheme.Show("System " + he.System.name + " unknown to EDSM");
+                        ExtendedControls.MessageBoxTheme.Show(FindForm(), "System " + he.System.name + " unknown to EDSM");
                 }
                 else
                 {

--- a/EliteDangerous/DB/SQLiteConnectionUser.cs
+++ b/EliteDangerous/DB/SQLiteConnectionUser.cs
@@ -134,8 +134,7 @@ namespace EliteDangerousCore.DB
             }
             catch (Exception ex)
             {
-                ExtendedControls.MessageBoxTheme.Show("UpgradeUserDB error: " + ex.Message);
-                ExtendedControls.MessageBoxTheme.Show(ex.StackTrace);
+                ExtendedControls.MessageBoxTheme.Show("UpgradeUserDB error: " + ex.Message + Environment.NewLine + ex.StackTrace);
                 return false;
             }
         }

--- a/ExtendedControls/Controls/AutoCompleteTextBox.cs
+++ b/ExtendedControls/Controls/AutoCompleteTextBox.cs
@@ -190,13 +190,7 @@ namespace ExtendedControls
                     _cbdropdown.Activated += _cbdropdown_DropDown;
                     _cbdropdown.SelectedIndexChanged += _cbdropdown_SelectedIndexChanged;
 
-                    Control parent = this.Parent;
-                    while (parent != null && !(parent is Form))
-                    {
-                        parent = parent.Parent;
-                    }
-
-                    _cbdropdown.Show(parent);
+                    _cbdropdown.Show(FindForm());
                     Focus();                // Major change.. we now keep the focus at all times
                 }
                 else

--- a/ExtendedControls/Controls/ComboBoxCustom.cs
+++ b/ExtendedControls/Controls/ComboBoxCustom.cs
@@ -488,13 +488,7 @@ namespace ExtendedControls
             _customdropdown.OtherKeyPressed += _customdropdown_OtherKeyPressed;
             _customdropdown.Deactivate += _customdropdown_Deactivate;
 
-            Control parent = this.Parent;
-            while (parent != null && !(parent is Form))
-            {
-                parent = parent.Parent;
-            }
-
-            _customdropdown.Show(parent);
+            _customdropdown.Show(FindForm());
              
             // enforce size.. some reason SHow is scaling it probably due to autosizing.. can't turn off. force back
             _customdropdown.Size = new Size(this.DropDownWidth > 9 ? this.DropDownWidth : this.Width, fittableitems * this.ItemHeight + 4);

--- a/ExtendedControls/Controls/PanelSelectionList.cs
+++ b/ExtendedControls/Controls/PanelSelectionList.cs
@@ -97,7 +97,7 @@ namespace ExtendedControls
                         fittableitems = this.Items.Count();
 
                     ddc.Size = new Size(this.DropDownWidth > 9 ? this.DropDownWidth : this.Width, fittableitems * this.ItemHeight + 4);
-                    ddc.Show();
+                    ddc.Show(FindForm());
                 }
                 else
                 {

--- a/ExtendedControls/Forms/KeyForm.cs
+++ b/ExtendedControls/Forms/KeyForm.cs
@@ -293,16 +293,16 @@ namespace ExtendedControls
             if (target.HasChars())
             {
                 if (target == BaseUtils.EnhancedSendKeys.CurrentWindow)
-                    MessageBoxTheme.Show("Name a process to test sending keys");
+                    MessageBoxTheme.Show(this, "Name a process to test sending keys");
                 else
                 {
                     string err = BaseUtils.EnhancedSendKeys.Send(textBoxKeys.Text, DefaultDelay, 2 , 2, textBoxSendTo.Text);
                     if (err.Length > 0)
-                        MessageBoxTheme.Show("Error " + err + " - check entry");
+                        MessageBoxTheme.Show(this, "Error " + err + " - check entry");
                 }
             }
             else
-                MessageBoxTheme.Show("No process names to send keys to");
+                MessageBoxTheme.Show(this, "No process names to send keys to");
         }
 
         private void textBox_Enter(object sender, EventArgs e)

--- a/ExtendedControls/Forms/MessageBoxTheme.Designer.cs
+++ b/ExtendedControls/Forms/MessageBoxTheme.Designer.cs
@@ -76,7 +76,7 @@
             this.buttonExt3.TabIndex = 4;
             this.buttonExt3.Text = "Retry";
             this.buttonExt3.UseVisualStyleBackColor = true;
-            this.buttonExt3.Click += new System.EventHandler(this.buttonExt3_Click);
+            this.buttonExt3.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button_MouseClick);
             // 
             // buttonExt1
             // 
@@ -90,7 +90,7 @@
             this.buttonExt1.TabIndex = 2;
             this.buttonExt1.Text = "OK";
             this.buttonExt1.UseVisualStyleBackColor = true;
-            this.buttonExt1.Click += new System.EventHandler(this.buttonExt1_Click);
+            this.buttonExt1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button_MouseClick);
             // 
             // buttonExt2
             // 
@@ -104,7 +104,7 @@
             this.buttonExt2.TabIndex = 3;
             this.buttonExt2.Text = "Cancel";
             this.buttonExt2.UseVisualStyleBackColor = true;
-            this.buttonExt2.Click += new System.EventHandler(this.buttonExt2_Click);
+            this.buttonExt2.MouseClick += new System.Windows.Forms.MouseEventHandler(this.button_MouseClick);
             // 
             // MessageBoxTheme
             // 
@@ -116,7 +116,6 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "MessageBox";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MessageBoxTheme_FormClosed);
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.ResumeLayout(false);

--- a/ExtendedControls/Forms/MessageBoxTheme.cs
+++ b/ExtendedControls/Forms/MessageBoxTheme.cs
@@ -75,40 +75,40 @@ namespace ExtendedControls
                     buttonExt1.Visible = buttonExt2.Visible = buttonExt3.Visible = false;
                     break;
                 case MessageBoxButtons.AbortRetryIgnore:
-                    buttonExt1.DialogResult = DialogResult.Ignore; buttonExt1.Text = "&Ignore";
-                    buttonExt2.DialogResult = DialogResult.Retry; buttonExt2.Text = "&Retry";
-                    buttonExt3.DialogResult = DialogResult.Abort; buttonExt3.Text = "&Abort";
+                    buttonExt1.DialogResult = DialogResult.Ignore; buttonExt1.Text = "Ignore";
+                    buttonExt2.DialogResult = DialogResult.Retry; buttonExt2.Text = "Retry";
+                    buttonExt3.DialogResult = DialogResult.Abort; buttonExt3.Text = "Abort";
                     this.AcceptButton = buttonExt2;
                     this.CancelButton = buttonExt3;
                     break;
                 case MessageBoxButtons.OKCancel:
-                    buttonExt1.DialogResult = DialogResult.Cancel; buttonExt1.Text = "&Cancel";
-                    buttonExt2.DialogResult = DialogResult.OK; buttonExt2.Text = "&OK";
+                    buttonExt1.DialogResult = DialogResult.Cancel; buttonExt1.Text = "Cancel";
+                    buttonExt2.DialogResult = DialogResult.OK; buttonExt2.Text = "OK";
                     buttonExt3.Visible = false;
                     this.AcceptButton = buttonExt2;
                     this.CancelButton = buttonExt1;
                     break;
                 case MessageBoxButtons.RetryCancel:
-                    buttonExt1.DialogResult = DialogResult.Cancel; buttonExt1.Text = "&Cancel";
-                    buttonExt2.DialogResult = DialogResult.OK; buttonExt2.Text = "&Retry";
+                    buttonExt1.DialogResult = DialogResult.Cancel; buttonExt1.Text = "Cancel";
+                    buttonExt2.DialogResult = DialogResult.OK; buttonExt2.Text = "Retry";
                     buttonExt3.Visible = false;
                     this.AcceptButton = buttonExt2;
                     this.CancelButton = buttonExt1;
                     break;
                 case MessageBoxButtons.YesNo:
-                    buttonExt1.DialogResult = DialogResult.No; buttonExt1.Text = "&No";
-                    buttonExt2.DialogResult = DialogResult.Yes; buttonExt2.Text = "&Yes";
+                    buttonExt1.DialogResult = DialogResult.No; buttonExt1.Text = "No";
+                    buttonExt2.DialogResult = DialogResult.Yes; buttonExt2.Text = "Yes";
                     buttonExt3.Visible = false;
                     break;
                 case MessageBoxButtons.YesNoCancel:
-                    buttonExt1.DialogResult = DialogResult.Cancel; buttonExt1.Text = "&Cancel";
-                    buttonExt2.DialogResult = DialogResult.No; buttonExt2.Text = "&No";
-                    buttonExt3.DialogResult = DialogResult.Yes; buttonExt3.Text = "&Yes";
+                    buttonExt1.DialogResult = DialogResult.Cancel; buttonExt1.Text = "Cancel";
+                    buttonExt2.DialogResult = DialogResult.No; buttonExt2.Text = "No";
+                    buttonExt3.DialogResult = DialogResult.Yes; buttonExt3.Text = "Yes";
                     this.AcceptButton = this.CancelButton = buttonExt1;
                     break;
                 case MessageBoxButtons.OK:
                 default:
-                    buttonExt1.DialogResult = DialogResult.OK; buttonExt1.Text = "&OK";
+                    buttonExt1.DialogResult = DialogResult.OK; buttonExt1.Text = "OK";
                     buttonExt2.Visible = false;
                     buttonExt3.Visible = false;
                     this.AcceptButton = this.CancelButton = buttonExt1;

--- a/ExtendedControls/Themes/ThemeStandardEditor.cs
+++ b/ExtendedControls/Themes/ThemeStandardEditor.cs
@@ -175,7 +175,7 @@ namespace ExtendedControls
             MyDialog.FullOpen = true;
             MyDialog.Color = theme.currentsettings.colors[ex];
 
-            if (MyDialog.ShowDialog() == DialogResult.OK)
+            if (MyDialog.ShowDialog(this) == DialogResult.OK)
             {
                 theme.currentsettings.colors[ex] = MyDialog.Color;
                 theme.SetCustom();
@@ -197,7 +197,7 @@ namespace ExtendedControls
             fd.MinSize = 4;
             fd.MaxSize = 12;
 
-            if (fd.ShowDialog() == DialogResult.OK)
+            if (fd.ShowDialog(this) == DialogResult.OK)
             {
                 if (fd.Font.Style == FontStyle.Regular)
                 {
@@ -207,7 +207,7 @@ namespace ExtendedControls
                     ApplyChanges?.Invoke();
                 }
                 else
-                    ExtendedControls.MessageBoxTheme.Show("Font does not have regular style");
+                    ExtendedControls.MessageBoxTheme.Show(this, "Font does not have regular style");
             }
 
         }


### PR DESCRIPTION
* Essentially, this change replaces every `Form.ShowDialog();` call with `Form.ShowDialog(otherForm);`.
* Add `TopMostChanged` event paradigm to `SmartSysMenuForm`.
  * `((Form)SmartSysMenuForm).TopMost = ...;` will bypass event dispatching
* A few un-parented `Form.Show()` classes were hooked in to this `TopMostChanged` paradigm.
  * `EDDiscoveryForm`->3dMap and `UserControlSettings`->ThemeEditor
* Fix the various places where we are using a `Control` instead of a `Form` for parenting.
* And fix the usage of `ParentForm` when `FindForm()` is hardened for this purpose.
* Re-write `MessageBoxTheme`:
  * Avoid focus stealing and z-order chaos caused by an out-of-place `CreateGraphics()` call.
  * *Should* even be safe for use from a background thread? (I have not tried this.)
  * Improve icon quality by converting to bitmap before scaling:
![beforeandafter](https://user-images.githubusercontent.com/14035789/31857923-48a45c84-b6b0-11e7-953c-5d3a2daca9db.png)
* Update `UserControlSettings.checkBoxKeepOnTop.Checked` when `TopMost` gets externally changed.