### PR TITLE
Fixed up system cache and multiple systems around this area (W1)

### DIFF
--- a/EDDiscovery/3DMap/StarGrid.cs
+++ b/EDDiscovery/3DMap/StarGrid.cs
@@ -107,7 +107,7 @@ namespace EDDiscovery
 
             foreach (HistoryEntry vs in cls)
             {                                                               // all vs stars which are not in edsm and have co-ords.
-                if (vs.IsLocOrJump && vs.System.status != SystemStatusEnum.EDSC && vs.System.HasCoordinate )
+                if (vs.IsLocOrJump && vs.System.status != SystemStatusEnum.EDSM && vs.System.HasCoordinate )
                 {
                     Vector3 ent = new Vector3((float)vs.System.x, (float)vs.System.y, (float)vs.System.z);
                     if (!ents.Contains(ent))

--- a/EDDiscovery/Actions/ActionController.cs
+++ b/EDDiscovery/Actions/ActionController.cs
@@ -102,8 +102,8 @@ namespace EDDiscovery.Actions
             inputdevicesactions = new Actions.ActionsFromInputDevices(inputdevices, frontierbindings, this);
 
             frontierbindings.LoadBindingsFile();
-            System.Diagnostics.Debug.WriteLine("Bindings" + frontierbindings.ListBindings());
-            System.Diagnostics.Debug.WriteLine("Key Names" + frontierbindings.ListKeyNames("{","}"));
+            //System.Diagnostics.Debug.WriteLine("Bindings" + frontierbindings.ListBindings());
+            //System.Diagnostics.Debug.WriteLine("Key Names" + frontierbindings.ListKeyNames("{","}"));
 
             voicerecon.SpeechRecognised += Voicerecon_SpeechRecognised;
             voicerecon.SpeechNotRecognised += Voicerecon_SpeechNotRecognised;

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionPerform.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionPerform.cs
@@ -67,7 +67,7 @@ namespace EDDiscovery.Actions
                 }
                 else if (cmdname.Equals("refresh"))
                 {
-                    (ap.actioncontroller as ActionController).DiscoveryForm.RefreshHistoryAsync(checkedsm: true);
+                    (ap.actioncontroller as ActionController).DiscoveryForm.RefreshHistoryAsync();
                 }
                 else if (cmdname.Equals("url"))
                 {

--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -224,7 +224,7 @@ namespace EDDiscovery
         #endregion
 
         #region History
-        public bool RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool forcejournalreload = false, bool checkedsm = false, int? currentcmdr = null)
+        public bool RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool forcejournalreload = false, int? currentcmdr = null)
         {
             if (PendingClose)
             {
@@ -237,7 +237,6 @@ namespace EDDiscovery
             if (refreshRequestedFlag == 0)
             {
                 if (curargs == null ||
-                    curargs.CheckEdsm != checkedsm ||
                     curargs.ForceNetLogReload != forcenetlogreload ||
                     curargs.ForceJournalReload != forcejournalreload ||
                     curargs.CurrentCommander != (currentcmdr ?? history.CommanderId) ||
@@ -254,7 +253,6 @@ namespace EDDiscovery
                     NetLogPath = netlogpath,
                     ForceNetLogReload = forcenetlogreload,
                     ForceJournalReload = forcejournalreload,
-                    CheckEdsm = checkedsm,
                     CurrentCommander = currentcmdr ?? history.CommanderId
                 });
 
@@ -476,7 +474,7 @@ namespace EDDiscovery
                 {
                     LogLine("Refresh due to updating systems");
                     HistoryRefreshed += HistoryFinishedRefreshing;
-                    RefreshHistoryAsync(checkedsm:true);
+                    RefreshHistoryAsync();
                 }
 
                 OnSyncComplete?.Invoke();
@@ -509,7 +507,6 @@ namespace EDDiscovery
             public string NetLogPath;
             public bool ForceNetLogReload;
             public bool ForceJournalReload;
-            public bool CheckEdsm;
             public int CurrentCommander;
         }
 
@@ -521,7 +518,7 @@ namespace EDDiscovery
                 refreshWorkerArgs = args;
                 Debug.WriteLine(BaseUtils.AppTicks.TickCount100 + " Load history");
                 hist = HistoryList.LoadHistory(journalmonitor, () => PendingClose, (p, s) => ReportProgress(p, $"Processing log file {s}"), args.NetLogPath, 
-                    args.ForceJournalReload, args.ForceJournalReload, args.CheckEdsm, args.CurrentCommander , EDDConfig.Instance.ShowUIEvents );
+                    args.ForceJournalReload, args.ForceJournalReload, args.CurrentCommander , EDDConfig.Instance.ShowUIEvents );
                 Debug.WriteLine(BaseUtils.AppTicks.TickCount100 + " Load history complete");
             }
             catch (Exception ex)

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -117,9 +117,9 @@ namespace EDDiscovery
         #endregion
 
         #region History
-        public bool RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool forcejournalreload = false, bool checkedsm = false, int? currentcmdr = null)
+        public bool RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool forcejournalreload = false, int? currentcmdr = null)
         {
-            return Controller.RefreshHistoryAsync(netlogpath, forcenetlogreload, forcejournalreload, checkedsm, currentcmdr);
+            return Controller.RefreshHistoryAsync(netlogpath, forcenetlogreload, forcejournalreload, currentcmdr);
         }
         public void RefreshDisplays() { Controller.RefreshDisplays(); }
         public void RecalculateHistoryDBs() { Controller.RecalculateHistoryDBs(); }
@@ -1125,7 +1125,7 @@ namespace EDDiscovery
 
         private void rescanAllJournalFilesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Controller.RefreshHistoryAsync(forcejournalreload: true, checkedsm: true);
+            Controller.RefreshHistoryAsync(forcejournalreload: true);
         }
 
         private void checkForNewReleaseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1206,6 +1206,8 @@ namespace EDDiscovery
         public void Open3DMap(HistoryEntry he)
         {
             this.Cursor = Cursors.WaitCursor;
+
+            history.FillInPositionsFSDJumps();
 
             Map.Prepare(he?.System, EDDConfig.Instance.HomeSystem,
                         EDDConfig.Instance.MapCentreOnSelection ? he?.System : EDDConfig.Instance.HomeSystem,
@@ -1598,7 +1600,7 @@ namespace EDDiscovery
         private void buttonExtRefresh_Click(object sender, EventArgs e)
         {
             LogLine("Refresh History.");
-            RefreshHistoryAsync(checkedsm: true);
+            RefreshHistoryAsync();
         }
 
         private void buttonExtEDSMSync_Click(object sender, EventArgs e)

--- a/EDDiscovery/IDiscoveryController.cs
+++ b/EDDiscovery/IDiscoveryController.cs
@@ -50,7 +50,7 @@ namespace EDDiscovery
         #endregion
 
         #region History
-        bool RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool forcejournalreload = false, bool checkedsm = false, int? currentcmdr = null);
+        bool RefreshHistoryAsync(string netlogpath = null, bool forcenetlogreload = false, bool forcejournalreload = false, int? currentcmdr = null);
         void RefreshDisplays();
         void RecalculateHistoryDBs();
         #endregion

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -153,7 +153,6 @@ namespace EDDiscovery.UserControls
                 return;
             }
 
-            discoveryform.history.FillEDSM(last_he, reload: true); // Fill in any EDSM info we have, force it to try again.. in case system db updated
             StarScan.SystemNode last_sn = discoveryform.history.starscan.FindSystem(last_he.System, checkBoxEDSM.Checked);
 
             SetControlText((last_sn == null) ? "No Scan" : last_sn.system.name);

--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -153,6 +153,7 @@ namespace EDDiscovery.UserControls
                 return;
             }
 
+            discoveryform.history.FillEDSM(last_he, reload: true); // Fill in any EDSM info we have, force it to try again.. in case system db updated
             StarScan.SystemNode last_sn = discoveryform.history.starscan.FindSystem(last_he.System, checkBoxEDSM.Checked);
 
             SetControlText((last_sn == null) ? "No Scan" : last_sn.system.name);

--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -140,7 +140,7 @@ namespace EDDiscovery.UserControls
             {
                 SetControlText(he.System.name);
                 textBoxSystem.Text = he.System.name;
-                discoveryform.history.FillEDSM(he, reload: true, useedsm: true); // Fill in any EDSM info we have, force it to try again.. in case system db updated
+                discoveryform.history.FillEDSM(he, reload: true); // Fill in any EDSM info we have, force it to try again.. in case system db updated
 
                 textBoxBody.Text = he.WhereAmI + ((he.IsInHyperSpace) ? " (HS)": "");
 

--- a/EliteDangerous/EDDB/SystemClassEDDB.cs
+++ b/EliteDangerous/EDDB/SystemClassEDDB.cs
@@ -92,7 +92,7 @@ namespace EliteDangerousCore.EDDB
                                     {
                                         JObject jo = JObject.Parse(line);
 
-                                        ISystem system = SystemClassDB.FromJson(jo, SystemInfoSource.EDDB);
+                                        ISystem system = SystemClassDB.FromEDDB(jo);
 
                                         if (system.HasEDDBInformation)                                  // screen out for speed any EDDB data with empty interesting fields
                                         {

--- a/EliteDangerous/EDSM/EDSMLogFetcher.cs
+++ b/EliteDangerous/EDSM/EDSMLogFetcher.cs
@@ -137,7 +137,7 @@ namespace EliteDangerousCore.EDSM
 
                         // Get all of the local entries now that we have the entries from EDSM
                         // Moved here to avoid the race that could have been causing duplicate entries
-                        List<HistoryEntry> hlfsdlist = JournalEntry.GetAll(Commander.Nr, logstarttime.AddDays(-1), logendtime.AddDays(1)).OfType<JournalLocOrJump>().OrderBy(je => je.EventTimeUTC).Select(je => HistoryEntry.FromJournalEntry(je, null, false, out jupdate)).ToList();
+                        List<HistoryEntry> hlfsdlist = JournalEntry.GetAll(Commander.Nr, logstarttime.AddDays(-1), logendtime.AddDays(1)).OfType<JournalLocOrJump>().OrderBy(je => je.EventTimeUTC).Select(je => HistoryEntry.FromJournalEntry(je, null, out jupdate)).ToList();
 
                         HistoryList hl = new HistoryList(hlfsdlist);
                         List<DateTime> hlfsdtimes = hlfsdlist.Select(he => he.EventTimeUTC).ToList();

--- a/EliteDangerous/EliteDangerous/BindingsFile.cs
+++ b/EliteDangerous/EliteDangerous/BindingsFile.cs
@@ -432,7 +432,7 @@ namespace EliteDangerousCore
             if (device == KeyboardDeviceName)
             {
                 string ret = EliteDangerousCore.FrontierKeyConversion.FrontierToKeys(frontiername);
-                System.Diagnostics.Debug.WriteLine("Frontier Name Convert {0} to {1}", frontiername, ret);
+                //System.Diagnostics.Debug.WriteLine("Frontier Name Convert {0} to {1}", frontiername, ret);
                 return ret;
             }
             else

--- a/EliteDangerous/EliteDangerous/ISystem.cs
+++ b/EliteDangerous/EliteDangerous/ISystem.cs
@@ -106,7 +106,14 @@ namespace EliteDangerousCore
         Terraforming = 8,
         Tourism = 9,
         None = 10,
+    }
 
+    public enum SystemStatusEnum                // Who made the information?
+    {
+        Unknown = 0,
+        EDSM = 1,
+        EDDiscovery = 3,
+        EDDB = 4,
     }
 
     public interface ISystemBase : IEquatable<ISystemBase>
@@ -148,7 +155,7 @@ namespace EliteDangerousCore
         string CommanderCreate { get; set; }
         DateTime CreateDate { get; set; }
         string CommanderUpdate { get; set; }
-        EliteDangerousCore.DB.SystemStatusEnum status { get; set; }        // Who made this entry, where did the info come from?
+        SystemStatusEnum status { get; set; }        // Who made this entry, where did the info come from?
         string SystemNote { get; set; }
     }
 }

--- a/EliteDangerous/EliteDangerous/JournalEntry.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntry.cs
@@ -559,7 +559,7 @@ namespace EliteDangerousCore
                         cmd2.AddParameterWithValue("@EventData", jo.ToString());
                         cmd2.AddParameterWithValue("@EdsmId", system.id_edsm);
 
-                        //System.Diagnostics.Trace.WriteLine(string.Format("Update journal ID {0} with pos {1}/edsmid {2} dist {3}", journalid, jsonpos, system.id_edsm, dist));
+                        System.Diagnostics.Trace.WriteLine(string.Format("Update journal ID {0} with pos {1}/edsmid {2} dist {3}", journalid, jsonpos, system.id_edsm, dist));
                         cmd2.ExecuteNonQuery();
                     }
                 }

--- a/EliteDangerous/EliteDangerous/SystemCache.cs
+++ b/EliteDangerous/EliteDangerous/SystemCache.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using EliteDangerousCore.EDSM;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -63,83 +64,148 @@ namespace EliteDangerousCore
             return dx * dx + dy * dy + dz * dz;
         }
 
-        public static ISystem FindEDSM(ISystem sys, bool usedb = false, bool useedsm = false, DB.SQLiteConnectionSystem conn = null)
+        public static ISystem FindSystemConditional(ISystem sys, bool checkedsm , bool reload, DB.SQLiteConnectionSystem conn = null)
         {
-            List<ISystem> systems = systemsByName.ContainsKey(sys.name) ? systemsByName[sys.name] : new List<ISystem>();
-            ISystem sysbyid = sys.id_edsm != 0 && systemsByEdsmId.ContainsKey(sys.id_edsm) ? systemsByEdsmId[sys.id_edsm] : null;
-            ISystem sysbynamepos = null;
-            ISystem dbsys = null;
+            if (sys.status == SystemStatusEnum.EDSM || (!reload && sys.id_edsm == -1))  // if set already, or we tried and failed..
+                return null;
 
-            if (systems.Count == 1 && !sys.HasCoordinate && sys.id_edsm < 1)
+            return FindSystem(sys, checkedsm , conn);
+        }
+
+        public static ISystem FindSystem(ISystem sys, bool checkedsm , DB.SQLiteConnectionSystem conn = null)
+        {
+            List<ISystem> foundlist = new List<ISystem>();
+
+            if (sys.id_edsm > 0 && systemsByEdsmId.ContainsKey(sys.id_edsm))        // add to list
+                foundlist.Add(systemsByEdsmId[sys.id_edsm]);
+
+            if (systemsByName.ContainsKey(sys.name))            // and all names cached
+                foundlist.AddRange(systemsByName[sys.name]);
+
+            ISystem found = null;
+
+            if (sys.HasCoordinate && foundlist.Count > 0)           // if sys has a co-ord, find the best match within 0.5 ly
+                found = NearestTo(foundlist, sys , 0.5);
+
+            if (found == null && foundlist.Count == 1)              // if we did not find one, but we have only 1 candidate, use it.
+                found = foundlist[0];
+
+            if ( found == null )
             {
-                sysbynamepos = systems[0];
-            }
+                System.Diagnostics.Debug.WriteLine("Look up from DB/EDSM " + sys.name + " " + sys.id_edsm);
 
-            if (systems.Count != 0 && sys.HasCoordinate)
-            {
-                double minsqdist = 0.25;
+                bool closeit = false;
 
-                foreach (ISystem csys in systems)
+                if (conn == null)       // we may touch the db multiple times, so if we don't have it open, do it.
                 {
-                    if (csys.HasCoordinate)
+                    closeit = true;
+                    conn = new DB.SQLiteConnectionSystem();
+                }
+
+                if (sys.id_edsm > 0)        // if we have an ID, look it up
+                    found = DB.SystemClassDB.GetSystem(sys.id_edsm, conn, DB.SystemClassDB.SystemIDType.EdsmId);
+
+                // if not found, or no co-ord (unlikely), or its old as the hills, AND has a name
+
+                if ((found == null || !found.HasCoordinate || DateTime.UtcNow.Subtract(found.UpdateDate).TotalDays > 7) && sys.name.Length >= 2)
+                {
+                    if (found == null)
+                        System.Diagnostics.Trace.WriteLine($"System {sys.name} ID not found");
+                    else
+                        System.Diagnostics.Trace.WriteLine($"System {sys.name} found but rejected");
+
+                    List<ISystem> _systems = DB.SystemClassDB.GetSystemsByName(sys.name, cn: conn);     // try DB via names..
+
+                    if (_systems.Count == 0 && checkedsm)      // no name, try EDSM
                     {
-                        double sqdist = SqDist(sys, csys);
-                        if (sqdist < minsqdist)
+                        System.Diagnostics.Trace.WriteLine($"System {sys.name} not in local DB; fetching from EDSM");
+                        EDSMClass edsm = new EDSMClass();
+                        _systems = edsm.GetSystemsByName(sys.name); //from edsm, systems with this name, may return null
+                    }
+
+                    if (_systems != null)
+                    {
+                        if (_systems.Count == 1 && !sys.HasCoordinate)  // 1 name, no co-ord, go with it as a back stop
+                            found = _systems[0];
+                        else if (_systems.Count > 0 && sys.HasCoordinate)  // entries, and we have a co-ord to distinguish
                         {
-                            sysbynamepos = csys;
-                            minsqdist = sqdist;
+                            found = NearestTo(_systems, sys, 0.5);
                         }
                     }
                 }
-            }
 
-            if (sysbyid != null && sysbyid.HasCoordinate && sysbyid.UpdateDate > sys.UpdateDate)
-            {
-                return sysbyid;
-            }
-            else if (sysbynamepos != null && sysbynamepos.id_edsm > 0 && sysbynamepos.HasCoordinate && sysbynamepos.UpdateDate > sys.UpdateDate)
-            {
-                return sysbynamepos;
-            }
+                if (found == null && sys.HasCoordinate)           // finally, not foud, but we have a co-ord, find it from the db
+                    found = DB.SystemClassDB.GetSystemNearestTo(sys.x, sys.y, sys.z, conn);
 
-            if (usedb)
-            {
-                dbsys = DB.SystemClassDB.FindEDSM(sys, conn: conn, useedsm: false);
-
-                if (false && useedsm && dbsys == null && (sys.id_edsm <= 0 || !sys.HasCoordinate || DateTime.UtcNow.Subtract(sys.UpdateDate).TotalDays > 7))
+                if (closeit && conn != null)                // finished with db, close
                 {
-                    dbsys = DB.SystemClassDB.FindEDSM(sys, conn: conn, useedsm: true);
-                }
-
-                if (dbsys != null && dbsys.UpdateDate > sys.UpdateDate)
-                {
-                    sys = dbsys;
+                    conn.Dispose();
                 }
             }
 
-            if (sys.id_edsm > 0 && (sysbyid == null || sys.UpdateDate > sysbyid.UpdateDate))
+            if (found != null)                              // if we have a good db, go for it
             {
-                systemsByEdsmId[sys.id_edsm] = sys;
-            }
-
-            if (sysbynamepos == null || sys.UpdateDate > sysbynamepos.UpdateDate)
-            {
-                if (systems != null)
+                if (systemsByName.ContainsKey(sys.name))    // remove before we may alter found
                 {
-                    if (sysbynamepos != null)
+                    systemsByName[sys.name].Remove(found);  // if found did not come from this, no worries
+                }
+
+                if (sys.UpdateDate > found.UpdateDate)      // Bravada, check that we are not overwriting newer info..
+                {                                           // if the journal info is newer than the db system name, lets presume the journal data is better
+                    if (sys.HasCoordinate)
                     {
-                        systems.Remove(sysbynamepos);
+                        found.x = sys.x; found.y = sys.y; found.z = sys.z;
                     }
 
-                    systems.Add(sys);
+                    found.name = sys.name;
+                    found.UpdateDate = sys.UpdateDate;
                 }
-                else
+
+                sys = found;
+                System.Diagnostics.Trace.WriteLine($"Resolved reference to {sys.name} {sys.id_edsm}");
+            }
+
+            if (sys.id_edsm > 0)
+            {
+                if (!systemsByEdsmId.ContainsKey(sys.id_edsm)) System.Diagnostics.Trace.WriteLine($"Added {sys.name} to id cache");
+
+                systemsByEdsmId[sys.id_edsm] = sys;         // must be definition the best ID found.. and if the update date of sys is better, its now been updated
+                
+            }
+
+            if ( !systemsByName.ContainsKey(sys.name))  System.Diagnostics.Trace.WriteLine($"Added {sys.name} to name cache");
+
+            if (systemsByName.ContainsKey(sys.name))
+                systemsByName[sys.name].Add(sys);   // add to list..
+            else
+                systemsByName[sys.name] = new List<ISystem> { sys }; // or make list
+
+            System.Diagnostics.Trace.WriteLine($"Return {sys.name} {sys.id_edsm}");
+            return sys;
+
+        }
+
+        static private ISystem NearestTo(List<ISystem> list, ISystem comparesystem ,double mindist)
+        {
+            ISystem dbsys = null;
+
+            foreach (ISystem isys in list)
+            {
+                if (isys.HasCoordinate)
                 {
-                    systemsByName[sys.name] = new List<ISystem> { sys };
+                    double dist = DB.SystemClassDB.Distance(isys, comparesystem);
+
+                    if (dist < mindist)
+                    {
+                        mindist = dist;
+                        dbsys = isys;
+                    }
                 }
             }
 
-            return sys;
+            return dbsys;
         }
     }
 }
+
+

--- a/EliteDangerous/EliteDangerous/SystemCache.cs
+++ b/EliteDangerous/EliteDangerous/SystemCache.cs
@@ -64,16 +64,18 @@ namespace EliteDangerousCore
             return dx * dx + dy * dy + dz * dz;
         }
 
-        public static ISystem FindSystemConditional(ISystem sys, bool checkedsm , bool reload, DB.SQLiteConnectionSystem conn = null)
+        public static ISystem FindSystemConditional(ISystem sys, bool reload, DB.SQLiteConnectionSystem conn = null)
         {
             if (sys.status == SystemStatusEnum.EDSM || (!reload && sys.id_edsm == -1))  // if set already, or we tried and failed..
                 return null;
 
-            return FindSystem(sys, checkedsm , conn);
+            return FindSystem(sys, conn);
         }
 
-        public static ISystem FindSystem(ISystem sys, bool checkedsm , DB.SQLiteConnectionSystem conn = null)
+        public static ISystem FindSystem(ISystem sys, DB.SQLiteConnectionSystem conn = null)
         {
+            ISystem orgsys = sys;
+
             List<ISystem> foundlist = new List<ISystem>();
 
             if (sys.id_edsm > 0 && systemsByEdsmId.ContainsKey(sys.id_edsm))        // add to list
@@ -90,9 +92,9 @@ namespace EliteDangerousCore
             if (found == null && foundlist.Count == 1)              // if we did not find one, but we have only 1 candidate, use it.
                 found = foundlist[0];
 
-            if ( found == null )
+            if ( found == null )                                    // nope, no cache, so use the db
             {
-                System.Diagnostics.Debug.WriteLine("Look up from DB/EDSM " + sys.name + " " + sys.id_edsm);
+                //System.Diagnostics.Debug.WriteLine("Look up from DB " + sys.name + " " + sys.id_edsm);
 
                 bool closeit = false;
 
@@ -103,86 +105,79 @@ namespace EliteDangerousCore
                 }
 
                 if (sys.id_edsm > 0)        // if we have an ID, look it up
+                {
                     found = DB.SystemClassDB.GetSystem(sys.id_edsm, conn, DB.SystemClassDB.SystemIDType.EdsmId);
-
+                }
+                 
                 // if not found, or no co-ord (unlikely), or its old as the hills, AND has a name
 
                 if ((found == null || !found.HasCoordinate || DateTime.UtcNow.Subtract(found.UpdateDate).TotalDays > 7) && sys.name.Length >= 2)
                 {
-                    if (found == null)
-                        System.Diagnostics.Trace.WriteLine($"System {sys.name} ID not found");
-                    else
-                        System.Diagnostics.Trace.WriteLine($"System {sys.name} found but rejected");
-
                     List<ISystem> _systems = DB.SystemClassDB.GetSystemsByName(sys.name, cn: conn);     // try DB via names..
 
-                    if (_systems.Count == 0 && checkedsm)      // no name, try EDSM
-                    {
-                        System.Diagnostics.Trace.WriteLine($"System {sys.name} not in local DB; fetching from EDSM");
-                        EDSMClass edsm = new EDSMClass();
-                        _systems = edsm.GetSystemsByName(sys.name); //from edsm, systems with this name, may return null
-                    }
+                    if ( found != null )
+                        _systems.Add(found);        // add on the EDSM ID candidate.. if present
 
-                    if (_systems != null)
+                    if (_systems.Count == 1 && !sys.HasCoordinate)  // 1 name, no co-ord, go with it as a back stop
+                        found = _systems[0];
+                    else if (_systems.Count > 0 && sys.HasCoordinate)  // entries, and we have a co-ord to distinguish
                     {
-                        if (_systems.Count == 1 && !sys.HasCoordinate)  // 1 name, no co-ord, go with it as a back stop
-                            found = _systems[0];
-                        else if (_systems.Count > 0 && sys.HasCoordinate)  // entries, and we have a co-ord to distinguish
-                        {
-                            found = NearestTo(_systems, sys, 0.5);
-                        }
-                    }
+                        found = NearestTo(_systems, sys, 0.5);      // find it..
+                    }                                               // else, found will be edsmid lookup if set..
                 }
 
-                if (found == null && sys.HasCoordinate)           // finally, not foud, but we have a co-ord, find it from the db
+                if (found == null && sys.HasCoordinate)           // finally, not found, but we have a co-ord, find it from the db  by distance
                     found = DB.SystemClassDB.GetSystemNearestTo(sys.x, sys.y, sys.z, conn);
 
                 if (closeit && conn != null)                // finished with db, close
                 {
                     conn.Dispose();
                 }
-            }
 
-            if (found != null)                              // if we have a good db, go for it
-            {
-                if (systemsByName.ContainsKey(sys.name))    // remove before we may alter found
+                if (found != null)                              // if we have a good db, go for it
                 {
-                    systemsByName[sys.name].Remove(found);  // if found did not come from this, no worries
-                }
-
-                if (sys.UpdateDate > found.UpdateDate)      // Bravada, check that we are not overwriting newer info..
-                {                                           // if the journal info is newer than the db system name, lets presume the journal data is better
-                    if (sys.HasCoordinate)
+                    if ((sys.HasCoordinate && !found.HasCoordinate) || sys.UpdateDate > found.UpdateDate) // if found does not have co-ord, or sys is more up to date..
                     {
                         found.x = sys.x; found.y = sys.y; found.z = sys.z;
                     }
 
-                    found.name = sys.name;
-                    found.UpdateDate = sys.UpdateDate;
-                }
+                    if (sys.UpdateDate > found.UpdateDate)      // Bravada, check that we are not overwriting newer info..
+                    {                                           // if the journal info is newer than the db system name, lets presume the journal data is better
+                        found.name = sys.name;
+                        found.UpdateDate = sys.UpdateDate;
+                    }
 
+                    //System.Diagnostics.Trace.WriteLine($"DB found {found.name} {found.id_edsm} sysid {sys.id_edsm}");
+                    sys = found;
+                }
+                else
+                {
+                    //System.Diagnostics.Trace.WriteLine($"DB NOT found {sys.name} {sys.id_edsm} ");
+                }
+            }
+            else
+            {                                               // FROM CACHE
                 sys = found;
-                System.Diagnostics.Trace.WriteLine($"Resolved reference to {sys.name} {sys.id_edsm}");
+                //System.Diagnostics.Trace.WriteLine($"Cached reference to {sys.name} {sys.id_edsm}");
             }
 
             if (sys.id_edsm > 0)
             {
-                if (!systemsByEdsmId.ContainsKey(sys.id_edsm)) System.Diagnostics.Trace.WriteLine($"Added {sys.name} to id cache");
-
+                //if (!systemsByEdsmId.ContainsKey(sys.id_edsm)) System.Diagnostics.Trace.WriteLine($"Added {sys.name} to id cache");
                 systemsByEdsmId[sys.id_edsm] = sys;         // must be definition the best ID found.. and if the update date of sys is better, its now been updated
-                
             }
 
-            if ( !systemsByName.ContainsKey(sys.name))  System.Diagnostics.Trace.WriteLine($"Added {sys.name} to name cache");
+            if (found != null && systemsByName.ContainsKey(orgsys.name))    // use the original name we looked it up in, if we found one.. remove it
+            {
+                systemsByName[orgsys.name].Remove(found);  // if found did not come from this, no worries
+            }
 
             if (systemsByName.ContainsKey(sys.name))
                 systemsByName[sys.name].Add(sys);   // add to list..
             else
                 systemsByName[sys.name] = new List<ISystem> { sys }; // or make list
 
-            System.Diagnostics.Trace.WriteLine($"Return {sys.name} {sys.id_edsm}");
             return sys;
-
         }
 
         static private ISystem NearestTo(List<ISystem> list, ISystem comparesystem ,double mindist)

--- a/EliteDangerous/EliteDangerous/SystemCache.cs
+++ b/EliteDangerous/EliteDangerous/SystemCache.cs
@@ -12,58 +12,6 @@ namespace EliteDangerousCore
         private static Dictionary<long, ISystem> systemsByEdsmId = new Dictionary<long, ISystem>();
         private static Dictionary<string, List<ISystem>> systemsByName = new Dictionary<string, List<ISystem>>(StringComparer.InvariantCultureIgnoreCase);
 
-        public static List<ISystem> GetSystemsByName(string name)
-        {
-            if (systemsByName.ContainsKey(name))
-            {
-                return systemsByName[name];
-            }
-            else
-            {
-                List<ISystem> systems = DB.SystemClassDB.GetSystemsByName(name);
-
-                if (systems.Count != 0)
-                {
-                    systemsByName[name] = systems;
-
-                    foreach (ISystem sys in systems)
-                    {
-                        if (sys.id_edsm > 0)
-                        {
-                            systemsByEdsmId[sys.id_edsm] = sys;
-                        }
-                    }
-                }
-
-                return systems;
-            }
-        }
-
-        public static ISystem GetSystemByEdsmId(long id)
-        {
-            if (systemsByEdsmId.ContainsKey(id))
-            {
-                return systemsByEdsmId[id];
-            }
-            else
-            {
-                ISystem sys = DB.SystemClassDB.GetSystem(id, idtype: DB.SystemClassDB.SystemIDType.EdsmId);
-                if (sys != null)
-                {
-                    systemsByEdsmId[id] = sys;
-                }
-                return sys;
-            }
-        }
-
-        private static double SqDist(ISystem a, ISystem b)
-        {
-            double dx = a.x - b.x;
-            double dy = a.y - b.y;
-            double dz = a.z - b.z;
-            return dx * dx + dy * dy + dz * dz;
-        }
-
         public static ISystem FindSystemConditional(ISystem sys, bool reload, DB.SQLiteConnectionSystem conn = null)
         {
             if (sys.status == SystemStatusEnum.EDSM || (!reload && sys.id_edsm == -1))  // if set already, or we tried and failed..

--- a/EliteDangerous/EliteDangerous/SystemClass.cs
+++ b/EliteDangerous/EliteDangerous/SystemClass.cs
@@ -62,13 +62,13 @@ namespace EliteDangerousCore
         public SystemClass(string Name)
         {
             name = Name;
-            status = DB.SystemStatusEnum.Unknown;
+            status = SystemStatusEnum.Unknown;
         }
 
         public SystemClass(string Name, double vx, double vy, double vz)
         {
             name = Name;
-            status = DB.SystemStatusEnum.Unknown;
+            status = SystemStatusEnum.Unknown;
             x = vx; y = vy; z = vz;
         }
 
@@ -76,7 +76,8 @@ namespace EliteDangerousCore
         public string CommanderCreate { get; set; }
         public DateTime CreateDate { get; set; }
         public string CommanderUpdate { get; set; }
-        public EliteDangerousCore.DB.SystemStatusEnum status { get; set; }
+
+        public SystemStatusEnum status { get; set; }
         public string SystemNote { get; set; }
 
         public long id_eddb { get; set; }

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -814,7 +814,7 @@ namespace EliteDangerousCore
                             double dist = (je is JournalFSDJump) ? (je as JournalFSDJump).JumpDist : 0;
                             bool updatecoord = (je is JournalLocOrJump) ? (!(je as JournalLocOrJump).HasCoordinate && he.System.HasCoordinate) : false;
 
-                            Debug.WriteLine("Push update {0} {1}", he.System.id_edsm, he.System.name);
+                            Debug.WriteLine("Push update {0} {1} to JE {2} HE {3}", he.System.id_edsm, he.System.name, je.Id, he.Indexno);
                             JournalEntry.UpdateEDSMIDPosJump(je.Id, he.System, updatecoord, dist, conn, txn);
                         }
 

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -413,7 +413,6 @@ namespace EliteDangerousCore
             }
         }
 
-
         #endregion
 
         #region EDSM
@@ -426,8 +425,9 @@ namespace EliteDangerousCore
             {
                 foreach (HistoryEntry he in historylist)
                 {
+                    // because of the volume of requests, and for speed, do not do EDSM lookup
                     if (he.IsFSDJump && !he.System.HasCoordinate)   // try and load ones without position.. if its got pos we are happy
-                        updatesystems.Add(new Tuple<HistoryEntry, ISystem>(he, FindEDSM(he)));
+                        updatesystems.Add(new Tuple<HistoryEntry, ISystem>(he, SystemCache.FindSystemConditional(he.System,checkedsm:false,reload:false,conn:cn)));
                 }
             }
 
@@ -437,35 +437,29 @@ namespace EliteDangerousCore
             }
         }
 
-        private ISystem FindEDSM(HistoryEntry syspos, SQLiteConnectionSystem conn = null, bool reload = false, bool useedsm = false)
+        public void FillEDSM(HistoryEntry syspos, ISystem edsmsys = null, bool reload = false, SQLiteConnectionUser uconn = null)       // call to fill in ESDM data for entry, and also fills in all others pointing to the system object
         {
-            if (syspos.System.status == SystemStatusEnum.EDSC || (!reload && syspos.System.id_edsm == -1))  // if set already, or we tried and failed..
-                return null;
-
-            return SystemCache.FindEDSM(syspos.System, usedb: true, useedsm: useedsm, conn: conn);
-        }
-
-        public void FillEDSM(HistoryEntry syspos, ISystem edsmsys = null, bool reload = false, SQLiteConnectionUser uconn = null, bool useedsm = false)       // call to fill in ESDM data for entry, and also fills in all others pointing to the system object
-        {
-            if (syspos.System.status == SystemStatusEnum.EDSC || (!reload && syspos.System.id_edsm == -1))  // if set already, or we tried and failed..
+            if (syspos.System.status == SystemStatusEnum.EDSM || (!reload && syspos.System.id_edsm == -1))  // if set already, or we tried and failed..
                 return;
 
             List<HistoryEntry> alsomatching = new List<HistoryEntry>();
 
             foreach (HistoryEntry he in historylist)       // list of systems in historylist using the same system object
             {
-                if (Object.ReferenceEquals(he.System, syspos.System))
+                if (Object.ReferenceEquals(he.System, syspos.System))  
                     alsomatching.Add(he);
             }
 
             if (edsmsys == null)                              // if we found it externally, do not find again
-                edsmsys = FindEDSM(syspos, reload: reload, useedsm: useedsm);
+            {
+                edsmsys = SystemCache.FindSystem(syspos.System, checkedsm:true );   // low volume clicks which call this can do EDSM lookups
+            }
 
             if (edsmsys != null)
             {
                 foreach (HistoryEntry he in alsomatching)       // list of systems in historylist using the same system object
                 {
-                    bool updateedsmid = he.System.id_edsm <= 0;
+                    bool updateedsmid = he.System.id_edsm <= 0 && edsmsys.id_edsm>0;
                     bool updatepos = (he.EntryType == JournalTypeEnum.FSDJump || he.EntryType == JournalTypeEnum.Location) && !syspos.System.HasCoordinate && edsmsys.HasCoordinate;
 
                     if (updatepos || updateedsmid)
@@ -693,7 +687,7 @@ namespace EliteDangerousCore
             HistoryEntry prev = GetLast;
 
             bool journalupdate = false;
-            HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, true, out journalupdate);
+            HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, true, out journalupdate);     // we may check edsm for this entry
 
             if (journalupdate)
             {
@@ -745,7 +739,6 @@ namespace EliteDangerousCore
                                     string NetLogPath = null,
                                     bool ForceNetLogReload = false,
                                     bool ForceJournalReload = false,
-                                    bool CheckEdsm = false,
                                     int CurrentCommander = Int32.MinValue,
                                     bool Keepuievents = true)
         {
@@ -790,7 +783,7 @@ namespace EliteDangerousCore
                     }
 
                     bool journalupdate = false;
-                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, CheckEdsm, out journalupdate, conn, cmdr);
+                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, false, out journalupdate, conn, cmdr);
 
                     prev = he;
                     jprev = je;
@@ -800,6 +793,7 @@ namespace EliteDangerousCore
                     if (journalupdate)
                     {
                         jlistUpdated.Add(new Tuple<JournalEntry, HistoryEntry>(je, he));
+                        Debug.WriteLine("Queued update requested {0} {1}", he.System.id_edsm, he.System.name);
                     }
                 }
             }
@@ -816,11 +810,12 @@ namespace EliteDangerousCore
                         {
                             JournalEntry je = jehe.Item1;
                             HistoryEntry he = jehe.Item2;
-                            JournalFSDJump jfsd = je as JournalFSDJump;
-                            if (jfsd != null)
-                            {
-                                JournalEntry.UpdateEDSMIDPosJump(jfsd.Id, he.System, !jfsd.HasCoordinate && he.System.HasCoordinate, jfsd.JumpDist, conn, txn);
-                            }
+
+                            double dist = (je is JournalFSDJump) ? (je as JournalFSDJump).JumpDist : 0;
+                            bool updatecoord = (je is JournalLocOrJump) ? (!(je as JournalLocOrJump).HasCoordinate && he.System.HasCoordinate) : false;
+
+                            Debug.WriteLine("Push update {0} {1}", he.System.id_edsm, he.System.name);
+                            JournalEntry.UpdateEDSMIDPosJump(je.Id, he.System, updatecoord, dist, conn, txn);
                         }
 
                         txn.Commit();
@@ -838,6 +833,7 @@ namespace EliteDangerousCore
 
             return hist;
         }
+
 
         // go through the history list and recalculate the materials ledger and the materials count, plus any other stuff..
         public void ProcessUserHistoryListEntries(Func<HistoryList, List<HistoryEntry>> hlfilter)

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -427,7 +427,7 @@ namespace EliteDangerousCore
                 {
                     // because of the volume of requests, and for speed, do not do EDSM lookup
                     if (he.IsFSDJump && !he.System.HasCoordinate)   // try and load ones without position.. if its got pos we are happy
-                        updatesystems.Add(new Tuple<HistoryEntry, ISystem>(he, SystemCache.FindSystemConditional(he.System,checkedsm:false,reload:false,conn:cn)));
+                        updatesystems.Add(new Tuple<HistoryEntry, ISystem>(he, SystemCache.FindSystemConditional(he.System,reload:false,conn:cn)));
                 }
             }
 
@@ -452,7 +452,7 @@ namespace EliteDangerousCore
 
             if (edsmsys == null)                              // if we found it externally, do not find again
             {
-                edsmsys = SystemCache.FindSystem(syspos.System, checkedsm:true );   // low volume clicks which call this can do EDSM lookups
+                edsmsys = SystemCache.FindSystem(syspos.System);   
             }
 
             if (edsmsys != null)
@@ -687,7 +687,7 @@ namespace EliteDangerousCore
             HistoryEntry prev = GetLast;
 
             bool journalupdate = false;
-            HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, true, out journalupdate);     // we may check edsm for this entry
+            HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, out journalupdate);     // we may check edsm for this entry
 
             if (journalupdate)
             {
@@ -783,7 +783,7 @@ namespace EliteDangerousCore
                     }
 
                     bool journalupdate = false;
-                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, false, out journalupdate, conn, cmdr);
+                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, out journalupdate, conn, cmdr);
 
                     prev = he;
                     jprev = je;


### PR DESCRIPTION
Removed discretion of edsm lookup from eddiscoverycontroller. EDSM
lookup is only done on discrete lookups, not history compile, due to
EDSM throttling us if we ask too much
Added back FillInPositionsFSDJumps to 3dmap as they are now not very
heavy
SystemClassDB now is system DB only - no EDSM. Removed unused EDSM JSON
convert
ISystem Class now owns the source SystemStatusEnum as it should have
done
SystemCache rewriten with new logic to find a system..
HistoryEntry rewrote start up sequence and optimised.  There were
repeated parts in here, and logic errors had crept in
HistoryList FindEDSM and FillEDSM logic checked.. LoadHistory never uses
the EDSM lookup. Discrete checks do.
Other files are just minor fixes to reflect other changes