### PR TITLE
Tabcontrolmain fixup

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -126,14 +126,15 @@ namespace EDDiscovery
             // 
             // menuStrip1
             // 
+            this.menuStrip1.Dock = System.Windows.Forms.DockStyle.None;
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolsToolStripMenuItem,
             this.adminToolStripMenuItem,
             this.addOnsToolStripMenuItem,
             this.helpToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Location = new System.Drawing.Point(2, 2);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(1004, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(313, 24);
             this.menuStrip1.TabIndex = 16;
             this.menuStrip1.Text = "menuStrip1";
             this.menuStrip1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MouseDownCAPTION);
@@ -590,6 +591,8 @@ namespace EDDiscovery
             // 
             // panelToolBar
             // 
+            this.panelToolBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panelToolBar.BackColor = System.Drawing.Color.Transparent;
             this.panelToolBar.Controls.Add(this.comboBoxCommander);
             this.panelToolBar.Controls.Add(this.buttonExtEDSMSync);
@@ -600,16 +603,15 @@ namespace EDDiscovery
             this.panelToolBar.Controls.Add(this.buttonExt2dmap);
             this.panelToolBar.Controls.Add(this.buttonExt3dmap);
             this.panelToolBar.Controls.Add(this.buttonReloadActions);
-            this.panelToolBar.Dock = System.Windows.Forms.DockStyle.Top;
             this.panelToolBar.HiddenMarkerWidth = 0;
-            this.panelToolBar.Location = new System.Drawing.Point(0, 24);
+            this.panelToolBar.Location = new System.Drawing.Point(2, 26);
             this.panelToolBar.Name = "panelToolBar";
             this.panelToolBar.PinState = true;
             this.panelToolBar.RolledUpHeight = 5;
             this.panelToolBar.RollUpAnimationTime = 500;
             this.panelToolBar.RollUpDelay = 1000;
             this.panelToolBar.ShowHiddenMarker = true;
-            this.panelToolBar.Size = new System.Drawing.Size(1004, 32);
+            this.panelToolBar.Size = new System.Drawing.Size(1000, 32);
             this.panelToolBar.TabIndex = 1;
             this.panelToolBar.UnrolledHeight = 32;
             this.panelToolBar.UnrollHoverDelay = 1000;
@@ -772,13 +774,15 @@ namespace EDDiscovery
             // tabControlMain
             // 
             this.tabControlMain.AllowDragReorder = true;
+            this.tabControlMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControlMain.Controls.Add(this.tabPageTravelHistory);
-            this.tabControlMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControlMain.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.tabControlMain.Location = new System.Drawing.Point(0, 56);
+            this.tabControlMain.Location = new System.Drawing.Point(2, 58);
             this.tabControlMain.Name = "tabControlMain";
             this.tabControlMain.SelectedIndex = 0;
-            this.tabControlMain.Size = new System.Drawing.Size(1004, 456);
+            this.tabControlMain.Size = new System.Drawing.Size(1000, 454);
             this.tabControlMain.TabColorScaling = 0.5F;
             this.tabControlMain.TabControlBorderBrightColor = System.Drawing.Color.LightGray;
             this.tabControlMain.TabControlBorderColor = System.Drawing.Color.DarkGray;

--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -772,7 +772,6 @@ namespace EDDiscovery
             // tabControlMain
             // 
             this.tabControlMain.AllowDragReorder = true;
-            this.tabControlMain.ContextMenuStrip = this.contextMenuStripTabs;
             this.tabControlMain.Controls.Add(this.tabPageTravelHistory);
             this.tabControlMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControlMain.FlatStyle = System.Windows.Forms.FlatStyle.System;
@@ -794,6 +793,7 @@ namespace EDDiscovery
             this.tabControlMain.TextNotSelectedColor = System.Drawing.SystemColors.ControlText;
             this.tabControlMain.TextSelectedColor = System.Drawing.SystemColors.ControlText;
             this.toolTip.SetToolTip(this.tabControlMain, "Right click to add/remove tabs, Left click drag to reorder");
+            this.tabControlMain.MouseClick += new System.Windows.Forms.MouseEventHandler(this.tabControlMain_MouseClick);
             // 
             // contextMenuStripTabs
             // 
@@ -802,6 +802,7 @@ namespace EDDiscovery
             this.removeTabToolStripMenuItem});
             this.contextMenuStripTabs.Name = "contextMenuStripTabs";
             this.contextMenuStripTabs.Size = new System.Drawing.Size(190, 70);
+            this.contextMenuStripTabs.Opening += new System.ComponentModel.CancelEventHandler(this.ContextMenuStripTabs_Opening);
             // 
             // addTabToolStripMenuItem
             // 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -433,8 +433,6 @@ namespace EDDiscovery
                 travelHistoryControl.Init(this, null, UserControls.UserControlCommonBase.DisplayNumberHistoryGrid); // and init at this point with 0 as dn
             }
 
-            contextMenuStripTabs.Opening += ContextMenuStripTabs_Opening;
-
             for (int i = 0; i < PanelInformation.GetNumberPanels(); i++)
             {
                 addTabToolStripMenuItem.DropDownItems.Add(PanelInformation.MakeToolStripMenuItem(i, (s, e) =>
@@ -464,7 +462,7 @@ namespace EDDiscovery
 
         private void ContextMenuStripTabs_Opening(object sender, CancelEventArgs e)
         {       // don't remove history!
-            removeTabToolStripMenuItem.Enabled = !(tabControlMain.TabPages[tabControlMain.LastTabClicked].Controls[0] is UserControls.UserControlHistory);
+            removeTabToolStripMenuItem.Enabled = tabControlMain.LastTabClicked >= 0 && tabControlMain.TabPages.Count >= tabControlMain.LastTabClicked && !(tabControlMain.TabPages[tabControlMain.LastTabClicked].Controls[0] is UserControls.UserControlHistory);
         }
 
         private TabPage CreateTab(PanelInformation.PanelIDs ptype, int dn , int posindex, bool dotheme)
@@ -573,6 +571,14 @@ namespace EDDiscovery
             }
 
             return false;
+        }
+
+        private void tabControlMain_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right && tabControlMain.TabAt(e.Location) != -1)
+            {
+                contextMenuStripTabs.Show(tabControlMain.PointToScreen(e.Location));
+            }
         }
 
         #endregion


### PR DESCRIPTION
* Undock many main form controls that interfere with unframed resizing.
  * Yes: this is a huge pain to design around, but is required if you want to be able to resize the unframed `Form` on the top edges (otherwise, the menu eats *everything*).
  * We *should* really be handling `WM_NCCALCSIZE` to make design-time easier, but then we also have to handle non-client painting, and that's an ever large mess than this.
* Don't display `ContextMenuStripTabs` unless clicking directly on an existing tab. Previously, this menu would appear when clicking anywhere that didn't have it's own context menu set.
* Fix an argument out of range exception in `ContextMenuStripTabs_Opening`:
```
System.ArgumentOutOfRangeException occurred
  HResult=0x80131502
  Message=InvalidArgument=Value of '-1' is not valid for 'index'.
Parameter name: index
  Source=System.Windows.Forms
  StackTrace:
   at System.Windows.Forms.TabControl.GetTabPage(Int32 index)
   at EDDiscovery.EDDiscoveryForm.ContextMenuStripTabs_Opening(Object sender, CancelEventArgs e) in D:\Users\phroggie\source\EDD\EDDiscovery\EDDiscoveryForm.cs:line 467
   at System.Windows.Forms.ToolStripDropDown.OnOpening(CancelEventArgs e)
   at System.Windows.Forms.ToolStripDropDown.SetVisibleCore(Boolean visible)
   at System.Windows.Forms.ToolStripDropDown.Show(Control control, Point position)
   at System.Windows.Forms.ContextMenuStrip.ShowInternal(Control source, Point location, Boolean isKeyboardActivated)
   at System.Windows.Forms.Control.WmContextMenu(Message& m, Control sourceControl)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.TabControl.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.DebuggableCallback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```