### PR TITLE
Fix AppVeyor and Travis builds

### DIFF
--- a/Audio/VoiceRecognitionWindows.cs
+++ b/Audio/VoiceRecognitionWindows.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Speech.Recognition;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace AudioExtensions
 {
+#if !NO_SYSTEM_SPEECH
+    using System.Speech.Recognition;
+
     public class VoiceRecognitionWindows : VoiceRecognition
     {
         public float Confidence { get; set; } = 0.98F;
@@ -154,4 +156,5 @@ namespace AudioExtensions
         }
 
     }
+#endif
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-version: 3.2.1.{build}
+version: 8.4.1.{build}
+image: Visual Studio 2017
 configuration: Release
 before_build:
   - nuget restore


### PR DESCRIPTION
* Exclude VoiceRecognitionWindows from compilation when `NO_SYSTEM_SPEECH` is defined.
* Switch AppVeyor to the Visual Studio 2017 image.