### PR TITLE
Resolve #1508 the right way

### DIFF
--- a/BaseUtils/WinForms/ControlHelpers.cs
+++ b/BaseUtils/WinForms/ControlHelpers.cs
@@ -196,28 +196,17 @@ public static class ControlHelpersStaticFunc
     {
         int a = (sp.Orientation == Orientation.Vertical) ? sp.Width : sp.Height;
         int b = (int)(a * value);
-
-        if (a >= 2)        // just make sure we have some width/height
-        {
-            b = Math.Max(b, sp.Panel1MinSize);
-            b = Math.Min(b, a - sp.Panel2MinSize);  // clip to sides in case its too big.
-        }
-        else
-            b = sp.Panel1MinSize;
-
-        if (b >= sp.Panel1MinSize && b < a - sp.Panel2MinSize)   // still check, may be clipped out of bounds
+        b = Math.Max(b, sp.Panel1MinSize);
+        b = Math.Min(b, a - sp.Panel2MinSize);  // clip to sides in case its too big.
+        if ( b >= sp.Panel1MinSize && b < a-sp.Panel2MinSize)   // still check, may be clipped out of bounds
             sp.SplitterDistance = b;
-
         //System.Diagnostics.Debug.WriteLine("Splitter {0} {1} {2} {3}-{4} Set {5:N2} wsize {6} -> {7} set {8}", sp.Name, sp.DisplayRectangle, sp.SplitterDistance,  sp.Panel1MinSize,sp.Panel2MinSize, value, a, b , sp.SplitterDistance);
     }
 
     static public double GetSplitterDistance(this SplitContainer sp)                    // get the splitter distance as a fractional double
     {
         int a = (sp.Orientation == Orientation.Vertical) ? sp.Width : sp.Height;
-
-        double v = 0.5;
-        if ( a > 0 )    // if sized..
-            v = (double)sp.SplitterDistance / (double)a;
+        double v = (double)sp.SplitterDistance / (double)a;
         //System.Diagnostics.Debug.WriteLine("Splitter {0} {1} {2} Get wsize {3} -> {4:N2}", sp.Name, sp.DisplayRectangle, sp.SplitterDistance, a, v);
         return v;
     }

--- a/BaseUtils/WinForms/ControlHelpers.cs
+++ b/BaseUtils/WinForms/ControlHelpers.cs
@@ -194,20 +194,28 @@ public static class ControlHelpersStaticFunc
 
     static public void SplitterDistance(this SplitContainer sp, double value)           // set the splitter distance from a double value.. safe from exceptions.
     {
-        int a = (sp.Orientation == Orientation.Vertical) ? sp.Width : sp.Height;
-        int b = (int)(a * value);
-        b = Math.Max(b, sp.Panel1MinSize);
-        b = Math.Min(b, a - sp.Panel2MinSize);  // clip to sides in case its too big.
-        if ( b >= sp.Panel1MinSize && b < a-sp.Panel2MinSize)   // still check, may be clipped out of bounds
-            sp.SplitterDistance = b;
-        //System.Diagnostics.Debug.WriteLine("Splitter {0} {1} {2} {3}-{4} Set {5:N2} wsize {6} -> {7} set {8}", sp.Name, sp.DisplayRectangle, sp.SplitterDistance,  sp.Panel1MinSize,sp.Panel2MinSize, value, a, b , sp.SplitterDistance);
+        if (!double.IsNaN(value) && !double.IsInfinity(value))
+        {
+            int a = (sp.Orientation == Orientation.Vertical) ? sp.Width : sp.Height;
+            int curDist = sp.SplitterDistance;
+            if (a == 0)     // Sometimes the size is {0,0} if minimized. Calc dimension from the inner panels. See issue #1508.
+                a = (sp.Orientation == Orientation.Vertical ? sp.Panel1.Width + sp.Panel2.Width : sp.Panel1.Height + sp.Panel2.Height) + sp.SplitterWidth;
+            sp.SplitterDistance = Math.Min(Math.Max((int)Math.Round(a * value), sp.Panel1MinSize), a - sp.Panel2MinSize);
+            //System.Diagnostics.Debug.WriteLine($"SplitContainer {sp.Name} {sp.DisplayRectangle} {sp.Panel1MinSize}-{sp.Panel2MinSize} Set SplitterDistance to {value:N2} (was {curDist}, now {sp.SplitterDistance})");
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine($"SplitContainer {sp.Name} {sp.DisplayRectangle} {sp.Panel1MinSize}-{sp.Panel2MinSize} Set SplitterDistance attempted with unsupported value ({value})");
+        }
     }
 
     static public double GetSplitterDistance(this SplitContainer sp)                    // get the splitter distance as a fractional double
     {
         int a = (sp.Orientation == Orientation.Vertical) ? sp.Width : sp.Height;
+        if (a == 0)     // Sometimes the size is {0,0} if minimized. Calc dimension from the inner panels. See issue #1508.
+            a = (sp.Orientation == Orientation.Vertical ? sp.Panel1.Width + sp.Panel2.Width : sp.Panel1.Height + sp.Panel2.Height) + sp.SplitterWidth;
         double v = (double)sp.SplitterDistance / (double)a;
-        //System.Diagnostics.Debug.WriteLine("Splitter {0} {1} {2} Get wsize {3} -> {4:N2}", sp.Name, sp.DisplayRectangle, sp.SplitterDistance, a, v);
+        //System.Diagnostics.Debug.WriteLine($"SplitContainer {sp.Name} {sp.DisplayRectangle} {sp.SplitterDistance} Get SplitterDistance {a} -> {v:N2}");
         return v;
     }
 }


### PR DESCRIPTION
Previously, the splitter distance would reset to 50%. This will instead calculate the dimension from the size of the inner panels, which don't seem to be impacted by zero-size problems like the outer control does.