### PR TITLE
Fix some IDE1006 interface naming rule violations (redo #1456)

### DIFF
--- a/ActionLanguage/ActionsCoreCmds/ActionKey.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionKey.cs
@@ -72,7 +72,7 @@ namespace ActionLanguage
             return FromString(userdata, out saying, out vars) ? null : "Key command line not in correct format";
         }
 
-        static public string Menu(Form parent, System.Drawing.Icon ic, string userdata, List<string> additionalkeys, BaseUtils.EnhancedSendKeys.AdditionalKeyParser additionalparser)
+        static public string Menu(Form parent, System.Drawing.Icon ic, string userdata, List<string> additionalkeys, BaseUtils.EnhancedSendKeys.IAdditionalKeyParser additionalparser)
         {
             ConditionVariables vars;
             string keys;
@@ -118,7 +118,7 @@ namespace ActionLanguage
 
         static List<string> errorsreported = new List<string>();
 
-        public bool ExecuteAction(ActionProgramRun ap, BaseUtils.EnhancedSendKeys.AdditionalKeyParser akp )      // additional parser
+        public bool ExecuteAction(ActionProgramRun ap, BaseUtils.EnhancedSendKeys.IAdditionalKeyParser akp )      // additional parser
         { 
             string keys;
             ConditionVariables statementvars;

--- a/BaseUtils/Keys/EnhancedSendKeys.cs
+++ b/BaseUtils/Keys/EnhancedSendKeys.cs
@@ -51,7 +51,7 @@ namespace BaseUtils
     {
         public static string CurrentWindow = "Current window";
 
-        public interface AdditionalKeyParser
+        public interface IAdditionalKeyParser
         {
             Tuple<string, int, string> Parse(string s);      // return replace key string, or null if not recognised.  int is parse length, Any errors signal in second string or null
         }
@@ -114,7 +114,7 @@ namespace BaseUtils
 
         enum KMode { press, up, down };
 
-        private static string ParseKeys(string s, int defdelay, int defshiftdelay, int defupdelay, AdditionalKeyParser additionalkeyparser = null)
+        private static string ParseKeys(string s, int defdelay, int defshiftdelay, int defupdelay, IAdditionalKeyParser additionalkeyparser = null)
         {
             if (events != null)
                 events.Clear();
@@ -381,7 +381,7 @@ namespace BaseUtils
         }
 
 
-        public static string Send(string keys, int keydelay, int shiftdelay, int updelay, string pname = null, AdditionalKeyParser additionalkeyparser = null)
+        public static string Send(string keys, int keydelay, int shiftdelay, int updelay, string pname = null, IAdditionalKeyParser additionalkeyparser = null)
         {
             if (!keys.HasChars())
                 return "";
@@ -425,7 +425,7 @@ namespace BaseUtils
             return "";
         }
 
-        public static string VerifyKeys(string s, AdditionalKeyParser additionalkeyparser = null)
+        public static string VerifyKeys(string s, IAdditionalKeyParser additionalkeyparser = null)
         {
             return ParseKeys(s, 10, 10, 10, additionalkeyparser);
         }

--- a/DirectInput/DirectInput.csproj
+++ b/DirectInput/DirectInput.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IInputDevice.cs" />
     <Compile Include="InputDeviceJoystickWindows.cs" />
     <Compile Include="InputDeviceKeyboard.cs" />
     <Compile Include="InputDeviceList.cs" />

--- a/DirectInput/IInputDevice.cs
+++ b/DirectInput/IInputDevice.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using System.Collections.Generic;
+using System.Threading;
+
+namespace DirectInputDevices
+{
+    public interface IInputDevice
+    {
+        InputDeviceIdentity ID();
+        AutoResetEvent Eventhandle();               // set when device changes state
+
+        List<InputDeviceEvent> GetEvents();         // get events after change state
+        void Dispose();
+
+        string EventName(InputDeviceEvent e);       // Frontier event name from input event
+
+        bool? IsPressed(string eventname);          // if an input supports pressed, true/false, else null
+
+        string ToString();
+    }
+}

--- a/DirectInput/InputDeviceJoystickWindows.cs
+++ b/DirectInput/InputDeviceJoystickWindows.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace DirectInputDevices
 {
-    public class InputDeviceJoystickWindows : InputDeviceInterface
+    public class InputDeviceJoystickWindows : IInputDevice
     {
         public InputDeviceIdentity ID() { return jsi;  }
         InputDeviceIdentity jsi;

--- a/DirectInput/InputDeviceKeyboard.cs
+++ b/DirectInput/InputDeviceKeyboard.cs
@@ -298,7 +298,7 @@ namespace DirectInputDevices
     }
 
 
-    public class InputDeviceKeyboard : InputDeviceInterface
+    public class InputDeviceKeyboard : IInputDevice
     {
         public InputDeviceIdentity ID() { return ksi; }
         InputDeviceIdentity ksi;

--- a/DirectInput/InputDeviceList.cs
+++ b/DirectInput/InputDeviceList.cs
@@ -24,31 +24,31 @@ namespace DirectInputDevices
 {
     // list of devices, and main event loop.  Hook to OnNewEvent
 
-    public class InputDeviceList : IEnumerable<InputDeviceInterface>
+    public class InputDeviceList : IEnumerable<IInputDevice>
     {
         public event Action<List<InputDeviceEvent>> OnNewEvent;
 
         private Action<Action> invokeAsyncOnUiThread;
         private System.Threading.AutoResetEvent stophandle = new System.Threading.AutoResetEvent(false);        // used by dispose to tell thread to stop
         private System.Threading.Thread waitfordatathread;      // the background worker
-        private List<InputDeviceInterface> inputdevices { get; set; } = new List<InputDeviceInterface>();
+        private List<IInputDevice> inputdevices { get; set; } = new List<IInputDevice>();
 
         public InputDeviceList(Action<Action> i)            // Action context is pass to call in.. 
         {
             invokeAsyncOnUiThread = i;
         }
 
-        public void Add(InputDeviceInterface i)
+        public void Add(IInputDevice i)
         {
             inputdevices.Add(i);
         }
 
-        public InputDeviceInterface Find(Predicate<InputDeviceInterface> p)
+        public IInputDevice Find(Predicate<IInputDevice> p)
         {
             return inputdevices.Find(p);
         }
 
-        public IEnumerator<InputDeviceInterface> GetEnumerator()
+        public IEnumerator<IInputDevice> GetEnumerator()
         {
             foreach (var e in inputdevices)
                 yield return e;
@@ -62,7 +62,7 @@ namespace DirectInputDevices
         public string ListDevices()
         {
             string ret = "";
-            foreach (InputDeviceInterface i in inputdevices)
+            foreach (IInputDevice i in inputdevices)
                 ret += i.ToString() + Environment.NewLine;
             return ret;
         }
@@ -91,7 +91,7 @@ namespace DirectInputDevices
         {
             Stop();
 
-            foreach (InputDeviceInterface i in inputdevices)
+            foreach (IInputDevice i in inputdevices)
                 i.Dispose();
 
             inputdevices.Clear();

--- a/DirectInput/InputDeviceMouse.cs
+++ b/DirectInput/InputDeviceMouse.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace DirectInputDevices
 {
-    public class InputDeviceMouse : InputDeviceInterface
+    public class InputDeviceMouse : IInputDevice
     {
         public InputDeviceIdentity ID() { return msi; }
         InputDeviceIdentity msi;

--- a/DirectInput/InputDevicesInterface.cs
+++ b/DirectInput/InputDevicesInterface.cs
@@ -29,13 +29,13 @@ namespace DirectInputDevices
 
     public class InputDeviceEvent
     {
-        public InputDeviceInterface Device;
+        public IInputDevice Device;
 
         public int EventNumber { get; set; }     // indentity of event : keys code, joystick buttons/axis/pov number, etc
         public bool Pressed { get; set; }   // button pressed.. or POV is not centred, or null if it does not press.
         public int Value { get; set; }      // if applicable, axis for instance..
 
-        public InputDeviceEvent(InputDeviceInterface d, int en , bool p, int v = 0)
+        public InputDeviceEvent(IInputDevice d, int en , bool p, int v = 0)
         {
             Device = d; EventNumber = en; Pressed = p; Value = v; 
         }
@@ -47,20 +47,5 @@ namespace DirectInputDevices
 
         //public Tuple<string, bool> BindingsMatch() { return Device.BindingsMatch(this); }
         public string EventName() { return Device.EventName(this); }
-    }
-
-    public interface InputDeviceInterface
-    {
-        InputDeviceIdentity ID();
-        System.Threading.AutoResetEvent Eventhandle();          // set when device changes state
-
-        List<InputDeviceEvent> GetEvents();                     // get events after change state
-        void Dispose();
-
-        string EventName(InputDeviceEvent e);   // Frontier event name from input event
-
-        bool? IsPressed(string eventname);       // if an input supports pressed, true/false, else null
-
-        string ToString();
     }
 }

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionKeyED.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionKeyED.cs
@@ -31,7 +31,7 @@ namespace EDDiscovery.Actions
     {
         const string errmsgforbinding = "No keyboard binding for ";
 
-        class AKP : BaseUtils.EnhancedSendKeys.AdditionalKeyParser      // AKP parser to pass to SendKeys
+        class AKP : BaseUtils.EnhancedSendKeys.IAdditionalKeyParser      // AKP parser to pass to SendKeys
         {
             public EliteDangerousCore.BindingsFile bindingsfile;
 

--- a/EDDiscovery/Actions/ActionsFromInputDevices.cs
+++ b/EDDiscovery/Actions/ActionsFromInputDevices.cs
@@ -57,7 +57,7 @@ namespace EDDiscovery.Actions
             string ret = "";
             foreach (BindingsFile.Device bd in bf)     // for all devices listed in the binding file
             {
-                InputDeviceInterface idi = GetInputDeviceFromBindingDevice(bd);
+                IInputDevice idi = GetInputDeviceFromBindingDevice(bd);
 
                 if (idi == null)
                     ret += "ERROR: Missing physical device for " + bd.Name + Environment.NewLine;
@@ -168,7 +168,7 @@ namespace EDDiscovery.Actions
 
             foreach (BindingsFile.DeviceKeyPair ma in a.keys)
             {
-                InputDeviceInterface idi = GetInputDeviceFromBindingDevice(ma.Device);
+                IInputDevice idi = GetInputDeviceFromBindingDevice(ma.Device);
 
                 if (idi == null )       // no device, false
                     return new Tuple<bool,bool>(false,false);
@@ -193,9 +193,9 @@ namespace EDDiscovery.Actions
             return dv;
         }
 
-        InputDeviceInterface GetInputDeviceFromBindingDevice(BindingsFile.Device dv)
+        IInputDevice GetInputDeviceFromBindingDevice(BindingsFile.Device dv)
         {
-            InputDeviceInterface i = devices.Find(x =>
+            IInputDevice i = devices.Find(x =>
             {
                 BindingsFile.Device b = bf.FindDevice(x.ID().Name, x.ID().Instanceguid, x.ID().Productguid);
                 return b != null && b.Name.Equals(dv.Name);

--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -31,7 +31,7 @@ using EliteDangerousCore.DB;
 
 namespace EDDiscovery
 {
-    public class EDDConfig : EliteDangerousCore.EliteConfig
+    public class EDDConfig : EliteDangerousCore.IEliteConfig
     {
         private static EDDConfig _instance;
 

--- a/EDDiscovery/EDDOptions.cs
+++ b/EDDiscovery/EDDOptions.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace EDDiscovery
 {
-    public class EDDOptions : EliteDangerousCore.EliteOptions
+    public class EDDOptions : EliteDangerousCore.IEliteOptions
     {
         public static EDDOptions Instance
         {

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -225,6 +225,7 @@
     <Compile Include="ScreenShots\ScreenShotConverter.cs" />
     <Compile Include="ScreenShots\ScreenShotDirectoryWatcher.cs" />
     <Compile Include="ScreenShots\ScreenShotImageConverter.cs" />
+    <Compile Include="UserControls\IHistoryCursor.cs" />
     <Compile Include="UserControls\UserControlContainerGrid.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/EDDiscovery/UserControls/IHistoryCursor.cs
+++ b/EDDiscovery/UserControls/IHistoryCursor.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using EliteDangerousCore;
+
+namespace EDDiscovery.UserControls
+{
+    // Any UCs wanting to be a cursor, must implement this interface
+
+    public delegate void ChangedSelectionHandler(int rowno, int colno, bool doubleclick, bool note);
+    public delegate void ChangedSelectionHEHandler(HistoryEntry he, HistoryList hl);
+
+    public interface IHistoryCursor
+    {
+        event ChangedSelectionHandler OnChangedSelection;           // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
+        event ChangedSelectionHEHandler OnTravelSelectionChanged;   // as above, different format, for certain older controls
+        void FireChangeSelection();                                 // fire a change sel event to everyone
+        void GotoPosByJID(long jid);                                // goto a pos by JID
+        HistoryEntry GetCurrentHistoryEntry { get; }                // whats your current entry, null if not
+    }
+}

--- a/EDDiscovery/UserControls/UserControlCommonBase.cs
+++ b/EDDiscovery/UserControls/UserControlCommonBase.cs
@@ -54,10 +54,10 @@ namespace EDDiscovery.UserControls
 
         public int displaynumber { get; protected set; }
         public EDDiscoveryForm discoveryform { get; protected set; }
-        public UserControlCursorType uctg { get; protected set; }
+        public IHistoryCursor uctg { get; protected set; }
 
         // in calling order..
-        public void Init(EDDiscoveryForm ed, UserControlCursorType thc, int dn)
+        public void Init(EDDiscoveryForm ed, IHistoryCursor thc, int dn)
         {
             System.Diagnostics.Debug.WriteLine("Open UCCB " + this.Name + " of " + this.GetType().Name + " with " + dn);
             discoveryform = ed;
@@ -71,7 +71,7 @@ namespace EDDiscovery.UserControls
         public virtual void InitialDisplay() { }    // then after the themeing, do the initial display
         public virtual void Closing() { }           // close it
 
-        public virtual void ChangeCursorType(UserControlCursorType thc) { }     // optional, cursor has changed
+        public virtual void ChangeCursorType(IHistoryCursor thc) { }     // optional, cursor has changed
 
         public virtual Color ColorTransparency { get { return Color.Transparent; } }        // override to say support transparency, and what colour you want.
         public virtual void SetTransparency(bool on, Color curcol) { }                      // set on/off transparency of components.
@@ -176,19 +176,5 @@ namespace EDDiscovery.UserControls
         }
 
         #endregion
-    }
-
-    // Any UCs wanting to be a cursor, must implement this interface
-
-    public delegate void ChangedSelection(int rowno, int colno, bool doubleclick, bool note);
-    public delegate void ChangedSelectionHE(HistoryEntry he, HistoryList hl);
-
-    public interface UserControlCursorType
-    {
-        event ChangedSelection OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
-        event ChangedSelectionHE OnTravelSelectionChanged;   // as above, different format, for certain older controls
-        void FireChangeSelection(); // fire a change sel event to everyone
-        void GotoPosByJID(long jid);    // goto a pos by JID
-        HistoryEntry GetCurrentHistoryEntry { get; }    // whats your current entry, null if not
     }
 }

--- a/EDDiscovery/UserControls/UserControlContainerGrid.cs
+++ b/EDDiscovery/UserControls/UserControlContainerGrid.cs
@@ -16,8 +16,8 @@ namespace EDDiscovery.UserControls
 {
     public partial class UserControlContainerGrid: UserControlCommonBase        // circular, huh! neat!
     {
-        private UserControlCursorType ucursor_history;     // one passed to us, refers to thc.uctg
-        private UserControlCursorType ucursor_inuse;  // one in use
+        private IHistoryCursor ucursor_history;     // one passed to us, refers to thc.uctg
+        private IHistoryCursor ucursor_inuse;  // one in use
 
         private List<UserControlContainerResizable> uccrlist = new List<UserControlContainerResizable>();
 
@@ -138,7 +138,7 @@ namespace EDDiscovery.UserControls
             System.Diagnostics.Debug.WriteLine("---- END Grid Saving to " + DbWindows);
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)     // a grid below changed its travel grid, update our history one
+        public override void ChangeCursorType(IHistoryCursor thc)     // a grid below changed its travel grid, update our history one
         {
             bool changedinuse = Object.ReferenceEquals(ucursor_inuse, ucursor_history);   // if we are using the history as the current tg
             //System.Diagnostics.Debug.WriteLine("Grid CTG " + ucursor_history.GetHashCode() + " IU " + ucursor_inuse.GetHashCode() + " New " + thc.GetHashCode());
@@ -241,7 +241,7 @@ namespace EDDiscovery.UserControls
             if (v == null)
                 v = uccrlist.Find(x => x.control.GetType() == typeof(UserControlStarList));   // find one with Journal grid if no TG
 
-            UserControlCursorType uctgfound = (v != null) ? (v.control as UserControlCursorType) : null;    // if found, set to it
+            IHistoryCursor uctgfound = (v != null) ? (v.control as IHistoryCursor) : null;    // if found, set to it
 
             if ( (uctgfound != null && !Object.ReferenceEquals(uctgfound,ucursor_inuse) ) ||    // if got one but its not the one currently in use
                  (uctgfound == null && !Object.ReferenceEquals(ucursor_history,ucursor_inuse))    // or not found, but we are not on the history one

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -117,7 +117,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlEstimatedValues.cs
+++ b/EDDiscovery/UserControls/UserControlEstimatedValues.cs
@@ -45,7 +45,7 @@ namespace EDDiscovery.UserControls
             discoveryform.OnNewEntry += NewEntry;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.cs
@@ -65,7 +65,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -30,7 +30,7 @@ using EliteDangerousCore;
 
 namespace EDDiscovery.UserControls
 {
-    public partial class UserControlJournalGrid : UserControlCommonBase, UserControlCursorType
+    public partial class UserControlJournalGrid : UserControlCommonBase, IHistoryCursor
     {
         EventFilterSelector cfs = new EventFilterSelector();
         private Conditions.ConditionLists fieldfilter = new Conditions.ConditionLists();
@@ -47,8 +47,8 @@ namespace EDDiscovery.UserControls
 
         private HistoryList current_historylist;        // the last one set, for internal refresh purposes on sort
 
-        public event ChangedSelection OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
-        public event ChangedSelectionHE OnTravelSelectionChanged;   // as above, different format, for certain older controls
+        public event ChangedSelectionHandler OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
+        public event ChangedSelectionHEHandler OnTravelSelectionChanged;   // as above, different format, for certain older controls
         public HistoryEntry GetCurrentHistoryEntry { get { return dataGridViewJournal.CurrentCell != null ? dataGridViewJournal.Rows[dataGridViewJournal.CurrentCell.RowIndex].Cells[JournalHistoryColumns.HistoryTag].Tag as HistoryEntry : null; } }
 
 

--- a/EDDiscovery/UserControls/UserControlMarketData.cs
+++ b/EDDiscovery/UserControls/UserControlMarketData.cs
@@ -57,7 +57,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += OnChanged;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= OnChanged;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -66,7 +66,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlMissions.cs
+++ b/EDDiscovery/UserControls/UserControlMissions.cs
@@ -74,7 +74,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlModules.cs
+++ b/EDDiscovery/UserControls/UserControlModules.cs
@@ -54,7 +54,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlNotePanel.cs
+++ b/EDDiscovery/UserControls/UserControlNotePanel.cs
@@ -68,7 +68,7 @@ namespace EDDiscovery.UserControls
             DisplaySelected(uctg.GetCurrentHistoryEntry, discoveryform.history);
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= DisplaySelected;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlRoute.cs
+++ b/EDDiscovery/UserControls/UserControlRoute.cs
@@ -77,7 +77,7 @@ namespace EDDiscovery.UserControls
 
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg = thc;
         }

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -75,7 +75,7 @@ namespace EDDiscovery.UserControls
             imagebox.ClickElement += ClickElement;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlScreenshot.cs
+++ b/EDDiscovery/UserControls/UserControlScreenshot.cs
@@ -46,7 +46,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -54,7 +54,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Uctg_OnTravelSelectionChanged;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -31,7 +31,7 @@ using EliteDangerousCore.JournalEvents;
 
 namespace EDDiscovery.UserControls
 {
-    public partial class UserControlStarList : UserControlCommonBase, UserControlCursorType
+    public partial class UserControlStarList : UserControlCommonBase, IHistoryCursor
     {
         #region Public IF
 
@@ -42,9 +42,9 @@ namespace EDDiscovery.UserControls
 
         #region Events
 
-        // implement UserControlCursorType fields
-        public event ChangedSelection OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
-        public event ChangedSelectionHE OnTravelSelectionChanged;   // as above, different format, for certain older controls
+        // implement IHistoryCursor fields
+        public event ChangedSelectionHandler OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
+        public event ChangedSelectionHEHandler OnTravelSelectionChanged;   // as above, different format, for certain older controls
 
         #endregion
 

--- a/EDDiscovery/UserControls/UserControlStats.cs
+++ b/EDDiscovery/UserControls/UserControlStats.cs
@@ -42,7 +42,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += SelectionChanged;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= SelectionChanged;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -109,7 +109,7 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += Display;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -99,7 +99,7 @@ namespace EDDiscovery.UserControls
             discoveryform.OnNoteChanged += OnNoteChanged;
         }
 
-        public override void ChangeCursorType(UserControlCursorType thc)
+        public override void ChangeCursorType(IHistoryCursor thc)
         {
             uctg.OnTravelSelectionChanged -= Display;
             uctg = thc;

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -30,7 +30,7 @@ using EliteDangerousCore.EDDN;
 
 namespace EDDiscovery.UserControls
 {
-    public partial class UserControlTravelGrid : UserControlCommonBase, UserControlCursorType
+    public partial class UserControlTravelGrid : UserControlCommonBase, IHistoryCursor
     {
         #region Public IF
 
@@ -44,9 +44,9 @@ namespace EDDiscovery.UserControls
 
         #region Events
 
-        // implement UserControlCursorType fields
-        public event ChangedSelection OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
-        public event ChangedSelectionHE OnTravelSelectionChanged;   // as above, different format, for certain older controls
+        // implement IHistoryCursor fields
+        public event ChangedSelectionHandler OnChangedSelection;   // After a change of selection by the user, or after a OnHistoryChanged, or after a sort.
+        public event ChangedSelectionHEHandler OnTravelSelectionChanged;   // as above, different format, for certain older controls
 
         // for primary travel grid for auto note jump
         public delegate void KeyDownInCell(int asciikeycode, int rowno, int colno, bool note);

--- a/EliteDangerous/Config/EliteConfigInstance.cs
+++ b/EliteDangerous/Config/EliteConfigInstance.cs
@@ -1,0 +1,26 @@
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+
+// provides access to some config items via interface and singleton needed by this code.
+
+namespace EliteDangerousCore
+{
+    public static class EliteConfigInstance
+    {
+        static public IEliteOptions InstanceOptions { get; set; }
+        static public IEliteConfig InstanceConfig { get; set; }
+    }
+}

--- a/EliteDangerous/Config/IEliteConfig.cs
+++ b/EliteDangerous/Config/IEliteConfig.cs
@@ -14,33 +14,12 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 
- using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-// provides access to some config items via interface and singleton needed by this code.
-
 namespace EliteDangerousCore
 {
-    public interface EliteOptions
-    {
-        string AppDataDirectory { get; }
-        string SystemDatabasePath { get; }
-        string UserDatabasePath { get; }
-    }
-
-    public interface EliteConfig
+    public interface IEliteConfig
     {
         int DefaultMapColour { get; }
         bool ClearCommodities { get; }
         bool ClearMaterials { get; }
-    }
-
-    public static class EliteConfigInstance
-    {
-        static public EliteOptions InstanceOptions { get; set; }
-        static public EliteConfig InstanceConfig { get; set; }
     }
 }

--- a/EliteDangerous/Config/IEliteOptions.cs
+++ b/EliteDangerous/Config/IEliteOptions.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+
+namespace EliteDangerousCore
+{
+    public interface IEliteOptions
+    {
+        string AppDataDirectory { get; }
+        string SystemDatabasePath { get; }
+        string UserDatabasePath { get; }
+    }
+}

--- a/EliteDangerous/EliteDangerous.csproj
+++ b/EliteDangerous/EliteDangerous.csproj
@@ -74,7 +74,9 @@
     <Compile Include="CompanionAPI\CStarport.cs" />
     <Compile Include="CompanionAPI\CSystem.cs" />
     <Compile Include="CompanionAPI\RijndaelCrypt.cs" />
-    <Compile Include="Config\EliteConfig.cs" />
+    <Compile Include="Config\EliteConfigInstance.cs" />
+    <Compile Include="Config\IEliteConfig.cs" />
+    <Compile Include="Config\IEliteOptions.cs" />
     <Compile Include="DB\BookmarkClass.cs" />
     <Compile Include="DB\IVisitedSystems.cs" />
     <Compile Include="DB\RegisterEntry.cs" />

--- a/ExtendedControls/ExtendedControls.csproj
+++ b/ExtendedControls/ExtendedControls.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Controls\PanelSelectionList.Designer.cs">
       <DependentUpon>PanelSelectionList.cs</DependentUpon>
     </Compile>
+    <Compile Include="Themes\ITheme.cs" />
     <Compile Include="Themes\ThemeStandardEditor.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/ExtendedControls/Forms/InfoForm.cs
+++ b/ExtendedControls/Forms/InfoForm.cs
@@ -42,7 +42,7 @@ namespace ExtendedControls
 
             labelCaption.Text = title;
 
-            ThemeableForms theme = ThemeableFormsInstance.Instance;
+            ITheme theme = ThemeableFormsInstance.Instance;
 
             if (themeit && theme != null)
             {

--- a/ExtendedControls/Forms/KeyForm.cs
+++ b/ExtendedControls/Forms/KeyForm.cs
@@ -44,7 +44,7 @@ namespace ExtendedControls
         int curinsertpoint = 0;
         string seperator;
         const string DefaultProcessID = "Default";
-        BaseUtils.EnhancedSendKeys.AdditionalKeyParser additionalkeyparser;
+        BaseUtils.EnhancedSendKeys.IAdditionalKeyParser additionalkeyparser;
 
         public KeyForm()
         {
@@ -63,7 +63,7 @@ namespace ExtendedControls
                                 int defdelay = 50,     // -1 means program default, return -1 back
                                 bool allowkeysedit = false,
                                 List<string> additionalkeys = null,
-                                BaseUtils.EnhancedSendKeys.AdditionalKeyParser parser = null)
+                                BaseUtils.EnhancedSendKeys.IAdditionalKeyParser parser = null)
         {
             if ( i != null )
                 Icon = i;

--- a/ExtendedControls/Forms/KeyForm.cs
+++ b/ExtendedControls/Forms/KeyForm.cs
@@ -105,7 +105,7 @@ namespace ExtendedControls
             //System.Diagnostics.Debug.WriteLine("T" + textBoxKeys.Text + " at " + curinsertpoint + " >" + textBoxSendTo.Text);
 
             bool border = true;
-            ThemeableForms theme = ThemeableFormsInstance.Instance;
+            ITheme theme = ThemeableFormsInstance.Instance;
             if (theme != null)  // paranoid
             {
                 border = theme.ApplyToForm(this);

--- a/ExtendedControls/Forms/MessageBoxTheme.cs
+++ b/ExtendedControls/Forms/MessageBoxTheme.cs
@@ -143,7 +143,7 @@ namespace ExtendedControls
             }
 
             bool framed = !(FormBorderStyle == FormBorderStyle.None);
-            ThemeableForms theme = ThemeableFormsInstance.Instance;
+            ITheme theme = ThemeableFormsInstance.Instance;
             if (theme != null)  // paranoid
             {
                 this.Font = new Font(theme.FontName, 12.0F);

--- a/ExtendedControls/Forms/PromptDialogs.cs
+++ b/ExtendedControls/Forms/PromptDialogs.cs
@@ -27,7 +27,7 @@ namespace ExtendedControls
         // lab sets the items, def can be less or null
         public static List<string> ShowDialog(Form p, string caption, Icon ic, string[] lab, string[] def, bool multiline = false, string[] tooltips = null)
         {
-            ThemeableForms theme = ThemeableFormsInstance.Instance;
+            ITheme theme = ThemeableFormsInstance.Instance;
 
             int vstart = theme.WindowsFrame ? 20 : 40;
             int vspacing = multiline ? 60 : 40;
@@ -237,7 +237,7 @@ namespace ExtendedControls
             entries = e;
             callertag = t;      // passed back to caller via trigger
 
-            ThemeableForms theme = ThemeableFormsInstance.Instance;
+            ITheme theme = ThemeableFormsInstance.Instance;
 
             FormBorderStyle = FormBorderStyle.FixedDialog;
 

--- a/ExtendedControls/Themes/ITheme.cs
+++ b/ExtendedControls/Themes/ITheme.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ExtendedControls
+{
+    public interface ITheme                     // Extended controls use this if they want to be themed
+    {
+        bool ApplyToForm(Form form, Font fnt = null);   // null means use standard one
+        void ApplyToControls(Control parent, Font fnt = null, bool applytothis = false);
+
+        Color ButtonBackColor { get; set; }
+        Color ButtonTextColor { get; set; }
+        Color ButtonBorderColor { get; set; }
+
+        Color GridCellText { get; set; }
+        Color GridBorderLines { get; set; }
+
+        Color TextBlockColor { get; set; }
+        Color TextBlockHighlightColor { get; set; }
+        Color TextBlockSuccessColor { get; set; }
+        Color TextBackColor { get; set; }
+        Color TextBlockBorderColor { get; set; }
+
+        Color LabelColor { get; set; }
+
+
+        string FontName { get; set; }
+        bool WindowsFrame { get; set; }
+        Icon MessageBoxWindowIcon { get; set; }
+    }
+}

--- a/ExtendedControls/Themes/Theme.cs
+++ b/ExtendedControls/Themes/Theme.cs
@@ -13,42 +13,11 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ExtendedControls
 {
-    public interface ThemeableForms             // Extended controls use this if they want to be themed
-    {
-        bool ApplyToForm(System.Windows.Forms.Form form, System.Drawing.Font fnt = null);   // null means use standard one
-        void ApplyToControls(System.Windows.Forms.Control parent, System.Drawing.Font fnt = null, bool applytothis = false);
-
-        System.Drawing.Color ButtonBackColor { get; set; }
-        System.Drawing.Color ButtonTextColor { get; set; }
-        System.Drawing.Color ButtonBorderColor { get; set; }
-
-        System.Drawing.Color GridCellText { get; set; }
-        System.Drawing.Color GridBorderLines { get; set; }
-
-        System.Drawing.Color TextBlockColor { get; set; }
-        System.Drawing.Color TextBlockHighlightColor { get; set; }
-        System.Drawing.Color TextBlockSuccessColor { get; set; }
-        System.Drawing.Color TextBackColor { get; set; }
-        System.Drawing.Color TextBlockBorderColor { get; set; }
-
-        System.Drawing.Color LabelColor { get; set; }
-
-
-        string FontName { get; set; }
-        bool WindowsFrame { get; set; }
-        System.Drawing.Icon MessageBoxWindowIcon { get; set; }
-    }
-
     public static class ThemeableFormsInstance
     {
-        static public ThemeableForms Instance { get; set; }
+        static public ITheme Instance { get; set; }
     }
 }

--- a/ExtendedControls/Themes/ThemeStandard.cs
+++ b/ExtendedControls/Themes/ThemeStandard.cs
@@ -12,7 +12,7 @@ namespace ExtendedControls
 {
     // specific implementation of a Themeable system.. does not include save/load to file etc due to the user may want their own implementation
 
-    public class ThemeStandard : ThemeableForms
+    public class ThemeStandard : ITheme
     {
         public static readonly string[] ButtonStyles = "System Flat Gradient".Split();
         public static readonly string[] TextboxBorderStyles = "None FixedSingle Fixed3D Colour".Split();


### PR DESCRIPTION
#### Renamed interfaces:
| Namespace | Old Name | New Name |
|--------------------------|-----------------------|------------------|
| BaseUtils (`.EnhancedSendKeys`) | AdditionalKeyParser | IAdditionalKeyParser |
| DirectInputDevices | InputDeviceInterface | IInputDevice |
| EDDiscovery.UserControls | UserControlCursorType | IHistoryCursor |
| EliteDangerousCore | EliteOptions | IEliteOptions |
| EliteDangerousCore | EliteConfig | IEliteConfig |
| ExtendedControls | ThemeableForms | ITheme |

#### Renamed delegates:
| Namespace | Domain | Old Name | New Name |
|--------------------------|------------------|--------------------|---------------------------|
| EDDiscovery.UserControls | IHistoryCursor | ChangedSelection | ChangedSelectionHandler |
| EDDiscovery.UserControls | IHistoryCursor | ChangedSelectionHE | ChangedSelectionHEHandler |

#### Misc:
* Split (most) renamed interfaces off into their own individual files.