### PR TITLE
Improved performance opening 3D map

### DIFF
--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -476,7 +476,7 @@ namespace EDDiscovery
                 {
                     LogLine("Refresh due to updating systems");
                     HistoryRefreshed += HistoryFinishedRefreshing;
-                    RefreshHistoryAsync();
+                    RefreshHistoryAsync(checkedsm:true);
                 }
 
                 OnSyncComplete?.Invoke();

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1207,8 +1207,6 @@ namespace EDDiscovery
         {
             this.Cursor = Cursors.WaitCursor;
 
-            //Controller.history.FillInPositionsFSDJumps();
-
             Map.Prepare(he?.System, EDDConfig.Instance.HomeSystem,
                         EDDConfig.Instance.MapCentreOnSelection ? he?.System : EDDConfig.Instance.HomeSystem,
                         EDDConfig.Instance.MapZoom, Controller.history.FilterByTravel);

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1207,7 +1207,7 @@ namespace EDDiscovery
         {
             this.Cursor = Cursors.WaitCursor;
 
-            Controller.history.FillInPositionsFSDJumps();
+            //Controller.history.FillInPositionsFSDJumps();
 
             Map.Prepare(he?.System, EDDConfig.Instance.HomeSystem,
                         EDDConfig.Instance.MapCentreOnSelection ? he?.System : EDDConfig.Instance.HomeSystem,


### PR DESCRIPTION
Remove checking of all travel history with no coordinates against EDSM before opening 3D map
Ensure that a history refresh triggered by updates to EDSM systems updates travel history that now has coordinates