### PR TITLE
Fix some various UI things

### DIFF
--- a/EDDiscovery/Forms/ExportForm.Designer.cs
+++ b/EDDiscovery/Forms/ExportForm.Designer.cs
@@ -258,6 +258,7 @@
             this.label_index.TabIndex = 28;
             this.label_index.Text = "Export";
             this.label_index.MouseDown += new System.Windows.Forms.MouseEventHandler(this.label_index_MouseDown);
+            this.label_index.MouseUp += new System.Windows.Forms.MouseEventHandler(this.label_index_MouseUp);
             // 
             // panelOuter
             // 

--- a/EDDiscovery/Forms/ExportForm.cs
+++ b/EDDiscovery/Forms/ExportForm.cs
@@ -101,6 +101,11 @@ namespace EDDiscovery.Forms
             OnCaptionMouseDown((Control)sender, e);
         }
 
+        private void label_index_MouseUp(object sender, MouseEventArgs e)
+        {
+            OnCaptionMouseUp((Control)sender, e);
+        }
+
         private void panel_close_MouseClick(object sender, MouseEventArgs e)
         {
             Close();

--- a/EDDiscovery/Forms/NewReleaseForm.Designer.cs
+++ b/EDDiscovery/Forms/NewReleaseForm.Designer.cs
@@ -290,10 +290,12 @@ namespace EDDiscovery.Forms
             // 
             // lblCaption
             // 
-            this.lblCaption.AutoSize = true;
+            this.lblCaption.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblCaption.AutoEllipsis = true;
             this.lblCaption.Location = new System.Drawing.Point(9, 6);
             this.lblCaption.Name = "lblCaption";
-            this.lblCaption.Size = new System.Drawing.Size(111, 13);
+            this.lblCaption.Size = new System.Drawing.Size(344, 13);
             this.lblCaption.TabIndex = 0;
             this.lblCaption.Text = "EDDiscovery Release";
             this.lblCaption.MouseDown += new System.Windows.Forms.MouseEventHandler(this.Caption_MouseDown);
@@ -317,6 +319,7 @@ namespace EDDiscovery.Forms
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnClose;
+            this.CaptionHeight = ((uint)(27u));
             this.ClientSize = new System.Drawing.Size(419, 246);
             this.Controls.Add(this.pnlBack);
             this.DoubleBuffered = true;
@@ -331,7 +334,6 @@ namespace EDDiscovery.Forms
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.pnlCaption.ResumeLayout(false);
-            this.pnlCaption.PerformLayout();
             this.pnlBack.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/EDDiscovery/ScreenShots/ScreenShotConfigureForm.Designer.cs
+++ b/EDDiscovery/ScreenShots/ScreenShotConfigureForm.Designer.cs
@@ -523,7 +523,8 @@
             this.panelTop.Name = "panelTop";
             this.panelTop.Size = new System.Drawing.Size(822, 26);
             this.panelTop.TabIndex = 32;
-            this.panelTop.MouseDown += new System.Windows.Forms.MouseEventHandler(this.label_index_MouseDown);
+            this.panelTop.MouseDown += new System.Windows.Forms.MouseEventHandler(this.captionControl_MouseDown);
+            this.panelTop.MouseUp += new System.Windows.Forms.MouseEventHandler(this.captionControl_MouseUp);
             // 
             // panel_close
             // 
@@ -558,7 +559,8 @@
             this.label_index.Size = new System.Drawing.Size(109, 13);
             this.label_index.TabIndex = 23;
             this.label_index.Text = "Screenshot Configure";
-            this.label_index.MouseDown += new System.Windows.Forms.MouseEventHandler(this.label_index_MouseDown);
+            this.label_index.MouseDown += new System.Windows.Forms.MouseEventHandler(this.captionControl_MouseDown);
+            this.label_index.MouseUp += new System.Windows.Forms.MouseEventHandler(this.captionControl_MouseUp);
             // 
             // ScreenShotConfigureForm
             // 

--- a/EDDiscovery/ScreenShots/ScreenShotConfigureForm.cs
+++ b/EDDiscovery/ScreenShots/ScreenShotConfigureForm.cs
@@ -81,21 +81,27 @@ namespace EDDiscovery.ScreenShots
             this.WindowState = FormWindowState.Minimized;
         }
 
-        private void label_index_MouseDown(object sender, MouseEventArgs e)
+        private void captionControl_MouseDown(object sender, MouseEventArgs e)
         {
             OnCaptionMouseDown((Control)sender, e);
         }
 
+        private void captionControl_MouseUp(object sender, MouseEventArgs e)
+        {
+            OnCaptionMouseUp((Control)sender, e);
+        }
+
         private void buttonChangeEDScreenshot_Click(object sender, EventArgs e)
         {
-            FolderBrowserDialog dlg = new FolderBrowserDialog();
-
-            dlg.Description = "Select ED screenshot folder";
-            dlg.SelectedPath = textBoxScreenshotsDir.Text;
-
-            if (dlg.ShowDialog(this) == DialogResult.OK)
+            using (var dlg = new FolderBrowserDialog())
             {
-                initialssfolder = textBoxScreenshotsDir.Text = dlg.SelectedPath;
+                dlg.Description = "Select ED screenshot folder";
+                dlg.SelectedPath = textBoxScreenshotsDir.Text;
+
+                if (dlg.ShowDialog(this) == DialogResult.OK)
+                {
+                    initialssfolder = textBoxScreenshotsDir.Text = dlg.SelectedPath;
+                }
             }
         }
 


### PR DESCRIPTION
Errata patch from #1622:
* Fix missing caption `MouseUp` in `ExportForm`, `ScreenShotConfigureForm`.
* Fix `NewReleaseForm` caption to be able to handle large `Text`.
* Mark `NewReleaseForm` with appropriate `CaptionHeight`.
* `Dispose` of a `FolderBrowserDialog` in `ScreenshotConfigureForm`.