### PR TITLE
Implement PR1555 search timer delay but in a safe UI Form timer

### DIFF
--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -63,6 +63,8 @@ namespace EDDiscovery.UserControls
             public const int HistoryTag = 2;
         }
 
+        Timer searchtimer;
+
         public UserControlJournalGrid()
         {
             InitializeComponent();
@@ -87,6 +89,9 @@ namespace EDDiscovery.UserControls
 
             ExtraIcons(false,false);
 
+            searchtimer = new Timer() { Interval = 500 };
+            searchtimer.Tick += Searchtimer_Tick;
+
             discoveryform.OnHistoryChange += Display;
             discoveryform.OnNewEntry += AddNewEntry;
         }
@@ -109,6 +114,7 @@ namespace EDDiscovery.UserControls
             discoveryform.OnHistoryChange -= Display;
             discoveryform.OnNewEntry -= AddNewEntry;
             SQLiteConnectionUser.PutSettingBool(DbAutoTop, checkBoxMoveToTop.Checked);
+            searchtimer.Dispose();
         }
 
         #endregion
@@ -248,6 +254,15 @@ namespace EDDiscovery.UserControls
 
         private void textBoxFilter_TextChanged(object sender, EventArgs e)
         {
+            searchtimer.Stop();
+            searchtimer.Start();
+        }
+
+        private void Searchtimer_Tick(object sender, EventArgs e)
+        {
+            searchtimer.Stop();
+            this.Cursor = Cursors.WaitCursor;
+
             Tuple<long, int> pos = CurrentGridPosByJID();
 
             StaticFilters.FilterGridView(dataGridViewJournal, textBoxFilter.Text);
@@ -255,6 +270,8 @@ namespace EDDiscovery.UserControls
             int rowno = FindGridPosByJID(pos.Item1,true);
             if (rowno >= 0)
                 dataGridViewJournal.CurrentCell = dataGridViewJournal.Rows[rowno].Cells[pos.Item2];       // its the current cell which needs to be set, moves the row marker as well            currentGridRow = (rowno!=-1) ? 
+
+            this.Cursor = Cursors.Default;
         }
 
         private void comboBoxJournalWindow_SelectedIndexChanged(object sender, EventArgs e)

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -91,6 +91,8 @@ namespace EDDiscovery.UserControls
 
         EventFilterSelector cfs = new EventFilterSelector();
 
+        Timer searchtimer;
+
         public UserControlTravelGrid()
         {
             InitializeComponent();
@@ -118,6 +120,9 @@ namespace EDDiscovery.UserControls
 
             ExtraIcons(false,false);
 
+            searchtimer = new Timer() { Interval = 500 };
+            searchtimer.Tick += Searchtimer_Tick;
+
             discoveryform.OnHistoryChange += HistoryChanged;
             discoveryform.OnNewEntry += AddNewEntry;
             discoveryform.OnNoteChanged += OnNoteChanged;
@@ -141,6 +146,7 @@ namespace EDDiscovery.UserControls
             discoveryform.OnHistoryChange -= HistoryChanged;
             discoveryform.OnNewEntry -= AddNewEntry;
             SQLiteConnectionUser.PutSettingBool(DbAutoTop, checkBoxMoveToTop.Checked);
+            searchtimer.Dispose();
         }
 
         #endregion
@@ -395,15 +401,30 @@ namespace EDDiscovery.UserControls
             }
         }
 
+
         private void textBoxFilter_TextChanged(object sender, EventArgs e)
         {
+            searchtimer.Stop();
+            searchtimer.Start();
+            //System.Diagnostics.Debug.WriteLine(Environment.TickCount % 10000 + "Char");
+        }
+
+        private void Searchtimer_Tick(object sender, EventArgs e)
+        {
+            searchtimer.Stop();
+            this.Cursor = Cursors.WaitCursor;
+
+            //System.Diagnostics.Debug.WriteLine(Environment.TickCount % 10000 + "Searching");
             Tuple<long, int> pos = CurrentGridPosByJID();
 
             StaticFilters.FilterGridView(dataGridViewTravel, textBoxFilter.Text);
 
-            int rowno = FindGridPosByJID(pos.Item1,true);
+            int rowno = FindGridPosByJID(pos.Item1, true);
             if (rowno >= 0)
                 dataGridViewTravel.CurrentCell = dataGridViewTravel.Rows[rowno].Cells[pos.Item2];
+
+            this.Cursor = Cursors.Default;
+            //System.Diagnostics.Debug.WriteLine(Environment.TickCount % 10000 + "Complete");
         }
 
         private void dataGridViewTravel_RowPostPaint(object sender, DataGridViewRowPostPaintEventArgs e)


### PR DESCRIPTION
Using a form timer means its inheritently UI thread safe.  Uses a wait
cursor for the delay time so as not to need yet another UI element on
screen