### PR TITLE
Add support for scan value for VP 6.0.1

### DIFF
--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionPerform.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionPerform.cs
@@ -154,6 +154,14 @@ namespace EDDiscovery.Actions
                 {
                     ap["VoiceNames"] = (ap.actioncontroller as ActionController).SpeechSynthesizer.GetVoiceNames().QuoteStrings();
                 }
+                else if (cmdname.Equals("bindings"))
+                {
+                    ap["Bindings"] = (ap.actioncontroller as ActionController).FrontierBindings.ListBindings();
+                }
+                else if (cmdname.Equals("bindingvalues"))
+                {
+                    ap["BindingValues"] = (ap.actioncontroller as ActionController).FrontierBindings.ListValues();
+                }
                 else
                     ap.ReportError("Unknown command " + cmdname + " in Performaction");
             }

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionScanStar.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionScanStar.cs
@@ -188,6 +188,7 @@ namespace EDDiscovery.Actions
                 }
 
                 ap[prefix + "_text"] = sc.DisplayString();
+                ap[prefix + "_value"] = sc.EstimatedValue.ToStringInvariant();
             }
 
             if ( subname != null )

--- a/EDDiscovery/UserControls/UserControlEstimatedValues.cs
+++ b/EDDiscovery/UserControls/UserControlEstimatedValues.cs
@@ -110,7 +110,7 @@ namespace EDDiscovery.UserControls
                 foreach(StarScan.ScanNode sn in all_nodes)
                 {
                     if ( sn.ScanData != null && sn.ScanData.BodyName != null )
-                        dataGridViewEstimatedValues.Rows.Add(new object[] { sn.ScanData.BodyName, sn.ScanData.EstimatedValue() });
+                        dataGridViewEstimatedValues.Rows.Add(new object[] { sn.ScanData.BodyName, sn.ScanData.EstimatedValue });
                 }
 
                 dataGridViewEstimatedValues.Sort(this.EstValue, ListSortDirection.Descending);

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -280,9 +280,9 @@ namespace EDDiscovery.UserControls
 
             foreach (var body in system.Bodies)
             {
-                if (body?.ScanData?.EstimatedValue() != null)
+                if (body?.ScanData?.EstimatedValue != null)
                 {
-                    value += body.ScanData.EstimatedValue();
+                    value += body.ScanData.EstimatedValue;
                 }
             }
 
@@ -449,7 +449,7 @@ namespace EDDiscovery.UserControls
                                     g.DrawImage(EDDiscovery.Properties.Resources.Volcano, new Rectangle(quarterheight / 2, (int)(quarterheight * 1.5), quarterheight, quarterheight));
 
                                 //experiment - does this take all the fun out of it?
-                                if (sc.EstimatedValue() > 50000)
+                                if (sc.EstimatedValue > 50000)
                                     g.DrawImage(EDDiscovery.Properties.Resources.startflag, new Rectangle(quarterheight / 2, (int)(quarterheight * 2.5), quarterheight, quarterheight));
                             }
 
@@ -522,7 +522,7 @@ namespace EDDiscovery.UserControls
                 indicatematerials || 
                 sc.Terraformable ||
                 HasMeaningfulVolcanism(sc) ||
-                sc.EstimatedValue() > 50000;
+                sc.EstimatedValue > 50000;
         }
 
         private static bool HasMeaningfulVolcanism(JournalScan sc)
@@ -1019,7 +1019,7 @@ namespace EDDiscovery.UserControls
 
                                 writer.Write(csv.Format(scan.EventTimeUTC));
                                 writer.Write(csv.Format(scan.BodyName));
-                                writer.Write(csv.Format(scan.EstimatedValue()));
+                                writer.Write(csv.Format(scan.EstimatedValue));
                                 writer.Write(csv.Format(scan.DistanceFromArrivalLS));
 
                                 if (ShowStars)

--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -209,7 +209,7 @@ namespace EDDiscovery.UserControls
                         if (sn.ScanData.Atmosphere != null && sn.ScanData.Atmosphere != "None")
                             bdDetails.Append(sn.ScanData.Atmosphere + ". ");
 
-                        int value = sn.ScanData.EstimatedValueED22();
+                        int value = sn.ScanData.EstimatedValue;
                         bdDetails.Append("Value " + value.ToString("N0"));
 
                         Image img = null;

--- a/EliteDangerous/EliteDangerous/Bodies.cs
+++ b/EliteDangerous/EliteDangerous/Bodies.cs
@@ -95,7 +95,6 @@ namespace EliteDangerousCore
         SuperMassiveBlackHole,
     };
 
-
     public enum EDPlanet
     {
         Unknown = 0,
@@ -354,5 +353,120 @@ namespace EliteDangerousCore
         }
 
 
+        public static string StarName( EDStar id )
+        {
+            switch (id)       // see journal, section 11.2
+            {
+                case EDStar.O:
+                    return string.Format("Luminous Hot Main Sequence {0} star", id.ToString());
+
+                case EDStar.B:
+                    // also have an B1V
+                    return string.Format("Luminous Blue Main Sequence {0} star", id.ToString());
+
+                case EDStar.A:
+                    // also have an A3V..
+                    return string.Format("Bluish-White Main Sequence {0} star", id.ToString());
+
+                case EDStar.F:
+                    return string.Format("White Main Sequence {0} star", id.ToString());
+
+                case EDStar.G:
+                    // also have a G8V
+                    return string.Format("Yellow Main Sequence {0} star", id.ToString());
+
+                case EDStar.K:
+                    // also have a K0V
+                    return string.Format("Orange Main Sequence {0} star", id.ToString());
+                case EDStar.M:
+                    // also have a M1VA
+                    return string.Format("Red Main Sequence {0} star", id.ToString());
+
+                // dwarfs
+                case EDStar.L:
+                    return string.Format("Dark Red Non Main Sequence {0} star", id.ToString());
+                case EDStar.T:
+                    return string.Format("Methane Dwarf star");
+                case EDStar.Y:
+                    return string.Format("Brown Dwarf star");
+
+                // proto stars
+                case EDStar.AeBe:    // Herbig
+                    return "Herbig Ae/Be";
+                case EDStar.TTS:     // seen in logs
+                    return "T Tauri";
+
+                // wolf rayet
+                case EDStar.W:
+                case EDStar.WN:
+                case EDStar.WNC:
+                case EDStar.WC:
+                case EDStar.WO:
+                    return string.Format("Wolf-Rayet {0} star", id.ToString());
+
+                // Carbon
+                case EDStar.CS:
+                case EDStar.C:
+                case EDStar.CN:
+                case EDStar.CJ:
+                case EDStar.CHd:
+                    return string.Format("Carbon {0} star", id.ToString());
+
+                case EDStar.MS: //seen in log https://en.wikipedia.org/wiki/S-type_star
+                    return string.Format("Intermediate low Zirconium Monoxide Type star");
+
+                case EDStar.S:   // seen in log, data from http://elite-dangerous.wikia.com/wiki/Stars
+                    return string.Format("Cool Giant Zirconium Monoxide rich Type star");
+
+                // white dwarf
+                case EDStar.D:
+                case EDStar.DA:
+                case EDStar.DAB:
+                case EDStar.DAO:
+                case EDStar.DAZ:
+                case EDStar.DAV:
+                case EDStar.DB:
+                case EDStar.DBZ:
+                case EDStar.DBV:
+                case EDStar.DO:
+                case EDStar.DOV:
+                case EDStar.DQ:
+                case EDStar.DC:
+                case EDStar.DCV:
+                case EDStar.DX:
+                    return string.Format("White Dwarf {0} star", id.ToString());
+
+                case EDStar.N:
+                    return "Neutron Star";
+
+                case EDStar.H:
+
+                    return "Black Hole";
+
+                case EDStar.X:
+                    // currently speculative, not confirmed with actual data... in journal
+                    return "Exotic";
+
+                // Journal.. really?  need evidence these actually are formatted like this.
+
+                case EDStar.SuperMassiveBlackHole:
+                    return "Super Massive Black Hole";
+                case EDStar.A_BlueWhiteSuperGiant:
+                    return "Blue White Super Giant";
+                case EDStar.F_WhiteSuperGiant:
+                    return "F White Super Giant";
+                case EDStar.M_RedSuperGiant:
+                    return "M Red Super Giant";
+                case EDStar.M_RedGiant:
+                    return "M Red Giant";
+                case EDStar.K_OrangeGiant:
+                    return "K Orange Giant";
+                case EDStar.RoguePlanet:
+                    return "Rogue Planet";
+
+                default:
+                    return string.Format("Class {0} star\n", id.ToString());
+            }
+        }
     }
 }

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -305,7 +305,7 @@ namespace EliteDangerousCore
         {
             var list = (from s in historylist where s.EntryType == JournalTypeEnum.Scan && s.EventTimeLocal >= start && s.EventTimeLocal < to select s.journalEntry as JournalScan).ToList<JournalScan>();
 
-            return (from t in list select (long)t.EstimatedValue()).Sum();
+            return (from t in list select (long)t.EstimatedValue).Sum();
         }
 
         public int GetDocked(DateTime start, DateTime to)

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -73,6 +73,7 @@ namespace EliteDangerousCore.JournalEvents
         public double? nRadius { get; set; }                        // direct
         public bool HasRings { get { return Rings != null && Rings.Length > 0; } }
         public StarPlanetRing[] Rings { get; set; }
+        public int EstimatedValue { get; set; }
 
         // STAR
         public string StarType { get; set; }                        // null if no StarType, direct from journal, K, A, B etc
@@ -299,6 +300,8 @@ namespace EliteDangerousCore.JournalEvents
             }
 
             IsEDSMBody = evt["EDDFromEDSMBodie"].Bool(false);
+
+            EstimatedValue = CalculateEstimatedValue();
         }
 
         public override void FillInformation(out string summary, out string info, out string detailed)  //V
@@ -483,9 +486,8 @@ namespace EliteDangerousCore.JournalEvents
             if (scanText.Length > 0 && scanText[scanText.Length - 1] == '\n')
                 scanText.Remove(scanText.Length - 1, 1);
 
-            int estvalue = EstimatedValue();
-            if (estvalue > 0)
-                scanText.AppendFormat("\nEstimated value: {0:N0}", estvalue);
+            if (EstimatedValue > 0)
+                scanText.AppendFormat("\nEstimated value: {0:N0}", EstimatedValue);
 
             return scanText.ToNullSafeString().Replace("\n", "\n" + inds);
         }
@@ -570,118 +572,7 @@ namespace EliteDangerousCore.JournalEvents
 
         public string GetStarTypeName()           // give description to star class
         {
-            switch (StarTypeID)       // see journal, section 11.2
-            {
-                case EDStar.O:
-                    return string.Format("Luminous Hot Main Sequence star", StarType);
-
-                case EDStar.B:
-                    // also have an B1V
-                    return string.Format("Luminous Blue Main Sequence star", StarType);
-
-                case EDStar.A:
-                    // also have an A3V..
-                    return string.Format("Bluish-White Main Sequence star", StarType);
-
-                case EDStar.F:
-                    return string.Format("White Main Sequence star", StarType);
-
-                case EDStar.G:
-                    // also have a G8V
-                    return string.Format("Yellow Main Sequence star", StarType);
-
-                case EDStar.K:
-                    // also have a K0V
-                    return string.Format("Orange Main Sequence {0} star", StarType);
-                case EDStar.M:
-                    // also have a M1VA
-                    return string.Format("Red Main Sequence {0} star", StarType);
-
-                // dwarfs
-                case EDStar.L:
-                    return string.Format("Dark Red Non Main Sequence {0} star", StarType);
-                case EDStar.T:
-                    return string.Format("Methane Dwarf star", StarType);
-                case EDStar.Y:
-                    return string.Format("Brown Dwarf star", StarType);
-
-                // proto stars
-                case EDStar.AeBe:    // Herbig
-                    return "Herbig Ae/Be";
-                case EDStar.TTS:     // seen in logs
-                    return "T Tauri";
-
-                // wolf rayet
-                case EDStar.W:
-                case EDStar.WN:
-                case EDStar.WNC:
-                case EDStar.WC:
-                case EDStar.WO:
-                    return string.Format("Wolf-Rayet {0} star", StarType);
-
-                // Carbon
-                case EDStar.CS:
-                case EDStar.C:
-                case EDStar.CN:
-                case EDStar.CJ:
-                case EDStar.CHd:
-                    return string.Format("Carbon {0} star", StarType);
-
-                case EDStar.MS: //seen in log https://en.wikipedia.org/wiki/S-type_star
-                    return string.Format("Intermediate low Zirconium Monoxide Type {0} star", StarType);
-
-                case EDStar.S:   // seen in log, data from http://elite-dangerous.wikia.com/wiki/Stars
-                    return string.Format("Cool Giant Zirconium Monoxide rich Type {0} star", StarType);
-
-                // white dwarf
-                case EDStar.D:
-                case EDStar.DA:
-                case EDStar.DAB:
-                case EDStar.DAO:
-                case EDStar.DAZ:
-                case EDStar.DAV:
-                case EDStar.DB:
-                case EDStar.DBZ:
-                case EDStar.DBV:
-                case EDStar.DO:
-                case EDStar.DOV:
-                case EDStar.DQ:
-                case EDStar.DC:
-                case EDStar.DCV:
-                case EDStar.DX:
-                    return string.Format("White Dwarf {0} star", StarType);
-
-                case EDStar.N:
-                    return "Neutron Star";
-
-                case EDStar.H:
-
-                    return "Black Hole";
-
-                case EDStar.X:
-                    // currently speculative, not confirmed with actual data... in journal
-                    return "Exotic";
-
-                // Journal.. really?  need evidence these actually are formatted like this.
-
-                case EDStar.SuperMassiveBlackHole:
-                    return "Super Massive Black Hole";
-                case EDStar.A_BlueWhiteSuperGiant:
-                    return "Blue White Super Giant";
-                case EDStar.F_WhiteSuperGiant:
-                    return "F White Super Giant";
-                case EDStar.M_RedSuperGiant:
-                    return "M Red Super Giant";
-                case EDStar.M_RedGiant:
-                    return "M Red Giant";
-                case EDStar.K_OrangeGiant:
-                    return "K Orange Giant";
-                case EDStar.RoguePlanet:
-                    return "Rogue Planet";
-
-                default:
-                    return string.Format("Class {0} star\n", StarType.Replace("_", " "));
-            }
+            return Bodies.StarName(StarTypeID);
         }
 
         public System.Drawing.Image GetStarTypeImage()           // give image and description to star class
@@ -943,7 +834,7 @@ namespace EliteDangerousCore.JournalEvents
             return radius_metres / oneLS_m;
         }
 
-        public int EstimatedValue()
+        private int CalculateEstimatedValue()
         {
             if (EventTimeUTC < new DateTime(2017, 4, 11, 12, 0, 0, 0, DateTimeKind.Utc))
                 return EstimatedValueED22();
@@ -1043,13 +934,8 @@ namespace EliteDangerousCore.JournalEvents
             return k + (3 * k * Math.Pow(m, 0.199977) / 5.3);
         }
 
-        public int EstimatedValueED22()
+        private int EstimatedValueED22()
         {
-
-
-            //int low;
-            //int high;
-
             if (IsStar)
             {
                 switch (StarTypeID)      // http://elite-dangerous.wikia.com/wiki/Explorer

--- a/EliteDangerous/JournalEvents/JournalStartJump.cs
+++ b/EliteDangerous/JournalEvents/JournalStartJump.cs
@@ -31,18 +31,20 @@ namespace EliteDangerousCore.JournalEvents
             JumpType = evt["JumpType"].Str();
             StarSystem = evt["StarSystem"].Str();
             StarClass = evt["StarClass"].Str();
+            FriendlyStarClass = (StarClass.Length > 0) ? Bodies.StarName(Bodies.StarStr2Enum(StarClass)) : "";
         }
 
         public string JumpType { get; set; }            // Hyperspace, Supercruise
         public string StarSystem { get; set; }
         public string StarClass { get; set; }
+        public string FriendlyStarClass { get; set; }
 
         public override System.Drawing.Bitmap Icon { get { return EliteDangerous.Properties.Resources.startjump; } }
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {
             summary = EventTypeStr.SplitCapsWord();
-            info = BaseUtils.FieldBuilder.Build("",JumpType , "< to " , StarSystem, "Class:" , StarClass);
+            info = BaseUtils.FieldBuilder.Build("",JumpType , "< to " , StarSystem, "" , FriendlyStarClass);
             detailed = "";
         }
     }


### PR DESCRIPTION
Can print binding list without devices directly
Moved star name print to bodies where it belongs so it can be used
outside of scan
Start jump prints friendly name
EstimatedValue now a value in journal scan so is accessible to action
packs