### PR TITLE
Prevent UI exception when mouse over DGV top-left

### DIFF
--- a/EDDiscovery/UserControls/UserControlEDSM.cs
+++ b/EDDiscovery/UserControls/UserControlEDSM.cs
@@ -41,6 +41,7 @@ namespace EDDiscovery.UserControls
         public UserControlEDSM()
         {
             InitializeComponent();
+            var corner = dataGridViewEDSM.TopLeftHeaderCell; // work around #1487
             buttonExtEDSMSphere.Enabled = buttonExtDBLookup.Enabled = false;
         }
 

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -57,6 +57,7 @@ namespace EDDiscovery.UserControls
         public UserControlEngineering()
         {
             InitializeComponent();
+            var corner = dataGridViewEngineering.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlEstimatedValues.cs
+++ b/EDDiscovery/UserControls/UserControlEstimatedValues.cs
@@ -37,6 +37,7 @@ namespace EDDiscovery.UserControls
         public UserControlEstimatedValues()
         {
             InitializeComponent();
+            var corner = dataGridViewNearest.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlExpedition.cs
+++ b/EDDiscovery/UserControls/UserControlExpedition.cs
@@ -53,6 +53,7 @@ namespace EDDiscovery.UserControls
         public UserControlExpedition()
         {
             InitializeComponent();
+            var corner = dataGridViewRouteSystems.TopLeftHeaderCell; // work around #1487
             SystemName.AutoCompleteGenerator = SystemClassDB.ReturnOnlySystemsListForAutoComplete;
             currentroute = new SavedRouteClass("");
             savedroute = new List<SavedRouteClass>();

--- a/EDDiscovery/UserControls/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/UserControlExploration.cs
@@ -52,6 +52,7 @@ namespace EDDiscovery.UserControls
         public UserControlExploration()
         {
             InitializeComponent();
+            var corner = dataGridViewExplore.TopLeftHeaderCell; // work around #1487
             ColumnSystemName.AutoCompleteGenerator = SystemClassDB.ReturnOnlySystemsListForAutoComplete;
             _currentExplorationSet = new ExplorationSetClass();
         }

--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -66,6 +66,7 @@ namespace EDDiscovery.UserControls
         public UserControlJournalGrid()
         {
             InitializeComponent();
+            var corner = dataGridViewJournal.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlLedger.cs
+++ b/EDDiscovery/UserControls/UserControlLedger.cs
@@ -41,6 +41,7 @@ namespace EDDiscovery.UserControls
         public UserControlLedger()
         {
             InitializeComponent();
+            var corner = dataGridViewLedger.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlMarketData.cs
+++ b/EDDiscovery/UserControls/UserControlMarketData.cs
@@ -41,6 +41,7 @@ namespace EDDiscovery.UserControls
         public UserControlMarketData()
         {
             InitializeComponent();
+            var corner = dataGridViewMarketData.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/UserControlMaterialCommodities.cs
@@ -38,6 +38,7 @@ namespace EDDiscovery.UserControls
         public UserControlMaterialCommodities()
         {
             InitializeComponent();
+            var corner = dataGridViewMC.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlMissions.cs
+++ b/EDDiscovery/UserControls/UserControlMissions.cs
@@ -43,6 +43,8 @@ namespace EDDiscovery.UserControls
         public UserControlMissions()
         {
             InitializeComponent();
+            var corner = dataGridViewCurrent.TopLeftHeaderCell; // work around #1487
+            var corner2 = dataGridViewPrevious.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlModules.cs
+++ b/EDDiscovery/UserControls/UserControlModules.cs
@@ -39,6 +39,7 @@ namespace EDDiscovery.UserControls
         public UserControlModules()
         {
             InitializeComponent();
+            var corner = dataGridViewModules.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlRoute.cs
+++ b/EDDiscovery/UserControls/UserControlRoute.cs
@@ -29,6 +29,7 @@ namespace EDDiscovery.UserControls
         public UserControlRoute()
         {
             InitializeComponent();
+            var corner = dataGridViewRoute.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlSettings.cs
+++ b/EDDiscovery/UserControls/UserControlSettings.cs
@@ -35,6 +35,7 @@ namespace EDDiscovery.UserControls
         public UserControlSettings()
         {
             InitializeComponent();
+            var corner = dataGridViewCommanders.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -37,6 +37,7 @@ namespace EDDiscovery.UserControls
         public UserControlStarDistance()
         {
             InitializeComponent();
+            var corner = dataGridViewNearest.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -72,6 +72,7 @@ namespace EDDiscovery.UserControls
         public UserControlStarList()
         {
             InitializeComponent();
+            var corner = dataGridViewStarList.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlStats.cs
+++ b/EDDiscovery/UserControls/UserControlStats.cs
@@ -33,6 +33,7 @@ namespace EDDiscovery.UserControls
         public UserControlStats()
         {
             InitializeComponent();
+            var corner = dataGridViewStats.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -56,6 +56,7 @@ namespace EDDiscovery.UserControls
         public UserControlSynthesis()
         {
             InitializeComponent();
+            var corner = dataGridViewSynthesis.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -94,6 +94,7 @@ namespace EDDiscovery.UserControls
         public UserControlTravelGrid()
         {
             InitializeComponent();
+            var corner = dataGridViewTravel.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()

--- a/EDDiscovery/UserControls/UserControlTrilateration.cs
+++ b/EDDiscovery/UserControls/UserControlTrilateration.cs
@@ -43,6 +43,8 @@ namespace EDDiscovery.UserControls
         public UserControlTrilateration()
         {
             InitializeComponent();
+            var corner = dataGridViewDistances.TopLeftHeaderCell; // work around #1487
+            var corner2 = dataGridViewClosestSystems.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()


### PR DESCRIPTION
#1487 exposed a "feature" in System.Windows.Forms that results in a reproducible UI exception when the mouse cursor is over where the top left header cell of a DataGridView is when it is initially instantiated.

Work around this by instantiating that cell before returning from the constructor of the containing UserControl.