### PR TITLE
Synth/Eng/Shopping Lists work better in grids and tabs

### DIFF
--- a/EDDiscovery/UserControls/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/UserControlEngineering.cs
@@ -121,17 +121,14 @@ namespace EDDiscovery.UserControls
             chkHistoric.Visible = !isEmbedded;
 
             discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            if (isHistoric) uctg.OnTravelSelectionChanged += Display;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         public override void ChangeCursorType(IHistoryCursor thc)
         {
-            if (isHistoric)
-            {
-                uctg.OnTravelSelectionChanged -= Display;
-                uctg = thc;
-                uctg.OnTravelSelectionChanged += Display;
-            }
+            uctg.OnTravelSelectionChanged -= Display;
+            uctg = thc;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         #endregion
@@ -142,12 +139,10 @@ namespace EDDiscovery.UserControls
             isHistoric = newVal;
             if (isHistoric)
             {
-                uctg.OnTravelSelectionChanged += Display;
                 last_he = uctg.GetCurrentHistoryEntry;
             }
             else
             {
-                uctg.OnTravelSelectionChanged -= Display;
                 last_he = discoveryform.history.GetLast;
             }
             Display();
@@ -169,9 +164,8 @@ namespace EDDiscovery.UserControls
         HistoryEntry last_he = null;
         private void Display(HistoryEntry he, HistoryList hl)
         {
-            if (isHistoric)
+            if (isHistoric || last_he == null)
             {
-                // this event isn't reliably disconnecting when calling SetHistoric(false) - not sure why
                 last_he = he;
                 Display();
             }

--- a/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.Designer.cs
@@ -54,9 +54,9 @@ namespace EDDiscovery.UserControls
             this.showMaxFSDInjectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAllMaterialsWhenLandedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.useHistoricMaterialCountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showSystemAvailabilityOfMaterialsInShoppingListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.useEDSMDataInSystemAvailabilityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.useHistoricMaterialCountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerVertical)).BeginInit();
             this.splitContainerVertical.Panel1.SuspendLayout();
             this.splitContainerVertical.Panel2.SuspendLayout();
@@ -75,9 +75,6 @@ namespace EDDiscovery.UserControls
             // 
             // splitContainerVertical
             // 
-            this.splitContainerVertical.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.splitContainerVertical.Location = new System.Drawing.Point(0, 0);
             this.splitContainerVertical.Name = "splitContainerVertical";
             // 
@@ -149,7 +146,7 @@ namespace EDDiscovery.UserControls
             this.useEDSMDataInSystemAvailabilityToolStripMenuItem,
             this.useHistoricMaterialCountsToolStripMenuItem});
             this.contextMenuConfig.Name = "contextMenuConfig";
-            this.contextMenuConfig.Size = new System.Drawing.Size(369, 158);
+            this.contextMenuConfig.Size = new System.Drawing.Size(369, 136);
             // 
             // showMaxFSDInjectionsToolStripMenuItem
             // 
@@ -177,14 +174,6 @@ namespace EDDiscovery.UserControls
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Text = "Include Material %age on Landed Body in Shopping List";
             this.showAvailableMaterialsInListWhenLandedToolStripMenuItem.Click += new System.EventHandler(this.showAvailableMaterialsInListWhenLandedToolStripMenuItem_Click);
             // 
-            // useHistoricMaterialCountsToolStripMenuItem
-            // 
-            this.useHistoricMaterialCountsToolStripMenuItem.CheckOnClick = true;
-            this.useHistoricMaterialCountsToolStripMenuItem.Name = "useHistoricMaterialCountsToolStripMenuItem";
-            this.useHistoricMaterialCountsToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
-            this.useHistoricMaterialCountsToolStripMenuItem.Text = "Use Historic Material Counts";
-            this.useHistoricMaterialCountsToolStripMenuItem.Click += new System.EventHandler(this.useHistoricMaterialCountsToolStripMenuItem_Click);
-            // 
             // showSystemAvailabilityOfMaterialsInShoppingListToolStripMenuItem
             // 
             this.showSystemAvailabilityOfMaterialsInShoppingListToolStripMenuItem.CheckOnClick = true;
@@ -200,6 +189,14 @@ namespace EDDiscovery.UserControls
             this.useEDSMDataInSystemAvailabilityToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
             this.useEDSMDataInSystemAvailabilityToolStripMenuItem.Text = "Use EDSM data in System Availability";
             this.useEDSMDataInSystemAvailabilityToolStripMenuItem.Click += new System.EventHandler(this.useEDSMDataInSystemAvailabilityToolStripMenuItem_Click);
+            // 
+            // useHistoricMaterialCountsToolStripMenuItem
+            // 
+            this.useHistoricMaterialCountsToolStripMenuItem.CheckOnClick = true;
+            this.useHistoricMaterialCountsToolStripMenuItem.Name = "useHistoricMaterialCountsToolStripMenuItem";
+            this.useHistoricMaterialCountsToolStripMenuItem.Size = new System.Drawing.Size(368, 22);
+            this.useHistoricMaterialCountsToolStripMenuItem.Text = "Use Historic Material Counts";
+            this.useHistoricMaterialCountsToolStripMenuItem.Click += new System.EventHandler(this.useHistoricMaterialCountsToolStripMenuItem_Click);
             // 
             // UserControlShoppingList
             // 

--- a/EDDiscovery/UserControls/UserControlShoppingList.cs
+++ b/EDDiscovery/UserControls/UserControlShoppingList.cs
@@ -261,7 +261,7 @@ namespace EDDiscovery.UserControls
                 userControlEngineering.Visible = userControlSynthesis.Visible = !IsTransparent;
                 userControlEngineering.Enabled = userControlSynthesis.Enabled = !IsTransparent;
 
-                splitContainerVertical.Panel1MinSize = displayList.img.Width+8;       // panel left has minimum width to accomodate the text
+                splitContainerVertical.Panel1MinSize = displayList.img.Width + 8;       // panel left has minimum width to accomodate the text
 
                 if (IsTransparent)
                 {

--- a/EDDiscovery/UserControls/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/UserControlSynthesis.cs
@@ -113,17 +113,14 @@ namespace EDDiscovery.UserControls
             chkHistoric.Visible = !isEmbedded;
 
             discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
-            if (isHistoric) uctg.OnTravelSelectionChanged += Display;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         public override void ChangeCursorType(IHistoryCursor thc)
         {
-            if (isHistoric)
-            {
-                uctg.OnTravelSelectionChanged -= Display;
-                uctg = thc;
-                uctg.OnTravelSelectionChanged += Display;
-            }
+            uctg.OnTravelSelectionChanged -= Display;
+            uctg = thc;
+            uctg.OnTravelSelectionChanged += Display;
         }
 
         #endregion
@@ -134,12 +131,10 @@ namespace EDDiscovery.UserControls
             isHistoric = newVal;
             if (isHistoric)
             {
-                uctg.OnTravelSelectionChanged += Display;
                 last_he = uctg.GetCurrentHistoryEntry;
             }
             else
             {
-                uctg.OnTravelSelectionChanged -= Display;
                 last_he = discoveryform.history.GetLast;
             }
             Display();
@@ -163,9 +158,8 @@ namespace EDDiscovery.UserControls
         HistoryEntry last_he = null;
         private void Display(HistoryEntry he, HistoryList hl)
         {
-            if (isHistoric)
+            if (isHistoric || last_he == null)
             {
-                // this event isn't reliably disconnecting when calling SetHistoric(false) - not sure why
                 last_he = he;
                 Display();
             }


### PR DESCRIPTION
Fixed anchoring so display of shopping list in grid works properly (fixes #1578 )
Now responds to a cursor change if historic is off but last_he is null (so will do initial display properly in a tab/grid before first new history entry after start)