### PR TITLE
Bump NFluent from 2.1.0 to 2.1.1

### DIFF
--- a/EDDiscoveryTests/EDDiscoveryTests.csproj
+++ b/EDDiscoveryTests/EDDiscoveryTests.csproj
@@ -88,8 +88,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NFluent, Version=2.1.0.99, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
-      <HintPath>..\packages\NFluent.2.1.0\lib\net45\NFluent.dll</HintPath>
+    <Reference Include="NFluent, Version=2.1.1.107, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
+      <HintPath>..\packages\NFluent.2.1.1\lib\net45\NFluent.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>

--- a/EDDiscoveryTests/packages.config
+++ b/EDDiscoveryTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
-  <package id="NFluent" version="2.1.0" targetFramework="net46" />
+  <package id="NFluent" version="2.1.1" targetFramework="net46" />
   <package id="NUnit" version="3.9.0" targetFramework="net46" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net46" />
   <package id="OpenTK" version="2.0.0" targetFramework="net46" />


### PR DESCRIPTION
* The changelog for it is one line, and it's something we're not using.
* Still, up-to-date on testing means stronger code.
* Changelog: https://www.nuget.org/packages/NFluent/2.1.1