### PR TITLE
Total value and materials in ScanGrid. Jumponium notication in StarList.

### DIFF
--- a/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.Designer.cs
@@ -54,8 +54,11 @@ namespace EDDiscovery.UserControls
             this.colBriefing = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.labelTotalValue = new ExtendedControls.LabelExt();
             this.dataViewScrollerPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewScangrid)).BeginInit();
+            this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // dataViewScrollerPanel2
@@ -64,10 +67,10 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel2.Controls.Add(this.vScrollBarCustom2);
             this.dataViewScrollerPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataViewScrollerPanel2.InternalMargin = new System.Windows.Forms.Padding(0);
-            this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 0);
+            this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 26);
             this.dataViewScrollerPanel2.Name = "dataViewScrollerPanel2";
             this.dataViewScrollerPanel2.ScrollBarWidth = 20;
-            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(572, 572);
+            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(572, 546);
             this.dataViewScrollerPanel2.TabIndex = 25;
             this.dataViewScrollerPanel2.VerticalScrollBarDockRight = true;
             // 
@@ -101,7 +104,7 @@ namespace EDDiscovery.UserControls
             this.dataGridViewScangrid.RowTemplate.Height = 36;
             this.dataGridViewScangrid.RowTemplate.ReadOnly = true;
             this.dataGridViewScangrid.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewScangrid.Size = new System.Drawing.Size(552, 572);
+            this.dataGridViewScangrid.Size = new System.Drawing.Size(552, 546);
             this.dataGridViewScangrid.TabIndex = 23;
             this.dataGridViewScangrid.RowPostPaint += new System.Windows.Forms.DataGridViewRowPostPaintEventHandler(this.dataGridViewScangrid_RowPostPaint);
             // 
@@ -164,7 +167,7 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
             this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
             this.vScrollBarCustom2.Name = "vScrollBarCustom2";
-            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 551);
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(20, 525);
             this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
             this.vScrollBarCustom2.SmallChange = 1;
             this.vScrollBarCustom2.TabIndex = 24;
@@ -176,15 +179,37 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.Value = -1;
             this.vScrollBarCustom2.ValueLimited = -1;
             // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.labelTotalValue);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(572, 26);
+            this.panel1.TabIndex = 26;
+            // 
+            // labelTotalValue
+            // 
+            this.labelTotalValue.AutoSize = true;
+            this.labelTotalValue.Location = new System.Drawing.Point(3, 5);
+            this.labelTotalValue.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
+            this.labelTotalValue.Name = "labelTotalValue";
+            this.labelTotalValue.Size = new System.Drawing.Size(85, 13);
+            this.labelTotalValue.TabIndex = 0;
+            this.labelTotalValue.Text = "Scan data value";
+            // 
             // UserControlScanGrid
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.dataViewScrollerPanel2);
+            this.Controls.Add(this.panel1);
             this.Name = "UserControlScanGrid";
             this.Size = new System.Drawing.Size(572, 572);
             this.dataViewScrollerPanel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewScangrid)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -199,5 +224,7 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.DataGridViewTextBoxColumn colClass;
         private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
         private System.Windows.Forms.DataGridViewTextBoxColumn colBriefing;
+        private System.Windows.Forms.Panel panel1;
+        private ExtendedControls.LabelExt labelTotalValue;
     }
 }

--- a/EDDiscovery/UserControls/UserControlScanGrid.resx
+++ b/EDDiscovery/UserControls/UserControlScanGrid.resx
@@ -130,6 +130,6 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>307</value>
+    <value>128</value>
   </metadata>
 </root>

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -250,7 +250,7 @@ namespace EDDiscovery.UserControls
                         if (sn.ScanData!=null)
                         {
                             JournalScan sc = sn.ScanData;
-                                                                                    
+
                             if (sc.IsStar) // brief notification for special or uncommon celestial bodies, useful to traverse the history and search for that special body you discovered.
                             {
                                 // Sagittarius A* is a special body: is the centre of the Milky Way, and the only one which is classified as a Super Massive Black Hole. As far as we know...                                
@@ -274,7 +274,7 @@ namespace EDDiscovery.UserControls
                                 string WolfRayet = "Wolf-Rayet";
                                 if (sc.StarTypeText.Contains(WolfRayet))
                                     extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a " + sc.StarTypeID + " wolf-rayet star", prefix);
-                                
+
                                 // giants. It should recognize all classes of giants.
                                 string Giant = "Giant";
                                 if (sc.StarTypeText.Contains(Giant))
@@ -290,9 +290,9 @@ namespace EDDiscovery.UserControls
                             {
                                 // Check if a non-star body is a moon or not. We want it to further refine our brief summary in the visited star list.
                                 // To avoid duplicates, we need to apply our filters before on the bodies recognized as a moon, than do the same for the other bodies that do not fulfill that criteria.
-                                                               
+
                                 if (sn.level >= 2 && sn.type == StarScan.ScanNodeType.body)
-                                
+
                                 // Tell us that that special body is a moon. After all, it can be quite an outstanding discovery...
                                 {
                                     // Earth-like moon
@@ -312,7 +312,7 @@ namespace EDDiscovery.UserControls
 
                                     // Ammonia moon
                                     if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
-                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia moon", prefix);                                  
+                                        extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia moon", prefix);
                                 }
 
                                 else
@@ -329,7 +329,7 @@ namespace EDDiscovery.UserControls
                                     // Water world
                                     if (sc.PlanetTypeID == EDPlanet.Water_world && sc.Terraformable == false)
                                         extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a water world", prefix);
-                                    
+
                                     // Terraformable planet
                                     if (sc.Terraformable == true && sc.PlanetTypeID != EDPlanet.Water_world)
                                         extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is a terraformable planet", prefix);
@@ -337,6 +337,103 @@ namespace EDDiscovery.UserControls
                                     // Ammonia world
                                     if (sc.PlanetTypeID == EDPlanet.Ammonia_world)
                                         extrainfo = extrainfo.AppendPrePad(sc.BodyName + " is an ammonia world", prefix);
+                                }
+
+                                // Landable bodies with valuable materials
+                                if (sn.ScanData.IsLandable == true && sn.ScanData.HasMaterials)
+                                {
+                                    string MaterialsBrief = sn.ScanData.DisplayMaterials(4).ToString();
+                                    // jumponium materials: Arsenic (As), Cadmium (Cd), Germanium (Ge), Niobium (Nb), Polonium (Po), Vanadium (V), Yttrium (Y)
+                                    
+                                    int jump1 = 0;
+                                    int jump2 = 0;
+                                    int jump3 = 0;
+                                    int njump = 0;
+
+                                    if (MaterialsBrief.Contains("Arsenic"))
+                                    {
+                                        jump3 += 1;
+                                    }
+                                    if (MaterialsBrief.Contains("Cadmium"))
+                                    {
+                                        jump2 += 1;
+                                    }
+                                    if (MaterialsBrief.Contains("Germanium"))
+                                    {
+                                        jump1 += 1;
+                                    }
+                                    if (MaterialsBrief.Contains("Niobium"))
+                                    {
+                                        jump2 += 1;
+                                        jump3 += 1;
+                                    }
+                                    if (MaterialsBrief.Contains("Polonium"))
+                                    {
+                                        jump3 += 1;
+                                    }
+                                    if (MaterialsBrief.Contains("Vanadium"))
+                                    {
+                                        jump1 += 1;
+                                    }
+                                    if (MaterialsBrief.Contains("Yttrium"))
+                                    {
+                                        jump3 += 1;
+                                    }
+
+                                    if (jump1 > 0 || jump2 > 0 || jump3 > 0)
+                                    {
+                                        njump = jump1 + jump2 + jump3;
+
+                                        //string jumpLevel = "";
+                                        StringBuilder jumpLevel = new StringBuilder();
+                                            
+                                        // level I
+                                        if (jump1 != 0 && jump2 == 0 && jump3 == 0)
+                                        {
+                                            jumpLevel.Append(jump1 + " level I");
+                                        }
+                                        // level I and II
+                                        if (jump1 != 0 && jump2 != 0 && jump3 == 0)
+                                        {
+                                            jumpLevel.Append(jump1 + " level I and " + jump2 + " level II");
+                                        }
+                                        // level I
+                                        if (jump1 == 0 && jump2 != 0 && jump3 == 0)
+                                        {
+                                            jumpLevel.Append(jump2 + " level II");
+                                        }
+                                        // level II and III
+                                        if (jump1 == 0 && jump2 != 0 && jump3 != 0)
+                                        {
+                                            jumpLevel.Append(jump2 + " level II and " + jump2 + " level III");
+                                        }
+                                        // level III
+                                        if (jump1 == 0 && jump2 == 0 && jump3 != 0)
+                                        {
+                                            jumpLevel.Append(jump3 + " level III");
+                                        }
+                                        // level I and III
+                                        if (jump1 != 0 && jump2 == 0 && jump3 != 0)
+                                        {
+                                            jumpLevel.Append(jump1 + " level I and " + jump3 + " level III");
+                                        }
+                                        // all levels
+                                        if (jump1 != 0 && jump2 != 0 && jump3 != 0)
+                                        {
+                                            jumpLevel.Append(jump1 + " level I, " + jump2 + " level II and " + jump3 + " level III");
+                                        }
+
+                                        extrainfo = extrainfo.AppendPrePad("\n" + sc.BodyName + " has " + jumpLevel );
+                                        if (njump > 1)
+                                        {
+                                            extrainfo = extrainfo.AppendPrePad("jumponium materials. ");
+                                        }
+                                        else
+                                        {
+                                            extrainfo = extrainfo.AppendPrePad("jumponium material. ");
+                                        }
+                                    }
+
                                 }
                             }
                         }


### PR DESCRIPTION
Rewrited following the directives of @robbyxp1.

Added jumponium notification to StarList: it shows the body names, and how much of each FSD boot level it has.

Added materials for jumponium in ScanGrid: for each body which has jumponium material, display which material is available.

Added total scans value to ScanGrid: it calculate the approximate total value of the scanned bodies in the system.