### PR TITLE
Apply themeing to TabStrip sub-controls

### DIFF
--- a/ExtendedControls/Themes/ThemeStandard.cs
+++ b/ExtendedControls/Themes/ThemeStandard.cs
@@ -818,7 +818,7 @@ namespace ExtendedControls
                     }
                 }
             }
-            else if (myControl is TabStrip )
+            else if (myControl is TabStrip)
             {
                 TabStrip ts = myControl as TabStrip;
                 ts.DropDownBackgroundColor = currentsettings.colors[Settings.CI.button_back];
@@ -826,7 +826,6 @@ namespace ExtendedControls
                 ts.DropDownScrollBarButtonColor = currentsettings.colors[Settings.CI.textbox_scrollbutton];
                 ts.DropDownScrollBarColor = currentsettings.colors[Settings.CI.textbox_sliderback];
                 ts.DropDownMouseOverBackgroundColor = currentsettings.colors[Settings.CI.button_back].Multiply(mouseoverscaling);
-                return;
             }
             else
             {


### PR DESCRIPTION
[113a8314](https://github.com/EDDiscovery/EDDiscovery/commit/113a83144532657195e88c6c26a43c8535559d64#diff-a656338ecbcf571e60eeffc8f54125cdR814) seems to have added a return that wasn't needed?

Previously, changing theme during runtime would yield mixed colouring for the UserControlHistory tab, as it makes extensive use of TabStrips inside the SplitContainers. Now, all of the splits get updated appropriately.

However, the UserControlScan control may still have odd fonts and scroll bar, depending on the image size, scroll position, and theme choices. Better than it was, though! (Would have to migrate `ThemeStandard` back to `EDDiscovery` namespace to be able to correct this fully. Too much work...)

Here's before and after shots. Both images were taken starting up in the Windows Default theme, then switching over to the Elite Verdana theme.
Before: 
![01-before](https://user-images.githubusercontent.com/14035789/34681546-d6397e14-f461-11e7-8a72-23dba3428268.png)

After:
![02-after](https://user-images.githubusercontent.com/14035789/34681553-dae295f4-f461-11e7-8922-7daaab8ff1fe.png)

  