### PR TITLE
Fill name and name in EDSM log fetch

### DIFF
--- a/EliteDangerous/EDSM/EDSMClass.cs
+++ b/EliteDangerous/EDSM/EDSMClass.cs
@@ -527,6 +527,9 @@ namespace EliteDangerousCore.EDSM
                             }
                         }
 
+                        if (sc.name == null)
+                            sc.name = name;
+
                         HistoryEntry he = HistoryEntry.MakeVSEntry(sc, etutc, EliteConfigInstance.InstanceConfig.DefaultMapColour, "", "", firstdiscover: firstdiscover);       // FSD jump entry
                         log.Add(he);
                     }

--- a/EliteDangerous/EDSM/EDSMLogFetcher.cs
+++ b/EliteDangerous/EDSM/EDSMLogFetcher.cs
@@ -213,7 +213,7 @@ namespace EliteDangerousCore.EDSM
                                                                                                       EliteConfigInstance.InstanceConfig.DefaultMapColour);
                                     JournalEntry je =
                                         JournalEntry.CreateFSDJournalEntry(tlu.id, tlu.CommanderId.Value,
-                                                                                                      (int)SyncFlags.EDSM, jo);
+                                                                                                      (int)SyncFlags.EDSM, jo, he.System.id_edsm);
 
                                     System.Diagnostics.Trace.WriteLine(string.Format("Add {0} {1}", je.EventTimeUTC, he.System.name));
                                     je.Add(jo, cn);

--- a/EliteDangerous/EliteDangerous/JournalEntry.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntry.cs
@@ -413,12 +413,13 @@ namespace EliteDangerousCore
             return jo;
         }
 
-        public static JournalEntry CreateFSDJournalEntry(long tluid, int cmdrid, int syncflag, JObject jo)
+        public static JournalEntry CreateFSDJournalEntry(long tluid, int cmdrid, int syncflag, JObject jo, long edsmid = 0)
         {
             JournalEntry je = CreateJournalEntry(jo.ToString());
             je.TLUId = tluid;
             je.CommanderId = cmdrid;
             je.Synced = syncflag;
+            je.EdsmID = edsmid;
             return je;
         }
 


### PR DESCRIPTION
This should fix the rare case where the system name is null when retrieving logs from EDSM.