### PR TITLE
Put EDDN and EDSM sync conns into txn lock

### DIFF
--- a/EliteDangerous/EDDB/SystemClassEDDB.cs
+++ b/EliteDangerous/EDDB/SystemClassEDDB.cs
@@ -27,160 +27,164 @@ namespace EliteDangerousCore.EDDB
 
             while (!sr.EndOfStream)
             {
-                using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))  // open the db
+                using (SQLiteTxnLockED<SQLiteConnectionSystem> tl = new SQLiteTxnLockED<SQLiteConnectionSystem>())
                 {
-                    DbCommand selectCmd = null;
-                    DbCommand insertCmd = null;
-                    DbCommand updateCmd = null;
-                    DbCommand updateSysCmd = null;
-
-                    using (DbTransaction txn = cn.BeginTransaction())
+                    tl.OpenWriter();
+                    using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))  // open the db
                     {
-                        try
+                        DbCommand selectCmd = null;
+                        DbCommand insertCmd = null;
+                        DbCommand updateCmd = null;
+                        DbCommand updateSysCmd = null;
+
+                        using (DbTransaction txn = cn.BeginTransaction())
                         {
-                            selectCmd = cn.CreateCommand("SELECT EddbId, Population, EddbUpdatedAt FROM EddbSystems WHERE EdsmId = @EdsmId LIMIT 1", txn);   // 1 return matching ID
-                            selectCmd.AddParameter("@Edsmid", DbType.Int64);
-
-                            insertCmd = cn.CreateCommand("INSERT INTO EddbSystems (EdsmId, EddbId, Name, Faction, Population, GovernmentId, AllegianceId, State, Security, PrimaryEconomyId, NeedsPermit, EddbUpdatedAt) " +
-                                                                          "VALUES (@EdsmId, @EddbId, @Name, @Faction, @Population, @GovernmentId, @AllegianceId, @State, @Security, @PrimaryEconomyid, @NeedsPermit, @EddbUpdatedAt)", txn);
-                            insertCmd.AddParameter("@EdsmId", DbType.Int64);
-                            insertCmd.AddParameter("@EddbId", DbType.Int64);
-                            insertCmd.AddParameter("@Name", DbType.String);
-                            insertCmd.AddParameter("@Faction", DbType.String);
-                            insertCmd.AddParameter("@Population", DbType.Int64);
-                            insertCmd.AddParameter("@GovernmentId", DbType.Int64);
-                            insertCmd.AddParameter("@AllegianceId", DbType.Int64);
-                            insertCmd.AddParameter("@State", DbType.Int64);
-                            insertCmd.AddParameter("@Security", DbType.Int64);
-                            insertCmd.AddParameter("@PrimaryEconomyId", DbType.Int64);
-                            insertCmd.AddParameter("@NeedsPermit", DbType.Int64);
-                            insertCmd.AddParameter("@EddbUpdatedAt", DbType.Int64);
-
-                            updateCmd = cn.CreateCommand("UPDATE EddbSystems SET EddbId=@EddbId, Name=@Name, Faction=@Faction, Population=@Population, GovernmentId=@GovernmentId, AllegianceId=@AllegianceId, State=@State, Security=@Security, PrimaryEconomyId=@PrimaryEconomyId, NeedsPermit=@NeedsPermit, EddbUpdatedAt=@EddbUpdatedAt WHERE EdsmId=@EdsmId", txn);
-                            updateCmd.AddParameter("@EdsmId", DbType.Int64);
-                            updateCmd.AddParameter("@EddbId", DbType.Int64);
-                            updateCmd.AddParameter("@Name", DbType.String);
-                            updateCmd.AddParameter("@Faction", DbType.String);
-                            updateCmd.AddParameter("@Population", DbType.Int64);
-                            updateCmd.AddParameter("@GovernmentId", DbType.Int64);
-                            updateCmd.AddParameter("@AllegianceId", DbType.Int64);
-                            updateCmd.AddParameter("@State", DbType.Int64);
-                            updateCmd.AddParameter("@Security", DbType.Int64);
-                            updateCmd.AddParameter("@PrimaryEconomyId", DbType.Int64);
-                            updateCmd.AddParameter("@NeedsPermit", DbType.Int64);
-                            updateCmd.AddParameter("@EddbUpdatedAt", DbType.Int64);
-
-                            updateSysCmd = cn.CreateCommand("UPDATE EdsmSystems SET EddbId=@EddbId WHERE EdsmId=@EdsmId");
-                            updateSysCmd.AddParameter("@EdsmId", DbType.Int64);
-                            updateSysCmd.AddParameter("@EddbId", DbType.Int64);
-
-                            int c = 0;
-                            int hasinfo = 0;
-                            int lasttc = Environment.TickCount;
-
-                            while (!SQLiteConnectionSystem.IsReadWaiting)
+                            try
                             {
-                                line = sr.ReadLine();
-                                if (line == null)  // End of stream
+                                selectCmd = cn.CreateCommand("SELECT EddbId, Population, EddbUpdatedAt FROM EddbSystems WHERE EdsmId = @EdsmId LIMIT 1", txn);   // 1 return matching ID
+                                selectCmd.AddParameter("@Edsmid", DbType.Int64);
+
+                                insertCmd = cn.CreateCommand("INSERT INTO EddbSystems (EdsmId, EddbId, Name, Faction, Population, GovernmentId, AllegianceId, State, Security, PrimaryEconomyId, NeedsPermit, EddbUpdatedAt) " +
+                                                                              "VALUES (@EdsmId, @EddbId, @Name, @Faction, @Population, @GovernmentId, @AllegianceId, @State, @Security, @PrimaryEconomyid, @NeedsPermit, @EddbUpdatedAt)", txn);
+                                insertCmd.AddParameter("@EdsmId", DbType.Int64);
+                                insertCmd.AddParameter("@EddbId", DbType.Int64);
+                                insertCmd.AddParameter("@Name", DbType.String);
+                                insertCmd.AddParameter("@Faction", DbType.String);
+                                insertCmd.AddParameter("@Population", DbType.Int64);
+                                insertCmd.AddParameter("@GovernmentId", DbType.Int64);
+                                insertCmd.AddParameter("@AllegianceId", DbType.Int64);
+                                insertCmd.AddParameter("@State", DbType.Int64);
+                                insertCmd.AddParameter("@Security", DbType.Int64);
+                                insertCmd.AddParameter("@PrimaryEconomyId", DbType.Int64);
+                                insertCmd.AddParameter("@NeedsPermit", DbType.Int64);
+                                insertCmd.AddParameter("@EddbUpdatedAt", DbType.Int64);
+
+                                updateCmd = cn.CreateCommand("UPDATE EddbSystems SET EddbId=@EddbId, Name=@Name, Faction=@Faction, Population=@Population, GovernmentId=@GovernmentId, AllegianceId=@AllegianceId, State=@State, Security=@Security, PrimaryEconomyId=@PrimaryEconomyId, NeedsPermit=@NeedsPermit, EddbUpdatedAt=@EddbUpdatedAt WHERE EdsmId=@EdsmId", txn);
+                                updateCmd.AddParameter("@EdsmId", DbType.Int64);
+                                updateCmd.AddParameter("@EddbId", DbType.Int64);
+                                updateCmd.AddParameter("@Name", DbType.String);
+                                updateCmd.AddParameter("@Faction", DbType.String);
+                                updateCmd.AddParameter("@Population", DbType.Int64);
+                                updateCmd.AddParameter("@GovernmentId", DbType.Int64);
+                                updateCmd.AddParameter("@AllegianceId", DbType.Int64);
+                                updateCmd.AddParameter("@State", DbType.Int64);
+                                updateCmd.AddParameter("@Security", DbType.Int64);
+                                updateCmd.AddParameter("@PrimaryEconomyId", DbType.Int64);
+                                updateCmd.AddParameter("@NeedsPermit", DbType.Int64);
+                                updateCmd.AddParameter("@EddbUpdatedAt", DbType.Int64);
+
+                                updateSysCmd = cn.CreateCommand("UPDATE EdsmSystems SET EddbId=@EddbId WHERE EdsmId=@EdsmId");
+                                updateSysCmd.AddParameter("@EdsmId", DbType.Int64);
+                                updateSysCmd.AddParameter("@EddbId", DbType.Int64);
+
+                                int c = 0;
+                                int hasinfo = 0;
+                                int lasttc = Environment.TickCount;
+
+                                while (!SQLiteConnectionSystem.IsReadWaiting)
                                 {
-                                    break;
-                                }
-
-                                {
-                                    JObject jo = JObject.Parse(line);
-
-                                    ISystem system = SystemClassDB.FromJson(jo, SystemInfoSource.EDDB);
-
-                                    if (system.HasEDDBInformation)                                  // screen out for speed any EDDB data with empty interesting fields
+                                    line = sr.ReadLine();
+                                    if (line == null)  // End of stream
                                     {
-                                        hasinfo++;
+                                        break;
+                                    }
 
-                                        selectCmd.Parameters["@EdsmId"].Value = system.id_edsm;     // EDDB carries EDSM ID, so find entry in dB
+                                    {
+                                        JObject jo = JObject.Parse(line);
 
-                                        //DEBUGif ( c > 30000 )  Console.WriteLine("EDDB ID " + system.id_eddb + " EDSM ID " + system.id_edsm + " " + system.name + " Late info system");
+                                        ISystem system = SystemClassDB.FromJson(jo, SystemInfoSource.EDDB);
 
-                                        long updated_at = 0;
-                                        long population = 0;
-                                        long eddbid = 0;
-
-                                        using (DbDataReader reader1 = selectCmd.ExecuteReader())         // if found (if not, we ignore EDDB system)
+                                        if (system.HasEDDBInformation)                                  // screen out for speed any EDDB data with empty interesting fields
                                         {
-                                            if (reader1.Read())                                     // its there.. check its got the right stuff in it.
+                                            hasinfo++;
+
+                                            selectCmd.Parameters["@EdsmId"].Value = system.id_edsm;     // EDDB carries EDSM ID, so find entry in dB
+
+                                            //DEBUGif ( c > 30000 )  Console.WriteLine("EDDB ID " + system.id_eddb + " EDSM ID " + system.id_edsm + " " + system.name + " Late info system");
+
+                                            long updated_at = 0;
+                                            long population = 0;
+                                            long eddbid = 0;
+
+                                            using (DbDataReader reader1 = selectCmd.ExecuteReader())         // if found (if not, we ignore EDDB system)
                                             {
-                                                eddbid = (long)reader1["EddbId"];
-                                                updated_at = (long)reader1["EddbUpdatedAt"];
-                                                population = (long)reader1["Population"];
+                                                if (reader1.Read())                                     // its there.. check its got the right stuff in it.
+                                                {
+                                                    eddbid = (long)reader1["EddbId"];
+                                                    updated_at = (long)reader1["EddbUpdatedAt"];
+                                                    population = (long)reader1["Population"];
+                                                }
                                             }
-                                        }
 
-                                        updateSysCmd.Parameters["@EdsmId"].Value = system.id_edsm;
-                                        updateSysCmd.Parameters["@EddbId"].Value = system.id_eddb;
-                                        updateSysCmd.ExecuteNonQuery();
+                                            updateSysCmd.Parameters["@EdsmId"].Value = system.id_edsm;
+                                            updateSysCmd.Parameters["@EddbId"].Value = system.id_eddb;
+                                            updateSysCmd.ExecuteNonQuery();
 
-                                        if (eddbid != 0)
-                                        {
-                                            if (updated_at != system.eddb_updated_at || population != system.population)
+                                            if (eddbid != 0)
                                             {
-                                                updateCmd.Parameters["@EddbId"].Value = system.id_eddb;
-                                                updateCmd.Parameters["@Name"].Value = system.name;
-                                                updateCmd.Parameters["@Faction"].Value = system.faction;
-                                                updateCmd.Parameters["@Population"].Value = system.population;
-                                                updateCmd.Parameters["@GovernmentId"].Value = system.government;
-                                                updateCmd.Parameters["@AllegianceId"].Value = system.allegiance;
-                                                updateCmd.Parameters["@State"].Value = system.state;
-                                                updateCmd.Parameters["@Security"].Value = system.security;
-                                                updateCmd.Parameters["@PrimaryEconomyId"].Value = system.primary_economy;
-                                                updateCmd.Parameters["@NeedsPermit"].Value = system.needs_permit;
-                                                updateCmd.Parameters["@EddbUpdatedAt"].Value = system.eddb_updated_at;
-                                                updateCmd.Parameters["@EdsmId"].Value = system.id_edsm;
-                                                updateCmd.ExecuteNonQuery();
-                                                updated++;
+                                                if (updated_at != system.eddb_updated_at || population != system.population)
+                                                {
+                                                    updateCmd.Parameters["@EddbId"].Value = system.id_eddb;
+                                                    updateCmd.Parameters["@Name"].Value = system.name;
+                                                    updateCmd.Parameters["@Faction"].Value = system.faction;
+                                                    updateCmd.Parameters["@Population"].Value = system.population;
+                                                    updateCmd.Parameters["@GovernmentId"].Value = system.government;
+                                                    updateCmd.Parameters["@AllegianceId"].Value = system.allegiance;
+                                                    updateCmd.Parameters["@State"].Value = system.state;
+                                                    updateCmd.Parameters["@Security"].Value = system.security;
+                                                    updateCmd.Parameters["@PrimaryEconomyId"].Value = system.primary_economy;
+                                                    updateCmd.Parameters["@NeedsPermit"].Value = system.needs_permit;
+                                                    updateCmd.Parameters["@EddbUpdatedAt"].Value = system.eddb_updated_at;
+                                                    updateCmd.Parameters["@EdsmId"].Value = system.id_edsm;
+                                                    updateCmd.ExecuteNonQuery();
+                                                    updated++;
+                                                }
+                                            }
+                                            else
+                                            {
+                                                insertCmd.Parameters["@EdsmId"].Value = system.id_edsm;
+                                                insertCmd.Parameters["@EddbId"].Value = system.id_eddb;
+                                                insertCmd.Parameters["@Name"].Value = system.name;
+                                                insertCmd.Parameters["@Faction"].Value = system.faction;
+                                                insertCmd.Parameters["@Population"].Value = system.population;
+                                                insertCmd.Parameters["@GovernmentId"].Value = system.government;
+                                                insertCmd.Parameters["@AllegianceId"].Value = system.allegiance;
+                                                insertCmd.Parameters["@State"].Value = system.state;
+                                                insertCmd.Parameters["@Security"].Value = system.security;
+                                                insertCmd.Parameters["@PrimaryEconomyId"].Value = system.primary_economy;
+                                                insertCmd.Parameters["@NeedsPermit"].Value = system.needs_permit;
+                                                insertCmd.Parameters["@EddbUpdatedAt"].Value = system.eddb_updated_at;
+                                                insertCmd.ExecuteNonQuery();
+                                                inserted++;
                                             }
                                         }
                                         else
                                         {
-                                            insertCmd.Parameters["@EdsmId"].Value = system.id_edsm;
-                                            insertCmd.Parameters["@EddbId"].Value = system.id_eddb;
-                                            insertCmd.Parameters["@Name"].Value = system.name;
-                                            insertCmd.Parameters["@Faction"].Value = system.faction;
-                                            insertCmd.Parameters["@Population"].Value = system.population;
-                                            insertCmd.Parameters["@GovernmentId"].Value = system.government;
-                                            insertCmd.Parameters["@AllegianceId"].Value = system.allegiance;
-                                            insertCmd.Parameters["@State"].Value = system.state;
-                                            insertCmd.Parameters["@Security"].Value = system.security;
-                                            insertCmd.Parameters["@PrimaryEconomyId"].Value = system.primary_economy;
-                                            insertCmd.Parameters["@NeedsPermit"].Value = system.needs_permit;
-                                            insertCmd.Parameters["@EddbUpdatedAt"].Value = system.eddb_updated_at;
-                                            insertCmd.ExecuteNonQuery();
-                                            inserted++;
+                                            //Console.WriteLine("EDDB ID " + system.id_eddb + " EDSM ID " + system.id_edsm + " " + system.name + " No info reject");
+                                        }
+
+                                        if (++c % 10000 == 0)
+                                        {
+                                            Console.WriteLine("EDDB Count " + c + " Delta " + (Environment.TickCount - lasttc) + " info " + hasinfo + " update " + updated + " new " + inserted);
+                                            lasttc = Environment.TickCount;
                                         }
                                     }
-                                    else
-                                    {
-                                        //Console.WriteLine("EDDB ID " + system.id_eddb + " EDSM ID " + system.id_edsm + " " + system.name + " No info reject");
-                                    }
-
-                                    if (++c % 10000 == 0)
-                                    {
-                                        Console.WriteLine("EDDB Count " + c + " Delta " + (Environment.TickCount - lasttc) + " info " + hasinfo + " update " + updated + " new " + inserted);
-                                        lasttc = Environment.TickCount;
-                                    }
                                 }
-                            }
 
-                            txn.Commit();
-                        }
-                        catch
-                        {
-                            ExtendedControls.MessageBoxTheme.Show("There is a problem using the EDDB systems file." + Environment.NewLine +
-                                            "Please perform a manual EDDB sync (see Admin menu) next time you run the program ", "EDDB Sync Error");
-                            break;
-                        }
-                        finally
-                        {
-                            if (selectCmd != null) selectCmd.Dispose();
-                            if (updateCmd != null) updateCmd.Dispose();
-                            if (insertCmd != null) insertCmd.Dispose();
+                                txn.Commit();
+                            }
+                            catch
+                            {
+                                ExtendedControls.MessageBoxTheme.Show("There is a problem using the EDDB systems file." + Environment.NewLine +
+                                                "Please perform a manual EDDB sync (see Admin menu) next time you run the program ", "EDDB Sync Error");
+                                break;
+                            }
+                            finally
+                            {
+                                if (selectCmd != null) selectCmd.Dispose();
+                                if (updateCmd != null) updateCmd.Dispose();
+                                if (insertCmd != null) insertCmd.Dispose();
+                            }
                         }
                     }
                 }

--- a/EliteDangerous/EDSM/SystemClassEDSM.cs
+++ b/EliteDangerous/EDSM/SystemClassEDSM.cs
@@ -390,223 +390,227 @@ namespace EliteDangerousCore.EDSM
                     int oldupdatecnt = updatecount;
                     int oldcount = count;
 
-                    using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))
+                    using (SQLiteTxnLockED<SQLiteConnectionSystem> tl = new SQLiteTxnLockED<SQLiteConnectionSystem>())
                     {
-                        using (DbTransaction txn = cn.BeginTransaction())
+                        tl.OpenWriter();
+                        using (SQLiteConnectionSystem cn = new SQLiteConnectionSystem(mode: EDDbAccessMode.Writer))
                         {
-                            DbCommand updateNameCmd = null;
-                            DbCommand updateSysCmd = null;
-                            DbCommand insertNameCmd = null;
-                            DbCommand insertSysCmd = null;
-                            DbCommand selectSysCmd = null;
-                            DbCommand selectNameCmd = null;
-
-                            try
+                            using (DbTransaction txn = cn.BeginTransaction())
                             {
-                                updateNameCmd = cn.CreateCommand("UPDATE SystemNames SET Name=@Name WHERE EdsmId=@EdsmId", txn);
-                                updateNameCmd.AddParameter("@Name", DbType.String);
-                                updateNameCmd.AddParameter("@EdsmId", DbType.Int64);
+                                DbCommand updateNameCmd = null;
+                                DbCommand updateSysCmd = null;
+                                DbCommand insertNameCmd = null;
+                                DbCommand insertSysCmd = null;
+                                DbCommand selectSysCmd = null;
+                                DbCommand selectNameCmd = null;
 
-                                updateSysCmd = cn.CreateCommand("UPDATE EdsmSystems SET X=@X, Y=@Y, Z=@Z, UpdateTimestamp=@UpdateTimestamp, VersionTimestamp=@VersionTimestamp, GridId=@GridId, RandomId=@RandomId WHERE EdsmId=@EdsmId", txn);
-                                updateSysCmd.AddParameter("@X", DbType.Int64);
-                                updateSysCmd.AddParameter("@Y", DbType.Int64);
-                                updateSysCmd.AddParameter("@Z", DbType.Int64);
-                                updateSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
-                                updateSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
-                                updateSysCmd.AddParameter("@GridId", DbType.Int64);
-                                updateSysCmd.AddParameter("@RandomId", DbType.Int64);
-                                updateSysCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                                insertNameCmd = cn.CreateCommand("INSERT INTO " + sysnamesTableName + " (Name, EdsmId) VALUES (@Name, @EdsmId)", txn);
-                                insertNameCmd.AddParameter("@Name", DbType.String);
-                                insertNameCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                                insertSysCmd = cn.CreateCommand("INSERT INTO " + edsmsysTableName + " (EdsmId, X, Y, Z, CreateTimestamp, UpdateTimestamp, VersionTimestamp, GridId, RandomId) VALUES (@EdsmId, @X, @Y, @Z, @CreateTimestamp, @UpdateTimestamp, @VersionTimestamp, @GridId, @RandomId)", txn);
-                                insertSysCmd.AddParameter("@EdsmId", DbType.Int64);
-                                insertSysCmd.AddParameter("@X", DbType.Int64);
-                                insertSysCmd.AddParameter("@Y", DbType.Int64);
-                                insertSysCmd.AddParameter("@Z", DbType.Int64);
-                                insertSysCmd.AddParameter("@CreateTimestamp", DbType.Int64);
-                                insertSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
-                                insertSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
-                                insertSysCmd.AddParameter("@GridId", DbType.Int64);
-                                insertSysCmd.AddParameter("@RandomId", DbType.Int64);
-
-                                selectSysCmd = cn.CreateCommand("SELECT Id, X, Y, Z, GridId, RandomId FROM EdsmSystems WHERE EdsmId=@EdsmId");
-                                selectSysCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                                selectNameCmd = cn.CreateCommand("SELECT Name FROM SystemNames WHERE EdsmId = @EdsmId");
-                                selectNameCmd.AddParameter("@EdsmId", DbType.Int64);
-
-                                while (!cancelRequested())
+                                try
                                 {
-                                    if (!jo_enum.MoveNext())
+                                    updateNameCmd = cn.CreateCommand("UPDATE SystemNames SET Name=@Name WHERE EdsmId=@EdsmId", txn);
+                                    updateNameCmd.AddParameter("@Name", DbType.String);
+                                    updateNameCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                                    updateSysCmd = cn.CreateCommand("UPDATE EdsmSystems SET X=@X, Y=@Y, Z=@Z, UpdateTimestamp=@UpdateTimestamp, VersionTimestamp=@VersionTimestamp, GridId=@GridId, RandomId=@RandomId WHERE EdsmId=@EdsmId", txn);
+                                    updateSysCmd.AddParameter("@X", DbType.Int64);
+                                    updateSysCmd.AddParameter("@Y", DbType.Int64);
+                                    updateSysCmd.AddParameter("@Z", DbType.Int64);
+                                    updateSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
+                                    updateSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
+                                    updateSysCmd.AddParameter("@GridId", DbType.Int64);
+                                    updateSysCmd.AddParameter("@RandomId", DbType.Int64);
+                                    updateSysCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                                    insertNameCmd = cn.CreateCommand("INSERT INTO " + sysnamesTableName + " (Name, EdsmId) VALUES (@Name, @EdsmId)", txn);
+                                    insertNameCmd.AddParameter("@Name", DbType.String);
+                                    insertNameCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                                    insertSysCmd = cn.CreateCommand("INSERT INTO " + edsmsysTableName + " (EdsmId, X, Y, Z, CreateTimestamp, UpdateTimestamp, VersionTimestamp, GridId, RandomId) VALUES (@EdsmId, @X, @Y, @Z, @CreateTimestamp, @UpdateTimestamp, @VersionTimestamp, @GridId, @RandomId)", txn);
+                                    insertSysCmd.AddParameter("@EdsmId", DbType.Int64);
+                                    insertSysCmd.AddParameter("@X", DbType.Int64);
+                                    insertSysCmd.AddParameter("@Y", DbType.Int64);
+                                    insertSysCmd.AddParameter("@Z", DbType.Int64);
+                                    insertSysCmd.AddParameter("@CreateTimestamp", DbType.Int64);
+                                    insertSysCmd.AddParameter("@UpdateTimestamp", DbType.Int64);
+                                    insertSysCmd.AddParameter("@VersionTimestamp", DbType.Int64);
+                                    insertSysCmd.AddParameter("@GridId", DbType.Int64);
+                                    insertSysCmd.AddParameter("@RandomId", DbType.Int64);
+
+                                    selectSysCmd = cn.CreateCommand("SELECT Id, X, Y, Z, GridId, RandomId FROM EdsmSystems WHERE EdsmId=@EdsmId");
+                                    selectSysCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                                    selectNameCmd = cn.CreateCommand("SELECT Name FROM SystemNames WHERE EdsmId = @EdsmId");
+                                    selectNameCmd.AddParameter("@EdsmId", DbType.Int64);
+
+                                    while (!cancelRequested())
                                     {
-                                        reportProgress(-1, $"Syncing EDSM systems: {count:N0} processed, {insertcount:N0} new systems, {updatecount:N0} updated systems");
-                                        txn.Commit();
-
-                                        if (jr_eof)
+                                        if (!jo_enum.MoveNext())
                                         {
-                                            date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                                            reportProgress(-1, $"Syncing EDSM systems: {count:N0} processed, {insertcount:N0} new systems, {updatecount:N0} updated systems");
+                                            txn.Commit();
 
-                                            Console.WriteLine($"Import took {sw.ElapsedMilliseconds}ms");
-
-                                            for (int id = 0; id < histogramsystems.Length; id++)
+                                            if (jr_eof)
                                             {
-                                                if (histogramsystems[id] != 0)
-                                                    Console.WriteLine("Id " + id + " count " + histogramsystems[id]);
-                                            }
+                                                date = maxdate.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
-                                            return updatecount + insertcount;
-                                        }
+                                                Console.WriteLine($"Import took {sw.ElapsedMilliseconds}ms");
 
-                                        jo_enum_finished = true;
-                                        break;
-                                    }
-                                    else if (SQLiteConnectionSystem.IsReadWaiting)
-                                    {
-                                        if (blkcount < objs.Count * 3 / 4) // Let the reader barge in if we've processed less than 3/4 of the items
-                                        {
-                                            // Reset the counts, roll back the transaction, and let the reader through...
-                                            insertcount = oldinsertcnt;
-                                            updatecount = oldupdatecnt;
-                                            count = oldcount;
-                                            jo_enum.Reset();
-                                            txn.Rollback();
-                                            break;
-                                        }
-                                    }
-
-                                    EDSMDumpSystem jo = jo_enum.Current;
-                                    EDSMDumpSystemCoords coords = jo.coords;
-
-                                    if (coords != null)
-                                    {
-                                        double x = coords.x;
-                                        double y = coords.y;
-                                        double z = coords.z;
-                                        long edsmid = jo.id;
-                                        string name = jo.name;
-                                        int gridid = GridId.Id(x, z);
-                                        int randomid = rnd.Next(0, 99);
-                                        DateTime updatedate = jo.date;
-                                        histogramsystems[gridid]++;
-
-                                        if (updatedate > maxdate)
-                                            maxdate = updatedate;
-                                        else if (updatedate < maxdate - TimeSpan.FromHours(1))
-                                            outoforder = true;
-
-                                        SystemClassBase dbsys = null;
-
-                                        if (!useTempSystems)
-                                        {
-                                            if (useCache && systemsByEdsmId.ContainsKey(edsmid))
-                                                dbsys = systemsByEdsmId[edsmid];
-
-                                            if (!useCache)
-                                            {
-                                                selectSysCmd.Parameters["@EdsmId"].Value = edsmid;
-                                                using (DbDataReader reader = selectSysCmd.ExecuteReader())
+                                                for (int id = 0; id < histogramsystems.Length; id++)
                                                 {
-                                                    if (reader.Read())
-                                                    {
-                                                        dbsys = new SystemClassBase
-                                                        {
-                                                            id = (long)reader["id"],
-                                                            id_edsm = edsmid
-                                                        };
-
-                                                        if (System.DBNull.Value == reader["x"])
-                                                        {
-                                                            dbsys.x = double.NaN;
-                                                            dbsys.y = double.NaN;
-                                                            dbsys.z = double.NaN;
-                                                        }
-                                                        else
-                                                        {
-                                                            dbsys.x = ((double)(long)reader["X"]) / SystemClassDB.XYZScalar;
-                                                            dbsys.y = ((double)(long)reader["Y"]) / SystemClassDB.XYZScalar;
-                                                            dbsys.z = ((double)(long)reader["Z"]) / SystemClassDB.XYZScalar;
-                                                        }
-
-                                                        dbsys.id_edsm = edsmid;
-                                                        dbsys.gridid = reader["GridId"] == DBNull.Value ? 0 : (int)((long)reader["GridId"]);
-                                                        dbsys.randomid = reader["RandomId"] == DBNull.Value ? 0 : (int)((long)reader["RandomId"]);
-                                                    }
+                                                    if (histogramsystems[id] != 0)
+                                                        Console.WriteLine("Id " + id + " count " + histogramsystems[id]);
                                                 }
 
-                                                if (dbsys != null)
+                                                return updatecount + insertcount;
+                                            }
+
+                                            jo_enum_finished = true;
+                                            break;
+                                        }
+                                        else if (SQLiteConnectionSystem.IsReadWaiting)
+                                        {
+                                            if (blkcount < objs.Count * 3 / 4) // Let the reader barge in if we've processed less than 3/4 of the items
+                                            {
+                                                // Reset the counts, roll back the transaction, and let the reader through...
+                                                insertcount = oldinsertcnt;
+                                                updatecount = oldupdatecnt;
+                                                count = oldcount;
+                                                jo_enum.Reset();
+                                                txn.Rollback();
+                                                break;
+                                            }
+                                        }
+
+                                        EDSMDumpSystem jo = jo_enum.Current;
+                                        EDSMDumpSystemCoords coords = jo.coords;
+
+                                        if (coords != null)
+                                        {
+                                            double x = coords.x;
+                                            double y = coords.y;
+                                            double z = coords.z;
+                                            long edsmid = jo.id;
+                                            string name = jo.name;
+                                            int gridid = GridId.Id(x, z);
+                                            int randomid = rnd.Next(0, 99);
+                                            DateTime updatedate = jo.date;
+                                            histogramsystems[gridid]++;
+
+                                            if (updatedate > maxdate)
+                                                maxdate = updatedate;
+                                            else if (updatedate < maxdate - TimeSpan.FromHours(1))
+                                                outoforder = true;
+
+                                            SystemClassBase dbsys = null;
+
+                                            if (!useTempSystems)
+                                            {
+                                                if (useCache && systemsByEdsmId.ContainsKey(edsmid))
+                                                    dbsys = systemsByEdsmId[edsmid];
+
+                                                if (!useCache)
                                                 {
-                                                    selectNameCmd.Parameters["@EdsmId"].Value = edsmid;
-                                                    using (DbDataReader reader = selectNameCmd.ExecuteReader())
+                                                    selectSysCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                    using (DbDataReader reader = selectSysCmd.ExecuteReader())
                                                     {
                                                         if (reader.Read())
                                                         {
-                                                            dbsys.name = (string)reader["Name"];
+                                                            dbsys = new SystemClassBase
+                                                            {
+                                                                id = (long)reader["id"],
+                                                                id_edsm = edsmid
+                                                            };
+
+                                                            if (System.DBNull.Value == reader["x"])
+                                                            {
+                                                                dbsys.x = double.NaN;
+                                                                dbsys.y = double.NaN;
+                                                                dbsys.z = double.NaN;
+                                                            }
+                                                            else
+                                                            {
+                                                                dbsys.x = ((double)(long)reader["X"]) / SystemClassDB.XYZScalar;
+                                                                dbsys.y = ((double)(long)reader["Y"]) / SystemClassDB.XYZScalar;
+                                                                dbsys.z = ((double)(long)reader["Z"]) / SystemClassDB.XYZScalar;
+                                                            }
+
+                                                            dbsys.id_edsm = edsmid;
+                                                            dbsys.gridid = reader["GridId"] == DBNull.Value ? 0 : (int)((long)reader["GridId"]);
+                                                            dbsys.randomid = reader["RandomId"] == DBNull.Value ? 0 : (int)((long)reader["RandomId"]);
+                                                        }
+                                                    }
+
+                                                    if (dbsys != null)
+                                                    {
+                                                        selectNameCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                        using (DbDataReader reader = selectNameCmd.ExecuteReader())
+                                                        {
+                                                            if (reader.Read())
+                                                            {
+                                                                dbsys.name = (string)reader["Name"];
+                                                            }
                                                         }
                                                     }
                                                 }
                                             }
+
+                                            if (dbsys != null)
+                                            {
+                                                // see if EDSM data changed..
+                                                if (!dbsys.name.Equals(name))
+                                                {
+                                                    updateNameCmd.Parameters["@Name"].Value = name;
+                                                    updateNameCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                    updateNameCmd.ExecuteNonQuery();
+                                                }
+
+                                                if (Math.Abs(dbsys.x - x) > 0.01 ||
+                                                    Math.Abs(dbsys.y - y) > 0.01 ||
+                                                    Math.Abs(dbsys.z - z) > 0.01 ||
+                                                    dbsys.gridid != gridid)  // position changed
+                                                {
+                                                    updateSysCmd.Parameters["@X"].Value = (long)(x * SystemClassDB.XYZScalar);
+                                                    updateSysCmd.Parameters["@Y"].Value = (long)(y * SystemClassDB.XYZScalar);
+                                                    updateSysCmd.Parameters["@Z"].Value = (long)(z * SystemClassDB.XYZScalar);
+                                                    updateSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                                    updateSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                                    updateSysCmd.Parameters["@GridId"].Value = gridid;
+                                                    updateSysCmd.Parameters["@RandomId"].Value = randomid;
+                                                    updateSysCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                    updateSysCmd.ExecuteNonQuery();
+                                                    updatecount++;
+                                                }
+                                            }
+                                            else                                                                  // not in database..
+                                            {
+                                                insertNameCmd.Parameters["@Name"].Value = name;
+                                                insertNameCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                insertNameCmd.ExecuteNonQuery();
+                                                insertSysCmd.Parameters["@EdsmId"].Value = edsmid;
+                                                insertSysCmd.Parameters["@X"].Value = (long)(x * SystemClassDB.XYZScalar);
+                                                insertSysCmd.Parameters["@Y"].Value = (long)(y * SystemClassDB.XYZScalar);
+                                                insertSysCmd.Parameters["@Z"].Value = (long)(z * SystemClassDB.XYZScalar);
+                                                insertSysCmd.Parameters["@CreateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                                insertSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                                insertSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
+                                                insertSysCmd.Parameters["@GridId"].Value = gridid;
+                                                insertSysCmd.Parameters["@RandomId"].Value = randomid;
+                                                insertSysCmd.ExecuteNonQuery();
+                                                insertcount++;
+                                            }
                                         }
 
-                                        if (dbsys != null)
-                                        {
-                                            // see if EDSM data changed..
-                                            if (!dbsys.name.Equals(name))
-                                            {
-                                                updateNameCmd.Parameters["@Name"].Value = name;
-                                                updateNameCmd.Parameters["@EdsmId"].Value = edsmid;
-                                                updateNameCmd.ExecuteNonQuery();
-                                            }
-
-                                            if (Math.Abs(dbsys.x - x) > 0.01 ||
-                                                Math.Abs(dbsys.y - y) > 0.01 ||
-                                                Math.Abs(dbsys.z - z) > 0.01 ||
-                                                dbsys.gridid != gridid)  // position changed
-                                            {
-                                                updateSysCmd.Parameters["@X"].Value = (long)(x * SystemClassDB.XYZScalar);
-                                                updateSysCmd.Parameters["@Y"].Value = (long)(y * SystemClassDB.XYZScalar);
-                                                updateSysCmd.Parameters["@Z"].Value = (long)(z * SystemClassDB.XYZScalar);
-                                                updateSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                                updateSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                                updateSysCmd.Parameters["@GridId"].Value = gridid;
-                                                updateSysCmd.Parameters["@RandomId"].Value = randomid;
-                                                updateSysCmd.Parameters["@EdsmId"].Value = edsmid;
-                                                updateSysCmd.ExecuteNonQuery();
-                                                updatecount++;
-                                            }
-                                        }
-                                        else                                                                  // not in database..
-                                        {
-                                            insertNameCmd.Parameters["@Name"].Value = name;
-                                            insertNameCmd.Parameters["@EdsmId"].Value = edsmid;
-                                            insertNameCmd.ExecuteNonQuery();
-                                            insertSysCmd.Parameters["@EdsmId"].Value = edsmid;
-                                            insertSysCmd.Parameters["@X"].Value = (long)(x * SystemClassDB.XYZScalar);
-                                            insertSysCmd.Parameters["@Y"].Value = (long)(y * SystemClassDB.XYZScalar);
-                                            insertSysCmd.Parameters["@Z"].Value = (long)(z * SystemClassDB.XYZScalar);
-                                            insertSysCmd.Parameters["@CreateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                            insertSysCmd.Parameters["@UpdateTimestamp"].Value = updatedate.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                            insertSysCmd.Parameters["@VersionTimestamp"].Value = DateTime.UtcNow.Subtract(new DateTime(2015, 1, 1)).TotalSeconds;
-                                            insertSysCmd.Parameters["@GridId"].Value = gridid;
-                                            insertSysCmd.Parameters["@RandomId"].Value = randomid;
-                                            insertSysCmd.ExecuteNonQuery();
-                                            insertcount++;
-                                        }
+                                        count++;
+                                        blkcount++;
                                     }
-
-                                    count++;
-                                    blkcount++;
                                 }
-                            }
-                            finally
-                            {
-                                if (updateNameCmd != null) updateNameCmd.Dispose();
-                                if (updateSysCmd != null) updateSysCmd.Dispose();
-                                if (insertNameCmd != null) insertNameCmd.Dispose();
-                                if (insertSysCmd != null) insertSysCmd.Dispose();
-                                if (selectSysCmd != null) selectSysCmd.Dispose();
+                                finally
+                                {
+                                    if (updateNameCmd != null) updateNameCmd.Dispose();
+                                    if (updateSysCmd != null) updateSysCmd.Dispose();
+                                    if (insertNameCmd != null) insertNameCmd.Dispose();
+                                    if (insertSysCmd != null) insertSysCmd.Dispose();
+                                    if (selectSysCmd != null) selectSysCmd.Dispose();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This should close the connection before releasing the transaction lock, and therefore have SQLite finish whatever it is doing after the transaction has completed and release its database lock before any waiting readers are given access.  This should hopefully stop any "database is locked" errors that might occur after the transaction is committed but where SQLite keeps the database locked potentially until the connection is closed.