### PR TITLE
Hook events after init is complete

### DIFF
--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -157,6 +157,11 @@ namespace EDDiscovery
         {
             readyForInitialLoad.Set();
         }
+
+        public void InitComplete()
+        {
+            initComplete.Set();
+        }
         #endregion
 
         #region Shutdown
@@ -311,6 +316,7 @@ namespace EDDiscovery
 
         private ManualResetEvent closeRequested = new ManualResetEvent(false);
         private ManualResetEvent readyForInitialLoad = new ManualResetEvent(false);
+        private ManualResetEvent initComplete = new ManualResetEvent(false);
         private ManualResetEvent readyForNewRefresh = new ManualResetEvent(false);
         private AutoResetEvent refreshRequested = new AutoResetEvent(false);
         private AutoResetEvent resyncRequestedEvent = new AutoResetEvent(false);
@@ -520,6 +526,8 @@ namespace EDDiscovery
             {
                 LogLineHighlight("History Refresh Error: " + ex);
             }
+
+            initComplete.WaitOne();
 
             InvokeAsyncOnUiThread(() => RefreshHistoryWorkerCompleted(hist));
         }

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -241,6 +241,8 @@ namespace EDDiscovery
             SetUpLogging();
 
             Debug.WriteLine(BaseUtils.AppTicks.TickCount100 + " Finish ED Init");
+
+            Controller.InitComplete();
         }
 
         // OnLoad is called the first time the form is shown, before OnShown or OnActivated are called

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -65,9 +65,6 @@ namespace EDDiscovery.UserControls
             dataGridViewEngineering.DefaultCellStyle.WrapMode = DataGridViewTriState.False;
             dataGridViewEngineering.RowTemplate.Height = 26;
 
-            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            uctg.OnTravelSelectionChanged += Display;
-
             Order = SQLiteDBClass.GetSettingString(DbOSave, "").RestoreArrayFromString(0, EngineeringRecipes.Count);
             if (Order.Distinct().Count() != Order.Length)       // if not distinct..
                 for (int i = 0; i < Order.Length; i++)          // reset
@@ -115,6 +112,9 @@ namespace EDDiscovery.UserControls
                 row.Tag = rno;
                 row.Visible = false;
             }
+
+            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlHistory.cs
+++ b/EDDiscovery/UserControls/UserControlHistory.cs
@@ -64,15 +64,16 @@ namespace EDDiscovery.UserControls
         {
             userControlTravelGrid.Init(discoveryform, userControlTravelGrid, displaynumber);       // primary first instance - this registers with events in discoveryform to get info
                                                         // then this display, to update its own controls..
-            userControlTravelGrid.OnChangedSelection += ChangedSelection;   // and if the user clicks on something
-            userControlTravelGrid.OnPopOut += () => { discoveryform.PopOuts.PopOut(PanelInformation.PanelIDs.TravelGrid); };
-            userControlTravelGrid.OnKeyDownInCell += OnKeyDownInCell;
             userControlTravelGrid.ExtraIcons(true, true);
 
             TabConfigure(tabStripBottom,"Bottom", DisplayNumberHistoryBotLeft);          // codes are used to save info, 0 = primary (journal/travelgrid), 1..N are popups, these are embedded UCs
             TabConfigure(tabStripBottomRight,"Bottom-Right", DisplayNumberHistoryBotRight);
             TabConfigure(tabStripMiddleRight, "Middle-Right", DisplayNumberHistoryMidRight);
             TabConfigure(tabStripTopRight, "Top-Right", DisplayNumberHistoryTopRight);
+
+            userControlTravelGrid.OnChangedSelection += ChangedSelection;   // and if the user clicks on something
+            userControlTravelGrid.OnPopOut += () => { discoveryform.PopOuts.PopOut(PanelInformation.PanelIDs.TravelGrid); };
+            userControlTravelGrid.OnKeyDownInCell += OnKeyDownInCell;
         }
 
         #endregion

--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -80,14 +80,14 @@ namespace EDDiscovery.UserControls
 
             checkBoxMoveToTop.Checked = SQLiteConnectionUser.GetSettingBool(DbAutoTop, true);
 
-            discoveryform.OnHistoryChange += Display;
-            discoveryform.OnNewEntry += AddNewEntry;
-
             string filter = SQLiteDBClass.GetSettingString(DbFieldFilter, "");
             if (filter.Length > 0)
                 fieldfilter.FromJSON(filter);        // load filter
 
             ExtraIcons(false,false);
+
+            discoveryform.OnHistoryChange += Display;
+            discoveryform.OnNewEntry += AddNewEntry;
         }
 
         public void ExtraIcons(bool icon, bool popout)

--- a/EDDiscovery/UserControls/UserControlMarketData.cs
+++ b/EDDiscovery/UserControls/UserControlMarketData.cs
@@ -49,12 +49,12 @@ namespace EDDiscovery.UserControls
             dataGridViewMarketData.DefaultCellStyle.WrapMode = DataGridViewTriState.False;
             dataGridViewMarketData.RowTemplate.Height = 26;
 
-            discoveryform.OnNewEntry += OnChanged;
-            uctg.OnTravelSelectionChanged += OnChanged;
-
             checkBoxBuyOnly.Checked = SQLiteDBClass.GetSettingBool(DbBuyOnly, false);
             this.checkBoxBuyOnly.CheckedChanged += new System.EventHandler(this.checkBoxBuyOnly_CheckedChanged);
             checkBoxAutoSwap.Checked = SQLiteDBClass.GetSettingBool(DbAutoSwap, false);
+
+            discoveryform.OnNewEntry += OnChanged;
+            uctg.OnTravelSelectionChanged += OnChanged;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -61,9 +61,9 @@ namespace EDDiscovery.UserControls
 
             }
 
-            uctg.OnTravelSelectionChanged += Display;
-
             SetCheckBoxes();
+
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlMissions.cs
+++ b/EDDiscovery/UserControls/UserControlMissions.cs
@@ -57,9 +57,6 @@ namespace EDDiscovery.UserControls
             dataGridViewPrevious.DefaultCellStyle.WrapMode = DataGridViewTriState.True;
             dataGridViewPrevious.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCells;     // NEW! appears to work https://msdn.microsoft.com/en-us/library/74b2wakt(v=vs.110).aspx
 
-            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            uctg.OnTravelSelectionChanged += Display;
-
             string start = SQLiteDBClass.GetSettingString(DbStartDate, "");
             DateTime dt;
             if (start != "" && DateTime.TryParse(start, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out dt))
@@ -72,6 +69,9 @@ namespace EDDiscovery.UserControls
                 customDateTimePickerEnd.Value = dt;
 
             customDateTimePickerEnd.Checked = SQLiteDBClass.GetSettingBool(DbEndDateChecked, false);
+
+            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlModules.cs
+++ b/EDDiscovery/UserControls/UserControlModules.cs
@@ -47,11 +47,11 @@ namespace EDDiscovery.UserControls
             dataGridViewModules.DefaultCellStyle.WrapMode = DataGridViewTriState.False;
             dataGridViewModules.RowTemplate.Height = 26;
 
+            buttonExtCoriolis.Visible = false;
+
             discoveryform.OnHistoryChange += Discoveryform_OnHistoryChange; ;
             discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
             uctg.OnTravelSelectionChanged += Display;
-
-            buttonExtCoriolis.Visible = false;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlNotePanel.cs
+++ b/EDDiscovery/UserControls/UserControlNotePanel.cs
@@ -56,11 +56,11 @@ namespace EDDiscovery.UserControls
         {
             config = (Configuration)SQLiteDBClass.GetSettingInt(DbSave + "Config", (int)config);
 
+            displayfont = discoveryform.theme.GetFont;
+
             discoveryform.OnHistoryChange += Display;
             discoveryform.OnNewEntry += NewEntry;
             uctg.OnTravelSelectionChanged += DisplaySelected;
-
-            displayfont = discoveryform.theme.GetFont;
         }
 
         public override void InitialDisplay()

--- a/EDDiscovery/UserControls/UserControlRouteTracker.cs
+++ b/EDDiscovery/UserControls/UserControlRouteTracker.cs
@@ -42,10 +42,6 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            discoveryform.OnHistoryChange += Display;
-            discoveryform.OnNewEntry += NewEntry;
-            discoveryform.OnNewTarget += NewTarget;
-
             displayfont = discoveryform.theme.GetFont;
 
             autoCopyWPToolStripMenuItem.Checked = SQLiteDBClass.GetSettingBool(DbSave + "autoCopyWP", false);
@@ -55,6 +51,10 @@ namespace EDDiscovery.UserControls
             long id = long.Parse(selRoute);
             _currentRoute = SavedRouteClass.GetAllSavedRoutes().Find(r => r.Id.Equals(id));
             updateScreen();
+
+            discoveryform.OnHistoryChange += Display;
+            discoveryform.OnNewEntry += NewEntry;
+            discoveryform.OnNewTarget += NewTarget;
         }
 
         public override void Closing()

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -58,9 +58,6 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            uctg.OnTravelSelectionChanged += Display;
-            discoveryform.OnNewEntry += NewEntry;
-
             progchange = true;
             checkBoxMaterials.Checked = SQLiteDBClass.GetSettingBool(DbSave + "Materials", true);
             checkBoxMaterialsRare.Checked = SQLiteDBClass.GetSettingBool(DbSave + "MaterialsRare", false);
@@ -71,6 +68,9 @@ namespace EDDiscovery.UserControls
 
             int size = SQLiteDBClass.GetSettingInt(DbSave + "Size", 64);
             SetSizeCheckBoxes(size);
+
+            uctg.OnTravelSelectionChanged += Display;
+            discoveryform.OnNewEntry += NewEntry;
 
             imagebox.ClickElement += ClickElement;
         }

--- a/EDDiscovery/UserControls/UserControlShoppingList.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.cs
@@ -55,11 +55,11 @@ namespace EDDiscovery.UserControls
 
             // so the way it works, if the panels ever re-display (for whatever reason) they tell us, and we redisplay
 
-            userControlSynthesis.OnDisplayComplete += Synthesis_OnWantedChange;
-            userControlEngineering.OnDisplayComplete += Engineering_OnWantedChange;
-
             showMaxInjections = SQLiteDBClass.GetSettingBool(DbShowInjectionsSave, true);
             pictureBoxList.ContextMenuStrip = contextMenuConfig;
+
+            userControlSynthesis.OnDisplayComplete += Synthesis_OnWantedChange;
+            userControlEngineering.OnDisplayComplete += Engineering_OnWantedChange;
         }
 
         public override void Closing()

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -117,11 +117,6 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            discoveryform.OnHistoryChange += Display;
-            discoveryform.OnNewEntry += NewEntry;
-            discoveryform.OnNewTarget += NewTarget;
-            discoveryform.OnNewUIEvent += OnNewUIEvent;
-
             config = (long)(SQLiteDBClass.GetSettingInt(DbSave + "Config", (int)config)) | ((long)(SQLiteDBClass.GetSettingInt(DbSave + "ConfigH", (int)(config >> 32))) << 32);
             toolStripMenuItemTargetLine.Checked = Config(Configuration.showTargetLine);
             toolStripMenuItemTime.Checked = Config(Configuration.showTime);
@@ -175,6 +170,10 @@ namespace EDDiscovery.UserControls
 
             dividers = new ButtonExt[] { buttonExt0, buttonExt1, buttonExt2, buttonExt3, buttonExt4, buttonExt5, buttonExt6, buttonExt7, buttonExt8, buttonExt9, buttonExt10, buttonExt11, buttonExt12 };
 
+            discoveryform.OnHistoryChange += Display;
+            discoveryform.OnNewEntry += NewEntry;
+            discoveryform.OnNewTarget += NewTarget;
+            discoveryform.OnNewUIEvent += OnNewUIEvent;
         }
 
         public override void Closing()

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -41,8 +41,6 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            uctg.OnTravelSelectionChanged += Uctg_OnTravelSelectionChanged;
-
             computer = new StarDistanceComputer();
 
             HistoryEntry he = uctg.GetCurrentHistoryEntry;      // does our UCTG have a system selected?
@@ -52,6 +50,8 @@ namespace EDDiscovery.UserControls
                 //System.Diagnostics.Debug.WriteLine("Star grid started, uctg selected, ask");
                 computer.CalculateClosestSystems(he.System, (s, d) => BeginInvoke((MethodInvoker)delegate { NewStarListComputed(s, d); }));     // hook here, force closes system update
             }
+
+            uctg.OnTravelSelectionChanged += Uctg_OnTravelSelectionChanged;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -80,9 +80,6 @@ namespace EDDiscovery.UserControls
 
             checkBoxMoveToTop.Checked = SQLiteConnectionUser.GetSettingBool(DbAutoTop, true);
 
-            discoveryform.OnHistoryChange += HistoryChanged;
-            discoveryform.OnNewEntry += AddNewEntry;
-
             dataGridViewStarList.MakeDoubleBuffered();
             dataGridViewStarList.RowTemplate.Height = DefaultRowHeight;
             dataGridViewStarList.DefaultCellStyle.WrapMode = DataGridViewTriState.True;
@@ -92,6 +89,9 @@ namespace EDDiscovery.UserControls
             checkBoxEDSM.Checked = SQLiteDBClass.GetSettingBool(DbEDSM, false);
 
             ExtraIcons(false);
+
+            discoveryform.OnHistoryChange += HistoryChanged;
+            discoveryform.OnNewEntry += AddNewEntry;
         }
 
         public void ExtraIcons(bool icon)

--- a/EDDiscovery/UserControls/UserControlStats.cs
+++ b/EDDiscovery/UserControls/UserControlStats.cs
@@ -37,9 +37,9 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
+            userControlStatsTimeScan.ScanMode = true;
             discoveryform.OnNewEntry += AddNewEntry;
             uctg.OnTravelSelectionChanged += SelectionChanged;
-            userControlStatsTimeScan.ScanMode = true;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -64,9 +64,6 @@ namespace EDDiscovery.UserControls
             dataGridViewSynthesis.DefaultCellStyle.WrapMode = DataGridViewTriState.False;
             dataGridViewSynthesis.RowTemplate.Height = 26;
 
-            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            uctg.OnTravelSelectionChanged += Display;
-
             Order = SQLiteDBClass.GetSettingString(DbOSave, "").RestoreArrayFromString(0, SynthesisRecipes.Count);
             if (Order.Distinct().Count() != Order.Length)       // if not distinct..
                 for (int i = 0; i < Order.Length; i++)          // reset
@@ -107,6 +104,9 @@ namespace EDDiscovery.UserControls
                     row.Visible = false;
                 }
             }
+
+            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -77,9 +77,6 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            uctg.OnTravelSelectionChanged += Display;    // get this whenever current selection or refreshed..
-            discoveryform.OnNewTarget += RefreshTargetDisplay;
-            discoveryform.OnNoteChanged += OnNoteChanged;
             textBoxTarget.SetAutoCompletor(SystemClassDB.ReturnSystemListForAutoComplete);
 
             // same order as Sel bits are defined in, one bit per selection item.
@@ -96,6 +93,10 @@ namespace EDDiscovery.UserControls
                 Reset();
             else
                 Lines = BaseUtils.LineStore.Restore(rs, HorzPositions);
+
+            uctg.OnTravelSelectionChanged += Display;    // get this whenever current selection or refreshed..
+            discoveryform.OnNewTarget += RefreshTargetDisplay;
+            discoveryform.OnNoteChanged += OnNoteChanged;
         }
 
         public override void ChangeCursorType(UserControlCursorType thc)

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -104,10 +104,6 @@ namespace EDDiscovery.UserControls
 
             checkBoxMoveToTop.Checked = SQLiteConnectionUser.GetSettingBool(DbAutoTop, true);
 
-            discoveryform.OnHistoryChange += HistoryChanged;
-            discoveryform.OnNewEntry += AddNewEntry;
-            discoveryform.OnNoteChanged += OnNoteChanged;
-
             dataGridViewTravel.MakeDoubleBuffered();
             dataGridViewTravel.RowTemplate.Height = DefaultRowHeight;
 
@@ -120,6 +116,10 @@ namespace EDDiscovery.UserControls
 #endif
 
             ExtraIcons(false,false);
+
+            discoveryform.OnHistoryChange += HistoryChanged;
+            discoveryform.OnNewEntry += AddNewEntry;
+            discoveryform.OnNoteChanged += OnNoteChanged;
         }
 
         public void ExtraIcons(bool icon, bool popout )

--- a/EDDiscovery/UserControls/UserControlTrippanel.cs
+++ b/EDDiscovery/UserControls/UserControlTrippanel.cs
@@ -47,10 +47,6 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            discoveryform.OnHistoryChange += Display;
-            discoveryform.OnNewEntry += NewEntry;
-            discoveryform.OnNewTarget += NewTarget;
-
             displayfont = discoveryform.theme.GetFont;
 
             jumpRange = SQLiteDBClass.GetSettingDouble(DbSave + "JumpRange", -1.0);
@@ -65,7 +61,9 @@ namespace EDDiscovery.UserControls
             fsdDrive = SQLiteDBClass.GetSettingString(DbSave + "fsdDrive", null);
             tankWarning = SQLiteDBClass.GetSettingDouble(DbSave + "TankWarning", -1);
 
-
+            discoveryform.OnHistoryChange += Display;
+            discoveryform.OnNewEntry += NewEntry;
+            discoveryform.OnNewTarget += NewTarget;
         }
 
         private double jumpRange = -1;


### PR DESCRIPTION
An async timer or callback could be called during any synchronous UI call.  Hooking events that can be called by async events can result in e.g. `Display` being called before init is complete.

Moving the hooks to the end of `Init` should fix #1435 and #1441.