### PR TITLE
Protect against name not found in GetSystem

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1826,7 +1826,7 @@ namespace EDDiscovery
                 info = hoversystem.name + Environment.NewLine + string.Format("x:{0} y:{1} z:{2}", hoversystem.x.ToString("0.00"), hoversystem.y.ToString("0.00"), hoversystem.z.ToString("0.00"));
                 pos = new Vector3d(hoversystem.x, hoversystem.y, hoversystem.z);
 
-                ISystem sysclass = (hoversystem.id != 0) ? SystemClassDB.GetSystem(hoversystem.id) : SystemClassDB.GetSystem(hoversystem.name);
+                ISystem sysclass = (hoversystem.id != 0) ? SystemClassDB.GetSystem(hoversystem.id, name: hoversystem.name) : SystemClassDB.GetSystem(hoversystem.name);
 
                 if (sysclass != null)
                 {

--- a/EliteDangerous/DB/SystemClassDB.cs
+++ b/EliteDangerous/DB/SystemClassDB.cs
@@ -272,7 +272,7 @@ namespace EliteDangerousCore.DB
             {
                 foreach (long edsmid in edsmidlist)
                 {
-                    ISystem sys = GetSystem(edsmid, cn, SystemIDType.EdsmId);
+                    ISystem sys = GetSystem(edsmid, cn, SystemIDType.EdsmId, name: name);
                     if (sys != null)
                     {
                         systems.Add(sys);
@@ -285,7 +285,7 @@ namespace EliteDangerousCore.DB
 
         public enum SystemIDType { id, EdsmId, EddbId };       // which ID to match?
 
-        public static ISystem GetSystem(long id,  SQLiteConnectionSystem cn = null, SystemIDType idtype = SystemIDType.id)      // using an id
+        public static ISystem GetSystem(long id,  SQLiteConnectionSystem cn = null, SystemIDType idtype = SystemIDType.id, string name = null)      // using an id
         {
             ISystem sys = null;
             bool closeit = false;
@@ -348,6 +348,15 @@ namespace EliteDangerousCore.DB
                                 sys.name = (string)reader["Name"];
                             }
                         }
+                    }
+
+                    if (sys.name == null && name != null)
+                    {
+                        sys.name = name;
+                    }
+                    else
+                    {
+                        return null;
                     }
                 }
 
@@ -606,7 +615,9 @@ namespace EliteDangerousCore.DB
                         {
                             long edsmid = (long)reader[0];
                             {
-                                    distlist.Add(GetSystem(edsmid, cn, SystemIDType.EdsmId));
+                                ISystem sys = GetSystem(edsmid, cn, SystemIDType.EdsmId);
+                                if (sys != null)
+                                    distlist.Add(sys);
                             }
                         }
                     }
@@ -749,7 +760,8 @@ namespace EliteDangerousCore.DB
                     {
                         long pos_edsmid = (long)reader["EdsmId"];
                         sys = GetSystem(pos_edsmid, cn, SystemIDType.EdsmId);
-                        break;
+                        if (sys != null)
+                            break;
                     }
                 }
             }
@@ -945,14 +957,18 @@ namespace EliteDangerousCore.DB
                 if (sel_edsmid != 0)
                 {
                     edsmidmatch = GetSystem(sel_edsmid, cn, SystemIDType.EdsmId);
-                    matches.Add(edsmidmatch.id, edsmidmatch);
-
-                    while (aliasesById.ContainsKey(sel_edsmid))
+                    if (edsmidmatch != null)
                     {
-                        sel_edsmid = aliasesById[sel_edsmid];
-                        ISystem sys = GetSystem(sel_edsmid, cn, SystemIDType.EdsmId);
-                        altmatches.Add(sys.id, sys);
-                        edsmidmatch = null;
+                        matches.Add(edsmidmatch.id, edsmidmatch);
+
+                        while (aliasesById.ContainsKey(sel_edsmid))
+                        {
+                            sel_edsmid = aliasesById[sel_edsmid];
+                            ISystem sys = GetSystem(sel_edsmid, cn, SystemIDType.EdsmId);
+                            if (sys != null)
+                                altmatches.Add(sys.id, sys);
+                            edsmidmatch = null;
+                        }
                     }
                 }
 

--- a/EliteDangerous/EDSM/EDSMClass.cs
+++ b/EliteDangerous/EDSM/EDSMClass.cs
@@ -512,7 +512,7 @@ namespace EliteDangerousCore.EDSM
                         bool firstdiscover = jo["firstDiscover"].Value<bool>();
                         DateTime etutc = DateTime.ParseExact(ts, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal|DateTimeStyles.AssumeUniversal); // UTC time
 
-                        ISystem sc = SystemClassDB.GetSystem(id, cn, SystemClassDB.SystemIDType.EdsmId);
+                        ISystem sc = SystemClassDB.GetSystem(id, cn, SystemClassDB.SystemIDType.EdsmId, name: name);
                         if (sc == null)
                         {
                             if (DateTime.UtcNow.Subtract(etutc).TotalHours < 6) // Avoid running into the rate limit

--- a/EliteDangerous/EliteDangerous/SystemCache.cs
+++ b/EliteDangerous/EliteDangerous/SystemCache.cs
@@ -48,7 +48,7 @@ namespace EliteDangerousCore
 
                 if (find.id_edsm > 0)        // if we have an ID, look it up
                 {
-                    found = DB.SystemClassDB.GetSystem(find.id_edsm, conn, DB.SystemClassDB.SystemIDType.EdsmId);
+                    found = DB.SystemClassDB.GetSystem(find.id_edsm, conn, DB.SystemClassDB.SystemIDType.EdsmId, name: find.name);
                 }
                  
                 // if not found, or no co-ord (unlikely), or its old as the hills, AND has a name


### PR DESCRIPTION
* Add a `name` parameter for when the name is already known
* Return null if the name is not present in the database and is not already known.
* Handle a few cases where null would have caused an error.