### PR TITLE
Improvements and fixes in StarList panel, with further optimizations

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.Designer.cs
@@ -45,6 +45,7 @@ namespace EDDiscovery.UserControls
         {
             this.components = new System.ComponentModel.Container();
             this.TopPanel = new System.Windows.Forms.Panel();
+            this.checkBoxEDSM = new ExtendedControls.CheckBoxCustom();
             this.checkBoxMoveToTop = new ExtendedControls.CheckBoxCustom();
             this.buttonExtExcel = new ExtendedControls.ButtonExt();
             this.panelHistoryIcon = new System.Windows.Forms.Panel();
@@ -64,7 +65,6 @@ namespace EDDiscovery.UserControls
             this.Icon = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnSystem = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ColumnDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.checkBoxEDSM = new ExtendedControls.CheckBoxCustom();
             this.TopPanel.SuspendLayout();
             this.dataViewScrollerPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewStarList)).BeginInit();
@@ -87,6 +87,34 @@ namespace EDDiscovery.UserControls
             this.TopPanel.Size = new System.Drawing.Size(870, 38);
             this.TopPanel.TabIndex = 27;
             // 
+            // checkBoxEDSM
+            // 
+            this.checkBoxEDSM.Appearance = System.Windows.Forms.Appearance.Button;
+            this.checkBoxEDSM.BackColor = System.Drawing.Color.Transparent;
+            this.checkBoxEDSM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.checkBoxEDSM.CheckBoxColor = System.Drawing.Color.White;
+            this.checkBoxEDSM.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxEDSM.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxEDSM.Cursor = System.Windows.Forms.Cursors.Default;
+            this.checkBoxEDSM.FlatAppearance.BorderColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.checkBoxEDSM.FlatAppearance.CheckedBackColor = System.Drawing.Color.Green;
+            this.checkBoxEDSM.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
+            this.checkBoxEDSM.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver;
+            this.checkBoxEDSM.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.checkBoxEDSM.FontNerfReduction = 0.5F;
+            this.checkBoxEDSM.Image = global::EDDiscovery.Properties.Resources.edsm24;
+            this.checkBoxEDSM.ImageButtonDisabledScaling = 0.5F;
+            this.checkBoxEDSM.Location = new System.Drawing.Point(432, 3);
+            this.checkBoxEDSM.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxEDSM.Name = "checkBoxEDSM";
+            this.checkBoxEDSM.Size = new System.Drawing.Size(32, 32);
+            this.checkBoxEDSM.TabIndex = 30;
+            this.checkBoxEDSM.TickBoxReductionSize = 10;
+            this.toolTip.SetToolTip(this.checkBoxEDSM, "Show/Hide Body data from EDSM. Due to server constraints, you must click on a sys" +
+        "tem to retreive data on it from EDSM.");
+            this.checkBoxEDSM.UseVisualStyleBackColor = false;
+            this.checkBoxEDSM.CheckedChanged += new System.EventHandler(this.checkBoxEDSM_CheckedChanged);
+            // 
             // checkBoxMoveToTop
             // 
             this.checkBoxMoveToTop.AutoSize = true;
@@ -107,9 +135,6 @@ namespace EDDiscovery.UserControls
             // 
             // buttonExtExcel
             // 
-            this.buttonExtExcel.BorderColorScaling = 1.25F;
-            this.buttonExtExcel.ButtonColorScaling = 0.5F;
-            this.buttonExtExcel.ButtonDisabledScaling = 0.5F;
             this.buttonExtExcel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonExtExcel.Image = global::EDDiscovery.Properties.Resources.excel;
             this.buttonExtExcel.Location = new System.Drawing.Point(470, 6);
@@ -314,7 +339,7 @@ namespace EDDiscovery.UserControls
             // 
             // Icon
             // 
-            this.Icon.HeaderText = "Star";
+            this.Icon.HeaderText = "System";
             this.Icon.MinimumWidth = 50;
             this.Icon.Name = "Icon";
             this.Icon.ReadOnly = true;
@@ -322,7 +347,7 @@ namespace EDDiscovery.UserControls
             // ColumnSystem
             // 
             this.ColumnSystem.FillWeight = 40F;
-            this.ColumnSystem.HeaderText = "No Visits";
+            this.ColumnSystem.HeaderText = "Visits";
             this.ColumnSystem.MinimumWidth = 50;
             this.ColumnSystem.Name = "ColumnSystem";
             this.ColumnSystem.ReadOnly = true;
@@ -334,34 +359,6 @@ namespace EDDiscovery.UserControls
             this.ColumnDistance.MinimumWidth = 50;
             this.ColumnDistance.Name = "ColumnDistance";
             this.ColumnDistance.ReadOnly = true;
-            // 
-            // checkBoxEDSM
-            // 
-            this.checkBoxEDSM.Appearance = System.Windows.Forms.Appearance.Button;
-            this.checkBoxEDSM.BackColor = System.Drawing.Color.Transparent;
-            this.checkBoxEDSM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.checkBoxEDSM.CheckBoxColor = System.Drawing.Color.White;
-            this.checkBoxEDSM.CheckBoxInnerColor = System.Drawing.Color.White;
-            this.checkBoxEDSM.CheckColor = System.Drawing.Color.DarkBlue;
-            this.checkBoxEDSM.Cursor = System.Windows.Forms.Cursors.Default;
-            this.checkBoxEDSM.FlatAppearance.BorderColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.checkBoxEDSM.FlatAppearance.CheckedBackColor = System.Drawing.Color.Green;
-            this.checkBoxEDSM.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
-            this.checkBoxEDSM.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver;
-            this.checkBoxEDSM.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.checkBoxEDSM.FontNerfReduction = 0.5F;
-            this.checkBoxEDSM.Image = global::EDDiscovery.Properties.Resources.edsm24;
-            this.checkBoxEDSM.ImageButtonDisabledScaling = 0.5F;
-            this.checkBoxEDSM.Location = new System.Drawing.Point(432, 3);
-            this.checkBoxEDSM.MouseOverColor = System.Drawing.Color.CornflowerBlue;
-            this.checkBoxEDSM.Name = "checkBoxEDSM";
-            this.checkBoxEDSM.Size = new System.Drawing.Size(32, 32);
-            this.checkBoxEDSM.TabIndex = 30;
-            this.checkBoxEDSM.TickBoxReductionSize = 10;
-            this.toolTip.SetToolTip(this.checkBoxEDSM, "Show/Hide Body data from EDSM. Due to server constraints, you must click on a sys" +
-        "tem to retreive data on it from EDSM.");
-            this.checkBoxEDSM.UseVisualStyleBackColor = false;
-            this.checkBoxEDSM.CheckedChanged += new System.EventHandler(this.checkBoxEDSM_CheckedChanged);
             // 
             // UserControlStarList
             // 
@@ -398,10 +395,10 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ButtonExt buttonExtExcel;
         private ExtendedControls.CheckBoxCustom checkBoxMoveToTop;
         private System.Windows.Forms.ToolStripMenuItem setNoteToolStripMenuItem;
+        private ExtendedControls.CheckBoxCustom checkBoxEDSM;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnTime;
         private System.Windows.Forms.DataGridViewTextBoxColumn Icon;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnSystem;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColumnDistance;
-        private ExtendedControls.CheckBoxCustom checkBoxEDSM;
     }
 }

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -250,15 +250,43 @@ namespace EDDiscovery.UserControls
                         if (sn.ScanData!=null)
                         {
                             JournalScan sc = sn.ScanData;
-
-                            if (sc.IsStar)
+                                                                                    
+                            if (sc.IsStar) // brief notification for special or uncommon celestial bodies, useful to traverse the history and search for that special body you discovered.
                             {
-                                if (sc.StarTypeID == EDStar.N)
-                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a neutron star", prefix);
+                                // Sagittarius A* is a special body: is the centre of the Milky Way, and the only one which is classified as a Super Massive Black Hole. As far as we know...                                
+                                if (sc.StarTypeID == EDStar.SuperMassiveBlackHole)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a super massive black hole", prefix);
+
+                                // black holes
                                 if (sc.StarTypeID == EDStar.H)
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a black hole", prefix);
+
+                                // neutron stars
+                                if (sc.StarTypeID == EDStar.N)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a neutron star", prefix);
+
+                                // white dwarf (D, DA, DAB, DAO, DAZ, DAV, DB, DBZ, DBV, DO, DOV, DQ, DC, DCV, DX)
+                                string WhiteDwarf = "White Dwarf";
+                                if (sc.StarTypeText.Contains(WhiteDwarf))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeID + " white dwarf star", prefix);
+
+                                // wolf rayet (W, WN, WNC, WC, WO)
+                                string WolfRayet = "Wolf-Rayet";
+                                if (sc.StarTypeText.Contains(WolfRayet))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeID + " wolf-rayet star", prefix);
+                                
+                                // giants. It should recognize all classes of giants.
+                                string Giant = "Giant";
+                                if (sc.StarTypeText.Contains(Giant))
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeText, prefix);
+
+                                // rogue planets - not sure if they really exists, but they are in the journal, so...
+                                if (sc.StarTypeID == EDStar.RoguePlanet)
+                                    extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a rogue planet", prefix);
                             }
+
                             else
+
                             {
                                 // Check if a non-star body is a moon or not. We want it to further refine our brief summary in the visited star list.
                                 // To avoid duplicates, we need to apply our filters before on the bodies recognized as a moon, than do the same for the other bodies that do not fulfill that criteria.
@@ -286,8 +314,10 @@ namespace EDDiscovery.UserControls
                                     if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
                                         extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia moon", prefix);                                  
                                 }
+
                                 else
-                                // Now, tell us the special state of planets.
+
+                                // Do the same, for all planets
                                 {
                                     // Earth Like planet
                                     if (sc.PlanetTypeID == EDPlanet.Earthlike_body)
@@ -314,8 +344,12 @@ namespace EDDiscovery.UserControls
 
                     total -= node.starnodes.Count;
                     if (total > 0)
-                    {
+                    {   // tell us that a system has other bodies, and how much, beside stars
                         infostr = infostr.AppendPrePad(total.ToStringInvariant() + " Other bod" + ((total > 1) ? "ies" : "y"), ", ");
+                        infostr = infostr.AppendPrePad(extrainfo, prefix);
+                    }
+                    else
+                    {   // we need this to allow the panel to scan also through systems which has only stars
                         infostr = infostr.AppendPrePad(extrainfo, prefix);
                     }
                 }


### PR DESCRIPTION
Improvements and fixes in StarList panel, which now:

- works also on system with no additional bodies beside stars (bug fix).
Previously it only scans systems which has additional bodies, so lonely black holes and neutron star, in example, were not recognized and signaled. So now...
- ...recognize lonely black holes and neutron stars (as per the first bug fix)
- correctly recognize and display Sagittarius A* as a Super Massive Black Hole
- added Wolf-Rayet stars, with sub-classes
- added White Dwarfs stars, with sub-classes
- added Giants and Super Giants stars
- added and edited comments for the modified regions

For white dwarfes, wolf-rayet and giant stars, which has many classes, a .Contains(**string**) method was used, to avoid multiple checks and so to speed up the process.
