### PR TITLE
Add portable zip file to app update dialog

### DIFF
--- a/BaseUtils/HTTP/GitHubRelease.cs
+++ b/BaseUtils/HTTP/GitHubRelease.cs
@@ -52,7 +52,7 @@ namespace BaseUtils
         {
             get
             {
-                var asset = jo["assets"].FirstOrDefault(j => j["name"].Str().EndsWith(".exe"));
+                var asset = jo["assets"].FirstOrDefault(j => j["name"].Str().ToLower().EndsWith(".exe"));
                 if (asset != null)
                 {
                     string url = asset["browser_download_url"].Str();
@@ -65,7 +65,7 @@ namespace BaseUtils
         {
             get
             {
-                var asset = jo["assets"].FirstOrDefault(j => j["name"].Str().EndsWith(".msi"));
+                var asset = jo["assets"].FirstOrDefault(j => j["name"].Str().ToLower().EndsWith(".msi"));
                 if (asset != null)
                 {
                     string url = asset["browser_download_url"].Str();
@@ -78,7 +78,7 @@ namespace BaseUtils
         {
             get
             {
-                var asset = jo["assets"].FirstOrDefault(j => j["name"].Str().EndsWith(".Portable.zip"));
+                var asset = jo["assets"].FirstOrDefault(j => j["name"].Str().ToLower().EndsWith(".zip") && j["name"].Str().ToLower().Contains("portable"));
                 if (asset != null)
                 {
                     string url = asset["browser_download_url"].Str();

--- a/BaseUtils/Misc/NativeMethods.cs
+++ b/BaseUtils/Misc/NativeMethods.cs
@@ -266,10 +266,15 @@ namespace BaseUtils.Win32
         [StructLayout(LayoutKind.Sequential)]
         public struct MINMAXINFO
         {
+            /// <summary>Reserved. DO NOT USE.</summary>
             public System.Drawing.Point ptReserved;
+            /// <summary>The size of the window if it were maximized without being moved. This value defaults to the size of the primary monitor.</summary>
             public System.Drawing.Point ptMaxSize;
+            /// <summary>The position of the window if it were to be maximized without being moved.</summary>
             public System.Drawing.Point ptMaxPosition;
+            /// <summary>The minimum tracking size of the window.</summary>
             public System.Drawing.Point ptMinTrackSize;
+            /// <summary>The maximum tracking size of the window. This value defaults to slighter larger than the size of the virtual screen.</summary>
             public System.Drawing.Point ptMaxTrackSize;
         }
     }

--- a/BaseUtils/Misc/Win32Constants.cs
+++ b/BaseUtils/Misc/Win32Constants.cs
@@ -26,6 +26,18 @@ namespace BaseUtils.Win32Constants
     public static class CS
     {
         /// <summary>
+        /// CS_VREDRAW: Redraws the entire window if a movement or size adjustment changes the height of the client
+        /// area.
+        /// </summary>
+        public const int VREDRAW = 0x0001;
+
+        /// <summary>
+        /// CS_HREDRAW: Redraws the entire window if a movement or size adjustment changes the width of the client
+        /// area.
+        /// </summary>
+        public const int HREDRAW = 0x0002;
+
+        /// <summary>
         /// CS_DBLCLKS: Sends a double-click message to the window procedure when the user double-clicks the mouse
         /// while the cursor is within a window belonging to the class. Also allows for minimize/restore operations
         /// when clicking a <see cref="System.Windows.Forms.Form"/>'s TaskBar icon.
@@ -583,6 +595,7 @@ namespace BaseUtils.Win32Constants
         /// default minimum or maximum tracking size. wParam is not used, while lParam is a pointer to a
         /// <see cref="Win32.UnsafeNativeMethods.MINMAXINFO"/> struct.
         /// </summary>
+        /// <seealso href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms632626(v=vs.85).aspx"/>
         public const int GETMINMAXINFO = 0x0024;
 
         /// <summary>

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1138,10 +1138,8 @@ namespace EDDiscovery
             {
                 if (newRelease != null)
                 {
-                    NewReleaseForm frm = new NewReleaseForm();
-                    frm.release = newRelease;
-
-                    frm.ShowDialog(this);
+                    using (NewReleaseForm frm = new NewReleaseForm(newRelease))
+                        frm.ShowDialog(this);
                 }
             }
             else
@@ -1308,10 +1306,8 @@ namespace EDDiscovery
         {
             if (e.Button == MouseButtons.Left && newRelease != null)
             {
-                NewReleaseForm frm = new NewReleaseForm();
-                frm.release = newRelease;
-
-                frm.ShowDialog(this);
+                using (NewReleaseForm frm = new NewReleaseForm(newRelease))
+                    frm.ShowDialog(this);
             }
             else
             {

--- a/EDDiscovery/Forms/NewReleaseForm.Designer.cs
+++ b/EDDiscovery/Forms/NewReleaseForm.Designer.cs
@@ -55,79 +55,124 @@ namespace EDDiscovery.Forms
             this.buttonPortablezip = new ExtendedControls.ButtonExt();
             this.label3 = new System.Windows.Forms.Label();
             this.buttonMsiInstaller = new ExtendedControls.ButtonExt();
-            this.buttonExtCancel = new ExtendedControls.ButtonExt();
+            this.btnClose = new ExtendedControls.ButtonExt();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.pnlCaption = new System.Windows.Forms.Panel();
+            this.pnlMaxRestore = new ExtendedControls.DrawnPanel();
+            this.pnlClose = new ExtendedControls.DrawnPanel();
+            this.lblCaption = new System.Windows.Forms.Label();
+            this.pnlBack = new System.Windows.Forms.Panel();
             this.panel1.SuspendLayout();
+            this.pnlCaption.SuspendLayout();
+            this.pnlBack.SuspendLayout();
             this.SuspendLayout();
             // 
             // textBoxReleaseName
             // 
+            this.textBoxReleaseName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxReleaseName.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            this.textBoxReleaseName.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
             this.textBoxReleaseName.BorderColor = System.Drawing.Color.Transparent;
             this.textBoxReleaseName.BorderColorScaling = 0.5F;
-            this.textBoxReleaseName.Location = new System.Drawing.Point(99, 19);
+            this.textBoxReleaseName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBoxReleaseName.ControlBackground = System.Drawing.SystemColors.Control;
+            this.textBoxReleaseName.Location = new System.Drawing.Point(99, 9);
+            this.textBoxReleaseName.Multiline = false;
             this.textBoxReleaseName.Name = "textBoxReleaseName";
             this.textBoxReleaseName.ReadOnly = true;
-            this.textBoxReleaseName.Size = new System.Drawing.Size(155, 20);
+            this.textBoxReleaseName.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.textBoxReleaseName.SelectionLength = 0;
+            this.textBoxReleaseName.SelectionStart = 0;
+            this.textBoxReleaseName.Size = new System.Drawing.Size(298, 20);
             this.textBoxReleaseName.TabIndex = 0;
+            this.textBoxReleaseName.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            this.textBoxReleaseName.WordWrap = true;
             // 
             // labelName
             // 
             this.labelName.AutoSize = true;
-            this.labelName.Location = new System.Drawing.Point(14, 22);
+            this.labelName.Location = new System.Drawing.Point(15, 12);
             this.labelName.Name = "labelName";
             this.labelName.Size = new System.Drawing.Size(35, 13);
             this.labelName.TabIndex = 1;
             this.labelName.Text = "Name";
-            this.labelName.Click += new System.EventHandler(this.labelName_Click);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(14, 55);
+            this.label1.Location = new System.Drawing.Point(15, 43);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(54, 13);
+            this.label1.Size = new System.Drawing.Size(65, 13);
             this.label1.TabIndex = 2;
-            this.label1.Text = "GitHub url";
+            this.label1.Text = "GitHub URL";
             // 
             // textBoxGitHubURL
             // 
+            this.textBoxGitHubURL.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxGitHubURL.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            this.textBoxGitHubURL.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
             this.textBoxGitHubURL.BorderColor = System.Drawing.Color.Transparent;
             this.textBoxGitHubURL.BorderColorScaling = 0.5F;
-            this.textBoxGitHubURL.Location = new System.Drawing.Point(101, 52);
+            this.textBoxGitHubURL.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBoxGitHubURL.ControlBackground = System.Drawing.SystemColors.Control;
+            this.textBoxGitHubURL.Location = new System.Drawing.Point(99, 38);
+            this.textBoxGitHubURL.Multiline = false;
             this.textBoxGitHubURL.Name = "textBoxGitHubURL";
             this.textBoxGitHubURL.ReadOnly = true;
-            this.textBoxGitHubURL.Size = new System.Drawing.Size(278, 20);
+            this.textBoxGitHubURL.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.textBoxGitHubURL.SelectionLength = 0;
+            this.textBoxGitHubURL.SelectionStart = 0;
+            this.textBoxGitHubURL.Size = new System.Drawing.Size(218, 20);
             this.textBoxGitHubURL.TabIndex = 3;
+            this.textBoxGitHubURL.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            this.textBoxGitHubURL.WordWrap = true;
             // 
             // buttonUrlOpen
             // 
-            this.buttonUrlOpen.BorderColorScaling = 1.25F;
-            this.buttonUrlOpen.ButtonColorScaling = 0.5F;
-            this.buttonUrlOpen.ButtonDisabledScaling = 0.5F;
-            this.buttonUrlOpen.Location = new System.Drawing.Point(385, 50);
+            this.buttonUrlOpen.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonUrlOpen.Location = new System.Drawing.Point(323, 38);
             this.buttonUrlOpen.Name = "buttonUrlOpen";
-            this.buttonUrlOpen.Size = new System.Drawing.Size(75, 23);
+            this.buttonUrlOpen.Size = new System.Drawing.Size(74, 23);
             this.buttonUrlOpen.TabIndex = 4;
-            this.buttonUrlOpen.Text = "Open";
+            this.buttonUrlOpen.Text = "&Open";
             this.buttonUrlOpen.UseVisualStyleBackColor = true;
             this.buttonUrlOpen.Click += new System.EventHandler(this.buttonUrlOpen_Click);
             // 
             // richTextBoxReleaseInfo
             // 
+            this.richTextBoxReleaseInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.richTextBoxReleaseInfo.BorderColor = System.Drawing.Color.Transparent;
             this.richTextBoxReleaseInfo.BorderColorScaling = 0.5F;
             this.richTextBoxReleaseInfo.HideScrollBar = true;
-            this.richTextBoxReleaseInfo.Location = new System.Drawing.Point(101, 92);
+            this.richTextBoxReleaseInfo.Location = new System.Drawing.Point(99, 67);
             this.richTextBoxReleaseInfo.Name = "richTextBoxReleaseInfo";
+            this.richTextBoxReleaseInfo.ReadOnly = true;
+            this.richTextBoxReleaseInfo.ScrollBarArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.richTextBoxReleaseInfo.ScrollBarArrowButtonColor = System.Drawing.Color.LightGray;
+            this.richTextBoxReleaseInfo.ScrollBarBackColor = System.Drawing.SystemColors.Control;
+            this.richTextBoxReleaseInfo.ScrollBarBorderColor = System.Drawing.Color.White;
+            this.richTextBoxReleaseInfo.ScrollBarFlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.richTextBoxReleaseInfo.ScrollBarForeColor = System.Drawing.SystemColors.ControlText;
+            this.richTextBoxReleaseInfo.ScrollBarMouseOverButtonColor = System.Drawing.Color.Green;
+            this.richTextBoxReleaseInfo.ScrollBarMousePressedButtonColor = System.Drawing.Color.Red;
+            this.richTextBoxReleaseInfo.ScrollBarSliderColor = System.Drawing.Color.DarkGray;
+            this.richTextBoxReleaseInfo.ScrollBarThumbBorderColor = System.Drawing.Color.Yellow;
+            this.richTextBoxReleaseInfo.ScrollBarThumbButtonColor = System.Drawing.Color.DarkBlue;
             this.richTextBoxReleaseInfo.ScrollBarWidth = 20;
             this.richTextBoxReleaseInfo.ShowLineCount = false;
-            this.richTextBoxReleaseInfo.Size = new System.Drawing.Size(358, 180);
+            this.richTextBoxReleaseInfo.Size = new System.Drawing.Size(298, 75);
             this.richTextBoxReleaseInfo.TabIndex = 5;
+            this.richTextBoxReleaseInfo.TextBoxBackColor = System.Drawing.SystemColors.Control;
+            this.richTextBoxReleaseInfo.TextBoxForeColor = System.Drawing.SystemColors.ControlText;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(14, 95);
+            this.label2.Location = new System.Drawing.Point(15, 67);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(66, 13);
             this.label2.TabIndex = 6;
@@ -135,34 +180,31 @@ namespace EDDiscovery.Forms
             // 
             // buttonExeInstaller
             // 
-            this.buttonExeInstaller.BorderColorScaling = 1.25F;
-            this.buttonExeInstaller.ButtonColorScaling = 0.5F;
-            this.buttonExeInstaller.ButtonDisabledScaling = 0.5F;
-            this.buttonExeInstaller.Location = new System.Drawing.Point(101, 292);
+            this.buttonExeInstaller.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonExeInstaller.Location = new System.Drawing.Point(100, 148);
             this.buttonExeInstaller.Name = "buttonExeInstaller";
-            this.buttonExeInstaller.Size = new System.Drawing.Size(107, 23);
+            this.buttonExeInstaller.Size = new System.Drawing.Size(95, 23);
             this.buttonExeInstaller.TabIndex = 7;
-            this.buttonExeInstaller.Text = "Exe installer";
+            this.buttonExeInstaller.Text = "&Exe Installer";
             this.buttonExeInstaller.UseVisualStyleBackColor = true;
             this.buttonExeInstaller.Click += new System.EventHandler(this.buttonExeInstaller_Click);
             // 
             // buttonPortablezip
             // 
-            this.buttonPortablezip.BorderColorScaling = 1.25F;
-            this.buttonPortablezip.ButtonColorScaling = 0.5F;
-            this.buttonPortablezip.ButtonDisabledScaling = 0.5F;
-            this.buttonPortablezip.Location = new System.Drawing.Point(327, 292);
+            this.buttonPortablezip.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonPortablezip.Location = new System.Drawing.Point(302, 148);
             this.buttonPortablezip.Name = "buttonPortablezip";
-            this.buttonPortablezip.Size = new System.Drawing.Size(132, 23);
+            this.buttonPortablezip.Size = new System.Drawing.Size(95, 23);
             this.buttonPortablezip.TabIndex = 8;
-            this.buttonPortablezip.Text = "Portable Zip";
+            this.buttonPortablezip.Text = "&Portable Zip";
             this.buttonPortablezip.UseVisualStyleBackColor = true;
             this.buttonPortablezip.Click += new System.EventHandler(this.buttonPortablezip_Click);
             // 
             // label3
             // 
+            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(14, 297);
+            this.label3.Location = new System.Drawing.Point(15, 153);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(55, 13);
             this.label3.TabIndex = 9;
@@ -170,35 +212,34 @@ namespace EDDiscovery.Forms
             // 
             // buttonMsiInstaller
             // 
-            this.buttonMsiInstaller.BorderColorScaling = 1.25F;
-            this.buttonMsiInstaller.ButtonColorScaling = 0.5F;
-            this.buttonMsiInstaller.ButtonDisabledScaling = 0.5F;
-            this.buttonMsiInstaller.Location = new System.Drawing.Point(214, 292);
+            this.buttonMsiInstaller.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonMsiInstaller.Location = new System.Drawing.Point(201, 148);
             this.buttonMsiInstaller.Name = "buttonMsiInstaller";
-            this.buttonMsiInstaller.Size = new System.Drawing.Size(107, 23);
+            this.buttonMsiInstaller.Size = new System.Drawing.Size(95, 23);
             this.buttonMsiInstaller.TabIndex = 10;
-            this.buttonMsiInstaller.Text = "Msi installer";
+            this.buttonMsiInstaller.Text = "&Msi Installer";
             this.buttonMsiInstaller.UseVisualStyleBackColor = true;
             this.buttonMsiInstaller.Click += new System.EventHandler(this.buttonMsiInstaller_Click);
             // 
-            // buttonExtCancel
+            // btnClose
             // 
-            this.buttonExtCancel.BorderColorScaling = 1.25F;
-            this.buttonExtCancel.ButtonColorScaling = 0.5F;
-            this.buttonExtCancel.ButtonDisabledScaling = 0.5F;
-            this.buttonExtCancel.Location = new System.Drawing.Point(385, 330);
-            this.buttonExtCancel.Name = "buttonExtCancel";
-            this.buttonExtCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonExtCancel.TabIndex = 11;
-            this.buttonExtCancel.Text = "Close";
-            this.buttonExtCancel.UseVisualStyleBackColor = true;
-            this.buttonExtCancel.Click += new System.EventHandler(this.buttonExtCancel_Click);
+            this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnClose.Location = new System.Drawing.Point(322, 177);
+            this.btnClose.Name = "btnClose";
+            this.btnClose.Size = new System.Drawing.Size(75, 23);
+            this.btnClose.TabIndex = 11;
+            this.btnClose.Text = "&Close";
+            this.btnClose.UseVisualStyleBackColor = true;
+            this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
             // 
             // panel1
             // 
-            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.Controls.Add(this.labelName);
-            this.panel1.Controls.Add(this.buttonExtCancel);
+            this.panel1.Controls.Add(this.btnClose);
             this.panel1.Controls.Add(this.textBoxReleaseName);
             this.panel1.Controls.Add(this.buttonMsiInstaller);
             this.panel1.Controls.Add(this.label1);
@@ -209,25 +250,89 @@ namespace EDDiscovery.Forms
             this.panel1.Controls.Add(this.buttonExeInstaller);
             this.panel1.Controls.Add(this.richTextBoxReleaseInfo);
             this.panel1.Controls.Add(this.label2);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Location = new System.Drawing.Point(0, 30);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(477, 368);
+            this.panel1.Size = new System.Drawing.Size(413, 210);
             this.panel1.TabIndex = 12;
+            // 
+            // pnlCaption
+            // 
+            this.pnlCaption.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pnlCaption.Controls.Add(this.pnlMaxRestore);
+            this.pnlCaption.Controls.Add(this.pnlClose);
+            this.pnlCaption.Controls.Add(this.lblCaption);
+            this.pnlCaption.Location = new System.Drawing.Point(0, 0);
+            this.pnlCaption.Name = "pnlCaption";
+            this.pnlCaption.Size = new System.Drawing.Size(413, 24);
+            this.pnlCaption.TabIndex = 12;
+            this.pnlCaption.MouseDown += new System.Windows.Forms.MouseEventHandler(this.Caption_MouseDown);
+            this.pnlCaption.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Caption_MouseUp);
+            // 
+            // pnlMaxRestore
+            // 
+            this.pnlMaxRestore.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.pnlMaxRestore.ImageSelected = ExtendedControls.DrawnPanel.ImageType.Maximize;
+            this.pnlMaxRestore.Location = new System.Drawing.Point(359, 0);
+            this.pnlMaxRestore.Name = "pnlMaxRestore";
+            this.pnlMaxRestore.Size = new System.Drawing.Size(24, 24);
+            this.pnlMaxRestore.TabIndex = 2;
+            this.pnlMaxRestore.MouseClick += new System.Windows.Forms.MouseEventHandler(this.pnlMaxRestore_MouseClick);
+            // 
+            // pnlClose
+            // 
+            this.pnlClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.pnlClose.Location = new System.Drawing.Point(389, 0);
+            this.pnlClose.Name = "pnlClose";
+            this.pnlClose.Size = new System.Drawing.Size(24, 24);
+            this.pnlClose.TabIndex = 1;
+            this.pnlClose.MouseClick += new System.Windows.Forms.MouseEventHandler(this.pnlClose_MouseClick);
+            // 
+            // lblCaption
+            // 
+            this.lblCaption.AutoSize = true;
+            this.lblCaption.Location = new System.Drawing.Point(9, 6);
+            this.lblCaption.Name = "lblCaption";
+            this.lblCaption.Size = new System.Drawing.Size(111, 13);
+            this.lblCaption.TabIndex = 0;
+            this.lblCaption.Text = "EDDiscovery Release";
+            this.lblCaption.MouseDown += new System.Windows.Forms.MouseEventHandler(this.Caption_MouseDown);
+            this.lblCaption.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Caption_MouseUp);
+            // 
+            // pnlBack
+            // 
+            this.pnlBack.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pnlBack.Controls.Add(this.panel1);
+            this.pnlBack.Controls.Add(this.pnlCaption);
+            this.pnlBack.Location = new System.Drawing.Point(3, 3);
+            this.pnlBack.Name = "pnlBack";
+            this.pnlBack.Size = new System.Drawing.Size(413, 240);
+            this.pnlBack.TabIndex = 13;
             // 
             // NewReleaseForm
             // 
+            this.AcceptButton = this.btnClose;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(477, 368);
-            this.Controls.Add(this.panel1);
+            this.CancelButton = this.btnClose;
+            this.ClientSize = new System.Drawing.Size(419, 246);
+            this.Controls.Add(this.pnlBack);
+            this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(435, 285);
             this.Name = "NewReleaseForm";
+            this.ShowInTaskbar = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "EDDiscovery release";
-            this.Load += new System.EventHandler(this.NewReleaseForm_Load);
+            this.Text = "EDDiscovery Release";
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
+            this.pnlCaption.ResumeLayout(false);
+            this.pnlCaption.PerformLayout();
+            this.pnlBack.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -245,7 +350,12 @@ namespace EDDiscovery.Forms
         private ExtendedControls.ButtonExt buttonPortablezip;
         private System.Windows.Forms.Label label3;
         private ExtendedControls.ButtonExt buttonMsiInstaller;
-        private ExtendedControls.ButtonExt buttonExtCancel;
+        private ExtendedControls.ButtonExt btnClose;
         private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Panel pnlCaption;
+        private System.Windows.Forms.Label lblCaption;
+        private ExtendedControls.DrawnPanel pnlMaxRestore;
+        private ExtendedControls.DrawnPanel pnlClose;
+        private System.Windows.Forms.Panel pnlBack;
     }
 }

--- a/EDDiscovery/Forms/NewReleaseForm.cs
+++ b/EDDiscovery/Forms/NewReleaseForm.cs
@@ -13,6 +13,10 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using BaseUtils;
+using BaseUtils.Win32;
+using BaseUtils.Win32Constants;
+using ExtendedControls;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -26,69 +30,183 @@ using System.Windows.Forms;
 
 namespace EDDiscovery.Forms
 {
-    public partial class NewReleaseForm : Form
+    public partial class NewReleaseForm : DraggableForm
     {
-        public BaseUtils.GitHubRelease release;
-        public NewReleaseForm()
+        private GitHubRelease _release = null;
+
+        public NewReleaseForm(GitHubRelease release)
         {
+            _release = release;
             InitializeComponent();
-            EDDiscovery.EDDTheme theme = EDDiscovery.EDDTheme.Instance;
-            theme.ApplyToForm(this);
         }
 
 
-        private void NewReleaseForm_Load(object sender, EventArgs e)
+        protected override void OnFormClosed(FormClosedEventArgs e)
         {
-            if (release == null)
-                return;
+            base.OnFormClosed(e);
+            _release = null;
+        }
 
+        protected override void OnLoad(EventArgs e)
+        {
+            var framed = EDDTheme.Instance?.ApplyToForm(this) ?? true;
+            if (framed)
+            {
+                // hide the caption panel, and resize the bottom panel to fit.
+                var yoff = panel1.Location.Y - pnlCaption.Location.Y;
+                pnlCaption.Visible = false;
+                panel1.Location = pnlCaption.Location;
+                panel1.Height += yoff;
+            }
+            else
+            {
+                // draw a thin border to serve as a resizing frame.
+                pnlBack.BorderStyle = BorderStyle.FixedSingle;
+            }
 
-            textBoxReleaseName.Text = release.ReleaseName;
-            textBoxGitHubURL.Text = release.HtmlURL;
-            richTextBoxReleaseInfo.Text = release.Description;
+            if (_release != null)
+            {
+                textBoxReleaseName.Text = _release.ReleaseName;
+                textBoxGitHubURL.Text = _release.HtmlURL;
+                richTextBoxReleaseInfo.Text = _release.Description;
 
-            if (release.ExeInstallerLink == null)
-                buttonExeInstaller.Visible = false;
+                if (string.IsNullOrEmpty(_release.ExeInstallerLink))
+                    buttonExeInstaller.Visible = false;
 
-            if (release.PortableInstallerLink == null)
-                buttonPortablezip.Visible = false;
+                if (string.IsNullOrEmpty(_release.PortableInstallerLink))
+                    buttonPortablezip.Visible = false;
 
-            if (release.MsiInstallerLink == null)
-                buttonMsiInstaller.Visible = false;
+                if (string.IsNullOrEmpty(_release.MsiInstallerLink))
+                    buttonMsiInstaller.Visible = false;
+            }
 
+            base.OnLoad(e);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            if (pnlCaption.Visible)
+            {
+                if (this.WindowState == FormWindowState.Maximized && pnlMaxRestore.ImageSelected != DrawnPanel.ImageType.Restore)
+                {
+                    pnlMaxRestore.ImageSelected = DrawnPanel.ImageType.Restore;
+                    pnlMaxRestore.Invalidate();     // TODO: the control should really do this automatically
+                }
+                else if (this.WindowState == FormWindowState.Normal && pnlMaxRestore.ImageSelected != DrawnPanel.ImageType.Maximize)
+                {
+                    pnlMaxRestore.ImageSelected = DrawnPanel.ImageType.Maximize;
+                    pnlMaxRestore.Invalidate();     // TODO: the control should really do this automatically
+                }   
+            }
+
+            base.OnResize(e);
+
+            // Inhibit an issue where text box borders have artifacts displayed after a resize.
+            // For some reason ControlStyles.ResizeRedraw, CS_VREDRAW, and/or CS_HREDRAW don't seem to fix it.
+            if (this.FormBorderStyle == FormBorderStyle.None)
+                Invalidate(true);
+        }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            base.OnTextChanged(e);
+
+            lblCaption.Text = this.Text;
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case WM.INITMENU:       // Win32: disable the minimize system menu item.
+                    {
+                        base.WndProc(ref m);    // Base should always get first crack at this.
+
+                        if (m.WParam != IntPtr.Zero && Environment.OSVersion.Platform == PlatformID.Win32NT && IsHandleCreated)
+                        {
+                            UnsafeNativeMethods.EnableMenuItem(m.WParam, SC.MINIMIZE, MF.GRAYED);
+                        }
+                        return;
+                    }
+
+                case WM.SYSCOMMAND:     // Block the minimize system command.
+                    {
+                        if (m.WParam == (IntPtr)SC.MINIMIZE)
+                        {
+                            m.Result = IntPtr.Zero;
+                            return;
+                        }
+                        break;
+                    }
+            }
+            base.WndProc(ref m);
         }
 
 
         private void buttonUrlOpen_Click(object sender, EventArgs e)
         {
-            Process.Start(release.HtmlURL);
-        }
-
-        private void labelName_Click(object sender, EventArgs e)
-        {
-
+            Process.Start(_release.HtmlURL);
         }
 
         private void buttonExeInstaller_Click(object sender, EventArgs e)
         {
-            Process.Start(release.ExeInstallerLink);
+            Process.Start(_release.ExeInstallerLink);
         }
 
         private void buttonPortablezip_Click(object sender, EventArgs e)
         {
-            Process.Start(release.PortableInstallerLink);
-
+            Process.Start(_release.PortableInstallerLink);
         }
 
         private void buttonMsiInstaller_Click(object sender, EventArgs e)
         {
-            Process.Start(release.MsiInstallerLink);
-
+            Process.Start(_release.MsiInstallerLink);
         }
 
-        private void buttonExtCancel_Click(object sender, EventArgs e)
+        private void btnClose_Click(object sender, EventArgs e)
         {
             Close();
         }
+
+        #region Caption controls
+
+        private void Caption_MouseDown(object sender, MouseEventArgs e)
+        {
+            OnCaptionMouseDown((Control)sender, e);
+        }
+
+        private void Caption_MouseUp(object sender, MouseEventArgs e)
+        {
+            OnCaptionMouseUp((Control)sender, e);
+        }
+
+        private void pnlMaxRestore_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                switch (this.WindowState)
+                {
+                    case FormWindowState.Maximized:
+                        this.WindowState = FormWindowState.Normal;
+                        break;
+
+                    case FormWindowState.Normal:
+                        this.WindowState = FormWindowState.Maximized;
+                        break;
+                }
+            }
+            else if (e.Button == MouseButtons.Right)
+                Caption_MouseUp(sender, e);
+        }
+
+        private void pnlClose_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+                Close();
+            else if (e.Button == MouseButtons.Right)
+                Caption_MouseUp(sender, e);
+        }
+
+        #endregion
     }
 }

--- a/ExtendedControls/Forms/DraggableForm.cs
+++ b/ExtendedControls/Forms/DraggableForm.cs
@@ -119,13 +119,15 @@ namespace ExtendedControls
 
                             if (AllowResize)
                             {
-                                mmi.ptMaxSize.X = wa.Width;
-                                mmi.ptMaxSize.Y = wa.Height;
-
                                 if (!this.MaximumSize.IsEmpty)
                                 {
-                                    mmi.ptMaxTrackSize.X = this.MaximumSize.Width;
-                                    mmi.ptMaxTrackSize.Y = this.MaximumSize.Height;
+                                    mmi.ptMaxSize.X = mmi.ptMaxTrackSize.X = this.MaximumSize.Width;
+                                    mmi.ptMaxSize.Y = mmi.ptMaxTrackSize.Y = this.MaximumSize.Height;
+                                }
+                                else
+                                {
+                                    mmi.ptMaxSize.X = wa.Width;
+                                    mmi.ptMaxSize.Y = wa.Height;
                                 }
 
                                 if (!this.MinimumSize.IsEmpty)

--- a/ExtendedControls/Forms/DraggableForm.cs
+++ b/ExtendedControls/Forms/DraggableForm.cs
@@ -105,9 +105,9 @@ namespace ExtendedControls
 
             switch (m.Msg)
             {
-                case WM.GETMINMAXINFO:  // Don't overlap the taskbar when maximizing without a windows border.
+                case WM.GETMINMAXINFO:  // Set form min/max sizes when not using a windows border.
                     {
-                        if (m.LParam != IntPtr.Zero && !windowsborder && AllowResize)
+                        if (m.LParam != IntPtr.Zero && Environment.OSVersion.Platform == PlatformID.Win32NT && !windowsborder)
                         {
                             var sc = Screen.FromControl(this);
                             var scb = sc.Bounds;
@@ -117,8 +117,33 @@ namespace ExtendedControls
                             mmi.ptMaxPosition.X = wa.Left - scb.Left;
                             mmi.ptMaxPosition.Y = wa.Top - scb.Top;
 
-                            mmi.ptMaxSize.X = wa.Width;
-                            mmi.ptMaxSize.Y = wa.Height;
+                            if (AllowResize)
+                            {
+                                mmi.ptMaxSize.X = wa.Width;
+                                mmi.ptMaxSize.Y = wa.Height;
+
+                                if (!this.MaximumSize.IsEmpty)
+                                {
+                                    mmi.ptMaxTrackSize.X = this.MaximumSize.Width;
+                                    mmi.ptMaxTrackSize.Y = this.MaximumSize.Height;
+                                }
+
+                                if (!this.MinimumSize.IsEmpty)
+                                {
+                                    mmi.ptMinTrackSize.X = this.MinimumSize.Width;
+                                    mmi.ptMinTrackSize.Y = this.MinimumSize.Height;
+                                }
+                                else
+                                {
+                                    mmi.ptMinTrackSize.X = UnsafeNativeMethods.GetSystemMetrics(SystemMetrics.CXMINTRACK);
+                                    mmi.ptMinTrackSize.Y = UnsafeNativeMethods.GetSystemMetrics(SystemMetrics.CYMINTRACK);
+                                }
+                            }
+                            else
+                            {
+                                mmi.ptMaxSize.X = mmi.ptMaxTrackSize.X = mmi.ptMinTrackSize.X = ClientSize.Width;
+                                mmi.ptMaxSize.Y = mmi.ptMaxTrackSize.Y = mmi.ptMinTrackSize.Y = ClientSize.Height;
+                            }
 
                             Marshal.StructureToPtr(mmi, m.LParam, false);
                             m.Result = IntPtr.Zero;

--- a/ExtendedControls/Forms/SmartSysMenuForm.cs
+++ b/ExtendedControls/Forms/SmartSysMenuForm.cs
@@ -210,7 +210,7 @@ namespace ExtendedControls
                             Opacity = (wp - SC_OPACITYSUBMENU) / 10f;
                         else if (wp >= SC_ADDITIONALMENU && AdditionalSysMenus != null && wp < SC_ADDITIONALMENU + AdditionalSysMenus.Count)
                             AdditionalSysMenuSelected?.Invoke(wp - SC_ADDITIONALMENU);
-                        else if (m.WParam == (IntPtr)SC.KEYMENU && (CreateParams.Style & WS.SYSMENU) == 0 && (CreateParams.Style & WS.CAPTION) == 0)
+                        else if (m.WParam == (IntPtr)SC.KEYMENU && m.LParam == (IntPtr)' ' && (CreateParams.Style & WS.SYSMENU) == 0 && (CreateParams.Style & WS.CAPTION) == 0)
                             ShowSystemMenu(PointToScreen(new Point(5, 5)));
                         else if (!AllowResize && (m.WParam == (IntPtr)SC.MAXIMIZE || m.WParam == (IntPtr)SC.SIZE || m.WParam == (IntPtr)SC.RESTORE))
                             return;     // Access Denied.


### PR DESCRIPTION
Fixes #1611

This went overlooked when the portable zip was renamed for 8.3.3.

Squashed a number of other bugs discovered along the way:
* Match GitHub file names case-insensitively.
* `NewReleaseForm` dialog can now be resized.
* Fix `Form` min/max sizes being ignored by `DraggableForm`.
  * Was previously allowed to get down to `2x2`...
  * `Form.MaximumSize` and `Form.MinimumSize` values are now respected.
* Stop <kbd>Alt</kbd> keypresses (with no secondary key) from opening the system menu.
  * Only show the system menu with <kbd>Alt</kbd>+<kbd>Space</kbd>.