### PR TITLE
Fix EDSM system overriding new system name

### DIFF
--- a/EliteDangerous/EliteDangerous/SystemCache.cs
+++ b/EliteDangerous/EliteDangerous/SystemCache.cs
@@ -139,7 +139,7 @@ namespace EliteDangerousCore
                 }
             }
 
-            return dbsys;
+            return sys;
         }
     }
 }


### PR DESCRIPTION
For systems that have been renamed since they were sent to EDSM, EDDiscovery was taking the name from EDSM and overriding the displayed system name with that name.

This was causing the system name in the Scan entry to be incorrect.