### PR TITLE
(9.0.x) 3D Map correctly finds system data for unvisited stars again

### DIFF
--- a/EliteDangerous/DB/SystemClassDB.cs
+++ b/EliteDangerous/DB/SystemClassDB.cs
@@ -719,7 +719,7 @@ namespace EliteDangerousCore.DB
         public static ISystem FindNearestSystem(double x, double y, double z, bool removezerodiststar = false, double maxdist = 1000, SQLiteConnectionSystem cn = null)
         {
             SortedList<double, ISystem> distlist = new SortedList<double, ISystem>();
-            GetSystemSqDistancesFrom(distlist, x, y, z, 1, 8.0/128.0, maxdist,false,cn);
+            GetSystemSqDistancesFrom(distlist, x, y, z, 1, removezerodiststar ? 8.0/128.0 : 0.0, maxdist,false,cn);
             return distlist.Select(v => v.Value).FirstOrDefault();
         }
 


### PR DESCRIPTION
FindNearestSystem only sets mindistance greater than zero when removezerodiststar is true