### PR TITLE
New panel added - Scangrid - and many StarList panel improvement and fixes.

### DIFF
--- a/Audio/Audio.csproj
+++ b/Audio/Audio.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CSCore, Version=1.2.1.1, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSCore.1.2.1.1\lib\net35-client\CSCore.dll</HintPath>
+      <HintPath>..\packages\CSCore.1.2.1.2\lib\net35-client\CSCore.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -84,11 +84,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\BaseUtils\BaseUtils.csproj">
       <Project>{c657c881-f3e1-45ba-aca5-966348010414}</Project>
       <Name>BaseUtils</Name>
@@ -115,6 +110,9 @@
     <EmbeddedResource Include="WaveConfigureDialog.resx">
       <DependentUpon>WaveConfigureDialog.cs</DependentUpon>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Audio/packages.config
+++ b/Audio/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSCore" version="1.2.1.1" targetFramework="net452" />
+  <package id="CSCore" version="1.2.1.2" targetFramework="net46" />
 </packages>

--- a/DirectInput/DirectInput.csproj
+++ b/DirectInput/DirectInput.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="SharpDX, Version=3.1.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.3.1.1\lib\net45\SharpDX.dll</HintPath>
+      <HintPath>..\packages\SharpDX.4.0.1\lib\net45\SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.DirectInput, Version=3.1.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DirectInput.3.1.1\lib\net45\SharpDX.DirectInput.dll</HintPath>
+      <HintPath>..\packages\SharpDX.DirectInput.4.0.1\lib\net45\SharpDX.DirectInput.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -63,9 +63,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/DirectInput/packages.config
+++ b/DirectInput/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="3.1.1" targetFramework="net46" />
-  <package id="SharpDX.DirectInput" version="3.1.1" targetFramework="net46" />
+  <package id="SharpDX" version="4.0.1" targetFramework="net46" />
+  <package id="SharpDX.DirectInput" version="4.0.1" targetFramework="net46" />
 </packages>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -347,6 +347,12 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UserControls\UserControlScanGrid.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\UserControlScanGrid.Designer.cs">
+      <DependentUpon>UserControlScanGrid.cs</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\UserControlSettings.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -570,6 +576,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\UserControlContainerResizable.resx">
       <DependentUpon>UserControlContainerResizable.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserControls\UserControlScanGrid.resx">
+      <DependentUpon>UserControlScanGrid.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\UserControlEstimatedValues.resx">
       <DependentUpon>UserControlEstimatedValues.cs</DependentUpon>

--- a/EDDiscovery/PanelAndPopOuts.cs
+++ b/EDDiscovery/PanelAndPopOuts.cs
@@ -59,6 +59,7 @@ namespace EDDiscovery.Forms
             Expedition,             // 27
             Trilateration,          // 28
             Settings,               // 29
+            ScanGrid,
             // ****** ADD More here DO NOT REORDER *****
         };
 
@@ -81,6 +82,7 @@ namespace EDDiscovery.Forms
             { new PanelInfo( PanelIDs.Engineering, typeof(UserControlEngineering), "Engineering", "Engineering", EliteDangerous.Properties.Resources.engineercraft , "Display Engineering planner") },
             { new PanelInfo( PanelIDs.ShoppingList, typeof(UserControlShoppingList), "Shopping List", "ShoppingList", EDDiscovery.Properties.Resources.shoppinglist, "Shopping list of materials combining synthesis and engineering") },
             { new PanelInfo( PanelIDs.Scan, typeof(UserControlScan), "Scan", "Scan", EliteDangerous.Properties.Resources.scan, "Display scan data", transparent: false) },
+            { new PanelInfo( PanelIDs.ScanGrid, typeof(UserControlScanGrid), "Scan Grid", "ScanGrid", EliteDangerous.Properties.Resources.scan, "Display scan data in a grid", transparent: false) },
             { new PanelInfo( PanelIDs.EstimatedValues, typeof(UserControlEstimatedValues),"Estimated Values", "EstimatedValues", EliteDangerous.Properties.Resources.estval, "Display estimated scan values bodies in system", transparent: false) },
             { new PanelInfo( PanelIDs.Modules, typeof(UserControlModules), "Loadout", "Modules", EliteDangerous.Properties.Resources.module, "Display Loadout for current ships and also stored modules") },
             { new PanelInfo( PanelIDs.Exploration, typeof(UserControlExploration), "Exploration", "Exploration", EliteDangerous.Properties.Resources.sellexplorationdata, "Display Exploration Information") },

--- a/EDDiscovery/UserControls/UserControlEstimatedValues.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlEstimatedValues.Designer.cs
@@ -45,17 +45,17 @@ namespace EDDiscovery.UserControls
         {
             this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
-            this.dataGridViewNearest = new System.Windows.Forms.DataGridView();
+            this.dataGridViewEstimated = new System.Windows.Forms.DataGridView();
             this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.EstValue = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataViewScrollerPanel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEstimated)).BeginInit();
             this.SuspendLayout();
             // 
             // dataViewScrollerPanel2
             // 
             this.dataViewScrollerPanel2.Controls.Add(this.vScrollBarCustom2);
-            this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewNearest);
+            this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewEstimated);
             this.dataViewScrollerPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataViewScrollerPanel2.InternalMargin = new System.Windows.Forms.Padding(0);
             this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 0);
@@ -77,13 +77,13 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.vScrollBarCustom2.HideScrollBar = true;
             this.vScrollBarCustom2.LargeChange = 0;
-            this.vScrollBarCustom2.Location = new System.Drawing.Point(552, 18);
+            this.vScrollBarCustom2.Location = new System.Drawing.Point(552, 21);
             this.vScrollBarCustom2.Maximum = -1;
             this.vScrollBarCustom2.Minimum = 0;
             this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
             this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
             this.vScrollBarCustom2.Name = "vScrollBarCustom2";
-            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 554);
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 551);
             this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
             this.vScrollBarCustom2.SmallChange = 1;
             this.vScrollBarCustom2.TabIndex = 24;
@@ -95,23 +95,23 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.Value = -1;
             this.vScrollBarCustom2.ValueLimited = -1;
             // 
-            // dataGridViewNearest
+            // dataGridViewEstimated
             // 
-            this.dataGridViewNearest.AllowUserToAddRows = false;
-            this.dataGridViewNearest.AllowUserToDeleteRows = false;
-            this.dataGridViewNearest.AllowUserToResizeRows = false;
-            this.dataGridViewNearest.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
-            this.dataGridViewNearest.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewNearest.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.dataGridViewEstimated.AllowUserToAddRows = false;
+            this.dataGridViewEstimated.AllowUserToDeleteRows = false;
+            this.dataGridViewEstimated.AllowUserToResizeRows = false;
+            this.dataGridViewEstimated.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewEstimated.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewEstimated.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.BodyName,
             this.EstValue});
-            this.dataGridViewNearest.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.dataGridViewNearest.Location = new System.Drawing.Point(0, 0);
-            this.dataGridViewNearest.Name = "dataGridViewNearest";
-            this.dataGridViewNearest.RowHeadersVisible = false;
-            this.dataGridViewNearest.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewNearest.Size = new System.Drawing.Size(552, 572);
-            this.dataGridViewNearest.TabIndex = 23;
+            this.dataGridViewEstimated.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.dataGridViewEstimated.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewEstimated.Name = "dataGridViewEstimated";
+            this.dataGridViewEstimated.RowHeadersVisible = false;
+            this.dataGridViewEstimated.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewEstimated.Size = new System.Drawing.Size(552, 572);
+            this.dataGridViewEstimated.TabIndex = 23;
             // 
             // BodyName
             // 
@@ -135,7 +135,7 @@ namespace EDDiscovery.UserControls
             this.Name = "UserControlEstimatedValues";
             this.Size = new System.Drawing.Size(572, 572);
             this.dataViewScrollerPanel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEstimated)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -143,7 +143,7 @@ namespace EDDiscovery.UserControls
         #endregion
         private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel2;
         private ExtendedControls.VScrollBarCustom vScrollBarCustom2;
-        private System.Windows.Forms.DataGridView dataGridViewNearest;
+        private System.Windows.Forms.DataGridView dataGridViewEstimated;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyName;
         private System.Windows.Forms.DataGridViewTextBoxColumn EstValue;
     }

--- a/EDDiscovery/UserControls/UserControlEstimatedValues.cs
+++ b/EDDiscovery/UserControls/UserControlEstimatedValues.cs
@@ -37,7 +37,7 @@ namespace EDDiscovery.UserControls
         public UserControlEstimatedValues()
         {
             InitializeComponent();
-            var corner = dataGridViewNearest.TopLeftHeaderCell; // work around #1487
+            var corner = dataGridViewEstimated.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()
@@ -86,7 +86,7 @@ namespace EDDiscovery.UserControls
 
         void DrawSystem()   // draw last_sn, last_he
         {
-            dataGridViewNearest.Rows.Clear();
+            dataGridViewEstimated.Rows.Clear();
 
             if (last_he == null)
             {
@@ -110,10 +110,10 @@ namespace EDDiscovery.UserControls
                 foreach(StarScan.ScanNode sn in all_nodes)
                 {
                     if ( sn.ScanData != null && sn.ScanData.BodyName != null )
-                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, sn.ScanData.EstimatedValue() });
+                        dataGridViewEstimated.Rows.Add(new object[] { sn.ScanData.BodyName, sn.ScanData.EstimatedValue() });
                 }
 
-                dataGridViewNearest.Sort(this.EstValue, ListSortDirection.Descending);
+                dataGridViewEstimated.Sort(this.EstValue, ListSortDirection.Descending);
             }
         }
 

--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -43,12 +43,15 @@ namespace EDDiscovery.UserControls
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UserControlScanGrid));
             this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
             this.dataGridViewNearest = new System.Windows.Forms.DataGridView();
-            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.img = new System.Windows.Forms.DataGridViewImageColumn();
             this.BodyClass = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyDetails = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.dataViewScrollerPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).BeginInit();
             this.SuspendLayout();
@@ -75,6 +78,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewNearest.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridViewNearest.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.BodyName,
+            this.img,
             this.BodyClass,
             this.BodyDetails});
             this.dataGridViewNearest.Dock = System.Windows.Forms.DockStyle.Bottom;
@@ -84,6 +88,39 @@ namespace EDDiscovery.UserControls
             this.dataGridViewNearest.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.dataGridViewNearest.Size = new System.Drawing.Size(552, 572);
             this.dataGridViewNearest.TabIndex = 23;
+            // 
+            // BodyName
+            // 
+            this.BodyName.FillWeight = 25F;
+            this.BodyName.HeaderText = "Body";
+            this.BodyName.MinimumWidth = 20;
+            this.BodyName.Name = "BodyName";
+            // 
+            // img
+            // 
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle1.NullValue = ((object)(resources.GetObject("dataGridViewCellStyle1.NullValue")));
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.img.DefaultCellStyle = dataGridViewCellStyle1;
+            this.img.FillWeight = 5F;
+            this.img.HeaderText = "";
+            this.img.Name = "img";
+            this.img.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.img.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // BodyClass
+            // 
+            this.BodyClass.FillWeight = 35F;
+            this.BodyClass.HeaderText = "Class";
+            this.BodyClass.MinimumWidth = 20;
+            this.BodyClass.Name = "BodyClass";
+            // 
+            // BodyDetails
+            // 
+            this.BodyDetails.FillWeight = 40F;
+            this.BodyDetails.HeaderText = "Details";
+            this.BodyDetails.MinimumWidth = 30;
+            this.BodyDetails.Name = "BodyDetails";
             // 
             // vScrollBarCustom2
             // 
@@ -115,27 +152,6 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.Value = -1;
             this.vScrollBarCustom2.ValueLimited = -1;
             // 
-            // BodyName
-            // 
-            this.BodyName.FillWeight = 25F;
-            this.BodyName.HeaderText = "Body";
-            this.BodyName.MinimumWidth = 20;
-            this.BodyName.Name = "BodyName";
-            // 
-            // BodyClass
-            // 
-            this.BodyClass.FillWeight = 35F;
-            this.BodyClass.HeaderText = "Class";
-            this.BodyClass.MinimumWidth = 20;
-            this.BodyClass.Name = "BodyClass";
-            // 
-            // BodyDetails
-            // 
-            this.BodyDetails.FillWeight = 40F;
-            this.BodyDetails.HeaderText = "Details";
-            this.BodyDetails.MinimumWidth = 30;
-            this.BodyDetails.Name = "BodyDetails";
-            // 
             // UserControlScanGrid
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -154,6 +170,7 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.VScrollBarCustom vScrollBarCustom2;
         private System.Windows.Forms.DataGridView dataGridViewNearest;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyName;
+        private System.Windows.Forms.DataGridViewImageColumn img;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyClass;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyDetails;
     }

--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -47,11 +47,11 @@ namespace EDDiscovery.UserControls
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UserControlScanGrid));
             this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
             this.dataGridViewScangrid = new System.Windows.Forms.DataGridView();
+            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.img = new System.Windows.Forms.DataGridViewImageColumn();
             this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyClass = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyDetails = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.dataViewScrollerPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewScangrid)).BeginInit();
             this.SuspendLayout();
@@ -90,39 +90,6 @@ namespace EDDiscovery.UserControls
             this.dataGridViewScangrid.Size = new System.Drawing.Size(552, 572);
             this.dataGridViewScangrid.TabIndex = 23;
             // 
-            // img
-            // 
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle1.NullValue = ((object)(resources.GetObject("dataGridViewCellStyle1.NullValue")));
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.img.DefaultCellStyle = dataGridViewCellStyle1;
-            this.img.FillWeight = 5F;
-            this.img.HeaderText = "";
-            this.img.Name = "img";
-            this.img.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.img.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            // 
-            // BodyName
-            // 
-            this.BodyName.FillWeight = 15.60211F;
-            this.BodyName.HeaderText = "Name";
-            this.BodyName.MinimumWidth = 20;
-            this.BodyName.Name = "BodyName";
-            // 
-            // BodyClass
-            // 
-            this.BodyClass.FillWeight = 27.30368F;
-            this.BodyClass.HeaderText = "Class";
-            this.BodyClass.MinimumWidth = 20;
-            this.BodyClass.Name = "BodyClass";
-            // 
-            // BodyDetails
-            // 
-            this.BodyDetails.FillWeight = 31.20421F;
-            this.BodyDetails.HeaderText = "Details";
-            this.BodyDetails.MinimumWidth = 30;
-            this.BodyDetails.Name = "BodyDetails";
-            // 
             // vScrollBarCustom2
             // 
             this.vScrollBarCustom2.ArrowBorderColor = System.Drawing.Color.LightBlue;
@@ -152,6 +119,39 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.ThumbDrawAngle = 0F;
             this.vScrollBarCustom2.Value = -1;
             this.vScrollBarCustom2.ValueLimited = -1;
+            // 
+            // img
+            // 
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle1.NullValue = ((object)(resources.GetObject("dataGridViewCellStyle1.NullValue")));
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.img.DefaultCellStyle = dataGridViewCellStyle1;
+            this.img.FillWeight = 5F;
+            this.img.HeaderText = "";
+            this.img.Name = "img";
+            this.img.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.img.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // BodyName
+            // 
+            this.BodyName.FillWeight = 15F;
+            this.BodyName.HeaderText = "Name";
+            this.BodyName.MinimumWidth = 20;
+            this.BodyName.Name = "BodyName";
+            // 
+            // BodyClass
+            // 
+            this.BodyClass.FillWeight = 25F;
+            this.BodyClass.HeaderText = "Class";
+            this.BodyClass.MinimumWidth = 20;
+            this.BodyClass.Name = "BodyClass";
+            // 
+            // BodyDetails
+            // 
+            this.BodyDetails.FillWeight = 50F;
+            this.BodyDetails.HeaderText = "Details";
+            this.BodyDetails.MinimumWidth = 30;
+            this.BodyDetails.Name = "BodyDetails";
             // 
             // UserControlScanGrid
             // 

--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -149,7 +149,7 @@ namespace EDDiscovery.UserControls
             // BodyDetails
             // 
             this.BodyDetails.FillWeight = 50F;
-            this.BodyDetails.HeaderText = "Details";
+            this.BodyDetails.HeaderText = "Briefing";
             this.BodyDetails.MinimumWidth = 30;
             this.BodyDetails.Name = "BodyDetails";
             // 

--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -1,0 +1,160 @@
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+namespace EDDiscovery.UserControls
+{
+    partial class UserControlScanGrid
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
+            this.dataGridViewNearest = new System.Windows.Forms.DataGridView();
+            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
+            this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.BodyClass = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.BodyDetails = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataViewScrollerPanel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // dataViewScrollerPanel2
+            // 
+            this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewNearest);
+            this.dataViewScrollerPanel2.Controls.Add(this.vScrollBarCustom2);
+            this.dataViewScrollerPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataViewScrollerPanel2.InternalMargin = new System.Windows.Forms.Padding(0);
+            this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 0);
+            this.dataViewScrollerPanel2.Name = "dataViewScrollerPanel2";
+            this.dataViewScrollerPanel2.ScrollBarWidth = 20;
+            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(572, 572);
+            this.dataViewScrollerPanel2.TabIndex = 25;
+            this.dataViewScrollerPanel2.VerticalScrollBarDockRight = true;
+            // 
+            // dataGridViewNearest
+            // 
+            this.dataGridViewNearest.AllowUserToAddRows = false;
+            this.dataGridViewNearest.AllowUserToDeleteRows = false;
+            this.dataGridViewNearest.AllowUserToResizeRows = false;
+            this.dataGridViewNearest.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewNearest.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewNearest.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.BodyName,
+            this.BodyClass,
+            this.BodyDetails});
+            this.dataGridViewNearest.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.dataGridViewNearest.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewNearest.Name = "dataGridViewNearest";
+            this.dataGridViewNearest.RowHeadersVisible = false;
+            this.dataGridViewNearest.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewNearest.Size = new System.Drawing.Size(552, 572);
+            this.dataGridViewNearest.TabIndex = 23;
+            // 
+            // vScrollBarCustom2
+            // 
+            this.vScrollBarCustom2.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustom2.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustom2.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustom2.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustom2.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustom2.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustom2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustom2.HideScrollBar = true;
+            this.vScrollBarCustom2.LargeChange = 0;
+            this.vScrollBarCustom2.Location = new System.Drawing.Point(552, 21);
+            this.vScrollBarCustom2.Maximum = -1;
+            this.vScrollBarCustom2.Minimum = 0;
+            this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustom2.Name = "vScrollBarCustom2";
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 551);
+            this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustom2.SmallChange = 1;
+            this.vScrollBarCustom2.TabIndex = 24;
+            this.vScrollBarCustom2.Text = "vScrollBarCustom2";
+            this.vScrollBarCustom2.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustom2.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustom2.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustom2.ThumbDrawAngle = 0F;
+            this.vScrollBarCustom2.Value = -1;
+            this.vScrollBarCustom2.ValueLimited = -1;
+            // 
+            // BodyName
+            // 
+            this.BodyName.FillWeight = 25F;
+            this.BodyName.HeaderText = "Body";
+            this.BodyName.MinimumWidth = 20;
+            this.BodyName.Name = "BodyName";
+            // 
+            // BodyClass
+            // 
+            this.BodyClass.FillWeight = 35F;
+            this.BodyClass.HeaderText = "Class";
+            this.BodyClass.MinimumWidth = 20;
+            this.BodyClass.Name = "BodyClass";
+            // 
+            // BodyDetails
+            // 
+            this.BodyDetails.FillWeight = 40F;
+            this.BodyDetails.HeaderText = "Details";
+            this.BodyDetails.MinimumWidth = 30;
+            this.BodyDetails.Name = "BodyDetails";
+            // 
+            // UserControlScanGrid
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.dataViewScrollerPanel2);
+            this.Name = "UserControlScanGrid";
+            this.Size = new System.Drawing.Size(572, 572);
+            this.dataViewScrollerPanel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+        private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel2;
+        private ExtendedControls.VScrollBarCustom vScrollBarCustom2;
+        private System.Windows.Forms.DataGridView dataGridViewNearest;
+        private System.Windows.Forms.DataGridViewTextBoxColumn BodyName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn BodyClass;
+        private System.Windows.Forms.DataGridViewTextBoxColumn BodyDetails;
+    }
+}

--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -46,19 +46,19 @@ namespace EDDiscovery.UserControls
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UserControlScanGrid));
             this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
-            this.dataGridViewNearest = new System.Windows.Forms.DataGridView();
-            this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewScangrid = new System.Windows.Forms.DataGridView();
             this.img = new System.Windows.Forms.DataGridViewImageColumn();
+            this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyClass = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyDetails = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.dataViewScrollerPanel2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewScangrid)).BeginInit();
             this.SuspendLayout();
             // 
             // dataViewScrollerPanel2
             // 
-            this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewNearest);
+            this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewScangrid);
             this.dataViewScrollerPanel2.Controls.Add(this.vScrollBarCustom2);
             this.dataViewScrollerPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataViewScrollerPanel2.InternalMargin = new System.Windows.Forms.Padding(0);
@@ -69,32 +69,26 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel2.TabIndex = 25;
             this.dataViewScrollerPanel2.VerticalScrollBarDockRight = true;
             // 
-            // dataGridViewNearest
+            // dataGridViewScangrid
             // 
-            this.dataGridViewNearest.AllowUserToAddRows = false;
-            this.dataGridViewNearest.AllowUserToDeleteRows = false;
-            this.dataGridViewNearest.AllowUserToResizeRows = false;
-            this.dataGridViewNearest.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
-            this.dataGridViewNearest.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewNearest.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.BodyName,
+            this.dataGridViewScangrid.AllowUserToAddRows = false;
+            this.dataGridViewScangrid.AllowUserToDeleteRows = false;
+            this.dataGridViewScangrid.AllowUserToResizeRows = false;
+            this.dataGridViewScangrid.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewScangrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewScangrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.img,
+            this.BodyName,
             this.BodyClass,
             this.BodyDetails});
-            this.dataGridViewNearest.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.dataGridViewNearest.Location = new System.Drawing.Point(0, 0);
-            this.dataGridViewNearest.Name = "dataGridViewNearest";
-            this.dataGridViewNearest.RowHeadersVisible = false;
-            this.dataGridViewNearest.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewNearest.Size = new System.Drawing.Size(552, 572);
-            this.dataGridViewNearest.TabIndex = 23;
-            // 
-            // BodyName
-            // 
-            this.BodyName.FillWeight = 25F;
-            this.BodyName.HeaderText = "Body";
-            this.BodyName.MinimumWidth = 20;
-            this.BodyName.Name = "BodyName";
+            this.dataGridViewScangrid.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.dataGridViewScangrid.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewScangrid.Name = "dataGridViewScangrid";
+            this.dataGridViewScangrid.RowHeadersVisible = false;
+            this.dataGridViewScangrid.RowTemplate.Height = 35;
+            this.dataGridViewScangrid.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewScangrid.Size = new System.Drawing.Size(552, 572);
+            this.dataGridViewScangrid.TabIndex = 23;
             // 
             // img
             // 
@@ -108,16 +102,23 @@ namespace EDDiscovery.UserControls
             this.img.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.img.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             // 
+            // BodyName
+            // 
+            this.BodyName.FillWeight = 15.60211F;
+            this.BodyName.HeaderText = "Name";
+            this.BodyName.MinimumWidth = 20;
+            this.BodyName.Name = "BodyName";
+            // 
             // BodyClass
             // 
-            this.BodyClass.FillWeight = 35F;
+            this.BodyClass.FillWeight = 27.30368F;
             this.BodyClass.HeaderText = "Class";
             this.BodyClass.MinimumWidth = 20;
             this.BodyClass.Name = "BodyClass";
             // 
             // BodyDetails
             // 
-            this.BodyDetails.FillWeight = 40F;
+            this.BodyDetails.FillWeight = 31.20421F;
             this.BodyDetails.HeaderText = "Details";
             this.BodyDetails.MinimumWidth = 30;
             this.BodyDetails.Name = "BodyDetails";
@@ -160,7 +161,7 @@ namespace EDDiscovery.UserControls
             this.Name = "UserControlScanGrid";
             this.Size = new System.Drawing.Size(572, 572);
             this.dataViewScrollerPanel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewScangrid)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -168,9 +169,9 @@ namespace EDDiscovery.UserControls
         #endregion
         private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel2;
         private ExtendedControls.VScrollBarCustom vScrollBarCustom2;
-        private System.Windows.Forms.DataGridView dataGridViewNearest;
-        private System.Windows.Forms.DataGridViewTextBoxColumn BodyName;
+        private System.Windows.Forms.DataGridView dataGridViewScangrid;
         private System.Windows.Forms.DataGridViewImageColumn img;
+        private System.Windows.Forms.DataGridViewTextBoxColumn BodyName;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyClass;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyDetails;
     }

--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -47,11 +47,11 @@ namespace EDDiscovery.UserControls
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UserControlScanGrid));
             this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
             this.dataGridViewScangrid = new System.Windows.Forms.DataGridView();
-            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.img = new System.Windows.Forms.DataGridViewImageColumn();
             this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyClass = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.BodyDetails = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.dataViewScrollerPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewScangrid)).BeginInit();
             this.SuspendLayout();
@@ -90,36 +90,6 @@ namespace EDDiscovery.UserControls
             this.dataGridViewScangrid.Size = new System.Drawing.Size(552, 572);
             this.dataGridViewScangrid.TabIndex = 23;
             // 
-            // vScrollBarCustom2
-            // 
-            this.vScrollBarCustom2.ArrowBorderColor = System.Drawing.Color.LightBlue;
-            this.vScrollBarCustom2.ArrowButtonColor = System.Drawing.Color.LightGray;
-            this.vScrollBarCustom2.ArrowColorScaling = 0.5F;
-            this.vScrollBarCustom2.ArrowDownDrawAngle = 270F;
-            this.vScrollBarCustom2.ArrowUpDrawAngle = 90F;
-            this.vScrollBarCustom2.BorderColor = System.Drawing.Color.White;
-            this.vScrollBarCustom2.Dock = System.Windows.Forms.DockStyle.Top;
-            this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.vScrollBarCustom2.HideScrollBar = true;
-            this.vScrollBarCustom2.LargeChange = 0;
-            this.vScrollBarCustom2.Location = new System.Drawing.Point(552, 21);
-            this.vScrollBarCustom2.Maximum = -1;
-            this.vScrollBarCustom2.Minimum = 0;
-            this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
-            this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
-            this.vScrollBarCustom2.Name = "vScrollBarCustom2";
-            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 551);
-            this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
-            this.vScrollBarCustom2.SmallChange = 1;
-            this.vScrollBarCustom2.TabIndex = 24;
-            this.vScrollBarCustom2.Text = "vScrollBarCustom2";
-            this.vScrollBarCustom2.ThumbBorderColor = System.Drawing.Color.Yellow;
-            this.vScrollBarCustom2.ThumbButtonColor = System.Drawing.Color.DarkBlue;
-            this.vScrollBarCustom2.ThumbColorScaling = 0.5F;
-            this.vScrollBarCustom2.ThumbDrawAngle = 0F;
-            this.vScrollBarCustom2.Value = -1;
-            this.vScrollBarCustom2.ValueLimited = -1;
-            // 
             // img
             // 
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
@@ -152,6 +122,36 @@ namespace EDDiscovery.UserControls
             this.BodyDetails.HeaderText = "Briefing";
             this.BodyDetails.MinimumWidth = 30;
             this.BodyDetails.Name = "BodyDetails";
+            // 
+            // vScrollBarCustom2
+            // 
+            this.vScrollBarCustom2.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustom2.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustom2.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustom2.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustom2.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustom2.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustom2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustom2.HideScrollBar = true;
+            this.vScrollBarCustom2.LargeChange = 0;
+            this.vScrollBarCustom2.Location = new System.Drawing.Point(552, 21);
+            this.vScrollBarCustom2.Maximum = -1;
+            this.vScrollBarCustom2.Minimum = 0;
+            this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustom2.Name = "vScrollBarCustom2";
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 551);
+            this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustom2.SmallChange = 1;
+            this.vScrollBarCustom2.TabIndex = 24;
+            this.vScrollBarCustom2.Text = "vScrollBarCustom2";
+            this.vScrollBarCustom2.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustom2.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustom2.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustom2.ThumbDrawAngle = 0F;
+            this.vScrollBarCustom2.Value = -1;
+            this.vScrollBarCustom2.ValueLimited = -1;
             // 
             // UserControlScanGrid
             // 

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -145,9 +145,19 @@ namespace EDDiscovery.UserControls
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
                     {
-                        bdDetails.Append("Landable. " + "Gravity " + sn.ScanData.nSurfaceGravity);
+                        bdDetails.Append("Landable. ");
                     }
-                                        
+
+                    if (sn.ScanData.Volcanism != null)
+                    {
+                        bdDetails.Append("Volcanic activities. ");
+                    }
+
+                    if (sn.ScanData.HasMaterials != null)
+                    {
+                        bdDetails.Append("\n" + sn.ScanData.DisplayMaterials());
+                    }
+
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsStar == true)
                     {
                         bdDetails.Append("M:" + sn.ScanData.nStellarMass.Value.ToString("N2") + ", ");

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -136,16 +136,16 @@ namespace EDDiscovery.UserControls
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Terraformable == true)
                     {
-                        bdDetails.Append("Terraformable, ");
+                        bdDetails.Append("Terraformable. ");
                     }
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HasRings == true && sn.ScanData.IsStar == false)
                     {
-                        bdDetails.Append("Ringed, ");
+                        bdDetails.Append("Ringed. ");
                     }
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
                     {
-                        bdDetails.Append("Landable. " + "G:" + sn.ScanData.nSurfaceGravity.Value.ToString());
+                        bdDetails.Append("Landable. " + "Gravity " + sn.ScanData.nSurfaceGravity);
                     }
                                         
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsStar == true)

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -177,16 +177,22 @@ namespace EDDiscovery.UserControls
                     }
 
                     // Image Column
-                    if (sn.ScanData.IsStar != false)
+                    /* if (sn.ScanData.IsStar != false)
                     { Image bdImage = sn.ScanData.GetStarTypeImage(); }
                     else
-                    { Image bdImage = sn.ScanData.GetPlanetClassImage(); }
-                    
+                    { Image bdImage = sn.ScanData.GetPlanetClassImage(); } */
+
                     // populate the grid
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null)
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null && sn.ScanData.IsStar == true)
                     {
-                                                
+                        Image bdImage = sn.ScanData.GetStarTypeImage();
                         dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdImage , bdClass, bdDetails });
+                    }
+
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null && sn.ScanData.IsStar == false)
+                    {
+                        Image bdImage = sn.ScanData.GetPlanetClassImage();
+                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdImage, bdClass, bdDetails });
                     }
                 }
 

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -1,0 +1,197 @@
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Drawing.Drawing2D;
+using EliteDangerousCore;
+using EliteDangerousCore.EDSM;
+using EliteDangerousCore.DB;
+
+namespace EDDiscovery.UserControls
+{
+    public partial class UserControlScanGrid : UserControlCommonBase
+    {
+        private HistoryEntry last_he = null;
+
+        public UserControlScanGrid()
+        {
+            InitializeComponent();
+            var corner = dataGridViewNearest.TopLeftHeaderCell; // work around #1487
+        }
+
+        public override void Init()
+        {
+            uctg.OnTravelSelectionChanged += Display;      
+            discoveryform.OnNewEntry += NewEntry;
+        }
+
+        public override void ChangeCursorType(IHistoryCursor thc)
+        {
+            uctg.OnTravelSelectionChanged -= Display;
+            uctg = thc;
+            uctg.OnTravelSelectionChanged += Display;
+        }
+
+        public override void Closing()
+        {
+            uctg.OnTravelSelectionChanged -= Display;
+            discoveryform.OnNewEntry -= NewEntry;
+        }
+
+        public override void InitialDisplay()
+        {
+            Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
+        }
+
+        public void NewEntry(HistoryEntry he, HistoryList hl)               // called when a new entry is made.. check to see if its a scan update
+        {
+            // if he valid, and last is null, or not he, or we have a new scan
+            if (he != null && (last_he == null || he != last_he || he.EntryType == JournalTypeEnum.Scan))
+            {
+                last_he = he;
+                DrawSystem();
+            }
+        }
+
+
+        private void Display(HistoryEntry he, HistoryList hl)            // Called at first start or hooked to change cursor
+        {
+            if (he != null && (last_he == null || he.System != last_he.System))
+            {
+                last_he = he;
+                DrawSystem();
+            }
+        }
+
+        void DrawSystem()   // draw last_sn, last_he
+        {
+            dataGridViewNearest.Rows.Clear();
+
+            if (last_he == null)
+            {
+                SetControlText("No Scan");
+                return;
+            }
+
+            StarScan.SystemNode last_sn = discoveryform.history.starscan.FindSystem(last_he.System, true);
+
+            SetControlText((last_sn == null) ? "No Scan" : ("Brief Scan Summary for " + last_sn.system.name));
+
+            if (last_sn != null)
+            {
+                List<StarScan.ScanNode> all_nodes = new List<StarScan.ScanNode>();
+                foreach (StarScan.ScanNode starnode in last_sn.starnodes.Values)
+                {
+                    all_nodes = Flatten(starnode, all_nodes);
+                }
+
+                // flatten tree of scan nodes to prepare for listing
+                foreach (StarScan.ScanNode sn in all_nodes)
+                {
+
+                    // create the grid data
+
+                    // populate the body class
+                    StringBuilder bdClass = new StringBuilder();
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Terraformable == true)
+                    {
+                        bdClass.Append("Terraformable ");
+                    }
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HasRings == true && sn.ScanData.IsStar == false)
+                    {
+                        bdClass.Append("Ringed, ");
+                    }
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.PlanetClass != null)
+                    {
+                        bdClass.Append(sn.ScanData.PlanetClass);
+                    }
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.StarTypeText != null)
+                    {
+                        bdClass.Append(sn.ScanData.StarTypeText);
+                    }
+
+                    // populate the detailed information
+                    StringBuilder bdDetails = new StringBuilder();
+
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsStar == true)
+                    {
+                        bdDetails.Append("M: " + sn.ScanData.nStellarMass.Value.ToString("N2") + ", ");
+                    }
+
+                        // planet mass
+                        if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nMassEM != null)
+                    {
+                        bdDetails.Append("M: " + sn.ScanData.nMassEM.Value.ToString("N2") + ", ");
+                    }
+
+                    // radius
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nRadius != null)
+                    {
+                        bdDetails.Append("r: " + sn.ScanData.nRadius.Value.ToString("N0") + ", ");
+                    }
+                    
+                    // gravity
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nSurfaceGravity != null)
+                    {
+                        bdDetails.Append("G: " + sn.ScanData.nSurfaceGravity.Value.ToString("N1") + ", ");
+                    }
+
+                    // temperature
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nSurfaceTemperature != null)
+                    {
+                        bdDetails.Append("K: " + sn.ScanData.nSurfaceTemperature.Value.ToString("N0") + ", ");
+                    }
+
+                    // habitable zone
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HabitableZoneInner != null && sn.ScanData.HabitableZoneOuter != null)
+                    {
+                            bdDetails.AppendFormat("Habitable Zone Approx. {0}", sn.ScanData.GetHabZoneStringLs(), (sn.ScanData.HabitableZoneInner.Value).ToString("N2"), (sn.ScanData.HabitableZoneOuter.Value).ToString("N2"));
+                    }
+
+                    // populate the grid
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null)
+                    {
+                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdClass, bdDetails });
+                    }
+                }
+
+            }
+        }
+
+        private List<StarScan.ScanNode> Flatten(StarScan.ScanNode sn, List<StarScan.ScanNode> flattened)
+        {
+            flattened.Add(sn);
+            if (sn.children != null)
+            {
+                foreach (StarScan.ScanNode node in sn.children.Values)
+                {
+                    Flatten(node, flattened);
+                }
+            }
+            return flattened;
+        }
+
+    }
+}

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -138,19 +138,25 @@ namespace EDDiscovery.UserControls
                     {
                         bdDetails.Append("Terraformable. ");
                     }
+
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
+                    {
+                        double? g = sn.ScanData.nSurfaceGravity;
+                        double? oneGee_m_s2 = 9.80665;
+                        if (g.HasValue)
+                            g = g / oneGee_m_s2;
+                        string Gg = g.Value.ToString("N1");
+                        bdDetails.Append("Landable, " + "(G: " + Gg + "). ");
+                    }
+
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HasRings == true && sn.ScanData.IsStar == false)
                     {
                         bdDetails.Append("Ringed. ");
                     }
 
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
-                    {
-                        bdDetails.Append("Landable. ");
-                    }
-
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Volcanism != null)
                     {
-                        bdDetails.Append("Volcanic activities. ");
+                        bdDetails.Append("Volcanism. ");
                     }                                      
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsStar == true)
@@ -158,7 +164,7 @@ namespace EDDiscovery.UserControls
                         bdDetails.Append("M:" + sn.ScanData.nStellarMass.Value.ToString("N2") + ", ");
                     }
                                         
-                    // habitable zone
+                    // habitable zone - do not display for black holes.
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HabitableZoneInner != null && sn.ScanData.HabitableZoneOuter != null && sn.ScanData.StarTypeID != EDStar.H)
                     {
                         bdDetails.AppendFormat("Habitable Zone Approx. {0}", sn.ScanData.GetHabZoneStringLs(), (sn.ScanData.HabitableZoneInner.Value).ToString("N2"), (sn.ScanData.HabitableZoneOuter.Value).ToString("N2"));
@@ -167,13 +173,13 @@ namespace EDDiscovery.UserControls
                     // populate the grid                                                          
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null && sn.ScanData.IsStar == true)
                     {
-                        Image bdImage = sn.ScanData.GetStarTypeImage(); // if is a star, use the StarTypeImage property
+                        Image bdImage = sn.ScanData.GetStarTypeImage(); // if is a star, use the Star image
                         dataGridViewScangrid.Rows.Add(new object[] { bdImage, sn.ScanData.BodyName, bdClass, bdDetails });
                     }
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null && sn.ScanData.IsStar == false)
                     {
-                        Image bdImage = sn.ScanData.GetPlanetClassImage(); // is is a planet or a moon, use the PlanetClassImage property
+                        Image bdImage = sn.ScanData.GetPlanetClassImage(); // if is a planet or a moon, use the Planet image
                         dataGridViewScangrid.Rows.Add(new object[] { bdImage, sn.ScanData.BodyName, bdClass, bdDetails });
                     }
                     

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -117,18 +117,7 @@ namespace EDDiscovery.UserControls
 
                     // populate the body class
                     StringBuilder bdClass = new StringBuilder();
-                    /*if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
-                    {
-                        bdClass.Append("Landable, ");
-                    }*/
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Terraformable == true)
-                    {
-                        bdClass.Append("Terraformable ");
-                    }
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HasRings == true && sn.ScanData.IsStar == false)
-                    {
-                        bdClass.Append("Ringed, ");
-                    }
+                    
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.PlanetClass != null)
                     {
                         bdClass.Append(sn.ScanData.PlanetClass);
@@ -137,43 +126,37 @@ namespace EDDiscovery.UserControls
                     {
                         bdClass.Append(sn.ScanData.StarTypeText);
                     }
+                    if (sn.level >= 2 && sn.type == StarScan.ScanNodeType.body)
+                    {
+                        bdClass.Append(" Moon");
+                    }
 
-                    // populate the detailed information
-                    StringBuilder bdDetails = new StringBuilder();
+                        // populate the detailed information
+                        StringBuilder bdDetails = new StringBuilder();
 
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Terraformable == true)
+                    {
+                        bdDetails.Append("Terraformable, ");
+                    }
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HasRings == true && sn.ScanData.IsStar == false)
+                    {
+                        bdDetails.Append("Ringed, ");
+                    }
+
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
+                    {
+                        bdDetails.Append("Landable. " + "G:" + sn.ScanData.nSurfaceGravity.Value.ToString());
+                    }
+                                        
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsStar == true)
                     {
-                        bdDetails.Append("M: " + sn.ScanData.nStellarMass.Value.ToString("N2") + ", ");
+                        bdDetails.Append("M:" + sn.ScanData.nStellarMass.Value.ToString("N2") + ", ");
                     }
-
-                        // planet mass
-                        if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nMassEM != null)
-                    {
-                        bdDetails.Append("M: " + sn.ScanData.nMassEM.Value.ToString("N2") + ", ");
-                    }
-
-                    // radius
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nRadius != null)
-                    {
-                        bdDetails.Append("r: " + sn.ScanData.nRadius.Value.ToString("N0") + ", ");
-                    }
-                    
-                    // gravity
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nSurfaceGravity != null)
-                    {
-                        bdDetails.Append("G: " + sn.ScanData.nSurfaceGravity.Value.ToString("N1") + ", ");
-                    }
-
-                    // temperature
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.nSurfaceTemperature != null)
-                    {
-                        bdDetails.Append("K: " + sn.ScanData.nSurfaceTemperature.Value.ToString("N0") + ", ");
-                    }
-
+                                        
                     // habitable zone
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HabitableZoneInner != null && sn.ScanData.HabitableZoneOuter != null)
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.HabitableZoneInner != null && sn.ScanData.HabitableZoneOuter != null && sn.ScanData.StarTypeID != EDStar.H)
                     {
-                            bdDetails.AppendFormat("Habitable Zone Approx. {0}", sn.ScanData.GetHabZoneStringLs(), (sn.ScanData.HabitableZoneInner.Value).ToString("N2"), (sn.ScanData.HabitableZoneOuter.Value).ToString("N2"));
+                        bdDetails.AppendFormat("Habitable Zone Approx. {0}", sn.ScanData.GetHabZoneStringLs(), (sn.ScanData.HabitableZoneInner.Value).ToString("N2"), (sn.ScanData.HabitableZoneOuter.Value).ToString("N2"));
                     }
 
                     // populate the grid                                                          

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -34,8 +34,7 @@ namespace EDDiscovery.UserControls
     public partial class UserControlScanGrid : UserControlCommonBase
     {
         private HistoryEntry last_he = null;
-        private object bdImage;
-
+        
         public UserControlScanGrid()
         {
             InitializeComponent();

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -115,6 +115,10 @@ namespace EDDiscovery.UserControls
 
                     // populate the body class
                     StringBuilder bdClass = new StringBuilder();
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
+                    {
+                        bdClass.Append("Landable, ");
+                    }
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Terraformable == true)
                     {
                         bdClass.Append("Terraformable ");

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -34,6 +34,7 @@ namespace EDDiscovery.UserControls
     public partial class UserControlScanGrid : UserControlCommonBase
     {
         private HistoryEntry last_he = null;
+        private object bdImage;
 
         public UserControlScanGrid()
         {
@@ -43,7 +44,7 @@ namespace EDDiscovery.UserControls
 
         public override void Init()
         {
-            uctg.OnTravelSelectionChanged += Display;      
+            uctg.OnTravelSelectionChanged += Display;
             discoveryform.OnNewEntry += NewEntry;
         }
 
@@ -75,7 +76,6 @@ namespace EDDiscovery.UserControls
             }
         }
 
-
         private void Display(HistoryEntry he, HistoryList hl)            // Called at first start or hooked to change cursor
         {
             if (he != null && (last_he == null || he.System != last_he.System))
@@ -95,6 +95,7 @@ namespace EDDiscovery.UserControls
                 return;
             }
 
+
             StarScan.SystemNode last_sn = discoveryform.history.starscan.FindSystem(last_he.System, true);
 
             SetControlText((last_sn == null) ? "No Scan" : ("Brief Scan Summary for " + last_sn.system.name));
@@ -107,10 +108,12 @@ namespace EDDiscovery.UserControls
                     all_nodes = Flatten(starnode, all_nodes);
                 }
 
+
                 // flatten tree of scan nodes to prepare for listing
                 foreach (StarScan.ScanNode sn in all_nodes)
                 {
 
+                    
                     // create the grid data
 
                     // populate the body class
@@ -174,10 +177,17 @@ namespace EDDiscovery.UserControls
                             bdDetails.AppendFormat("Habitable Zone Approx. {0}", sn.ScanData.GetHabZoneStringLs(), (sn.ScanData.HabitableZoneInner.Value).ToString("N2"), (sn.ScanData.HabitableZoneOuter.Value).ToString("N2"));
                     }
 
+                    // Image Column
+                    if (sn.ScanData.IsStar != false)
+                    { Image bdImage = sn.ScanData.GetStarTypeImage(); }
+                    else
+                    { Image bdImage = sn.ScanData.GetPlanetClassImage(); }
+                    
                     // populate the grid
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null)
                     {
-                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdClass, bdDetails });
+                                                
+                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdImage , bdClass, bdDetails });
                     }
                 }
 

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -148,15 +148,10 @@ namespace EDDiscovery.UserControls
                         bdDetails.Append("Landable. ");
                     }
 
-                    if (sn.ScanData.Volcanism != null)
+                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Volcanism != null)
                     {
                         bdDetails.Append("Volcanic activities. ");
-                    }
-
-                    if (sn.ScanData.HasMaterials != null)
-                    {
-                        bdDetails.Append("\n" + sn.ScanData.DisplayMaterials());
-                    }
+                    }                                      
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsStar == true)
                     {

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -38,7 +38,7 @@ namespace EDDiscovery.UserControls
         public UserControlScanGrid()
         {
             InitializeComponent();
-            var corner = dataGridViewNearest.TopLeftHeaderCell; // work around #1487
+            var corner = dataGridViewScangrid.TopLeftHeaderCell; // work around #1487
         }
 
         public override void Init()
@@ -86,7 +86,7 @@ namespace EDDiscovery.UserControls
 
         void DrawSystem()   // draw last_sn, last_he
         {
-            dataGridViewNearest.Rows.Clear();
+            dataGridViewScangrid.Rows.Clear();
 
             if (last_he == null)
             {
@@ -117,10 +117,10 @@ namespace EDDiscovery.UserControls
 
                     // populate the body class
                     StringBuilder bdClass = new StringBuilder();
-                    if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
+                    /*if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.IsLandable == true)
                     {
                         bdClass.Append("Landable, ");
-                    }
+                    }*/
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && sn.ScanData.Terraformable == true)
                     {
                         bdClass.Append("Terraformable ");
@@ -176,24 +176,19 @@ namespace EDDiscovery.UserControls
                             bdDetails.AppendFormat("Habitable Zone Approx. {0}", sn.ScanData.GetHabZoneStringLs(), (sn.ScanData.HabitableZoneInner.Value).ToString("N2"), (sn.ScanData.HabitableZoneOuter.Value).ToString("N2"));
                     }
 
-                    // Image Column
-                    /* if (sn.ScanData.IsStar != false)
-                    { Image bdImage = sn.ScanData.GetStarTypeImage(); }
-                    else
-                    { Image bdImage = sn.ScanData.GetPlanetClassImage(); } */
-
-                    // populate the grid
+                    // populate the grid                                                          
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null && sn.ScanData.IsStar == true)
                     {
-                        Image bdImage = sn.ScanData.GetStarTypeImage();
-                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdImage , bdClass, bdDetails });
+                        Image bdImage = sn.ScanData.GetStarTypeImage(); // if is a star, use the StarTypeImage property
+                        dataGridViewScangrid.Rows.Add(new object[] { bdImage, sn.ScanData.BodyName, bdClass, bdDetails });
                     }
 
                     if (sn.ScanData != null && sn.ScanData.BodyName != null && bdClass != null && bdDetails != null && sn.ScanData.IsStar == false)
                     {
-                        Image bdImage = sn.ScanData.GetPlanetClassImage();
-                        dataGridViewNearest.Rows.Add(new object[] { sn.ScanData.BodyName, bdImage, bdClass, bdDetails });
+                        Image bdImage = sn.ScanData.GetPlanetClassImage(); // is is a planet or a moon, use the PlanetClassImage property
+                        dataGridViewScangrid.Rows.Add(new object[] { bdImage, sn.ScanData.BodyName, bdClass, bdDetails });
                     }
+                    
                 }
 
             }
@@ -202,6 +197,8 @@ namespace EDDiscovery.UserControls
         private List<StarScan.ScanNode> Flatten(StarScan.ScanNode sn, List<StarScan.ScanNode> flattened)
         {
             flattened.Add(sn);
+
+
             if (sn.children != null)
             {
                 foreach (StarScan.ScanNode node in sn.children.Values)

--- a/EDDiscovery/UserControls/UserControlScanGrid.resx
+++ b/EDDiscovery/UserControls/UserControlScanGrid.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="BodyName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="img.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -141,4 +138,7 @@
         hIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEAAA=
 </value>
   </data>
+  <metadata name="BodyName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/EDDiscovery/UserControls/UserControlScanGrid.resx
+++ b/EDDiscovery/UserControls/UserControlScanGrid.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="BodyName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/EDDiscovery/UserControls/UserControlScanGrid.resx
+++ b/EDDiscovery/UserControls/UserControlScanGrid.resx
@@ -120,4 +120,25 @@
   <metadata name="BodyName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="img.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="dataGridViewCellStyle1.NullValue" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        Qk32AgAAAAAAADYAAAAoAAAADgAAABAAAAABABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACEgoTGw8bGw8bGw8bGw8bGw8bGw8bG
+        w8bGw8bGw8bGw8bGw8bGw8YAAAAAAISChP///////////////////////////////////////////8bD
+        xgAAAAAAhIKE////////////////////////////////////////////xsPGAAAAAACEgoT/////////
+        ///////////////////////////////////Gw8YAAAAAAISChP//////////////////////////////
+        /////////////8bDxgAAAAAAhIKE////////////AAD/AAD/////////AAD/AAD/////////xsPGAAAA
+        AACEgoT///////////////8AAP8AAP8AAP8AAP/////////////Gw8YAAAAAAISChP//////////////
+        /////wAA/wAA/////////////////8bDxgAAAAAAhIKE////////////////AAD/AAD/AAD/AAD/////
+        ////////xsPGAAAAAACEgoT///////////8AAP8AAP////////8AAP8AAP/////////Gw8YAAAAAAISC
+        hP///////////////////////////////////////////8bDxgAAAAAAhIKE////////////////////
+        ////////////////////////xsPGAAAAAACEgoT/////////////////////////////////////////
+        ///Gw8YAAAAAAISChP///////////////////////////////////////////8bDxgAAAAAAhIKEhIKE
+        hIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEhIKEAAA=
+</value>
+  </data>
 </root>

--- a/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
@@ -161,7 +161,7 @@ namespace EDDiscovery.UserControls
             // Visited
             // 
             this.Visited.FillWeight = 25F;
-            this.Visited.HeaderText = "Visited";
+            this.Visited.HeaderText = "Visits";
             this.Visited.Name = "Visited";
             // 
             // UserControlStarDistance

--- a/EDDiscovery/UserControls/UserControlStarList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.Designer.cs
@@ -339,7 +339,7 @@ namespace EDDiscovery.UserControls
             // 
             // Icon
             // 
-            this.Icon.HeaderText = "Star";
+            this.Icon.HeaderText = "System";
             this.Icon.MinimumWidth = 50;
             this.Icon.Name = "Icon";
             this.Icon.ReadOnly = true;

--- a/EDDiscovery/UserControls/UserControlStarList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.Designer.cs
@@ -45,6 +45,7 @@ namespace EDDiscovery.UserControls
         {
             this.components = new System.ComponentModel.Container();
             this.TopPanel = new System.Windows.Forms.Panel();
+            this.checkBoxEDSM = new ExtendedControls.CheckBoxCustom();
             this.checkBoxMoveToTop = new ExtendedControls.CheckBoxCustom();
             this.buttonExtExcel = new ExtendedControls.ButtonExt();
             this.panelHistoryIcon = new System.Windows.Forms.Panel();
@@ -64,7 +65,6 @@ namespace EDDiscovery.UserControls
             this.Icon = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.checkBoxEDSM = new ExtendedControls.CheckBoxCustom();
             this.TopPanel.SuspendLayout();
             this.dataViewScrollerPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewStarList)).BeginInit();
@@ -87,6 +87,34 @@ namespace EDDiscovery.UserControls
             this.TopPanel.Size = new System.Drawing.Size(870, 38);
             this.TopPanel.TabIndex = 27;
             // 
+            // checkBoxEDSM
+            // 
+            this.checkBoxEDSM.Appearance = System.Windows.Forms.Appearance.Button;
+            this.checkBoxEDSM.BackColor = System.Drawing.Color.Transparent;
+            this.checkBoxEDSM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.checkBoxEDSM.CheckBoxColor = System.Drawing.Color.White;
+            this.checkBoxEDSM.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxEDSM.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxEDSM.Cursor = System.Windows.Forms.Cursors.Default;
+            this.checkBoxEDSM.FlatAppearance.BorderColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.checkBoxEDSM.FlatAppearance.CheckedBackColor = System.Drawing.Color.Green;
+            this.checkBoxEDSM.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
+            this.checkBoxEDSM.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver;
+            this.checkBoxEDSM.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.checkBoxEDSM.FontNerfReduction = 0.5F;
+            this.checkBoxEDSM.Image = global::EDDiscovery.Properties.Resources.edsm24;
+            this.checkBoxEDSM.ImageButtonDisabledScaling = 0.5F;
+            this.checkBoxEDSM.Location = new System.Drawing.Point(432, 3);
+            this.checkBoxEDSM.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxEDSM.Name = "checkBoxEDSM";
+            this.checkBoxEDSM.Size = new System.Drawing.Size(32, 32);
+            this.checkBoxEDSM.TabIndex = 30;
+            this.checkBoxEDSM.TickBoxReductionSize = 10;
+            this.toolTip.SetToolTip(this.checkBoxEDSM, "Show/Hide Body data from EDSM. Due to server constraints, you must click on a sys" +
+        "tem to retreive data on it from EDSM.");
+            this.checkBoxEDSM.UseVisualStyleBackColor = false;
+            this.checkBoxEDSM.CheckedChanged += new System.EventHandler(this.checkBoxEDSM_CheckedChanged);
+            // 
             // checkBoxMoveToTop
             // 
             this.checkBoxMoveToTop.AutoSize = true;
@@ -107,9 +135,6 @@ namespace EDDiscovery.UserControls
             // 
             // buttonExtExcel
             // 
-            this.buttonExtExcel.BorderColorScaling = 1.25F;
-            this.buttonExtExcel.ButtonColorScaling = 0.5F;
-            this.buttonExtExcel.ButtonDisabledScaling = 0.5F;
             this.buttonExtExcel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonExtExcel.Image = global::EDDiscovery.Properties.Resources.excel;
             this.buttonExtExcel.Location = new System.Drawing.Point(470, 6);
@@ -322,7 +347,7 @@ namespace EDDiscovery.UserControls
             // ColumnSystem
             // 
             this.ColumnSystem.FillWeight = 40F;
-            this.ColumnSystem.HeaderText = "No Visits";
+            this.ColumnSystem.HeaderText = "Visits";
             this.ColumnSystem.MinimumWidth = 50;
             this.ColumnSystem.Name = "ColumnSystem";
             this.ColumnSystem.ReadOnly = true;
@@ -334,34 +359,6 @@ namespace EDDiscovery.UserControls
             this.ColumnDistance.MinimumWidth = 50;
             this.ColumnDistance.Name = "ColumnDistance";
             this.ColumnDistance.ReadOnly = true;
-            // 
-            // checkBoxEDSM
-            // 
-            this.checkBoxEDSM.Appearance = System.Windows.Forms.Appearance.Button;
-            this.checkBoxEDSM.BackColor = System.Drawing.Color.Transparent;
-            this.checkBoxEDSM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.checkBoxEDSM.CheckBoxColor = System.Drawing.Color.White;
-            this.checkBoxEDSM.CheckBoxInnerColor = System.Drawing.Color.White;
-            this.checkBoxEDSM.CheckColor = System.Drawing.Color.DarkBlue;
-            this.checkBoxEDSM.Cursor = System.Windows.Forms.Cursors.Default;
-            this.checkBoxEDSM.FlatAppearance.BorderColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.checkBoxEDSM.FlatAppearance.CheckedBackColor = System.Drawing.Color.Green;
-            this.checkBoxEDSM.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
-            this.checkBoxEDSM.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver;
-            this.checkBoxEDSM.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.checkBoxEDSM.FontNerfReduction = 0.5F;
-            this.checkBoxEDSM.Image = global::EDDiscovery.Properties.Resources.edsm24;
-            this.checkBoxEDSM.ImageButtonDisabledScaling = 0.5F;
-            this.checkBoxEDSM.Location = new System.Drawing.Point(432, 3);
-            this.checkBoxEDSM.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.checkBoxEDSM.Name = "checkBoxEDSM";
-            this.checkBoxEDSM.Size = new System.Drawing.Size(32, 32);
-            this.checkBoxEDSM.TabIndex = 30;
-            this.checkBoxEDSM.TickBoxReductionSize = 10;
-            this.toolTip.SetToolTip(this.checkBoxEDSM, "Show/Hide Body data from EDSM. Due to server constraints, you must click on a sys" +
-        "tem to retreive data on it from EDSM.");
-            this.checkBoxEDSM.UseVisualStyleBackColor = false;
-            this.checkBoxEDSM.CheckedChanged += new System.EventHandler(this.checkBoxEDSM_CheckedChanged);
             // 
             // UserControlStarList
             // 
@@ -398,10 +395,10 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ButtonExt buttonExtExcel;
         private ExtendedControls.CheckBoxCustom checkBoxMoveToTop;
         private System.Windows.Forms.ToolStripMenuItem setNoteToolStripMenuItem;
+        private ExtendedControls.CheckBoxCustom checkBoxEDSM;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnTime;
         private System.Windows.Forms.DataGridViewTextBoxColumn Icon;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnSystem;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDistance;
-        private ExtendedControls.CheckBoxCustom checkBoxEDSM;
     }
 }

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -253,18 +253,12 @@ namespace EDDiscovery.UserControls
                                                                                     
                             if (sc.IsStar) // brief notification for special or uncommon celestial bodies, useful to traverse the history and search for that special body you discovered.
                             {
-                                // testing
-                                if (sc.BodyName != null)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeText, prefix);
-
-                                // Sagittarius A* is a special body: is the only one which is classified as Super Massive Black Hole. Yet, it refuse to work as expected...
-                                string SagA = "Sagittarius A";
-                                if (sc.GetStarTypeName() == "Super Massive Black Hole" || sc.StarTypeID == EDStar.SuperMassiveBlackHole || sc.BodyName.Contains(SagA))
+                                // Sagittarius A* is a special body: is the centre of the Milky Way, and the only one which is classified as Super Massive Black Hole.                                
+                                if (sc.StarTypeID == EDStar.SuperMassiveBlackHole)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
 
-                                // black holes (they are buggy - many shows up without problems, but a few refuse to cooperate). More work needed
-                                string BlackHole = "Black Hole";
-                                if (sc.StarTypeID == EDStar.H || sn.ScanData.StarTypeText == "Black Hole" || sc.StarTypeText.Contains(BlackHole))
+                                // black holes
+                                if (sc.StarTypeID == EDStar.H)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);
 
                                 // neutron stars
@@ -371,6 +365,10 @@ namespace EDDiscovery.UserControls
                     if (total > 0)
                     {
                         infostr = infostr.AppendPrePad(total.ToStringInvariant() + " Other bod" + ((total > 1) ? "ies" : "y"), ", ");
+                        infostr = infostr.AppendPrePad(extrainfo, prefix);
+                    }
+                    else
+                    {
                         infostr = infostr.AppendPrePad(extrainfo, prefix);
                     }
                 }

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -253,10 +253,15 @@ namespace EDDiscovery.UserControls
 
                             if (sc.IsStar)
                             {
+                                // wolf rayet W, WN, WNC, WC, WO
+                                if (sc.StarTypeID == EDStar.W || sc.StarTypeID == EDStar.WN || sc.StarTypeID == EDStar.WNC || sc.StarTypeID == EDStar.WC || sc.StarTypeID == EDStar.WO)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a wolf-rayet star", prefix);
                                 if (sc.StarTypeID == EDStar.N)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a neutron star", prefix);
-                                if (sc.StarTypeID == EDStar.H)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);
+                                if (sc.StarTypeID == EDStar.H || sc.StarTypeText == "Black Hole" || sc.StarTypeText == "Black hole")
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);                   
+                                if (sc.BodyName == "Sagittarius A*")
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
                             }
                             else
                             {

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -251,17 +251,61 @@ namespace EDDiscovery.UserControls
                         {
                             JournalScan sc = sn.ScanData;
 
-                            if (sc.IsStar)
-                            {
-                                // wolf rayet W, WN, WNC, WC, WO
-                                if (sc.StarTypeID == EDStar.W || sc.StarTypeID == EDStar.WN || sc.StarTypeID == EDStar.WNC || sc.StarTypeID == EDStar.WC || sc.StarTypeID == EDStar.WO)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a wolf-rayet star", prefix);
+                            // Sagittarius A* is a special body: is the only one which is classified as Super Massive Black Hole. Yet, it refuse to work as expected...
+                            string SagA = "Sagittarius A";
+                            if (sc.GetStarTypeName() == "Super Massive Black Hole" || sc.StarTypeID == EDStar.SuperMassiveBlackHole || sc.BodyName.Contains(SagA))
+                                extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
+
+                            // black holes (they are buggy - many shows up without problems, but a few refuse to cooperate). More work needed
+                            string BlackHole = "Black Hole";
+                            if (sc.StarTypeID == EDStar.H || sn.ScanData.StarTypeText == "Black Hole" || sc.StarTypeText.Contains(BlackHole))
+                                extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);
+                            
+                            if (sc.IsStar == true) // brief notification for special or uncommon celestial bodies, useful to traverse the history and search for that special body you discovered.
+                            {   
+                                // neutron stars
                                 if (sc.StarTypeID == EDStar.N)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a neutron star", prefix);
-                                if (sc.StarTypeID == EDStar.H || sc.StarTypeText == "Black Hole" || sc.StarTypeText == "Black hole")
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);                   
-                                if (sc.BodyName == "Sagittarius A*")
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
+
+                                // white dwarf D, DA, DAB, DAO, DAZ, DAV, DB, DBZ, DBV, DO, DOV, DQ, DC, DCV, DX,
+                                if (sc.StarTypeID == EDStar.D || sc.StarTypeID == EDStar.DA || sc.StarTypeID == EDStar.DAB || sc.StarTypeID == EDStar.DAO || sc.StarTypeID == EDStar.DAZ || sc.StarTypeID == EDStar.DAV || 
+                                    sc.StarTypeID == EDStar.DB || sc.StarTypeID == EDStar.DBZ || sc.StarTypeID == EDStar.DBV || sc.StarTypeID == EDStar.DO || sc.StarTypeID == EDStar.DOV || sc.StarTypeID == EDStar.DQ || 
+                                    sc.StarTypeID == EDStar.DC || sc.StarTypeID == EDStar.DCV || sc.StarTypeID == EDStar.DX)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeID + " white dwarf star", prefix);
+
+                                // wolf rayet W, WN, WNC, WC, WO
+                                if (sc.StarTypeID == EDStar.W || sc.StarTypeID == EDStar.WN || sc.StarTypeID == EDStar.WNC || sc.StarTypeID == EDStar.WC || sc.StarTypeID == EDStar.WO)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeID + " wolf-rayet star", prefix);
+
+                                // A_BlueWhiteSuperGiant
+                                string ABlueWhiteSuperGiant = "A Blue White Super Giant";
+                                if (sc.StarTypeID == EDStar.A_BlueWhiteSuperGiant || sc.StarTypeText.Contains(ABlueWhiteSuperGiant))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a A Blue White Super Giant", prefix);
+
+                                string FWhiteSuperGiant = "F White Super Giant";
+                                // F_WhiteSuperGiant
+                                if (sc.StarTypeID == EDStar.F_WhiteSuperGiant || sc.StarTypeText.Contains(FWhiteSuperGiant))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a F White Super Giant", prefix);
+
+                                // K_OrangeGiant
+                                string KOrangeGiant = "K Orange Giant";
+                                if (sc.StarTypeID == EDStar.K_OrangeGiant || sc.StarTypeText.Contains(KOrangeGiant))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a K Orange Giant", prefix);
+
+                                // M_RedSuperGiant
+                                string MRedSuperGiant = "M Red Super Giant";
+                                if (sc.StarTypeID == EDStar.M_RedSuperGiant || sc.StarTypeText.Contains(MRedSuperGiant))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a M Red Super Giant", prefix);
+
+                                // M_RedGiant
+                                string MRedGiant = "M Red Giant";
+                                if (sc.StarTypeID == EDStar.M_RedGiant || sc.StarTypeText.Contains(MRedGiant))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a M Red Giant", prefix);
+
+                                // RoguePlanet,
+                                string RouguePlanet = "Rougue";
+                                if (sc.StarTypeID == EDStar.RoguePlanet || sc.StarTypeText.Contains(RouguePlanet))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a rougue planet", prefix);
                             }
                             else
                             {

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -250,19 +250,23 @@ namespace EDDiscovery.UserControls
                         if (sn.ScanData!=null)
                         {
                             JournalScan sc = sn.ScanData;
+                                                                                    
+                            if (sc.IsStar) // brief notification for special or uncommon celestial bodies, useful to traverse the history and search for that special body you discovered.
+                            {
+                                // testing
+                                if (sc.BodyName != null)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeText, prefix);
 
-                            // Sagittarius A* is a special body: is the only one which is classified as Super Massive Black Hole. Yet, it refuse to work as expected...
-                            string SagA = "Sagittarius A";
-                            if (sc.GetStarTypeName() == "Super Massive Black Hole" || sc.StarTypeID == EDStar.SuperMassiveBlackHole || sc.BodyName.Contains(SagA))
-                                extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
+                                // Sagittarius A* is a special body: is the only one which is classified as Super Massive Black Hole. Yet, it refuse to work as expected...
+                                string SagA = "Sagittarius A";
+                                if (sc.GetStarTypeName() == "Super Massive Black Hole" || sc.StarTypeID == EDStar.SuperMassiveBlackHole || sc.BodyName.Contains(SagA))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
 
-                            // black holes (they are buggy - many shows up without problems, but a few refuse to cooperate). More work needed
-                            string BlackHole = "Black Hole";
-                            if (sc.StarTypeID == EDStar.H || sn.ScanData.StarTypeText == "Black Hole" || sc.StarTypeText.Contains(BlackHole))
-                                extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);
-                            
-                            if (sc.IsStar == true) // brief notification for special or uncommon celestial bodies, useful to traverse the history and search for that special body you discovered.
-                            {   
+                                // black holes (they are buggy - many shows up without problems, but a few refuse to cooperate). More work needed
+                                string BlackHole = "Black Hole";
+                                if (sc.StarTypeID == EDStar.H || sn.ScanData.StarTypeText == "Black Hole" || sc.StarTypeText.Contains(BlackHole))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);
+
                                 // neutron stars
                                 if (sc.StarTypeID == EDStar.N)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a neutron star", prefix);
@@ -307,7 +311,9 @@ namespace EDDiscovery.UserControls
                                 if (sc.StarTypeID == EDStar.RoguePlanet || sc.StarTypeText.Contains(RouguePlanet))
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a rougue planet", prefix);
                             }
+
                             else
+
                             {
                                 // Check if a non-star body is a moon or not. We want it to further refine our brief summary in the visited star list.
                                 // To avoid duplicates, we need to apply our filters before on the bodies recognized as a moon, than do the same for the other bodies that do not fulfill that criteria.

--- a/EDDiscoveryTests/EDDiscoveryTests.csproj
+++ b/EDDiscoveryTests/EDDiscoveryTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -89,10 +90,10 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NFluent, Version=2.0.0.71, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
-      <HintPath>..\packages\NFluent.2.0.0\lib\net45\NFluent.dll</HintPath>
+      <HintPath>..\packages\NFluent.2.1.0\lib\net45\NFluent.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenTK.2.0.0\lib\net20\OpenTK.dll</HintPath>
@@ -135,6 +136,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EDDiscoveryTests/packages.config
+++ b/EDDiscoveryTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
-  <package id="NFluent" version="2.0.0" targetFramework="net46" />
-  <package id="NUnit" version="3.7.1" targetFramework="net46" />
-  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net46" />
+  <package id="NFluent" version="2.1.0" targetFramework="net46" />
+  <package id="NUnit" version="3.9.0" targetFramework="net46" />
+  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net46" />
   <package id="OpenTK" version="2.0.0" targetFramework="net46" />
 </packages>

--- a/EliteDangerous/EliteDangerous.csproj
+++ b/EliteDangerous/EliteDangerous.csproj
@@ -47,10 +47,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite, Version=1.0.105.2, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.105.2\lib\net46\System.Data.SQLite.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.106.0\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite.Linq, Version=1.0.105.2, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.105.2\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.106.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
@@ -533,11 +533,11 @@
     <None Include="Resources\WolfRayet.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.105.2\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.105.2\build\net46\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.105.2\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.105.2\build\net46\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
 </Project>

--- a/EliteDangerous/app.config
+++ b/EliteDangerous/app.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <system.data>
-    <DbProviderFactories>
-      <remove invariant="System.Data.SQLite" />
-      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
-    </DbProviderFactories>
-  </system.data>
+  
   <dependentAssembly>
     <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-1.0.105.2" newVersion="1.0.105.2" />
   </dependentAssembly>
-</configuration>
+<system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SQLite" />
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
+    </DbProviderFactories>
+  </system.data></configuration>

--- a/EliteDangerous/packages.config
+++ b/EliteDangerous/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
-  <package id="System.Data.SQLite.Core" version="1.0.105.2" targetFramework="net46" />
-  <package id="System.Data.SQLite.Linq" version="1.0.105.2" targetFramework="net46" />
+  <package id="System.Data.SQLite.Core" version="1.0.106.0" targetFramework="net46" />
+  <package id="System.Data.SQLite.Linq" version="1.0.106.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Added a new panel, ScanGrid, which display the scanned bodies in a grid, with some briefing information. By now, it's somewhat limited, but still useful. The idea is to provide a clean view of a system, in an uncluttered and minimal view. Some improvements already planned, such as display Materials for landable planets.

Massive improvements and fixes in StarList panel:

-   now works also on system with no additional bodies beside stars (minor bug fix)
-   recognize lonely black holes and neutron stars (cause for the first bug fix)
-   correctly recognize and display Sagittarius A* as a Super Massive Black Hole
-   added Wolf-Rayet stars, with sub-classes
-   added White Dwarfs stars, with sub-classes
-   added Giants and Super Giants stars

Fixes in EstimatedValues panel: dataGridView, which was named wrongly dataGridViewNearest (cause it was copied by the StarDistances panel) now is dataGridViewEstimated.

Minor fixes.