### PR TITLE
Continue loading themes with missing fonts (master)

### DIFF
--- a/EDDiscovery/UserControls/UserControlSettings.cs
+++ b/EDDiscovery/UserControls/UserControlSettings.cs
@@ -261,15 +261,19 @@ namespace EDDiscovery.UserControls
             string fontwanted = null;                                               // don't check custom, only a stored theme..
             if (!themename.Equals("Custom") && !discoveryform.theme.IsFontAvailableInTheme(themename, out fontwanted))
             {
-                DialogResult res = ExtendedControls.MessageBoxTheme.Show(FindForm(), "The font used by this theme is not available on your system" + Environment.NewLine +
-                      "The font needed is \"" + fontwanted + "\"" + Environment.NewLine +
-                      "Install this font and you can use this scheme." + Environment.NewLine +
-                      "EuroCaps font is available www.edassets.org.",
-                      "Warning", MessageBoxButtons.OK);
-
-                discoveryform.theme.SetCustom();                              // go to custom theme whatever
-                SetEntryThemeComboBox();
-                return;
+                DialogResult res = ExtendedControls.MessageBoxTheme.Show(FindForm(),
+                      "The font used by this theme is not available on your system." + Environment.NewLine +
+                      "The font needed is \"" + fontwanted + "\"." + Environment.NewLine +
+                      "Install this font to fully use this theme." + Environment.NewLine +
+                      "Euro Caps font is freely available from www.edassets.org." + Environment.NewLine + Environment.NewLine +
+                      "Would you like to load this theme using a replacement font?",
+                      "Warning", MessageBoxButtons.YesNo);
+                if (res != DialogResult.Yes)
+                {
+                    // Reset the combo box to the previous theme name and don't change anything else.
+                    SetEntryThemeComboBox();
+                    return;
+                }   
             }
 
             if (!discoveryform.theme.SetThemeByName(themename))


### PR DESCRIPTION
* Even though it'll probably look like :faeces emoji:.
* Prompt the user about it first.
* Reset the theme chooser combo box text if we're returning early.
  * No more "Custom" if a font is missing but the theme wasn't loaded.