### PR TITLE
StarDistance control text reflect its settings

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -113,7 +113,7 @@ namespace EDDiscovery.UserControls
 
             if (csl.Count() > 0)
             {
-                SetControlText("Closest systems from " + name);
+                SetControlText("Systems in a " + ((Convert.ToInt16(textMinRadius.Text) > 0) ? ((Convert.ToInt16(textMinRadius.Text) + "-" + textMaxRadius.Text.InvariantParseDouble(defaultmaximumradius) + "ly shell")):(textMaxRadius.Text.InvariantParseDouble(defaultmaximumradius) + "ly radius")) + " from " + name);
                 foreach (KeyValuePair<double, ISystem> tvp in csl)
                 {
                     int visits = discoveryform.history.GetVisitsCount(tvp.Value.name, tvp.Value.id_edsm);


### PR DESCRIPTION
Pretty self explanatory image:
![stardistance-controltext](https://user-images.githubusercontent.com/4296635/34907922-c3102eb8-f86d-11e7-9a61-46ec385e1e20.PNG)

If only a maxradius is defined, control title text is: "Systems in a (maxradius)ly radius from sys.name". If a shell is defined, the control title text changes to "Systems in a (minradius-maxradius)ly shell from sys.name". 