### PR TITLE
Fix up Key system for multiple language keyboards

### DIFF
--- a/BaseUtils/Keys/KeyObjectExtensions.cs
+++ b/BaseUtils/Keys/KeyObjectExtensions.cs
@@ -32,6 +32,7 @@ public static class KeyObjectExtensions
         new Tuple<string,Keys>("Tilde", Keys.Oem3),
         new Tuple<string,Keys>("OpenBrackets", Keys.Oem4),
         new Tuple<string,Keys>("Pipe", Keys.Oem5),
+        new Tuple<string,Keys>("Equals", Keys.Oemplus),     // need to call it equals to avoid confusion with num key plus
         new Tuple<string,Keys>("CloseBrackets", Keys.Oem6),
         new Tuple<string,Keys>("Quotes", Keys.Oem7),
         new Tuple<string,Keys>("Backquote", Keys.Oem8),
@@ -286,6 +287,32 @@ public static class KeyObjectExtensions
 
         return keyseq;
     }
+
+    static public Dictionary<char, uint> CharToScanCode()       // give me a char vs scan code map
+    {
+        Dictionary<char, uint> chartoscancode = new Dictionary<char, uint>();
+        for (short i = 0; i < 0xff; i++)    // for OEMASCII codes on page 437, map to OEMASCII 
+        {
+            Encoding enc = Encoding.GetEncoding(437);
+            byte[] myByte = new byte[] { (byte)(i) };
+            string str = enc.GetString(myByte);     // now in unicode
+
+            int res = (int)BaseUtils.Win32.SafeNativeMethods.OemKeyScan(i);  // in code page 437
+
+            if (res != -1)
+            {
+                //System.Diagnostics.Debug.WriteLine("Char {0:x} {1} = SC {2:x}", i, str, res);
+
+                if (i == '.' && res == 0x53)    // some maps call '.' numpad period.. lets call it dot on sc 34
+                    res = 0x34;
+
+                chartoscancode[str[0]] = (uint)res;
+            }
+        }
+
+        return chartoscancode;
+    }
+
 
 }
 

--- a/BaseUtils/Misc/NativeMethods.cs
+++ b/BaseUtils/Misc/NativeMethods.cs
@@ -108,6 +108,11 @@ namespace BaseUtils.Win32
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern short VkKeyScan(char key);
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern short VkKeyScanEx(char key, IntPtr dwhkl);
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetKeyNameText(int lParam, [Out] StringBuilder str, int len);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr SetWindowsHookEx(int hookid, NativeMethods.HookProc pfnhook, HandleRef hinst, int threadid);
         [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
         public static extern int GetWindowLong(IntPtr hWnd, GWL nIndex);

--- a/DirectInput/InputDeviceKeyboard.cs
+++ b/DirectInput/InputDeviceKeyboard.cs
@@ -23,191 +23,61 @@ using System.Windows.Forms;
 
 namespace DirectInputDevices
 {
-    static public class KeyConversion       // three naming conventsions, lovely!
+    static public class SharpKeyConversion
     {
-        static public string SharpKeyToFrontierName(SharpDX.DirectInput.Key k)     
-        {
-            string keyname = k.ToString();
-            string newname = keyname;
-
-            if (keyname.Length == 2 && keyname[0] == 'D')
-                newname = keyname.Substring(1);
-            else if (keyname.StartsWith("NumberPad") && char.IsDigit(keyname[9]))
-                newname = "Numpad_" + keyname[9];
-            else
-            {
-                int i = Array.FindIndex(sharptofrontiername, x => x.Item1.Equals(keyname));
-                if (i >= 0)
-                    newname = sharptofrontiername[i].Item2;
-            }
-
-            newname = "Key_" + newname;
-            //System.Diagnostics.Debug.WriteLine("Name is " + keyname + "=>" + newname);
-            return newname;
-        }
-
-        static public SharpDX.DirectInput.Key? FrontierNameToSharpKey(string frontierkeyname)  
-        {
-            frontierkeyname = frontierkeyname.Substring(4);
-            if (frontierkeyname.Length == 1 && (frontierkeyname[0] >= '0' && frontierkeyname[0] <= '9'))
-                frontierkeyname = "D" + frontierkeyname;
-            else if (frontierkeyname.StartsWith("Numpad_") && char.IsDigit(frontierkeyname[7]))
-                frontierkeyname = "NumberPad" + frontierkeyname[7];
-            else
-            {
-                int i = Array.FindIndex(sharptofrontiername, x => x.Item2.Equals(frontierkeyname));
-                if (i >= 0)
-                    frontierkeyname = sharptofrontiername[i].Item1;
-            }
-
-            Key k;
-            if (Enum.TryParse<Key>(frontierkeyname, true, out k))   // a few sharp names have case differences (Semicolon) ignore it
-                return k;
-            else
-                return null;
-        }
+        // Sharp Keys are Scan codes for codes 1-0x36, 
+        // 37,38,39,3a,3b-44
+        // 45,46,47,48,49,4a,4b-4d,4e,4f-53, 57,58, 
+        // 9c = NUMPADENTER (0x80 Extended + 1C = numenter)
+        // 9D = RCONTROL = (0x80|1D)
+        // B5 = NUMDIVIDE = (0x80|35)
+        // B8 = RMENU (0x80|38)
+        // 0xC7 	DIK_HOME 	Home 	80 | 47
+        // 0xC8 	DIK_UP 	↑ 	        80 | 48
+        // 0xC9 	DIK_PRIOR Page Up 	80 | 49
+        // 0xCB 	DIK_LEFT 	← 	    80 | 4b
+        // 0xCD 	DIK_RIGHT 	→ 	    80 | 4d
+        // 0xCF 	DIK_END End 	    80 | 4F
+        // 0xD0 	DIK_DOWN 	↓ 	    80 | 50
+        // 0xD1 	DIK_NEXT Page Down 	80 | 51
+        // 0xD2 	DIK_INSERT Insert 	80 | 52
+        // 0xD3 	DIK_DELETE Delete   80 | 53
 
         static public System.Windows.Forms.Keys SharpKeyToKeys(SharpDX.DirectInput.Key k)        // Sharp DX - > Windows Keys
         {
-            if (sharptokeys.ContainsKey(k))
+            if (sharptokeys.ContainsKey(k))     // NEED to manually cope with this.. MapVirtualKey is very limited
+            {
+                //System.Diagnostics.Debug.WriteLine("Direct Sharp to Keys {0:x} -> vkey {1:x}", k, sharptokeys[k]);
                 return sharptokeys[k];
-            return Keys.None;
+            }
+
+            uint v = BaseUtils.Win32.UnsafeNativeMethods.MapVirtualKey((uint)k & 0x7f, 3);  // otherwise, the sharp key is the scan code.. use this.
+            //System.Diagnostics.Debug.WriteLine("Sharp to Keys {0:x} -> vkey {1:x}", k, v);
+
+            if (v > 0)
+                return (Keys)v;
+            else
+                return Keys.None;
         }
 
         static public SharpDX.DirectInput.Key KeysToSharpKey(System.Windows.Forms.Keys ky)       // Keys -> Sharp DX
         {
             Key k = sharptokeys.FirstOrDefault(x => x.Value == ky).Key; // if not found, returns enum 0, or Key.Unknown!
+            if ( k == Key.Unknown)
+            {
+                uint v = BaseUtils.Win32.UnsafeNativeMethods.MapVirtualKey((uint)ky, 0);  // otherwise, vkey to scan code
+                //System.Diagnostics.Debug.WriteLine("Keys to sharp {0:x} -> vkey {1:x}", ky, v);
+                if (v > 0)
+                    k = (Key)v; // SC is the DI key
+            }
             return k;
         }
 
-        static public Keys FrontierNameToKeys(string frontiername)       // None means no translation
-        {
-            Key? sk = FrontierNameToSharpKey(frontiername);     // slighly long way around it, but go to sharp, then to keys.
-            if (sk != null)
-            {
-                return SharpKeyToKeys(sk.Value);
-            }
-            else
-                return Keys.None;
-        }
+        // checked on USA/UK/FR 3/01/18
 
-        static public bool CheckTranslation(Key k, Keys winkey)     // test function just for debugging
-        {
-            //System.Diagnostics.Debug.WriteLine("Check " + k + " vs " + winkey);
-            if (sharptokeys.ContainsKey(k))
-            {
-                return sharptokeys[k] == winkey;
-            }
-
-            return false;
-        }
-
-        public const string FDKeys_Up = "UpArrow";          // naming as per Keys
-        public const string FDKeys_Down = "DownArrow";
-        public const string FDKeys_Left = "LeftArrow";
-        public const string FDKeys_Right = "RightArrow";
-        public const string FDKeys_Return = "Enter";
-        public const string FDKeys_Capital = "CapsLock";
-        public const string FDKeys_Back = "Backspace";
-        public const string FDKeys_NumLock = "NumLock";
-        public const string FDKeys_Subtract = "Numpad_Subtract";
-        public const string FDKeys_Divide = "Numpad_Divide";
-        public const string FDKeys_Multiply = "Numpad_Multiply";
-        public const string FDKeys_Add = "Numpad_Add";
-        public const string FDKeys_NumEnter = "Numpad_Enter";
-        public const string FDKeys_Decimal = "Numpad_Decimal";
-        public const string FDKeys_Quotes = "Hash";
-        public const string FDKeys_Pipe = "Backslash";
-        public const string FDKeys_LeftShift = "LeftShift";
-        public const string FDKeys_LeftControl = "LeftControl";
-
-        static Tuple<string, string>[] sharptofrontiername = new Tuple<string, string>[] // sharp name to Frontier Name
-        {
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Up.ToString(),FDKeys_Up),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Down.ToString(),FDKeys_Down),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Left.ToString(),FDKeys_Left),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Right.ToString(),FDKeys_Right),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Return.ToString(),FDKeys_Return),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Capital.ToString(),FDKeys_Capital),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Back.ToString(),FDKeys_Back),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.NumberLock.ToString(),FDKeys_NumLock),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Subtract.ToString(),FDKeys_Subtract),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Divide.ToString(),FDKeys_Divide),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Multiply.ToString(),FDKeys_Multiply),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Add.ToString(),FDKeys_Add),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.NumberPadEnter.ToString(),FDKeys_NumEnter),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Decimal.ToString(),FDKeys_Decimal),
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Backslash.ToString(),FDKeys_Quotes),     // new 13/11/2017
-            new Tuple<string,string>(SharpDX.DirectInput.Key.Oem102.ToString(),FDKeys_Pipe),     // new 13/11/2017
-            // same:
-            // Apostrophe (OEM3/Tilde)
-            // SemiColon (Ome1/OemSemicolon)
-            // Comma, Period, Slash, LeftBracket, RightBracket, Minus, Equals, Grave, 
-        };
-
-        // See word document edcontrols for map of sharp to keys
-        // manual table to go from DI Key to VKEY.. check on 11/sept/2017, rechecked 13 nov 2017
         static Dictionary<SharpDX.DirectInput.Key, System.Windows.Forms.Keys> sharptokeys = new Dictionary<Key, Keys>()
         {
-            {        SharpDX.DirectInput.Key.Unknown , Keys.None},
-            {        SharpDX.DirectInput.Key.Escape , Keys.Escape},
-            {        SharpDX.DirectInput.Key.D1 , Keys.D1},
-            {        SharpDX.DirectInput.Key.D2 , Keys.D2},
-            {        SharpDX.DirectInput.Key.D3 , Keys.D3},
-            {        SharpDX.DirectInput.Key.D4 , Keys.D4},
-            {        SharpDX.DirectInput.Key.D5 , Keys.D5},
-            {        SharpDX.DirectInput.Key.D6 , Keys.D6},
-            {        SharpDX.DirectInput.Key.D7 , Keys.D7},
-            {        SharpDX.DirectInput.Key.D8 , Keys.D8},
-            {        SharpDX.DirectInput.Key.D9 , Keys.D9},
-            {        SharpDX.DirectInput.Key.D0 , Keys.D0},
-            {        SharpDX.DirectInput.Key.Minus , Keys.OemMinus},
-            {        SharpDX.DirectInput.Key.Equals , Keys.Oemplus},
-            {        SharpDX.DirectInput.Key.Back , Keys.Back},
-            {        SharpDX.DirectInput.Key.Tab , Keys.Tab},
-            {        SharpDX.DirectInput.Key.Q , Keys.Q},
-            {        SharpDX.DirectInput.Key.W , Keys.W},
-            {        SharpDX.DirectInput.Key.E , Keys.E},
-            {        SharpDX.DirectInput.Key.R , Keys.R},
-            {        SharpDX.DirectInput.Key.T , Keys.T},
-            {        SharpDX.DirectInput.Key.Y , Keys.Y},
-            {        SharpDX.DirectInput.Key.U , Keys.U},
-            {        SharpDX.DirectInput.Key.I , Keys.I},
-            {        SharpDX.DirectInput.Key.O , Keys.O},
-            {        SharpDX.DirectInput.Key.P , Keys.P},
-            {        SharpDX.DirectInput.Key.LeftBracket , Keys.OemOpenBrackets},
-            {        SharpDX.DirectInput.Key.RightBracket , Keys.OemCloseBrackets},
-            {        SharpDX.DirectInput.Key.Return , Keys.Return},
-            {        SharpDX.DirectInput.Key.LeftControl , Keys.ControlKey},
-            {        SharpDX.DirectInput.Key.A , Keys.A},
-            {        SharpDX.DirectInput.Key.S , Keys.S},
-            {        SharpDX.DirectInput.Key.D , Keys.D},
-            {        SharpDX.DirectInput.Key.F , Keys.F},
-            {        SharpDX.DirectInput.Key.G , Keys.G},
-            {        SharpDX.DirectInput.Key.H , Keys.H},
-            {        SharpDX.DirectInput.Key.J , Keys.J},
-            {        SharpDX.DirectInput.Key.K , Keys.K},
-            {        SharpDX.DirectInput.Key.L , Keys.L},
-            {        SharpDX.DirectInput.Key.Semicolon , Keys.OemSemicolon},
-            {        SharpDX.DirectInput.Key.Apostrophe , Keys.Oemtilde},
-            {        SharpDX.DirectInput.Key.Grave , Keys.Oem8 },
-            {        SharpDX.DirectInput.Key.LeftShift , Keys.ShiftKey},
-            {        SharpDX.DirectInput.Key.Backslash , Keys.OemQuotes},       // NOT SURE
-            {        SharpDX.DirectInput.Key.Z , Keys.Z},
-            {        SharpDX.DirectInput.Key.X , Keys.X},
-            {        SharpDX.DirectInput.Key.C , Keys.C},
-            {        SharpDX.DirectInput.Key.V , Keys.V},
-            {        SharpDX.DirectInput.Key.B , Keys.B},
-            {        SharpDX.DirectInput.Key.N , Keys.N},
-            {        SharpDX.DirectInput.Key.M , Keys.M},
-            {        SharpDX.DirectInput.Key.Comma , Keys.Oemcomma},
-            {        SharpDX.DirectInput.Key.Period , Keys.OemPeriod},
-            {        SharpDX.DirectInput.Key.Slash , Keys.OemQuestion},
-            {        SharpDX.DirectInput.Key.RightShift , Keys.RShiftKey},
-            {        SharpDX.DirectInput.Key.Multiply , Keys.Multiply},
-            {        SharpDX.DirectInput.Key.LeftAlt , Keys.Menu},
-            {        SharpDX.DirectInput.Key.Space , Keys.Space},
-            {        SharpDX.DirectInput.Key.Capital , Keys.Capital},
+            {        SharpDX.DirectInput.Key.Unknown , Keys.None  },
             {        SharpDX.DirectInput.Key.F1 , Keys.F1},
             {        SharpDX.DirectInput.Key.F2 , Keys.F2},
             {        SharpDX.DirectInput.Key.F3 , Keys.F3},
@@ -233,7 +103,6 @@ namespace DirectInputDevices
             {        SharpDX.DirectInput.Key.NumberPad3 , Keys.NumPad3},
             {        SharpDX.DirectInput.Key.NumberPad0 , Keys.NumPad0},
             {        SharpDX.DirectInput.Key.Decimal , Keys.Decimal },
-            {        SharpDX.DirectInput.Key.Oem102 , Keys.OemPipe },
             {        SharpDX.DirectInput.Key.F11 , Keys.F11},
             {        SharpDX.DirectInput.Key.F12 , Keys.F12},
             {        SharpDX.DirectInput.Key.F13 , Keys.F13},
@@ -332,7 +201,7 @@ namespace DirectInputDevices
 
         KeyboardState ks;
 
-        public List<InputDeviceEvent> GetEvents()
+        public List<InputDeviceEvent> GetEvents()       // Events use keys enumeration
         {
             ks = keyboard.GetCurrentState();
             KeyboardUpdate[] ke = keyboard.GetBufferedData();
@@ -340,28 +209,30 @@ namespace DirectInputDevices
             List<InputDeviceEvent> events = new List<InputDeviceEvent>();
             foreach (KeyboardUpdate k in ke)
             {
-                //System.Diagnostics.Debug.WriteLine("key " + k.Key + " " + k.IsPressed );
-                events.Add(new InputDeviceEvent(this, (int)k.Key, k.IsPressed));
+                Keys ky = SharpKeyConversion.SharpKeyToKeys(k.Key);
+                //System.Diagnostics.Debug.WriteLine("** Sharp key " + k.Key + " " + (int)k.Key + k.IsPressed);
+                //System.Diagnostics.Debug.WriteLine( "      => " + ky.ToString() + " norm " + ky.VKeyToString() + ":" + (int)ky );
+                events.Add(new InputDeviceEvent(this, (int)ky, k.IsPressed));
             }
 
             return (events.Count > 0) ? events : null;
         }
 
-        public string EventName(InputDeviceEvent e) // need to return frontier naming convention!
+        public string EventName(InputDeviceEvent e)     // in Forms.keys naming convention - not in sharp DX.
         {
-            Key k = (Key)(e.EventNumber);
-            return KeyConversion.SharpKeyToFrontierName(k);
+            Keys k = (Keys)(e.EventNumber);
+            return k.VKeyToString();
         }
 
-        public bool? IsPressed(string frontierkeyname )      // frontier naming convention..  GetEvents must have filled in ks
+        public bool? IsPressed( string keyname )        // keyname is in keys
         {
-            Key? k = KeyConversion.FrontierNameToSharpKey(frontierkeyname);
+            Key? k = SharpKeyConversion.KeysToSharpKey(keyname.ToVkey());       // to VKEY, then to Sharp key
 
             if ( k != null )
-                return (ks != null) ? ks.IsPressed(k.Value) : false;
+                return (ks != null) ? ks.IsPressed(k.Value) : false;        // use keyboard state to determine
             else
             {
-                System.Diagnostics.Debug.WriteLine("FAILED IsPressed " + frontierkeyname);
+                System.Diagnostics.Debug.WriteLine("FAILED IsPressed " + keyname);
             }
 
             return false;
@@ -380,7 +251,7 @@ namespace DirectInputDevices
             if (recheck || ks == null)
                 ks = keyboard.GetCurrentState();
 
-            Key ky = KeyConversion.KeysToSharpKey(k);
+            Key ky = SharpKeyConversion.KeysToSharpKey(k);
             return ks.IsPressed(ky);
         }
 
@@ -415,17 +286,16 @@ namespace DirectInputDevices
 
         static public System.Windows.Forms.Keys ToKeys(InputDeviceEvent ev) // safe to call without including SharpDirectInput
         {
-            return KeyConversion.SharpKeyToKeys((Key)ev.EventNumber);
+            return (Keys)ev.EventNumber;
         }
 
-        static public string SharpKeyName(InputDeviceEvent ev) // safe to call without including SharpDirectInput
+        static public bool CheckTranslation(InputDeviceEvent ev) // safe to call without including SharpDirectInput Debug use
         {
-            return ((Key)ev.EventNumber).ToString();
-        }
-
-        static public bool CheckTranslation(InputDeviceEvent ev, Keys winkey) // safe to call without including SharpDirectInput
-        {
-            return KeyConversion.CheckTranslation((Key)ev.EventNumber, winkey);
+            Keys ky = ToKeys(ev);
+            Key sk = SharpKeyConversion.KeysToSharpKey(ky);
+            Keys back = SharpKeyConversion.SharpKeyToKeys(sk);
+            System.Diagnostics.Debug.WriteLine("Check " + ky.VKeyToString() + " -> " + sk + " ->" + back.VKeyToString());
+            return ky == back;
         }
     }
 }

--- a/EDDiscovery/Actions/ActionController.cs
+++ b/EDDiscovery/Actions/ActionController.cs
@@ -102,8 +102,8 @@ namespace EDDiscovery.Actions
             inputdevicesactions = new Actions.ActionsFromInputDevices(inputdevices, frontierbindings, this);
 
             frontierbindings.LoadBindingsFile();
-            //System.Diagnostics.Debug.WriteLine("Bindings" + frontierbindings.ListBindings());
-            // System.Diagnostics.Debug.WriteLine("Key Names" + frontierbindings.ListKeyNames("{","}"));
+            System.Diagnostics.Debug.WriteLine("Bindings" + frontierbindings.ListBindings());
+            System.Diagnostics.Debug.WriteLine("Key Names" + frontierbindings.ListKeyNames("{","}"));
 
             voicerecon.SpeechRecognised += Voicerecon_SpeechRecognised;
             voicerecon.SpeechNotRecognised += Voicerecon_SpeechNotRecognised;
@@ -163,9 +163,10 @@ namespace EDDiscovery.Actions
                         if (b.Name == "Key")
                         {
                             string err = ActionKeyED.VerifyBinding(b.UserData, frontierbindings);
-                            //System.Diagnostics.Debug.WriteLine("{0} Step {1} UD '{2}' err '{3}'", p.Name, b.Name, b.UserData, err);
                             if (err.Length > 0)
-                                errlist = af.name +":" + p.Name + ":" + b.LineNumber + " " + err + Environment.NewLine;
+                            {   // just a warning.. not a full error, as we don't want to stop someone using the pack due to a missing key mapping
+                                LogLine("Key Mapping error: " + string.Format( "{0}:{1}:{2} {3}", af.name, p.Name, b.LineNumber, err));
+                            }
                         }
                     }
                 }

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionKeyED.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionKeyED.cs
@@ -54,8 +54,8 @@ namespace EDDiscovery.Actions
 
                         if ( matches != null )      // null if no matches to keyboard is found
                         {
-                            // pick out the keys and convert them from fontier to Keys
-                            Keys[] keys = (from x in matches[0].Item2.keys select DirectInputDevices.KeyConversion.FrontierNameToKeys(x.Key)).ToArray();
+                            // pick out the keys and convert them from text to Vkey (they are in Vkey naming format)
+                            Keys[] keys = (from x in matches[0].Item2.keys select x.Key.ToVkey()).ToArray();        // bindings returns keys
 
                             if ( !keys.Contains(Keys.None)) // if no errors
                             {
@@ -66,12 +66,12 @@ namespace EDDiscovery.Actions
                             else
                             {
                                 string[] names = (from x in matches[0].Item2.keys select x.Key).ToArray();
-                                return new Tuple<string, int, string>(null, 0, "Frontier Key name not recognised: " + String.Join(",",names) );
+                                return new Tuple<string, int, string>(null, 0, "Key name(s) not recognised: " + String.Join(",",names) );
                             }
                         }
                         else
                         {
-                            System.Diagnostics.Debug.WriteLine("NO binding for " + binding);
+                            System.Diagnostics.Debug.WriteLine("No key binding for " + binding);
                             return new Tuple<string, int, string>(null, 0, errmsgforbinding + binding);
                         }
                     }

--- a/EliteDangerous/EliteDangerous.csproj
+++ b/EliteDangerous/EliteDangerous.csproj
@@ -114,6 +114,7 @@
     <Compile Include="EliteDangerous\EDJournalClass.cs" />
     <Compile Include="EliteDangerous\EDJournalReader.cs" />
     <Compile Include="EliteDangerous\EDTypesFromJSON.cs" />
+    <Compile Include="EliteDangerous\FrontierToVKey.cs" />
     <Compile Include="EliteDangerous\ISystem.cs" />
     <Compile Include="EliteDangerous\JournalEntry.cs" />
     <Compile Include="EliteDangerous\JournalEntryAttributes.cs" />

--- a/EliteDangerous/EliteDangerous/BindingsFile.cs
+++ b/EliteDangerous/EliteDangerous/BindingsFile.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows.Forms;
 using System.Xml.Linq;
 
 namespace EliteDangerousCore
@@ -43,7 +44,7 @@ namespace EliteDangerousCore
         public class DeviceKeyPair
         {
             public Device Device;
-            public string Key;          // in Frontier naming convention
+            public string Key;          // Keyboard: in Keys naming convention - converted from Frontier on input.
         }
 
         [System.Diagnostics.DebuggerDisplay("Assignment {assignedfunc} Keys {keys.Count}" )]
@@ -74,7 +75,7 @@ namespace EliteDangerousCore
                 return s.ToNullSafeString();
             }
 
-            public bool HasKeyAssignment(string key)        // is key in this list
+            public bool HasKeyAssignment(string key)        // is key in this list (Keys naming convention)
             {
                 foreach (DeviceKeyPair k in keys)
                 {
@@ -196,11 +197,11 @@ namespace EliteDangerousCore
                                 key = povroot + ((key.Contains("Up") || vm.Contains("Up")) ? "UpRight" : "DownRight");
                         }
                         else
-                            dvp.Add(new DeviceKeyPair() { Device = FindOrMakeDevice(km), Key = vm });
+                            dvp.Add(new DeviceKeyPair() { Device = FindOrMakeDevice(km), Key = FrontierToKeys(km, vm) });
                     }
                 }
 
-                dvp.Insert(0, new DeviceKeyPair() { Device = FindOrMakeDevice(xdevice.Value), Key = key });
+                dvp.Insert(0, new DeviceKeyPair() { Device = FindOrMakeDevice(xdevice.Value), Key = FrontierToKeys(xdevice.Value, key) });
 
                 Assignment a = new Assignment() { assignedfunc = d.Name.ToString(), keys = dvp };
 
@@ -423,6 +424,19 @@ namespace EliteDangerousCore
         public string ListKeyNames(string prefix = "", string postfix = "")
         {
             return String.Join(Environment.NewLine, (from x in KeyNames select prefix + x + postfix));
+        }
+
+
+        static private string FrontierToKeys(string device, string frontiername)
+        {
+            if (device == KeyboardDeviceName)
+            {
+                string ret = EliteDangerousCore.FrontierKeyConversion.FrontierToKeys(frontiername);
+                System.Diagnostics.Debug.WriteLine("Frontier Name Convert {0} to {1}", frontiername, ret);
+                return ret;
+            }
+            else
+                return frontiername;
         }
 
 

--- a/EliteDangerous/EliteDangerous/FrontierToVKey.cs
+++ b/EliteDangerous/EliteDangerous/FrontierToVKey.cs
@@ -1,0 +1,496 @@
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace EliteDangerousCore
+{
+    static public class FrontierKeyConversion
+    {
+        static private Dictionary<string,uint> nametoscan = null;
+        static private bool mapped = false;
+
+        // lovely frontier uses strange naming.. its dependent on input language, except for some locals (ESP) it isn't.
+        // do this is the best i can do.. tested UK,USA,FR,DE,IT,ESP,POL.
+        // will probably need more bodging.
+
+        static public string FrontierToKeys(string frontiername)
+        {
+            if (nametoscan == null)
+            {
+                Dictionary<char, uint> chartoscancode = KeyObjectExtensions.CharToScanCode();
+                //ScancodeToFrontierName(chartoscancode);
+                nametoscan = FrontierNameToScancode(chartoscancode);
+                mapped = IsFullyMapped(chartoscancode);
+                //System.Diagnostics.Debug.WriteLine("Mapped " + mapped);
+            }
+
+            string output;
+
+            if (frontiername.StartsWith("Key_"))
+            {
+                output = frontiername.Substring(4);
+
+                int num;
+
+                if (output.Length == 1 && ((output[0] >= '0' && output[0] <= '9') || (output[0] >= 'A' && output[0] <= 'Z')))
+                {
+                    // no action
+                }
+                else if (output.StartsWith("Numpad_") && char.IsDigit(output[7]))
+                    output = "NumPad" + output[7];
+                else if (output.StartsWith("F") && int.TryParse(output.Substring(1), out num))
+                    output = "F" + num;
+                else
+                {
+                    int i = Array.FindIndex(frontiertovkeyname, x => x.Item2.Equals(output));
+
+                    if (i >= 0)
+                        return frontiertovkeyname[i].Item1;
+
+                    uint sc = 0;
+
+//                    System.Diagnostics.Debug.WriteLine("Layout " + InputLanguage.CurrentInputLanguage.LayoutName);
+
+                    if (InputLanguage.CurrentInputLanguage.LayoutName != "Spanish" && mapped && nametoscan.ContainsKey(output))       // spanish uses default names
+                        sc = nametoscan[output];
+                    else
+                    {
+                        i = Array.FindIndex(defaultscancodes, x => x.Item1.Equals(output));
+
+                        if (i >= 0)
+                            sc = defaultscancodes[i].Item2;
+                    }
+
+                    if (sc != 0)      // if we have a code, convert it to a Vkey.
+                    {
+                        // System.Diagnostics.Debug.WriteLine("Name {0} ->SC {1:x}", output, sc);
+
+                        uint v = BaseUtils.Win32.UnsafeNativeMethods.MapVirtualKey(sc, 3);
+
+                        if (v != 0)
+                        {
+                            // System.Diagnostics.Debug.WriteLine("        .. {0} -> VK {1:x} {2}", sc, v, ((Keys)v).VKeyToString());
+                            output = ((Keys)v).VKeyToString();
+                        }
+                        else
+                        {
+                            System.Diagnostics.Debug.WriteLine("Scan code converstion failed {0} {1:x}", frontiername , sc);
+                            output = "Unknown_SCMap_" + frontiername + "_" + InputLanguage.CurrentInputLanguage.LayoutName;
+                        }
+                    }
+                    else
+                    {
+                        System.Diagnostics.Debug.WriteLine("Frontier Mapping failed {0}", frontiername);
+                        output = "Unknown_Key_" + frontiername + "_" + InputLanguage.CurrentInputLanguage.LayoutName;
+                    }
+                }
+            }
+            else
+                output = "Unknown_Format_" + frontiername;
+
+            return output;
+
+        }
+
+        static Tuple<string, string>[] frontiertovkeyname = new Tuple<string, string>[]
+        {
+            new Tuple<string,string>(Keys.Up.VKeyToString()          ,"UpArrow"),          // FD naming
+            new Tuple<string,string>(Keys.Down.VKeyToString()        ,"DownArrow"),
+            new Tuple<string,string>(Keys.Left.VKeyToString()        ,"LeftArrow"),
+            new Tuple<string,string>(Keys.Right.VKeyToString()       ,"RightArrow"),
+            new Tuple<string,string>(Keys.Return.VKeyToString()      ,"Enter"),
+            new Tuple<string,string>(Keys.Capital.VKeyToString()     ,"CapsLock"),
+            new Tuple<string,string>(Keys.NumLock.VKeyToString()     ,"NumLock"),
+            new Tuple<string,string>(Keys.Subtract.VKeyToString()    ,"Numpad_Subtract"),
+            new Tuple<string,string>(Keys.Divide.VKeyToString()      ,"Numpad_Divide"),
+            new Tuple<string,string>(Keys.Multiply.VKeyToString()    ,"Numpad_Multiply"),
+            new Tuple<string,string>(Keys.Add.VKeyToString()         ,"Numpad_Add"),
+            new Tuple<string,string>(Keys.Decimal.VKeyToString()     ,"Numpad_Decimal"),
+            new Tuple<string,string>(Keys.Insert.VKeyToString()     ,"Insert"),
+            new Tuple<string,string>(Keys.Home.VKeyToString()     ,"Home"),
+            new Tuple<string,string>(Keys.PageUp.VKeyToString()     ,"PageUp"),
+            new Tuple<string,string>(Keys.Delete.VKeyToString()     ,"Delete"),
+            new Tuple<string,string>(Keys.End.VKeyToString()     ,"End"),
+            new Tuple<string,string>(Keys.PageDown.VKeyToString()     ,"PageDown"),
+            new Tuple<string,string>("NumEnter", "Numpad_Enter"),
+            new Tuple<string,string>(Keys.Space.VKeyToString(), "Space"),
+            new Tuple<string,string>(Keys.Tab.VKeyToString(), "Tab"),
+
+            new Tuple<string,string>(Keys.LShiftKey.VKeyToString(),"LeftShift"),
+            new Tuple<string,string>(Keys.LControlKey.VKeyToString(),"LeftControl"),
+            new Tuple<string,string>(Keys.LMenu.VKeyToString(),"LeftAlt"),
+            new Tuple<string,string>(Keys.RShiftKey.VKeyToString(),"RightShift"),
+            new Tuple<string,string>(Keys.RControlKey.VKeyToString(),"RightControl"),
+            new Tuple<string,string>(Keys.RMenu.VKeyToString(),"RightAlt"),
+            new Tuple<string,string>(Keys.Back.VKeyToString(),"Backspace"),
+         };
+
+        static Tuple<string, uint>[] defaultscancodes = new Tuple<string, uint>[]       // used on some layouts (ESP) instead of local names.. no idea how its chosen
+        {
+            new Tuple<string, uint>("Grave",0x29),
+
+            new Tuple<string, uint>("Minus",0x0c),
+            new Tuple<string, uint>("Equals",0x0d),
+
+            new Tuple<string, uint>("LeftBracket",0x1a),
+            new Tuple<string, uint>("RightBracket",0x1b),
+
+            new Tuple<string, uint>("SemiColon",0x27),
+            new Tuple<string, uint>("Apostrophe",0x28),
+            new Tuple<string, uint>("Hash",0x2b),
+
+            new Tuple<string, uint>("Comma",0x33),
+            new Tuple<string, uint>("Period",0x34),
+            new Tuple<string, uint>("Slash",0x35),
+
+            new Tuple<string, uint>("BackSlash",0x56),
+
+        };
+
+
+        static public Dictionary<uint, string> ScancodeToFrontierName(Dictionary<char, uint> chartosc)  // list of scan codes vs frontier names
+        {
+            Dictionary<uint, string> scn = new Dictionary<uint, string>();
+
+            foreach (KeyValuePair<char, uint> kv in chartosc)
+            {
+                if ((kv.Value & 0xff) == kv.Value)
+                {
+                    string str = "";
+                    str += kv.Key;
+
+                    int i = Array.FindIndex(chartofrontiername, x => x.Item1.Equals(str));
+
+                    if (i >= 0)
+                        str = chartofrontiername[i].Item2;
+
+                    System.Diagnostics.Debug.WriteLine("Scan code {0:x} = '{1}'", kv.Value, str);
+                }
+            }
+
+            return scn;
+        }
+
+        static public bool IsFullyMapped(Dictionary<char, uint> chartosc)   // tell me if you have these keys in the name table
+        {
+            bool fullymapped = chartosc.ContainsValue(0x29) && chartosc.ContainsValue(0xc) && chartosc.ContainsValue(0xd)
+                            && chartosc.ContainsValue(0x1a) && chartosc.ContainsValue(0x1b) && chartosc.ContainsValue(0x27)
+                            && chartosc.ContainsValue(0x28) && chartosc.ContainsValue(0x2b) && chartosc.ContainsValue(0x33)
+                            && chartosc.ContainsValue(0x34) && chartosc.ContainsValue(0x35);
+
+            // USA does not support 0x56, so we don't call that a fully mapped key fullymapped = fullymapped && chartosc.ContainsValue(0x56);
+
+            return fullymapped;
+        }
+
+        static public Dictionary<string, uint> FrontierNameToScancode(Dictionary<char, uint> chartosc)  // given a name, give me the scan code..
+        {
+            Dictionary<string, uint> scn = new Dictionary<string, uint>();
+
+            foreach (KeyValuePair<char, uint> kv in chartosc)
+            {
+                if ((kv.Value & 0xff) == kv.Value)      // if not shifted..
+                {
+                    string str = "";
+                    str += kv.Key;
+
+                    int i = Array.FindIndex(chartofrontiername, x => x.Item1.Equals(str));
+
+                    if (i >= 0)
+                    {
+                        str = chartofrontiername[i].Item2;
+                    }
+
+                   // System.Diagnostics.Debug.WriteLine("'{0}' Scan code {1:x}", str, kv.Value);
+                    scn[str] = kv.Value;
+                }
+            }
+
+
+            return scn;
+        }
+
+        static Tuple<string, string>[] chartofrontiername = new Tuple<string, string>[]
+        {
+        new Tuple<string,string>("`","Grave"),
+        new Tuple<string,string>("-","Minus"),
+        new Tuple<string,string>("=","Equals"),
+        new Tuple<string,string>("[","LeftBracket"),
+        new Tuple<string,string>("]","RightBracket"),
+        new Tuple<string,string>(";","SemiColon"),
+        new Tuple<string,string>("'","Apostrophe"),
+        new Tuple<string,string>("#","Hash"),
+        new Tuple<string,string>(",","Comma"),
+        new Tuple<string,string>(".","Period"),
+        new Tuple<string,string>("/","Slash"),
+        new Tuple<string,string>("\\","BackSlash"),
+
+        // DE 28-12-2017 
+        new Tuple<string,string>("^","Circumflex"),
+        //ß
+        new Tuple<string,string>("∩","Acute"),
+        //ü
+        new Tuple<string,string>("+","Plus"),
+        //ö,ä
+        new Tuple<string,string>("#","Hash"),
+        //Comma,Period,Minus
+        new Tuple<string,string>("<","LessThan"),
+            
+        // FR 29 12 2017
+        new Tuple<string,string>("²","SuperscriptTwo"),
+        new Tuple<string,string>(")","RightParenthesis"),
+        //= Equals
+        //^ Cirumflex
+        new Tuple<string,string>("$","Dollar"),
+        //m auto
+        //ù auto
+        new Tuple<string,string>("*","Asterisk"),
+        //Semicolon
+        new Tuple<string,string>(":","Colon"),
+        new Tuple<string,string>("!","ExclamationPoint"),
+
+            // IT 29 12 2017
+            //Backslash
+            //Apostrophe
+            //ì auto
+            //è
+            //+
+            //ò
+            //à
+            //ù auto
+            //Comma
+            //Period 
+            //Minus
+            //LessThan
+        };
+
+#if DEBUG
+
+        static public void Check()
+        {
+            InputLanguage l = InputLanguage.CurrentInputLanguage;
+            if (l.Culture.Name.Contains("es-"))
+                CheckESP();
+            if (l.Culture.Name.Contains("en-GB"))
+                CheckUKUS(false);
+            if (l.Culture.Name.Contains("en-US"))
+                CheckUKUS(true);
+            if (l.Culture.Name.Contains("fr-"))
+                CheckFR();
+            if (l.Culture.Name.Contains("it-"))
+                CheckIT();
+            if (l.Culture.Name.Contains("de-"))
+                CheckDE();
+            if (l.Culture.Name.Contains("pl-"))
+                CheckPOL();
+        }
+
+        static public void CheckUKUS(bool usa)
+        {
+            Check(Keys.Up, "Key_UpArrow");
+            Check(Keys.Down, "Key_DownArrow");
+            Check(Keys.Left, "Key_LeftArrow");
+            Check(Keys.Right, "Key_RightArrow");
+            Check(Keys.Back, "Key_Backspace");
+            Check(Keys.Insert, "Key_Insert");
+            Check(Keys.Home, "Key_Home");
+            Check(Keys.PageUp, "Key_PageUp");
+            Check(Keys.PageDown, "Key_PageDown");
+            Check(Keys.Delete, "Key_Delete");
+            Check(Keys.End, "Key_End");
+            Check(Keys.Space, "Key_Space");
+            Check(Keys.F1, "Key_F1");
+            Check(Keys.F12, "Key_F12");
+
+            Check(Keys.Tab, "Key_Tab");
+            Check(Keys.Capital, "Key_CapsLock");
+            Check(Keys.LShiftKey, "Key_LeftShift");
+            Check(Keys.RShiftKey, "Key_RightShift");
+            Check(Keys.LControlKey, "Key_LeftControl");
+            Check(Keys.RControlKey, "Key_RightControl");
+            Check(Keys.LMenu, "Key_LeftAlt");
+            Check(Keys.RMenu, "Key_RightAlt");
+
+            Check(Keys.NumPad0, "Key_Numpad_0");
+            Check(Keys.NumPad9, "Key_Numpad_9");
+            Check(KeyObjectExtensions.NumEnter, "Key_Numpad_Enter");
+            Check(Keys.Multiply, "Key_Numpad_Multiply");
+            Check(Keys.Add, "Key_Numpad_Add");
+            Check(Keys.Subtract, "Key_Numpad_Subtract");
+            Check(Keys.Decimal, "Key_Numpad_Decimal");
+            Check(Keys.NumLock, "Key_NumLock");
+            
+            if ( usa )
+            {
+                Check(Keys.Oemtilde, "Key_Grave");
+
+                Check(Keys.OemMinus, "Key_Minus");
+                Check(Keys.Oemplus, "Key_Equals");
+
+                Check(Keys.OemOpenBrackets, "Key_LeftBracket");
+                Check(Keys.Oem6, "Key_RightBracket");
+
+                Check(Keys.Oem1, "Key_SemiColon");
+                Check(Keys.Oem7, "Key_Apostrophe");
+                Check(Keys.Oem5, "Key_BackSlash");
+
+                Check(Keys.Oemcomma, "Key_Comma");
+                Check(Keys.OemPeriod, "Key_Period");
+                Check(Keys.OemQuestion, "Key_Slash");
+
+               // No SC 56 on USA Check(Keys.OemBackslash, "Key_BackSlash");
+            }
+            else
+            {
+                Check(Keys.Oem8, "Key_Grave");
+
+                Check(Keys.OemMinus, "Key_Minus");
+                Check(Keys.Oemplus, "Key_Equals");
+
+                Check(Keys.Oem4, "Key_LeftBracket");
+                Check(Keys.Oem6, "Key_RightBracket");
+
+                Check(Keys.Oem1, "Key_SemiColon");
+                Check(Keys.Oem3, "Key_Apostrophe");
+                Check(Keys.Oem7, "Key_Hash");
+
+                Check(Keys.Oemcomma, "Key_Comma");
+                Check(Keys.OemPeriod, "Key_Period");
+                Check(Keys.Oem2, "Key_Slash");
+
+                Check(Keys.Oem5, "Key_BackSlash");
+            }
+        }
+
+        static public void CheckESP()
+        {
+            Check(Keys.Oem5, "Key_Grave");
+
+            Check(Keys.OemOpenBrackets, "Key_Minus");
+            Check(Keys.Oem6, "Key_Equals");
+
+            Check(Keys.Oem1, "Key_LeftBracket");
+            Check(Keys.Oemplus, "Key_RightBracket");
+
+            Check(Keys.Oemtilde, "Key_SemiColon");
+            Check(Keys.Oem7, "Key_Apostrophe");
+            Check(Keys.OemQuestion, "Key_Hash");
+
+            Check(Keys.Oemcomma, "Key_Comma");
+            Check(Keys.OemPeriod, "Key_Period");
+            Check(Keys.OemMinus, "Key_Slash");
+
+            Check(Keys.OemBackslash, "Key_BackSlash");
+
+        }
+
+        static public void CheckPOL()
+        {
+            Check(Keys.Oemtilde, "Key_Grave");
+
+            Check(Keys.Oemplus, "Key_Minus");
+            Check(Keys.OemQuestion, "Key_Equals");
+
+            Check(Keys.OemOpenBrackets, "Key_LeftBracket");
+            Check(Keys.Oem6, "Key_RightBracket");
+
+            Check(Keys.Oem1, "Key_SemiColon");
+            Check(Keys.Oem7, "Key_Apostrophe");
+            Check(Keys.Oem5, "Key_Hash");  
+
+            Check(Keys.Oemcomma, "Key_Comma");
+            Check(Keys.OemPeriod, "Key_Period");
+            Check(Keys.OemMinus, "Key_Slash");
+
+            Check(Keys.OemBackslash, "Key_BackSlash");
+
+        }
+
+        static public void CheckDE()
+        {
+            Check(Keys.Oem5, "Key_Circumflex");
+            Check(Keys.OemOpenBrackets, "Key_ß");
+            Check(Keys.Oem6, "Key_Acute");
+            Check(Keys.Oem1, "Key_ü");
+            Check(Keys.Oemplus, "Key_Plus");
+            Check(Keys.Oemtilde, "Key_ö");
+            Check(Keys.Oem7, "Key_ä");
+            Check(Keys.OemQuestion, "Key_Hash");
+            Check(Keys.Oemcomma, "Key_Comma");
+            Check(Keys.OemPeriod, "Key_Period");
+            Check(Keys.OemMinus, "Key_Minus");
+            Check(Keys.OemBackslash, "Key_LessThan");
+
+        }
+
+        static public void CheckFR()
+        {
+            Check(Keys.Oem7, "Key_SuperscriptTwo");
+            Check(Keys.OemOpenBrackets, "Key_RightParenthesis");
+            Check(Keys.Oemplus, "Key_Equals");
+            Check(Keys.Oem6, "Key_Circumflex");
+            Check(Keys.Oem1, "Key_Dollar");
+            Check(Keys.M, "Key_M");
+            Check(Keys.Oemtilde, "Key_ù");
+            Check(Keys.Oem5, "Key_Asterisk");
+            Check(Keys.OemPeriod, "Key_SemiColon");
+            Check(Keys.OemQuestion, "Key_Colon");
+            Check(Keys.Oem8, "Key_ExclamationPoint");
+            Check(Keys.OemBackslash, "Key_LessThan");
+
+        }
+
+        static public void CheckIT()
+        {
+            Check(Keys.Oem5, "Key_BackSlash");
+
+            Check(Keys.OemOpenBrackets, "Key_Apostrophe");
+            Check(Keys.Oem6, "Key_ì");
+
+            Check(Keys.Oem1, "Key_è");
+            Check(Keys.Oemplus, "Key_Plus");
+
+            Check(Keys.Oemtilde, "Key_ò");
+            Check(Keys.Oem7, "Key_à");
+            Check(Keys.OemQuestion, "Key_ù");
+
+            Check(Keys.Oemcomma, "Key_Comma");
+            Check(Keys.OemMinus, "Key_Minus");
+
+            Check(Keys.OemBackslash, "Key_LessThan");
+
+        }
+
+        static private void Check(Keys k, string key)
+        {
+            string output = FrontierToKeys(key);
+            Keys kc = output.ToVkey();
+            string check = "";
+            if (kc != k)
+                check = "********** ERROR";
+
+            System.Diagnostics.Debug.WriteLine("     Key {0} => {1} {2} {3}" + Environment.NewLine, key, output, kc, check);
+        }
+    }
+
+#endif
+}

--- a/TestExtendedControls/TestDirectInput.cs
+++ b/TestExtendedControls/TestDirectInput.cs
@@ -48,15 +48,17 @@ namespace DialogTest
                     if (ev.Pressed)
                     {
                         Keys k = InputDeviceKeyboard.ToKeys(ev);
-                        string t = "Sharp Name: " + InputDeviceKeyboard.SharpKeyName(ev) + Environment.NewLine;
-                        t += "Frontier Name " + ev.EventName() + Environment.NewLine;
+                        string t = ev.EventName() + " (" + k.VKeyToString() + ")" + " Vkey " + vkey.VKeyToString();
 
-                        System.Diagnostics.Debug.WriteLine("Direct Input detected " + t);
+                        bool ok = InputDeviceKeyboard.CheckTranslation(ev);
 
-                        if (!InputDeviceKeyboard.CheckTranslation(ev, vkey))
-                            t += Environment.NewLine + " ERROR TX WRONG!";
+                        if (!ok)
+                            t += " **** ERROR in sharp conversion";
 
-                        richTextBox1.Text += t + Environment.NewLine;
+                        if (vkey != k)
+                            t += "**** vkey not same as DI vkey";
+
+                        richTextBox1.Text += "Direct Input "  + t + Environment.NewLine;
                         richTextBox1.Select(richTextBox1.Text.Length, richTextBox1.Text.Length);
 
                     }


### PR DESCRIPTION
Converting Frontier to Vkeys enhanced.. tested with
FR,UK,US,DE,POL,IT,ESP keyboards. Frontier uses a strange method of
naming the keys - sometimes they are local, sometimes in UK format.  May
need to expand use cases later.

ChartoScanCode added - gives list of chars vs scan codes.
InputDeviceKeyboard - now holds Vkeys, converts from sharp->Vkeys
(method updated)
Action controller prints warnings on bad key mapping in the log window
instead of rejecting the pack.  In case we get more keyboards with
strange names from frontier
Bindings now holds the keys in Vkey format - it converts them from
Frontier to Vkey immediately.
FrontiertoVKey added - tested on keyboards above.  Uses keyboard
functions where it can.
TestDirectInput altered to test above