### PR TITLE
Option to show current body mats in shopping list when landed

### DIFF
--- a/EDDiscovery/UserControls/UserControlEngineering.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.Designer.cs
@@ -46,15 +46,6 @@ namespace EDDiscovery.UserControls
             this.components = new System.ComponentModel.Container();
             this.dataViewScrollerPanel = new ExtendedControls.DataViewScrollerPanel();
             this.dataGridViewEngineering = new System.Windows.Forms.DataGridView();
-            this.vScrollBarCustomMC = new ExtendedControls.VScrollBarCustom();
-            this.panelButtons = new System.Windows.Forms.Panel();
-            this.buttonClear = new ExtendedControls.ButtonExt();
-            this.buttonFilterMaterial = new ExtendedControls.ButtonExt();
-            this.buttonFilterUpgrade = new ExtendedControls.ButtonExt();
-            this.buttonFilterLevel = new ExtendedControls.ButtonExt();
-            this.buttonFilterEngineer = new ExtendedControls.ButtonExt();
-            this.buttonFilterModule = new ExtendedControls.ButtonExt();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.UpgradeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Module = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -64,6 +55,16 @@ namespace EDDiscovery.UserControls
             this.Notes = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Recipe = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Engineers = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.vScrollBarCustomMC = new ExtendedControls.VScrollBarCustom();
+            this.panelButtons = new System.Windows.Forms.Panel();
+            this.buttonClear = new ExtendedControls.ButtonExt();
+            this.buttonFilterMaterial = new ExtendedControls.ButtonExt();
+            this.buttonFilterUpgrade = new ExtendedControls.ButtonExt();
+            this.buttonFilterLevel = new ExtendedControls.ButtonExt();
+            this.buttonFilterEngineer = new ExtendedControls.ButtonExt();
+            this.buttonFilterModule = new ExtendedControls.ButtonExt();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.chkHistoric = new ExtendedControls.CheckBoxCustom();
             this.dataViewScrollerPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEngineering)).BeginInit();
             this.panelButtons.SuspendLayout();
@@ -112,139 +113,6 @@ namespace EDDiscovery.UserControls
             this.dataGridViewEngineering.DragOver += new System.Windows.Forms.DragEventHandler(this.dataGridViewEngineering_DragOver);
             this.dataGridViewEngineering.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewEngineering_MouseDown);
             this.dataGridViewEngineering.MouseMove += new System.Windows.Forms.MouseEventHandler(this.dataGridViewEngineering_MouseMove);
-            // 
-            // vScrollBarCustomMC
-            // 
-            this.vScrollBarCustomMC.ArrowBorderColor = System.Drawing.Color.LightBlue;
-            this.vScrollBarCustomMC.ArrowButtonColor = System.Drawing.Color.LightGray;
-            this.vScrollBarCustomMC.ArrowColorScaling = 0.5F;
-            this.vScrollBarCustomMC.ArrowDownDrawAngle = 270F;
-            this.vScrollBarCustomMC.ArrowUpDrawAngle = 90F;
-            this.vScrollBarCustomMC.BorderColor = System.Drawing.Color.White;
-            this.vScrollBarCustomMC.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.vScrollBarCustomMC.HideScrollBar = false;
-            this.vScrollBarCustomMC.LargeChange = 0;
-            this.vScrollBarCustomMC.Location = new System.Drawing.Point(780, 21);
-            this.vScrollBarCustomMC.Maximum = -1;
-            this.vScrollBarCustomMC.Minimum = 0;
-            this.vScrollBarCustomMC.MouseOverButtonColor = System.Drawing.Color.Green;
-            this.vScrollBarCustomMC.MousePressedButtonColor = System.Drawing.Color.Red;
-            this.vScrollBarCustomMC.Name = "vScrollBarCustomMC";
-            this.vScrollBarCustomMC.Size = new System.Drawing.Size(20, 519);
-            this.vScrollBarCustomMC.SliderColor = System.Drawing.Color.DarkGray;
-            this.vScrollBarCustomMC.SmallChange = 1;
-            this.vScrollBarCustomMC.TabIndex = 0;
-            this.vScrollBarCustomMC.Text = "vScrollBarCustom1";
-            this.vScrollBarCustomMC.ThumbBorderColor = System.Drawing.Color.Yellow;
-            this.vScrollBarCustomMC.ThumbButtonColor = System.Drawing.Color.DarkBlue;
-            this.vScrollBarCustomMC.ThumbColorScaling = 0.5F;
-            this.vScrollBarCustomMC.ThumbDrawAngle = 0F;
-            this.vScrollBarCustomMC.Value = -1;
-            this.vScrollBarCustomMC.ValueLimited = -1;
-            // 
-            // panelButtons
-            // 
-            this.panelButtons.Controls.Add(this.buttonClear);
-            this.panelButtons.Controls.Add(this.buttonFilterMaterial);
-            this.panelButtons.Controls.Add(this.buttonFilterUpgrade);
-            this.panelButtons.Controls.Add(this.buttonFilterLevel);
-            this.panelButtons.Controls.Add(this.buttonFilterEngineer);
-            this.panelButtons.Controls.Add(this.buttonFilterModule);
-            this.panelButtons.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panelButtons.Location = new System.Drawing.Point(0, 0);
-            this.panelButtons.Name = "panelButtons";
-            this.panelButtons.Size = new System.Drawing.Size(800, 32);
-            this.panelButtons.TabIndex = 2;
-            this.toolTip1.SetToolTip(this.panelButtons, "Left click and drag on grid to reorder");
-            // 
-            // buttonClear
-            // 
-            this.buttonClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClear.BorderColorScaling = 1.25F;
-            this.buttonClear.ButtonColorScaling = 0.5F;
-            this.buttonClear.ButtonDisabledScaling = 0.5F;
-            this.buttonClear.Location = new System.Drawing.Point(692, 4);
-            this.buttonClear.Name = "buttonClear";
-            this.buttonClear.Size = new System.Drawing.Size(88, 23);
-            this.buttonClear.TabIndex = 5;
-            this.buttonClear.Text = "Clear Wanted";
-            this.toolTip1.SetToolTip(this.buttonClear, "Set all wanted values to zero");
-            this.buttonClear.UseVisualStyleBackColor = true;
-            this.buttonClear.Click += new System.EventHandler(this.buttonClear_Click);
-            // 
-            // buttonFilterMaterial
-            // 
-            this.buttonFilterMaterial.BorderColorScaling = 1.25F;
-            this.buttonFilterMaterial.ButtonColorScaling = 0.5F;
-            this.buttonFilterMaterial.ButtonDisabledScaling = 0.5F;
-            this.buttonFilterMaterial.Location = new System.Drawing.Point(427, 4);
-            this.buttonFilterMaterial.Name = "buttonFilterMaterial";
-            this.buttonFilterMaterial.Size = new System.Drawing.Size(100, 23);
-            this.buttonFilterMaterial.TabIndex = 4;
-            this.buttonFilterMaterial.Text = "Filter By Material";
-            this.toolTip1.SetToolTip(this.buttonFilterMaterial, "Choose items by material");
-            this.buttonFilterMaterial.UseVisualStyleBackColor = true;
-            this.buttonFilterMaterial.Click += new System.EventHandler(this.buttonFilterMaterial_Click);
-            // 
-            // buttonFilterUpgrade
-            // 
-            this.buttonFilterUpgrade.BorderColorScaling = 1.25F;
-            this.buttonFilterUpgrade.ButtonColorScaling = 0.5F;
-            this.buttonFilterUpgrade.ButtonDisabledScaling = 0.5F;
-            this.buttonFilterUpgrade.Location = new System.Drawing.Point(3, 4);
-            this.buttonFilterUpgrade.Name = "buttonFilterUpgrade";
-            this.buttonFilterUpgrade.Size = new System.Drawing.Size(100, 23);
-            this.buttonFilterUpgrade.TabIndex = 3;
-            this.buttonFilterUpgrade.Text = "Filter By Upgrade";
-            this.toolTip1.SetToolTip(this.buttonFilterUpgrade, "Choose items by upgrade type");
-            this.buttonFilterUpgrade.UseVisualStyleBackColor = true;
-            this.buttonFilterUpgrade.Click += new System.EventHandler(this.buttonFilterUpgrade_Click);
-            // 
-            // buttonFilterLevel
-            // 
-            this.buttonFilterLevel.BorderColorScaling = 1.25F;
-            this.buttonFilterLevel.ButtonColorScaling = 0.5F;
-            this.buttonFilterLevel.ButtonDisabledScaling = 0.5F;
-            this.buttonFilterLevel.Location = new System.Drawing.Point(215, 4);
-            this.buttonFilterLevel.Name = "buttonFilterLevel";
-            this.buttonFilterLevel.Size = new System.Drawing.Size(100, 23);
-            this.buttonFilterLevel.TabIndex = 2;
-            this.buttonFilterLevel.Text = "Filter By Level";
-            this.toolTip1.SetToolTip(this.buttonFilterLevel, "Choose items by level");
-            this.buttonFilterLevel.UseVisualStyleBackColor = true;
-            this.buttonFilterLevel.Click += new System.EventHandler(this.buttonFilterLevel_Click);
-            // 
-            // buttonFilterEngineer
-            // 
-            this.buttonFilterEngineer.BorderColorScaling = 1.25F;
-            this.buttonFilterEngineer.ButtonColorScaling = 0.5F;
-            this.buttonFilterEngineer.ButtonDisabledScaling = 0.5F;
-            this.buttonFilterEngineer.Location = new System.Drawing.Point(321, 4);
-            this.buttonFilterEngineer.Name = "buttonFilterEngineer";
-            this.buttonFilterEngineer.Size = new System.Drawing.Size(100, 23);
-            this.buttonFilterEngineer.TabIndex = 1;
-            this.buttonFilterEngineer.Text = "Filter By Engineer";
-            this.toolTip1.SetToolTip(this.buttonFilterEngineer, "Choose items by engineer");
-            this.buttonFilterEngineer.UseVisualStyleBackColor = true;
-            this.buttonFilterEngineer.Click += new System.EventHandler(this.buttonFilterEngineer_Click);
-            // 
-            // buttonFilterModule
-            // 
-            this.buttonFilterModule.BorderColorScaling = 1.25F;
-            this.buttonFilterModule.ButtonColorScaling = 0.5F;
-            this.buttonFilterModule.ButtonDisabledScaling = 0.5F;
-            this.buttonFilterModule.Location = new System.Drawing.Point(109, 4);
-            this.buttonFilterModule.Name = "buttonFilterModule";
-            this.buttonFilterModule.Size = new System.Drawing.Size(100, 23);
-            this.buttonFilterModule.TabIndex = 0;
-            this.buttonFilterModule.Text = "Filter By Module";
-            this.toolTip1.SetToolTip(this.buttonFilterModule, "Choose items by Module type");
-            this.buttonFilterModule.UseVisualStyleBackColor = true;
-            this.buttonFilterModule.Click += new System.EventHandler(this.buttonFilterModule_Click);
-            // 
-            // toolTip1
-            // 
-            this.toolTip1.ShowAlways = true;
             // 
             // UpgradeCol
             // 
@@ -323,6 +191,140 @@ namespace EDDiscovery.UserControls
             this.Engineers.ReadOnly = true;
             this.Engineers.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             // 
+            // vScrollBarCustomMC
+            // 
+            this.vScrollBarCustomMC.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustomMC.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustomMC.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustomMC.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustomMC.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustomMC.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustomMC.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustomMC.HideScrollBar = false;
+            this.vScrollBarCustomMC.LargeChange = 0;
+            this.vScrollBarCustomMC.Location = new System.Drawing.Point(780, 21);
+            this.vScrollBarCustomMC.Maximum = -1;
+            this.vScrollBarCustomMC.Minimum = 0;
+            this.vScrollBarCustomMC.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustomMC.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustomMC.Name = "vScrollBarCustomMC";
+            this.vScrollBarCustomMC.Size = new System.Drawing.Size(20, 519);
+            this.vScrollBarCustomMC.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustomMC.SmallChange = 1;
+            this.vScrollBarCustomMC.TabIndex = 0;
+            this.vScrollBarCustomMC.Text = "vScrollBarCustom1";
+            this.vScrollBarCustomMC.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustomMC.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustomMC.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustomMC.ThumbDrawAngle = 0F;
+            this.vScrollBarCustomMC.Value = -1;
+            this.vScrollBarCustomMC.ValueLimited = -1;
+            // 
+            // panelButtons
+            // 
+            this.panelButtons.Controls.Add(this.chkHistoric);
+            this.panelButtons.Controls.Add(this.buttonClear);
+            this.panelButtons.Controls.Add(this.buttonFilterMaterial);
+            this.panelButtons.Controls.Add(this.buttonFilterUpgrade);
+            this.panelButtons.Controls.Add(this.buttonFilterLevel);
+            this.panelButtons.Controls.Add(this.buttonFilterEngineer);
+            this.panelButtons.Controls.Add(this.buttonFilterModule);
+            this.panelButtons.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelButtons.Location = new System.Drawing.Point(0, 0);
+            this.panelButtons.Name = "panelButtons";
+            this.panelButtons.Size = new System.Drawing.Size(800, 32);
+            this.panelButtons.TabIndex = 2;
+            this.toolTip1.SetToolTip(this.panelButtons, "Left click and drag on grid to reorder");
+            // 
+            // buttonClear
+            // 
+            this.buttonClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonClear.Location = new System.Drawing.Point(692, 4);
+            this.buttonClear.Name = "buttonClear";
+            this.buttonClear.Size = new System.Drawing.Size(88, 23);
+            this.buttonClear.TabIndex = 5;
+            this.buttonClear.Text = "Clear Wanted";
+            this.toolTip1.SetToolTip(this.buttonClear, "Set all wanted values to zero");
+            this.buttonClear.UseVisualStyleBackColor = true;
+            this.buttonClear.Click += new System.EventHandler(this.buttonClear_Click);
+            // 
+            // buttonFilterMaterial
+            // 
+            this.buttonFilterMaterial.Location = new System.Drawing.Point(427, 4);
+            this.buttonFilterMaterial.Name = "buttonFilterMaterial";
+            this.buttonFilterMaterial.Size = new System.Drawing.Size(100, 23);
+            this.buttonFilterMaterial.TabIndex = 4;
+            this.buttonFilterMaterial.Text = "Filter By Material";
+            this.toolTip1.SetToolTip(this.buttonFilterMaterial, "Choose items by material");
+            this.buttonFilterMaterial.UseVisualStyleBackColor = true;
+            this.buttonFilterMaterial.Click += new System.EventHandler(this.buttonFilterMaterial_Click);
+            // 
+            // buttonFilterUpgrade
+            // 
+            this.buttonFilterUpgrade.Location = new System.Drawing.Point(3, 4);
+            this.buttonFilterUpgrade.Name = "buttonFilterUpgrade";
+            this.buttonFilterUpgrade.Size = new System.Drawing.Size(100, 23);
+            this.buttonFilterUpgrade.TabIndex = 3;
+            this.buttonFilterUpgrade.Text = "Filter By Upgrade";
+            this.toolTip1.SetToolTip(this.buttonFilterUpgrade, "Choose items by upgrade type");
+            this.buttonFilterUpgrade.UseVisualStyleBackColor = true;
+            this.buttonFilterUpgrade.Click += new System.EventHandler(this.buttonFilterUpgrade_Click);
+            // 
+            // buttonFilterLevel
+            // 
+            this.buttonFilterLevel.Location = new System.Drawing.Point(215, 4);
+            this.buttonFilterLevel.Name = "buttonFilterLevel";
+            this.buttonFilterLevel.Size = new System.Drawing.Size(100, 23);
+            this.buttonFilterLevel.TabIndex = 2;
+            this.buttonFilterLevel.Text = "Filter By Level";
+            this.toolTip1.SetToolTip(this.buttonFilterLevel, "Choose items by level");
+            this.buttonFilterLevel.UseVisualStyleBackColor = true;
+            this.buttonFilterLevel.Click += new System.EventHandler(this.buttonFilterLevel_Click);
+            // 
+            // buttonFilterEngineer
+            // 
+            this.buttonFilterEngineer.Location = new System.Drawing.Point(321, 4);
+            this.buttonFilterEngineer.Name = "buttonFilterEngineer";
+            this.buttonFilterEngineer.Size = new System.Drawing.Size(100, 23);
+            this.buttonFilterEngineer.TabIndex = 1;
+            this.buttonFilterEngineer.Text = "Filter By Engineer";
+            this.toolTip1.SetToolTip(this.buttonFilterEngineer, "Choose items by engineer");
+            this.buttonFilterEngineer.UseVisualStyleBackColor = true;
+            this.buttonFilterEngineer.Click += new System.EventHandler(this.buttonFilterEngineer_Click);
+            // 
+            // buttonFilterModule
+            // 
+            this.buttonFilterModule.Location = new System.Drawing.Point(109, 4);
+            this.buttonFilterModule.Name = "buttonFilterModule";
+            this.buttonFilterModule.Size = new System.Drawing.Size(100, 23);
+            this.buttonFilterModule.TabIndex = 0;
+            this.buttonFilterModule.Text = "Filter By Module";
+            this.toolTip1.SetToolTip(this.buttonFilterModule, "Choose items by Module type");
+            this.buttonFilterModule.UseVisualStyleBackColor = true;
+            this.buttonFilterModule.Click += new System.EventHandler(this.buttonFilterModule_Click);
+            // 
+            // toolTip1
+            // 
+            this.toolTip1.ShowAlways = true;
+            // 
+            // chkHistoric
+            // 
+            this.chkHistoric.AutoSize = true;
+            this.chkHistoric.CheckBoxColor = System.Drawing.Color.Gray;
+            this.chkHistoric.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.chkHistoric.CheckColor = System.Drawing.Color.DarkBlue;
+            this.chkHistoric.FontNerfReduction = 0.5F;
+            this.chkHistoric.ImageButtonDisabledScaling = 0.5F;
+            this.chkHistoric.Location = new System.Drawing.Point(533, 8);
+            this.chkHistoric.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.chkHistoric.Name = "chkHistoric";
+            this.chkHistoric.Size = new System.Drawing.Size(128, 17);
+            this.chkHistoric.TabIndex = 6;
+            this.chkHistoric.Text = "Use Historic Materials";
+            this.chkHistoric.TickBoxReductionSize = 10;
+            this.chkHistoric.UseVisualStyleBackColor = true;
+            this.chkHistoric.CheckedChanged += new System.EventHandler(this.chkHistoric_CheckedChanged);
+            // 
             // UserControlEngineering
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -334,6 +336,7 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEngineering)).EndInit();
             this.panelButtons.ResumeLayout(false);
+            this.panelButtons.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -360,5 +363,6 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.DataGridViewTextBoxColumn Notes;
         private System.Windows.Forms.DataGridViewTextBoxColumn Recipe;
         private System.Windows.Forms.DataGridViewTextBoxColumn Engineers;
+        private ExtendedControls.CheckBoxCustom chkHistoric;
     }
 }

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -169,8 +169,12 @@ namespace EDDiscovery.UserControls
         HistoryEntry last_he = null;
         private void Display(HistoryEntry he, HistoryList hl)
         {
-            last_he = he;
-            Display();
+            if (isHistoric)
+            {
+                // this event isn't reliably disconnecting when calling SetHistoric(false) - not sure why
+                last_he = he;
+                Display();
+            }
         }
         
         private void Display()

--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -115,14 +115,6 @@ namespace EDDiscovery.UserControls
             }
 
             discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            uctg.OnTravelSelectionChanged += Display;
-        }
-
-        public override void ChangeCursorType(IHistoryCursor thc)
-        {
-            uctg.OnTravelSelectionChanged -= Display;
-            uctg = thc;
-            uctg.OnTravelSelectionChanged += Display;
         }
 
         #endregion
@@ -131,7 +123,7 @@ namespace EDDiscovery.UserControls
 
         public override void InitialDisplay()
         {
-            last_he = uctg.GetCurrentHistoryEntry;
+            last_he = discoveryform.history.GetLast;
             Display();
         }
 

--- a/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
@@ -54,6 +54,7 @@ namespace EDDiscovery.UserControls
             this.showMaxFSDInjectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAllMaterialsWhenLandedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.useHistoricMaterialCountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerVertical)).BeginInit();
             this.splitContainerVertical.Panel1.SuspendLayout();
             this.splitContainerVertical.Panel2.SuspendLayout();
@@ -141,9 +142,10 @@ namespace EDDiscovery.UserControls
             this.contextMenuConfig.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showMaxFSDInjectionsToolStripMenuItem,
             this.showAllMaterialsWhenLandedToolStripMenuItem,
-            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem});
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem,
+            this.useHistoricMaterialCountsToolStripMenuItem});
             this.contextMenuConfig.Name = "contextMenuConfig";
-            this.contextMenuConfig.Size = new System.Drawing.Size(369, 92);
+            this.contextMenuConfig.Size = new System.Drawing.Size(369, 114);
             // 
             // showMaxFSDInjectionsToolStripMenuItem
             // 
@@ -151,7 +153,7 @@ namespace EDDiscovery.UserControls
             this.showMaxFSDInjectionsToolStripMenuItem.CheckOnClick = true;
             this.showMaxFSDInjectionsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showMaxFSDInjectionsToolStripMenuItem.Name = "showMaxFSDInjectionsToolStripMenuItem";
-            this.showMaxFSDInjectionsToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
+            this.showMaxFSDInjectionsToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
             this.showMaxFSDInjectionsToolStripMenuItem.Text = "Show Max FSD Injections";
             this.showMaxFSDInjectionsToolStripMenuItem.Click += new System.EventHandler(this.showMaxFSDInjectionsToolStripMenuItem_Click);
             // 
@@ -170,6 +172,14 @@ namespace EDDiscovery.UserControls
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Text = "Include Material %age on Landed Body in Shopping List";
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Click += new System.EventHandler(this.showAvailableMaterialsInListWhenLandedToolStripMenuItem_Click);
+            // 
+            // useHistoricMaterialCountsToolStripMenuItem
+            // 
+            this.useHistoricMaterialCountsToolStripMenuItem.CheckOnClick = true;
+            this.useHistoricMaterialCountsToolStripMenuItem.Name = "useHistoricMaterialCountsToolStripMenuItem";
+            this.useHistoricMaterialCountsToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
+            this.useHistoricMaterialCountsToolStripMenuItem.Text = "Use Historic Material Counts";
+            this.useHistoricMaterialCountsToolStripMenuItem.Click += new System.EventHandler(this.useHistoricMaterialCountsToolStripMenuItem_Click);
             // 
             // UserControlShoppingList
             // 
@@ -203,5 +213,6 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.ToolStripMenuItem showMaxFSDInjectionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showAllMaterialsWhenLandedToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showAvailableMaterialsInListWhenLandedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem useHistoricMaterialCountsToolStripMenuItem;
     }
 }

--- a/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
@@ -52,6 +52,8 @@ namespace EDDiscovery.UserControls
             this.userControlEngineering = new EDDiscovery.UserControls.UserControlEngineering();
             this.contextMenuConfig = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showMaxFSDInjectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAllMaterialsWhenLandedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerVertical)).BeginInit();
             this.splitContainerVertical.Panel1.SuspendLayout();
             this.splitContainerVertical.Panel2.SuspendLayout();
@@ -137,9 +139,11 @@ namespace EDDiscovery.UserControls
             // contextMenuConfig
             // 
             this.contextMenuConfig.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.showMaxFSDInjectionsToolStripMenuItem});
+            this.showMaxFSDInjectionsToolStripMenuItem,
+            this.showAllMaterialsWhenLandedToolStripMenuItem,
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem});
             this.contextMenuConfig.Name = "contextMenuConfig";
-            this.contextMenuConfig.Size = new System.Drawing.Size(206, 48);
+            this.contextMenuConfig.Size = new System.Drawing.Size(369, 92);
             // 
             // showMaxFSDInjectionsToolStripMenuItem
             // 
@@ -147,9 +151,25 @@ namespace EDDiscovery.UserControls
             this.showMaxFSDInjectionsToolStripMenuItem.CheckOnClick = true;
             this.showMaxFSDInjectionsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showMaxFSDInjectionsToolStripMenuItem.Name = "showMaxFSDInjectionsToolStripMenuItem";
-            this.showMaxFSDInjectionsToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            this.showMaxFSDInjectionsToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
             this.showMaxFSDInjectionsToolStripMenuItem.Text = "Show Max FSD Injections";
             this.showMaxFSDInjectionsToolStripMenuItem.Click += new System.EventHandler(this.showMaxFSDInjectionsToolStripMenuItem_Click);
+            // 
+            // showAllMaterialsWhenLandedToolStripMenuItem
+            // 
+            this.showAllMaterialsWhenLandedToolStripMenuItem.CheckOnClick = true;
+            this.showAllMaterialsWhenLandedToolStripMenuItem.Name = "showAllMaterialsWhenLandedToolStripMenuItem";
+            this.showAllMaterialsWhenLandedToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
+            this.showAllMaterialsWhenLandedToolStripMenuItem.Text = "Show Body Materials When Landed";
+            this.showAllMaterialsWhenLandedToolStripMenuItem.Click += new System.EventHandler(this.showAllMaterialsWhenLandedToolStripMenuItem_Click);
+            // 
+            // showAvailableMaterialsInListWhenLandedToolStripMenuItem
+            // 
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.CheckOnClick = true;
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Name = "showAvailableMaterialsInListWhenLandedToolStripMenuItem";
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Text = "Include Material %age on Landed Body in Shopping List";
+            this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Click += new System.EventHandler(this.showAvailableMaterialsInListWhenLandedToolStripMenuItem_Click);
             // 
             // UserControlShoppingList
             // 
@@ -181,5 +201,7 @@ namespace EDDiscovery.UserControls
         private UserControlEngineering userControlEngineering;
         private System.Windows.Forms.ContextMenuStrip contextMenuConfig;
         private System.Windows.Forms.ToolStripMenuItem showMaxFSDInjectionsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAllMaterialsWhenLandedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAvailableMaterialsInListWhenLandedToolStripMenuItem;
     }
 }

--- a/EDDiscovery/UserControls/UserControlShoppingList.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.cs
@@ -36,6 +36,7 @@ namespace EDDiscovery.UserControls
         private bool showMaxInjections;
         private bool showPlanetMats;
         private bool showListAvailability;
+        private bool useHistoric = false;
         private string DbShowInjectionsSave { get { return "ShoppingListShowFSD" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
         private string DbShowAllMatsLandedSave { get { return "ShoppingListShowPlanetMats" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
         private string DbHighlightAvailableMats { get { return "ShoppingListHighlightAvailable" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
@@ -54,6 +55,7 @@ namespace EDDiscovery.UserControls
             //Can use display number for it, because their names for db save are unique between engineering and synthesis.
             userControlEngineering.isEmbedded = true;
             userControlEngineering.Init(discoveryform, uctg, displaynumber);
+            useHistoric = userControlEngineering.isHistoric;
 
             userControlSynthesis.isEmbedded = true;
             userControlSynthesis.Init(discoveryform, uctg, displaynumber);
@@ -90,6 +92,7 @@ namespace EDDiscovery.UserControls
             showMaxFSDInjectionsToolStripMenuItem.Checked = showMaxInjections;
             showAllMaterialsWhenLandedToolStripMenuItem.Checked = showPlanetMats;
             showAvailableMaterialsInListWhenLandedToolStripMenuItem.Checked = showListAvailability;
+            useHistoricMaterialCountsToolStripMenuItem.Checked = useHistoric;
             Display();
         }
 
@@ -252,6 +255,14 @@ namespace EDDiscovery.UserControls
         private void showAvailableMaterialsInListWhenLandedToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showListAvailability = ((ToolStripMenuItem)sender).Checked;
+            Display();
+        }
+
+        private void useHistoricMaterialCountsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            useHistoric = ((ToolStripMenuItem)sender).Checked;
+            userControlSynthesis.SetHistoric(useHistoric);
+            userControlEngineering.SetHistoric(useHistoric);
             Display();
         }
     }

--- a/EDDiscovery/UserControls/UserControlSynthesis.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.Designer.cs
@@ -55,11 +55,12 @@ namespace EDDiscovery.UserControls
             this.Recipe = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.vScrollBarCustomMC = new ExtendedControls.VScrollBarCustom();
             this.panelButtons = new System.Windows.Forms.Panel();
+            this.buttonMaterialFilter = new ExtendedControls.ButtonExt();
+            this.buttonFilterLevel = new ExtendedControls.ButtonExt();
             this.buttonRecipeFilter = new ExtendedControls.ButtonExt();
             this.buttonClear = new ExtendedControls.ButtonExt();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.buttonFilterLevel = new ExtendedControls.ButtonExt();
-            this.buttonMaterialFilter = new ExtendedControls.ButtonExt();
+            this.chkHistoric = new ExtendedControls.CheckBoxCustom();
             this.dataViewScrollerPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSynthesis)).BeginInit();
             this.panelButtons.SuspendLayout();
@@ -194,6 +195,7 @@ namespace EDDiscovery.UserControls
             // 
             // panelButtons
             // 
+            this.panelButtons.Controls.Add(this.chkHistoric);
             this.panelButtons.Controls.Add(this.buttonMaterialFilter);
             this.panelButtons.Controls.Add(this.buttonFilterLevel);
             this.panelButtons.Controls.Add(this.buttonRecipeFilter);
@@ -205,11 +207,28 @@ namespace EDDiscovery.UserControls
             this.panelButtons.TabIndex = 2;
             this.toolTip.SetToolTip(this.panelButtons, "Left click and drag on grid to reorder");
             // 
+            // buttonMaterialFilter
+            // 
+            this.buttonMaterialFilter.Location = new System.Drawing.Point(216, 4);
+            this.buttonMaterialFilter.Name = "buttonMaterialFilter";
+            this.buttonMaterialFilter.Size = new System.Drawing.Size(100, 23);
+            this.buttonMaterialFilter.TabIndex = 4;
+            this.buttonMaterialFilter.Text = "Filter By Material";
+            this.buttonMaterialFilter.UseVisualStyleBackColor = true;
+            this.buttonMaterialFilter.Click += new System.EventHandler(this.buttonMaterialFilter_Click);
+            // 
+            // buttonFilterLevel
+            // 
+            this.buttonFilterLevel.Location = new System.Drawing.Point(110, 4);
+            this.buttonFilterLevel.Name = "buttonFilterLevel";
+            this.buttonFilterLevel.Size = new System.Drawing.Size(100, 23);
+            this.buttonFilterLevel.TabIndex = 3;
+            this.buttonFilterLevel.Text = "Filter By Level";
+            this.buttonFilterLevel.UseVisualStyleBackColor = true;
+            this.buttonFilterLevel.Click += new System.EventHandler(this.buttonFilterLevel_Click);
+            // 
             // buttonRecipeFilter
             // 
-            this.buttonRecipeFilter.BorderColorScaling = 1.25F;
-            this.buttonRecipeFilter.ButtonColorScaling = 0.5F;
-            this.buttonRecipeFilter.ButtonDisabledScaling = 0.5F;
             this.buttonRecipeFilter.Location = new System.Drawing.Point(4, 4);
             this.buttonRecipeFilter.Name = "buttonRecipeFilter";
             this.buttonRecipeFilter.Size = new System.Drawing.Size(100, 23);
@@ -221,9 +240,6 @@ namespace EDDiscovery.UserControls
             // buttonClear
             // 
             this.buttonClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClear.BorderColorScaling = 1.25F;
-            this.buttonClear.ButtonColorScaling = 0.5F;
-            this.buttonClear.ButtonDisabledScaling = 0.5F;
             this.buttonClear.Location = new System.Drawing.Point(697, 4);
             this.buttonClear.Name = "buttonClear";
             this.buttonClear.Size = new System.Drawing.Size(100, 23);
@@ -237,31 +253,23 @@ namespace EDDiscovery.UserControls
             // 
             this.toolTip.ShowAlways = true;
             // 
-            // buttonFilterLevel
+            // chkHistoric
             // 
-            this.buttonFilterLevel.BorderColorScaling = 1.25F;
-            this.buttonFilterLevel.ButtonColorScaling = 0.5F;
-            this.buttonFilterLevel.ButtonDisabledScaling = 0.5F;
-            this.buttonFilterLevel.Location = new System.Drawing.Point(110, 4);
-            this.buttonFilterLevel.Name = "buttonFilterLevel";
-            this.buttonFilterLevel.Size = new System.Drawing.Size(100, 23);
-            this.buttonFilterLevel.TabIndex = 3;
-            this.buttonFilterLevel.Text = "Filter By Level";
-            this.buttonFilterLevel.UseVisualStyleBackColor = true;
-            this.buttonFilterLevel.Click += new System.EventHandler(this.buttonFilterLevel_Click);
-            // 
-            // buttonMaterialFilter
-            // 
-            this.buttonMaterialFilter.BorderColorScaling = 1.25F;
-            this.buttonMaterialFilter.ButtonColorScaling = 0.5F;
-            this.buttonMaterialFilter.ButtonDisabledScaling = 0.5F;
-            this.buttonMaterialFilter.Location = new System.Drawing.Point(216, 4);
-            this.buttonMaterialFilter.Name = "buttonMaterialFilter";
-            this.buttonMaterialFilter.Size = new System.Drawing.Size(100, 23);
-            this.buttonMaterialFilter.TabIndex = 4;
-            this.buttonMaterialFilter.Text = "Filter By Material";
-            this.buttonMaterialFilter.UseVisualStyleBackColor = true;
-            this.buttonMaterialFilter.Click += new System.EventHandler(this.buttonMaterialFilter_Click);
+            this.chkHistoric.AutoSize = true;
+            this.chkHistoric.CheckBoxColor = System.Drawing.Color.Gray;
+            this.chkHistoric.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.chkHistoric.CheckColor = System.Drawing.Color.DarkBlue;
+            this.chkHistoric.FontNerfReduction = 0.5F;
+            this.chkHistoric.ImageButtonDisabledScaling = 0.5F;
+            this.chkHistoric.Location = new System.Drawing.Point(322, 8);
+            this.chkHistoric.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.chkHistoric.Name = "chkHistoric";
+            this.chkHistoric.Size = new System.Drawing.Size(128, 17);
+            this.chkHistoric.TabIndex = 7;
+            this.chkHistoric.Text = "Use Historic Materials";
+            this.chkHistoric.TickBoxReductionSize = 10;
+            this.chkHistoric.UseVisualStyleBackColor = true;
+            this.chkHistoric.CheckedChanged += new System.EventHandler(this.chkHistoric_CheckedChanged);
             // 
             // UserControlSynthesis
             // 
@@ -274,6 +282,7 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewSynthesis)).EndInit();
             this.panelButtons.ResumeLayout(false);
+            this.panelButtons.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -296,5 +305,6 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ButtonExt buttonRecipeFilter;
         private ExtendedControls.ButtonExt buttonFilterLevel;
         private ExtendedControls.ButtonExt buttonMaterialFilter;
+        private ExtendedControls.CheckBoxCustom chkHistoric;
     }
 }

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -107,14 +107,6 @@ namespace EDDiscovery.UserControls
             }
 
             discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            uctg.OnTravelSelectionChanged += Display;
-        }
-
-        public override void ChangeCursorType(IHistoryCursor thc)
-        {
-            uctg.OnTravelSelectionChanged -= Display;
-            uctg = thc;
-            uctg.OnTravelSelectionChanged += Display;
         }
 
         #endregion
@@ -123,14 +115,15 @@ namespace EDDiscovery.UserControls
 
         public override void InitialDisplay()
         {
-            last_he = uctg.GetCurrentHistoryEntry;
+            last_he = discoveryform.history.GetLast;
             Display();
         }
 
         private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)
         {
             last_he = he;
-            if (he.journalEntry is IMaterialCommodityJournalEntry)
+            //touchdown and liftoff ensure shopping list refresh in case displaying landed planet ma
+            if (he.journalEntry is IMaterialCommodityJournalEntry || he.journalEntry.EventTypeID == JournalTypeEnum.Touchdown || he.journalEntry.EventTypeID == JournalTypeEnum.Liftoff  || he.IsLocOrJump)
                 Display();
         }
 

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -37,10 +37,12 @@ namespace EDDiscovery.UserControls
         private string DbRecipeFilterSave { get { return "SynthesisRecipeFilter" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
         private string DbLevelFilterSave { get { return "SynthesisLevelFilter" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
         private string DbMaterialFilterSave { get { return "SynthesisMaterialFilter" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
+        private string DbHistoricMatsSave { get { return "SynthesisHistoricMaterials" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
 
         int[] Order;        // order
         int[] Wanted;       // wanted, in order terms
         internal bool isEmbedded = false;
+        internal bool isHistoric = false;
 
         private List<Tuple<string, string>> matLookUp;
         RecipeFilterSelector rfs;
@@ -106,16 +108,46 @@ namespace EDDiscovery.UserControls
                 }
             }
 
+            isHistoric = SQLiteDBClass.GetSettingBool(DbHistoricMatsSave, false);
+            chkHistoric.Checked = isHistoric;
+            chkHistoric.Visible = !isEmbedded;
+
             discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
+            if (isHistoric) uctg.OnTravelSelectionChanged += Display;
+        }
+
+        public override void ChangeCursorType(IHistoryCursor thc)
+        {
+            if (isHistoric)
+            {
+                uctg.OnTravelSelectionChanged -= Display;
+                uctg = thc;
+                uctg.OnTravelSelectionChanged += Display;
+            }
         }
 
         #endregion
 
         #region Display
+        internal void SetHistoric(bool newVal)
+        {
+            isHistoric = newVal;
+            if (isHistoric)
+            {
+                uctg.OnTravelSelectionChanged += Display;
+                last_he = uctg.GetCurrentHistoryEntry;
+            }
+            else
+            {
+                uctg.OnTravelSelectionChanged -= Display;
+                last_he = discoveryform.history.GetLast;
+            }
+            Display();
+        }
 
         public override void InitialDisplay()
         {
-            last_he = discoveryform.history.GetLast;
+            last_he = isHistoric ? uctg.GetCurrentHistoryEntry : discoveryform.history.GetLast;
             Display();
         }
 
@@ -256,6 +288,7 @@ namespace EDDiscovery.UserControls
 
             SQLiteDBClass.PutSettingString(DbOSave, Order.ToString(","));
             SQLiteDBClass.PutSettingString(DbWSave, Wanted.ToString(","));
+            SQLiteDBClass.PutSettingBool(DbHistoricMatsSave, isHistoric);
         }
 
         #endregion
@@ -375,6 +408,11 @@ namespace EDDiscovery.UserControls
             Button b = sender as Button;
             mfs.FilterButton(DbMaterialFilterSave, b,
                              discoveryform.theme.TextBackColor, discoveryform.theme.TextBlockColor, this.FindForm());
+        }
+
+        private void chkHistoric_CheckedChanged(object sender, EventArgs e)
+        {
+            SetHistoric(chkHistoric.Checked);
         }
     }
 }

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -162,8 +162,12 @@ namespace EDDiscovery.UserControls
         HistoryEntry last_he = null;
         private void Display(HistoryEntry he, HistoryList hl)
         {
-            last_he = he;
-            Display();
+            if (isHistoric)
+            {
+                // this event isn't reliably disconnecting when calling SetHistoric(false) - not sure why
+                last_he = he;
+                Display();
+            }
         }
 
         private void Display()

--- a/EDDiscovery/UserControls/UserControlSynthesis.resx
+++ b/EDDiscovery/UserControls/UserControlSynthesis.resx
@@ -138,27 +138,6 @@
   <metadata name="Recipe.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="UpgradeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Level.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="MaxCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="WantedCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Available.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Notes.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Recipe.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -308,6 +308,7 @@ namespace EliteDangerousCore
             {
                 JournalLocation jl = je as JournalLocation;
                 he.docked = jl.Docked;
+                he.landed = jl.Latitude.HasValue;
                 he.whereami = jl.Docked ? jl.StationName : jl.Body;
                 he.hyperspace = false;
             }
@@ -322,7 +323,7 @@ namespace EliteDangerousCore
             else if (je.EventTypeID == JournalTypeEnum.Touchdown)
                 he.landed = true;
             else if (je.EventTypeID == JournalTypeEnum.Liftoff)
-                he.landed = false;
+                he.landed = !(je as JournalLiftoff).PlayerControlled;
             else if (je.EventTypeID == JournalTypeEnum.SupercruiseEntry)
             {
                 he.whereami = (je as JournalSupercruiseEntry).StarSystem;


### PR DESCRIPTION
Engineering/Synthesis/Shopping List panels are no longer historic (i.e. always use current mats whatever history entry is selected).

Shopping List now has context menu options to show all mats for current body or highlight available mats in the shopping list while landed.

Dismissing ship no longer sets IsLanded to false.