### PR TITLE
Expedition Enhancements

### DIFF
--- a/EliteDangerous/DB/SavedRouteClass.cs
+++ b/EliteDangerous/DB/SavedRouteClass.cs
@@ -16,11 +16,13 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Data.Common;
+using System.Diagnostics;
+using System.Linq;
 
 namespace EliteDangerousCore.DB
 {
+    [DebuggerDisplay("{DebugDisplay,nq}")]
     public class SavedRouteClass : IEquatable<SavedRouteClass>
     {
         public SavedRouteClass()
@@ -63,8 +65,7 @@ namespace EliteDangerousCore.DB
             return (this.Name == other.Name || (String.IsNullOrEmpty(this.Name) && String.IsNullOrEmpty(other.Name))) &&
                    this.StartDate == other.StartDate &&
                    this.EndDate == other.EndDate &&
-                   this.Systems.Count == other.Systems.Count &&
-                   this.Systems.Zip(other.Systems, (t, o) => t == o).All(v => v);
+                   this.Systems.SequenceEqual(other.Systems);
         }
 
         public override bool Equals(object obj)
@@ -232,6 +233,15 @@ namespace EliteDangerousCore.DB
             }
 
             return retVal;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected virtual string DebugDisplay
+        {
+            get
+            {
+                return $"\"{(Name ?? "(null)")}\" [{Id:n0}]: " + ((Systems == null || Systems.Count == 0) ? "no systems" : ((Systems?.Count == 1) ? "1 system" : (Systems.Count.ToString("n0") + " systems")));
+            }
         }
     }
 }

--- a/EliteDangerous/EDSM/Expeditions.cs
+++ b/EliteDangerous/EDSM/Expeditions.cs
@@ -28,7 +28,7 @@ namespace EliteDangerousCore.EDSM
             {
                 // ReadMe:
                 //      When logged into EDSM, start and end dates will be localized. Either set EDSM to use UTC or go incognito.
-                //      For TBD entries: duplicate the prior system.
+                //      For TBD entries: duplicate the prior system, and mark with a "TBD" comment for searching.
                 //      Be extremely careful when changing any route names.
                 return new SavedRouteClass[] {
                     #region 01: Distant Worlds (3302)
@@ -507,7 +507,7 @@ namespace EliteDangerousCore.EDSM
                         "Dryae Greau AA-A h19",
                         "Juenoe EG-Y g1913",
                         "Agnairt LN-T e3-3751",
-                        "Eol Prou LW-L c8-76"
+                        "Ratraii"
                     )
                     {
                         StartDate = new DateTime(2017, 3, 5, 20, 0, 0, DateTimeKind.Utc).ToLocalTime(),
@@ -781,7 +781,7 @@ namespace EliteDangerousCore.EDSM
                         "Stuemiae BB-O e6-61",
                         "Hypua Flyoae WU-X e1-4448",
                         "Dryooe Prou HH-C d1536",
-                        "Eol Prou LW-L c8-211"
+                        "Centralis"
                     )
                     {
                         StartDate = new DateTime(2018, 1, 20, 12, 0, 0, DateTimeKind.Utc).ToLocalTime(),
@@ -826,26 +826,89 @@ namespace EliteDangerousCore.EDSM
                     new SavedRouteClass(
                         "Minerva Centaurus Expedition",
                         "HIP 72043",
-                        "Nyeakio WU-S c6-7",
+                        "HIP 72043",                    // TBD
                         "Prooe Phio PZ-Z c0",
-                        "Droeth IM-W d1-164",
-                        "Phrooe Flyuae QE-Y d1-44",
-                        "Oob Chrea UY-L b35-7",
+                        "Droeth FS-K c8-36",
+                        "Phrooe Flyuae QE-Y d1-4",
+                        "Oob Chrea CV-U b30-3",
                         "Kyloopeia BA-W b4-1",
                         "Byeethiae FL-Y a0",
                         "Preou Free AA-A h0",
                         "Byooe Aoscs FG-Y g3",
-                        "Throefuae DL-Y g7",
-                        "Plio Broae AW-E b11-0",
-                        "Byeia Aoscs TD-K d8-17",
-                        "Bleethai DL-Y g5",
-                        "Dryoea Gree YE-A g1",
+                        "Throefuae VZ-O e6-16",
+                        "Plio Broae JM-W d1-100",
+                        "Byeia Aoscs PS-S c17-6",
+                        "Bleethai UP-J c24-58",
+                        "Dryoea Gree BW-B a40-5",
                         "Hypiae Ausms JU-I c12-1",
                         "Colonia"
                     )
                     {
-                        StartDate = new DateTime(2017, 11, 8, 0, 0, 0, DateTimeKind.Utc).ToLocalTime(),
-                        EndDate = new DateTime(2018, 3, 18, 0, 0, 0, DateTimeKind.Utc).ToLocalTime()
+                        StartDate = new DateTime(2017, 11, 19, 19, 0, 0, DateTimeKind.Utc).ToLocalTime(),
+                        EndDate = new DateTime(2018, 3, 11, 19, 0, 0, DateTimeKind.Utc).ToLocalTime()
+                    },
+                    #endregion
+
+                    #region 32: The Dead End's Circumnavigation Expedition
+                    // https://www.edsm.net/en/expeditions/summary/id/32/name/The+Dead+End%27s+Circumnavigation+Expedition
+                    new SavedRouteClass(
+                        "Dead End's Circumnavigation",
+                        "HIP 23759",
+                        "Crab Sector DL-Y d9",
+                        "3 Geminorum",
+                        "Angosk DL-P d5-0",
+                        "Angosk OM-W d1-0",
+                        "Lyed YJ-I d9-0",
+                        "Hypuae Euq ZK-P d5-0",
+                        "Aicods KD-K d8-3",
+                        "Syroifoe CL-Y g1",
+                        "HIP 117078",
+                        "Spongou FA-A e2",
+                        "Cyuefai BC-D d12-4",
+                        "Cyuefoo LC-D d12-0",
+                        "Byaa Thoi EW-E d11-0",
+                        "Byaa Thoi GC-D d12-0",
+                        "Auzorts NR-N d6-0",
+                        "Lyruewry BK-R d4-12",
+                        "Hypou Chreou RS-S c17-6",
+                        "Hypiae Brue DI-D c12-0",
+                        "Sphiesi HX-L d7-0",
+                        "Flyae Proae IN-S e4-1",
+                        "Footie AA-A g0",
+                        "Oedgaf DL-Y g0",
+                        "Gria Bloae YE-A g0",
+                        "Exahn AZ-S d3-8",
+                        "Chua Eop ZC-T c20-0",
+                        "Beagle Point",
+                        "Cheae Eurl AA-A e0",
+                        "Hyphielia QH-K c22-0",
+                        "Praei Bre WO-R d4-3",
+                        "Suvua FG-Y f0",
+                        "Hypaa Byio ZE-A g1",
+                        "Eembaitl DL-Y d13",
+                        "Synookaea MX-L d7-0",
+                        "Blea Airgh EI-B d13-1",
+                        "Ood Fleau ZJ-I d9-0",
+                        "Plae Eur DW-E d11-0",
+                        "Haffner 18 LSS 27",
+                        "Achrende"
+                    )
+                    {
+                        StartDate = new DateTime(2017, 10, 14, 0, 0, 0, DateTimeKind.Utc).ToLocalTime(),
+                        EndDate = new DateTime(2018, 10, 13, 0, 0, 0, DateTimeKind.Utc).ToLocalTime()
+                    },
+                    #endregion
+
+                    #region 33: Distant Friends Expedition
+                    // https://www.edsm.net/en/expeditions/summary/id/33/name/Distant+Friends+Expedition
+                    new SavedRouteClass(
+                        "Distant Friends Expedition",
+                        "Sol",
+                        "Beagle Point"
+                    )
+                    {
+                        StartDate = new DateTime(2017, 11, 7, 12, 0, 0, DateTimeKind.Utc).ToLocalTime(),
+                        EndDate = new DateTime(2018, 1, 7, 16, 0, 0, DateTimeKind.Utc).ToLocalTime()
                     },
                     #endregion
                 };

--- a/ExtendedControls/Controls/ComboBoxCustom.cs
+++ b/ExtendedControls/Controls/ComboBoxCustom.cs
@@ -202,7 +202,7 @@ namespace ExtendedControls
         public override AnchorStyles Anchor { get { return base.Anchor; } set { base.Anchor = value; _cbsystem.Anchor = value; } }
         public override DockStyle Dock { get { return base.Dock; } set { base.Dock = value; _cbsystem.Dock = value; } }
         public override Font Font { get { return base.Font; } set { base.Font = value; _cbsystem.Font = value; } }
-        public override string Text { get { return base.Text; } set { base.Text = value; _cbsystem.Text = value; } }
+        public override string Text { get { return base.Text; } set { base.Text = value; _cbsystem.Text = value; Invalidate();  } }
 
         // BEWARE SET value/display before DATA SOURCE
         public object DataSource { get { return _cbsystem.DataSource; } set { _cbsystem.DataSource = value; } }


### PR DESCRIPTION
* `EDDiscovery/UserControls/UserControlExpedition.cs`:
  * Update "deleted" hard-coded expeditions when they are changed.
  * Save and restore DataGridView column widths.
  * Reduce database impact of deleting, undeleting routes.
  * Stop scanning DB for deleted routes on each targetted right-click.
  * Use case-insensitive matching for hard-coded expeditions.
* `EliteDangerous/EDSM/Expeditions.cs`:
  * Add Dead End's Circumnavigation Expedition
  * Add Distant Friends Expedition
  * Update Minerva Centaurus Expedition (system and date changes).
  * Fix renamed systems in Mercury 7, Beagle Point expeditions.
* *Elsewhere*:
  * ComboBoxCustom: `Invalidate()` when `.Text` changes.
    * This fixes a bug in `UserControlExpedition` whereby deleting a route kept the old name visible when unthemed.
  * SavedRouteClass: Add debugging info, simplify `.Equals` comparator.