### PR TITLE
Remove unnecessary CSharp 7 feature usage

### DIFF
--- a/EDDiscovery/UserControls/UserControlExpedition.cs
+++ b/EDDiscovery/UserControls/UserControlExpedition.cs
@@ -763,7 +763,8 @@ namespace EDDiscovery.UserControls
 
         private ISystem GetSystem(string sysname)
         {
-            SystemClassDB.TryGetSystem(sysname, out ISystem sys, true);
+            ISystem sys;
+            SystemClassDB.TryGetSystem(sysname, out sys, true);
             return sys;
         }
 

--- a/EliteDangerous/DB/SystemClassDB.cs
+++ b/EliteDangerous/DB/SystemClassDB.cs
@@ -497,7 +497,8 @@ namespace EliteDangerousCore.DB
                 return false;
 
             result = GetSystem(systemName, cn);
-            if (result == null && checkMergers && privTryGetMergedSystem(systemName, out ISystem s, cn))
+            ISystem s;
+            if (result == null && checkMergers && privTryGetMergedSystem(systemName, out s, cn))
                 result = s;
 
             return (result != null);


### PR DESCRIPTION
Until it becomes necessary to use C# 7 features in the codebase, how about sticking to C# 6? (Apologies if this has already been discussed and decided upon)

This sort of syntactic sugar is not really necessary and stops people with older development environments from being able to compile the code and/or contribute.