### PR TITLE
Continue from the last system time when fetching systems

### DIFF
--- a/EliteDangerous/EDSM/EDSMClass.cs
+++ b/EliteDangerous/EDSM/EDSMClass.cs
@@ -270,8 +270,16 @@ namespace EliteDangerousCore.EDSM
                     break;
                 }
 
-                updates += SystemClassEDSM.ParseEDSMUpdateSystemsString(json, ref lstsyst, ref outoforder, false, cancelRequested, reportProgress, false);
-                lstsystdate += TimeSpan.FromHours(12);
+                long cnt = SystemClassEDSM.ParseEDSMUpdateSystemsString(json, ref lstsyst, ref outoforder, false, cancelRequested, reportProgress, false);
+                updates += cnt;
+                if (cnt < 100)
+                {
+                    lstsystdate += TimeSpan.FromHours(12);
+                }
+                else
+                {
+                    lstsystdate = DateTime.Parse(lstsyst, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                }
             }
             logLine($"System download complete");
 

--- a/EliteDangerous/EDSM/SystemClassEDSM.cs
+++ b/EliteDangerous/EDSM/SystemClassEDSM.cs
@@ -625,7 +625,7 @@ namespace EliteDangerousCore.EDSM
                 throw new OperationCanceledException();
             }
 
-            return updatecount + insertcount;
+            return count;
         }
 
         private static long ParseEDSMUpdateSystemsReader(JsonTextReader jr, ref string date, ref bool outoforder, bool removenonedsmids, Func<bool> cancelRequested, Action<int, string> reportProgress, bool useCache = true, bool useTempSystems = false)


### PR DESCRIPTION
EDSM Systems API will be limited to 1000 systems per request.  Take that limit into account, and continue fetching at the time of the most recently fetched system.