### PR TITLE
Added radius to Nearest Stars panel and duplicates removal

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
@@ -13,6 +13,9 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using System;
+using System.Windows.Forms;
+
 namespace EDDiscovery.UserControls
 {
     partial class UserControlStarDistance
@@ -53,9 +56,25 @@ namespace EDDiscovery.UserControls
             this.Col1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Visited = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.splitPanel = new System.Windows.Forms.SplitContainer();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.checkBoxFullRadius = new ExtendedControls.CheckBoxCustom();
+            this.panelMin = new System.Windows.Forms.Panel();
+            this.labelExt1 = new ExtendedControls.LabelExt();
+            this.textMinRadius = new ExtendedControls.TextBoxBorder();
+            this.panelMax = new System.Windows.Forms.Panel();
+            this.labelExt3 = new ExtendedControls.LabelExt();
+            this.textMaxRadius = new ExtendedControls.TextBoxBorder();
             this.closestContextMenu.SuspendLayout();
             this.dataViewScrollerPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.splitPanel)).BeginInit();
+            this.splitPanel.Panel1.SuspendLayout();
+            this.splitPanel.Panel2.SuspendLayout();
+            this.splitPanel.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.panelMin.SuspendLayout();
+            this.panelMax.SuspendLayout();
             this.SuspendLayout();
             // 
             // closestContextMenu
@@ -89,7 +108,7 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 0);
             this.dataViewScrollerPanel2.Name = "dataViewScrollerPanel2";
             this.dataViewScrollerPanel2.ScrollBarWidth = 20;
-            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(572, 572);
+            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(352, 540);
             this.dataViewScrollerPanel2.TabIndex = 25;
             this.dataViewScrollerPanel2.VerticalScrollBarDockRight = true;
             // 
@@ -105,13 +124,13 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.vScrollBarCustom2.HideScrollBar = true;
             this.vScrollBarCustom2.LargeChange = 0;
-            this.vScrollBarCustom2.Location = new System.Drawing.Point(552, 21);
+            this.vScrollBarCustom2.Location = new System.Drawing.Point(332, 21);
             this.vScrollBarCustom2.Maximum = -1;
             this.vScrollBarCustom2.Minimum = 0;
             this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
             this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
             this.vScrollBarCustom2.Name = "vScrollBarCustom2";
-            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 551);
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 519);
             this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
             this.vScrollBarCustom2.SmallChange = 1;
             this.vScrollBarCustom2.TabIndex = 24;
@@ -140,7 +159,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewNearest.Name = "dataGridViewNearest";
             this.dataGridViewNearest.RowHeadersVisible = false;
             this.dataGridViewNearest.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewNearest.Size = new System.Drawing.Size(552, 572);
+            this.dataGridViewNearest.Size = new System.Drawing.Size(332, 540);
             this.dataGridViewNearest.TabIndex = 23;
             this.dataGridViewNearest.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewNearest_SortCompare);
             this.dataGridViewNearest.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewNearest_MouseDown);
@@ -164,19 +183,159 @@ namespace EDDiscovery.UserControls
             this.Visited.HeaderText = "Visited";
             this.Visited.Name = "Visited";
             // 
+            // splitPanel
+            // 
+            this.splitPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitPanel.Location = new System.Drawing.Point(0, 0);
+            this.splitPanel.Name = "splitPanel";
+            this.splitPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitPanel.Panel1
+            // 
+            this.splitPanel.Panel1.Controls.Add(this.flowLayoutPanel1);
+            this.splitPanel.Panel1MinSize = 2;
+            // 
+            // splitPanel.Panel2
+            // 
+            this.splitPanel.Panel2.Controls.Add(this.dataViewScrollerPanel2);
+            this.splitPanel.Panel2MinSize = 50;
+            this.splitPanel.Size = new System.Drawing.Size(352, 572);
+            this.splitPanel.SplitterDistance = 28;
+            this.splitPanel.TabIndex = 26;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.checkBoxFullRadius);
+            this.flowLayoutPanel1.Controls.Add(this.panelMin);
+            this.flowLayoutPanel1.Controls.Add(this.panelMax);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(352, 28);
+            this.flowLayoutPanel1.TabIndex = 1;
+            // 
+            // checkBoxFullRadius
+            // 
+            this.checkBoxFullRadius.AutoSize = true;
+            this.checkBoxFullRadius.CheckBoxColor = System.Drawing.Color.Gray;
+            this.checkBoxFullRadius.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxFullRadius.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxFullRadius.FontNerfReduction = 0.5F;
+            this.checkBoxFullRadius.ImageButtonDisabledScaling = 0.5F;
+            this.checkBoxFullRadius.Location = new System.Drawing.Point(8, 5);
+            this.checkBoxFullRadius.Margin = new System.Windows.Forms.Padding(8, 5, 0, 3);
+            this.checkBoxFullRadius.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxFullRadius.Name = "checkBoxFullRadius";
+            this.checkBoxFullRadius.Size = new System.Drawing.Size(78, 17);
+            this.checkBoxFullRadius.TabIndex = 0;
+            this.checkBoxFullRadius.Text = "full / radius";
+            this.checkBoxFullRadius.TickBoxReductionSize = 10;
+            this.checkBoxFullRadius.UseVisualStyleBackColor = true;
+            this.checkBoxFullRadius.CheckedChanged += new System.EventHandler(this.checkBoxFullRadius_CheckedChanged);
+            // 
+            // panelMin
+            // 
+            this.panelMin.Controls.Add(this.labelExt1);
+            this.panelMin.Controls.Add(this.textMinRadius);
+            this.panelMin.Location = new System.Drawing.Point(86, 0);
+            this.panelMin.Margin = new System.Windows.Forms.Padding(0, 0, 3, 3);
+            this.panelMin.Name = "panelMin";
+            this.panelMin.Size = new System.Drawing.Size(60, 26);
+            this.panelMin.TabIndex = 1;
+            // 
+            // labelExt1
+            // 
+            this.labelExt1.AutoSize = true;
+            this.labelExt1.Location = new System.Drawing.Point(3, 7);
+            this.labelExt1.Name = "labelExt1";
+            this.labelExt1.Size = new System.Drawing.Size(24, 13);
+            this.labelExt1.TabIndex = 3;
+            this.labelExt1.Text = "Min";
+            // 
+            // textMinRadius
+            // 
+            this.textMinRadius.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            this.textMinRadius.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
+            this.textMinRadius.BorderColor = System.Drawing.Color.Transparent;
+            this.textMinRadius.BorderColorScaling = 0.5F;
+            this.textMinRadius.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textMinRadius.ControlBackground = System.Drawing.SystemColors.Control;
+            this.textMinRadius.Location = new System.Drawing.Point(28, 3);
+            this.textMinRadius.Multiline = false;
+            this.textMinRadius.Name = "textMinRadius";
+            this.textMinRadius.ReadOnly = false;
+            this.textMinRadius.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.textMinRadius.SelectionLength = 0;
+            this.textMinRadius.SelectionStart = 0;
+            this.textMinRadius.Size = new System.Drawing.Size(30, 20);
+            this.textMinRadius.TabIndex = 1;
+            this.textMinRadius.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            this.textMinRadius.WordWrap = true;
+            this.textMinRadius.TextChanged += new System.EventHandler(this.textMinRadius_TextChanged);
+            // 
+            // panelMax
+            // 
+            this.panelMax.Controls.Add(this.labelExt3);
+            this.panelMax.Controls.Add(this.textMaxRadius);
+            this.panelMax.Location = new System.Drawing.Point(149, 0);
+            this.panelMax.Margin = new System.Windows.Forms.Padding(0, 0, 3, 3);
+            this.panelMax.Name = "panelMax";
+            this.panelMax.Size = new System.Drawing.Size(62, 26);
+            this.panelMax.TabIndex = 5;
+            // 
+            // labelExt3
+            // 
+            this.labelExt3.AutoSize = true;
+            this.labelExt3.Location = new System.Drawing.Point(3, 7);
+            this.labelExt3.Name = "labelExt3";
+            this.labelExt3.Size = new System.Drawing.Size(27, 13);
+            this.labelExt3.TabIndex = 3;
+            this.labelExt3.Text = "Max";
+            // 
+            // textMaxRadius
+            // 
+            this.textMaxRadius.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            this.textMaxRadius.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
+            this.textMaxRadius.BorderColor = System.Drawing.Color.Transparent;
+            this.textMaxRadius.BorderColorScaling = 0.5F;
+            this.textMaxRadius.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textMaxRadius.ControlBackground = System.Drawing.SystemColors.Control;
+            this.textMaxRadius.Location = new System.Drawing.Point(30, 3);
+            this.textMaxRadius.Multiline = false;
+            this.textMaxRadius.Name = "textMaxRadius";
+            this.textMaxRadius.ReadOnly = false;
+            this.textMaxRadius.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.textMaxRadius.SelectionLength = 0;
+            this.textMaxRadius.SelectionStart = 0;
+            this.textMaxRadius.Size = new System.Drawing.Size(30, 20);
+            this.textMaxRadius.TabIndex = 1;
+            this.textMaxRadius.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            this.textMaxRadius.WordWrap = true;
+            this.textMaxRadius.TextChanged += new System.EventHandler(this.textMaxRadius_TextChanged);
+            // 
             // UserControlStarDistance
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.dataViewScrollerPanel2);
+            this.Controls.Add(this.splitPanel);
             this.Name = "UserControlStarDistance";
-            this.Size = new System.Drawing.Size(572, 572);
+            this.Size = new System.Drawing.Size(352, 572);
             this.closestContextMenu.ResumeLayout(false);
             this.dataViewScrollerPanel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewNearest)).EndInit();
+            this.splitPanel.Panel1.ResumeLayout(false);
+            this.splitPanel.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitPanel)).EndInit();
+            this.splitPanel.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
+            this.panelMin.ResumeLayout(false);
+            this.panelMin.PerformLayout();
+            this.panelMax.ResumeLayout(false);
+            this.panelMax.PerformLayout();
             this.ResumeLayout(false);
 
-        }
+        }               
 
         #endregion
         private System.Windows.Forms.ContextMenuStrip closestContextMenu;
@@ -188,5 +347,14 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.DataGridViewTextBoxColumn Col1;
         private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
         private System.Windows.Forms.DataGridViewTextBoxColumn Visited;
+        private System.Windows.Forms.SplitContainer splitPanel;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private ExtendedControls.CheckBoxCustom checkBoxFullRadius;
+        private System.Windows.Forms.Panel panelMin;
+        private ExtendedControls.LabelExt labelExt1;
+        private ExtendedControls.TextBoxBorder textMinRadius;
+        private System.Windows.Forms.Panel panelMax;
+        private ExtendedControls.LabelExt labelExt3;
+        private ExtendedControls.TextBoxBorder textMaxRadius;
     }
 }

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -95,15 +95,52 @@ namespace EDDiscovery.UserControls
             SetControlText("");
             dataGridViewNearest.Rows.Clear();
 
+            double minRadius;
+            double maxRadius;
+
+            // handle empty textboxes, assign default values or user defined ranges
+            if (textMinRadius.Text != "")
+            {
+                minRadius = double.Parse(textMinRadius.Text);
+            }
+            else
+            {
+                minRadius = 0;
+                textMinRadius.Text = minRadius.ToString();
+            }
+
+            if (textMaxRadius.Text != "")
+            {
+                maxRadius = double.Parse(textMaxRadius.Text);
+            }
+            else
+            {
+                maxRadius = 20;
+                textMaxRadius.Text = maxRadius.ToString();
+            }
+
             if (csl.Count() > 0)
             {
                 SetControlText("Closest systems from " + name);
                 foreach (KeyValuePair<double, ISystem> tvp in csl)
                 {
                     int visits = discoveryform.history.GetVisitsCount(tvp.Value.name, tvp.Value.id_edsm);
-                    object[] rowobj = { tvp.Value.name, Math.Sqrt(tvp.Key).ToString("0.00"), visits.ToStringInvariant()};       // distances are stored squared for speed, back to normal.
-                    int rowindex = dataGridViewNearest.Rows.Add(rowobj);
-                    dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
+                    object[] rowobj = { tvp.Value.name, Math.Sqrt(tvp.Key).ToString("0.00"), visits.ToStringInvariant() };       // distances are stored squared for speed, back to normal.
+
+                    if (checkBoxFullRadius.Checked == true)
+                    {
+                        double range = Math.Sqrt(tvp.Key);
+                        if (range >= minRadius && range <= maxRadius) // shows only the systems inside the defined radius
+                        {
+                            int rowindex = dataGridViewNearest.Rows.Add(rowobj);
+                            dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
+                        }
+                    }
+                    else
+                    {
+                        int rowindex = dataGridViewNearest.Rows.Add(rowobj);
+                        dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
+                    }
                 }
             }
         }
@@ -190,89 +227,119 @@ namespace EDDiscovery.UserControls
             }
         }
 
-    }
-
-
-    class StarDistanceComputer
-    {
-        private Thread backgroundStardistWorker;
-        private bool PendingClose { get;  set; }           // we want to close boys!
-
-        private class StardistRequest
+        class StarDistanceComputer
         {
-            public ISystem System;
-            public bool IgnoreOnDuplicate;
-            public Action<ISystem, SortedList<double, ISystem>> Callback;
-        }
+            private Thread backgroundStardistWorker;
+            private bool PendingClose { get; set; }           // we want to close boys!
 
-        private ConcurrentQueue<StardistRequest> closestsystem_queue = new ConcurrentQueue<StardistRequest>();
-
-        private AutoResetEvent stardistRequested = new AutoResetEvent(false);
-        private AutoResetEvent closeRequested = new AutoResetEvent(false);
-
-        public StarDistanceComputer()
-        {
-            PendingClose = false;
-            backgroundStardistWorker = new Thread(BackgroundStardistWorkerThread) { Name = "Star Distance Worker", IsBackground = true };
-            backgroundStardistWorker.Start();
-        }
-
-        public void CalculateClosestSystems(ISystem sys, Action<ISystem, SortedList<double, ISystem>> callback, bool ignoreDuplicates = true)
-        {
-            closestsystem_queue.Enqueue(new StardistRequest { System = sys, Callback = callback, IgnoreOnDuplicate = ignoreDuplicates });
-            stardistRequested.Set();
-        }
-
-        public void ShutDown()
-        {
-            PendingClose = true;
-            closeRequested.Set();
-            backgroundStardistWorker.Join();
-        }
-
-        private void BackgroundStardistWorkerThread()
-        {
-            while (!PendingClose)
+            private class StardistRequest
             {
-                int wh = WaitHandle.WaitAny(new WaitHandle[] { closeRequested, stardistRequested });
+                public ISystem System;
+                public bool IgnoreOnDuplicate;
+                public Action<ISystem, SortedList<double, ISystem>> Callback;
+            }
 
-                if (PendingClose)
-                    break;
+            private ConcurrentQueue<StardistRequest> closestsystem_queue = new ConcurrentQueue<StardistRequest>();
 
-                StardistRequest stardistreq = null;
+            private AutoResetEvent stardistRequested = new AutoResetEvent(false);
+            private AutoResetEvent closeRequested = new AutoResetEvent(false);
 
-                switch (wh)
+            public StarDistanceComputer()
+            {
+                PendingClose = false;
+                backgroundStardistWorker = new Thread(BackgroundStardistWorkerThread) { Name = "Star Distance Worker", IsBackground = true };
+                backgroundStardistWorker.Start();
+            }
+
+            public void CalculateClosestSystems(ISystem sys, Action<ISystem, SortedList<double, ISystem>> callback, bool ignoreDuplicates = true)
+            {
+                closestsystem_queue.Enqueue(new StardistRequest { System = sys, Callback = callback, IgnoreOnDuplicate = ignoreDuplicates });
+                stardistRequested.Set();
+            }
+
+            public void ShutDown()
+            {
+                PendingClose = true;
+                closeRequested.Set();
+                backgroundStardistWorker.Join();
+            }
+
+            private void BackgroundStardistWorkerThread()
+            {
+                while (!PendingClose)
                 {
-                    case 0:  // Close Requested
+                    int wh = WaitHandle.WaitAny(new WaitHandle[] { closeRequested, stardistRequested });
+
+                    if (PendingClose)
                         break;
-                    case 1:  // Star Distances Requested
-                        while (!PendingClose && closestsystem_queue.TryDequeue(out stardistreq))
-                        {
-                            if (!stardistreq.IgnoreOnDuplicate || closestsystem_queue.Count == 0)
+
+                    StardistRequest stardistreq = null;
+
+                    switch (wh)
+                    {
+                        case 0:  // Close Requested
+                            break;
+                        case 1:  // Star Distances Requested
+                            while (!PendingClose && closestsystem_queue.TryDequeue(out stardistreq))
                             {
-                                StardistRequest req = stardistreq;
-                                ISystem sys = req.System;
-                                SortedList<double, ISystem> closestsystemlist = new SortedList<double, ISystem>(new DuplicateKeyComparer<double>()); //lovely list allowing duplicate keys - can only iterate in it.
-                                SystemClassDB.GetSystemSqDistancesFrom(closestsystemlist, sys.x, sys.y, sys.z, 50, true, 1000);
-                                if (!PendingClose)
+                                if (!stardistreq.IgnoreOnDuplicate || closestsystem_queue.Count == 0)
                                 {
-                                    req.Callback(sys, closestsystemlist);
+                                    StardistRequest req = stardistreq;
+                                    ISystem sys = req.System;
+                                    SortedList<double, ISystem> closestsystemlist = new SortedList<double, ISystem>(new DuplicateKeyComparer<double>()); //lovely list allowing duplicate keys - can only iterate in it.
+                                    SystemClassDB.GetSystemSqDistancesFrom(closestsystemlist, sys.x, sys.y, sys.z, 50, true, 1000);
+                                    if (!PendingClose)
+                                    {
+                                        req.Callback(sys, closestsystemlist);
+                                    }
                                 }
                             }
-                        }
 
-                        break;
+                            break;
+                    }
+                }
+            }
+
+            private class DuplicateKeyComparer<TKey> : IComparer<TKey> where TKey : IComparable      // special compare for sortedlist
+            {
+                public int Compare(TKey x, TKey y)
+                {
+                    int result = x.CompareTo(y);
+                    return (result == 0) ? 1 : result;      // for this, equals just means greater than, to allow duplicate distance values to be added.
                 }
             }
         }
 
-        private class DuplicateKeyComparer<TKey> : IComparer<TKey> where TKey : IComparable      // special compare for sortedlist
+        // Event Handler
+        private void checkBoxFullRadius_CheckedChanged(object sender, EventArgs e)
         {
-            public int Compare(TKey x, TKey y)
+            Init();
+        }
+        
+        private void textMinRadius_TextChanged(object sender, EventArgs e)
+        {
+            double parsedValue;
+
+            if (!double.TryParse(textMinRadius.Text, out parsedValue))
             {
-                int result = x.CompareTo(y);
-                return (result == 0) ? 1 : result;      // for this, equals just means greater than, to allow duplicate distance values to be added.
+                textMinRadius.Text = "";
             }
+
+            Thread.Sleep(250);
+            Init();
+        }
+        
+        private void textMaxRadius_TextChanged(object sender, EventArgs e)
+        {
+            double parsedValue;
+
+            if (!double.TryParse(textMaxRadius.Text, out parsedValue))
+            {
+                textMaxRadius.Text = "";
+            }
+
+            Thread.Sleep(250);
+            Init();
         }
     }
 }

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -127,6 +127,7 @@ namespace EDDiscovery.UserControls
                     int visits = discoveryform.history.GetVisitsCount(tvp.Value.name, tvp.Value.id_edsm);
                     object[] rowobj = { tvp.Value.name, Math.Sqrt(tvp.Key).ToString("0.00"), visits.ToStringInvariant() };       // distances are stored squared for speed, back to normal.
 
+                    // Apply radius filter
                     if (checkBoxFullRadius.Checked == true)
                     {
                         double range = Math.Sqrt(tvp.Key);
@@ -137,9 +138,43 @@ namespace EDDiscovery.UserControls
                         }
                     }
                     else
-                    {
-                        int rowindex = dataGridViewNearest.Rows.Add(rowobj);
+                    {   int rowindex = dataGridViewNearest.Rows.Add(rowobj);
                         dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
+                    }
+
+                    // Check for duplicated entries and remove them
+                    if (dataGridViewNearest.Rows.Count > 2)
+                    {
+                        for (int currentRow = 0; currentRow < dataGridViewNearest.Rows.Count; currentRow++)
+                        {
+                            var rowToCompare = dataGridViewNearest.Rows[currentRow]; // Get row to compare against other rows
+
+                            // Iterate through all rows 
+                            //
+                            foreach (DataGridViewRow row in dataGridViewNearest.Rows)
+                            {
+                                if (rowToCompare.Equals(row))
+                                {
+                                    continue;
+                                }
+                                // If row is the same row being compared, skip.
+
+                                bool duplicateRow = true;
+
+                                // Compare the value of all cells
+                                if (rowToCompare.Cells[0].Value != null && rowToCompare.Cells[0].Value.ToString() != row.Cells[0].Value.ToString())
+                                {
+                                    duplicateRow = false;
+                                }
+
+                                // If duplicated, remove
+                                if (duplicateRow)
+                                {
+                                    dataGridViewNearest.Rows.RemoveAt(row.Index);
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -138,7 +138,8 @@ namespace EDDiscovery.UserControls
                         }
                     }
                     else
-                    {   int rowindex = dataGridViewNearest.Rows.Add(rowobj);
+                    {   
+                        int rowindex = dataGridViewNearest.Rows.Add(rowobj);
                         dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
                     }
 


### PR DESCRIPTION
Modification of StarDistance panel with a an inner and outer radius definition, and a checkbox to switch to the former or new behavior. Whenever the checkbox or the textboxes are modified, the panel refresh itself.
The controls reside in a split panel, and they can be completely hidden as well as re-position itself for narrower sizes.

It replace the StarInRange panel attempt, to avoid one more panel with similar functionalities. Thanks @robbyxp1 for your feedback!

![stardistance-mod](https://user-images.githubusercontent.com/4296635/34315090-caff9bca-e762-11e7-9da0-4fff0d87b1b4.PNG)
