### PR TITLE
Some UserControlStarDistance Enhancements (Branch_9_0_X)

### DIFF
--- a/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.Designer.cs
@@ -56,9 +56,9 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel2 = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom2 = new ExtendedControls.VScrollBarCustom();
             this.dataGridViewNearest = new System.Windows.Forms.DataGridView();
-            this.Col1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Visited = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colDistance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colVisited = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.labelExt1 = new System.Windows.Forms.Label();
             this.textMinRadius = new ExtendedControls.TextBoxBorder();
             this.labelExt3 = new System.Windows.Forms.Label();
@@ -153,9 +153,9 @@ namespace EDDiscovery.UserControls
             this.dataGridViewNearest.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.dataGridViewNearest.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridViewNearest.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Col1,
-            this.Distance,
-            this.Visited});
+            this.colName,
+            this.colDistance,
+            this.colVisited});
             this.dataGridViewNearest.ContextMenuStrip = this.closestContextMenu;
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
@@ -183,24 +183,27 @@ namespace EDDiscovery.UserControls
             this.dataGridViewNearest.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewNearest_SortCompare);
             this.dataGridViewNearest.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewNearest_MouseDown);
             // 
-            // Col1
+            // colName
             // 
-            this.Col1.HeaderText = "Name";
-            this.Col1.MinimumWidth = 50;
-            this.Col1.Name = "Col1";
+            this.colName.HeaderText = "Name";
+            this.colName.MinimumWidth = 50;
+            this.colName.Name = "colName";
+            this.colName.ReadOnly = true;
             // 
-            // Distance
+            // colDistance
             // 
-            this.Distance.FillWeight = 25F;
-            this.Distance.HeaderText = "Distance";
-            this.Distance.MinimumWidth = 50;
-            this.Distance.Name = "Distance";
+            this.colDistance.FillWeight = 25F;
+            this.colDistance.HeaderText = "Distance";
+            this.colDistance.MinimumWidth = 50;
+            this.colDistance.Name = "colDistance";
+            this.colDistance.ReadOnly = true;
             // 
-            // Visited
+            // colVisited
             // 
-            this.Visited.FillWeight = 25F;
-            this.Visited.HeaderText = "Visited";
-            this.Visited.Name = "Visited";
+            this.colVisited.FillWeight = 25F;
+            this.colVisited.HeaderText = "Visited";
+            this.colVisited.Name = "colVisited";
+            this.colVisited.ReadOnly = true;
             // 
             // labelExt1
             // 
@@ -226,12 +229,14 @@ namespace EDDiscovery.UserControls
             this.textMinRadius.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.textMinRadius.SelectionLength = 0;
             this.textMinRadius.SelectionStart = 0;
-            this.textMinRadius.Size = new System.Drawing.Size(40, 20);
+            this.textMinRadius.Size = new System.Drawing.Size(52, 20);
             this.textMinRadius.TabIndex = 1;
+            this.textMinRadius.Text = "0.00";
             this.textMinRadius.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
             this.toolTip1.SetToolTip(this.textMinRadius, "Minimum star distance in ly");
             this.textMinRadius.WordWrap = true;
             this.textMinRadius.TextChanged += new System.EventHandler(this.textMinRadius_TextChanged);
+            this.textMinRadius.Leave += new System.EventHandler(this.textMinRadius_Leave);
             // 
             // labelExt3
             // 
@@ -257,12 +262,14 @@ namespace EDDiscovery.UserControls
             this.textMaxRadius.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.textMaxRadius.SelectionLength = 0;
             this.textMaxRadius.SelectionStart = 0;
-            this.textMaxRadius.Size = new System.Drawing.Size(40, 20);
+            this.textMaxRadius.Size = new System.Drawing.Size(52, 20);
             this.textMaxRadius.TabIndex = 1;
+            this.textMaxRadius.Text = "1000.00";
             this.textMaxRadius.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
             this.toolTip1.SetToolTip(this.textMaxRadius, "Maximum star distance in ly");
             this.textMaxRadius.WordWrap = true;
             this.textMaxRadius.TextChanged += new System.EventHandler(this.textMaxRadius_TextChanged);
+            this.textMaxRadius.Leave += new System.EventHandler(this.textMaxRadius_Leave);
             // 
             // panelTop
             // 
@@ -320,9 +327,9 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel2;
         private ExtendedControls.VScrollBarCustom vScrollBarCustom2;
         private System.Windows.Forms.DataGridView dataGridViewNearest;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Col1;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Visited;
+        private DataGridViewTextBoxColumn colName;
+        private DataGridViewTextBoxColumn colDistance;
+        private DataGridViewTextBoxColumn colVisited;
         private System.Windows.Forms.Label labelExt1;
         private ExtendedControls.TextBoxBorder textMinRadius;
         private System.Windows.Forms.Label labelExt3;

--- a/EDDiscovery/UserControls/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/UserControlStarDistance.cs
@@ -13,38 +13,90 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EliteDangerousCore;
+using EliteDangerousCore.DB;
+using EliteDangerousCore.EDSM;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Data;
+using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Collections.Concurrent;
-using System.Threading;
-using EliteDangerousCore;
-using EliteDangerousCore.EDSM;
-using EliteDangerousCore.DB;
 
 namespace EDDiscovery.UserControls
 {
     public partial class UserControlStarDistance : UserControlCommonBase
     {
-        private string DbSave { get { return "StarDistancePanel" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
-
-        private StarDistanceComputer computer;
-        HistoryEntry last_he;
-
         public UserControlStarDistance()
         {
             InitializeComponent();
             var corner = dataGridViewNearest.TopLeftHeaderCell; // work around #1487
         }
 
-        const double defaultmaximumradius = 1000;
-        const int maxitems = 500;
+        private string DbSave { get { return "StarDistancePanel" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
+        [DefaultValue(defaultMaxRadius)]
+        private double MaxRadius
+        {
+            get { return _MaxRadius; }
+            set
+            {
+                if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+                    value = defaultMaxRadius;
+                if (_MaxRadius != value)
+                {
+                    _MaxRadius = value;
+                    if (last_he != null || uctg != null)
+                        KickComputation(last_he ?? uctg.GetCurrentHistoryEntry);
+                }
+                // Don't adjust text in a focused textbox while a user is typing.
+                if (textMaxRadius.ContainsFocus)
+                    pendingText = $"{value:0.00}";
+                else
+                    textMaxRadius.Text = $"{value:0.00}";
+            }
+        }
+        [DefaultValue(defaultMinRadius)]
+        private double MinRadius
+        {
+            get { return _MinRadius; }
+            set
+            {
+                if (double.IsNaN(value) || double.IsInfinity(value) || value < 0)
+                    value = defaultMinRadius;
+                if (_MinRadius != value)
+                {
+                    _MinRadius = value;
+                    if (last_he != null || uctg != null)
+                        KickComputation(last_he ?? uctg.GetCurrentHistoryEntry);
+                }
+                // Don't adjust text in a focused textbox while a user is typing.
+                if (textMinRadius.ContainsFocus)
+                    pendingText = $"{value:0.00}";
+                else
+                    textMinRadius.Text = $"{value:0.00}";
+            }
+        }
+
+        private StarDistanceComputer computer = null;
+        private HistoryEntry last_he = null;
+        private ISystem rightclicksystem = null;
+        private int rightclickrow = -1;
+        private string pendingText = null;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private double _MaxRadius = defaultMaxRadius;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private double _MinRadius = defaultMinRadius;
+
+        private const double defaultMaxRadius = 1000;
+        private const double defaultMinRadius = 0;
+        private const int maxitems = 500;
 
         public override void Init()
         {
@@ -52,8 +104,8 @@ namespace EDDiscovery.UserControls
 
             uctg.OnTravelSelectionChanged += Uctg_OnTravelSelectionChanged;
 
-            textMinRadius.Text = SQLiteConnectionUser.GetSettingDouble(DbSave + "Min", 0).ToStringInvariant();
-            textMaxRadius.Text = SQLiteConnectionUser.GetSettingDouble(DbSave + "Max", defaultmaximumradius).ToStringInvariant();
+            MaxRadius = SQLiteConnectionUser.GetSettingDouble(DbSave + "Max", MaxRadius);
+            MinRadius = SQLiteConnectionUser.GetSettingDouble(DbSave + "Min", MinRadius);
             checkBoxCube.Checked = SQLiteConnectionUser.GetSettingBool(DbSave + "Behaviour", false);
         }
 
@@ -68,8 +120,8 @@ namespace EDDiscovery.UserControls
         {
             uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
             computer.ShutDown();
-            SQLiteConnectionUser.PutSettingDouble(DbSave + "Min", textMinRadius.Text.InvariantParseDouble(0));
-            SQLiteConnectionUser.PutSettingDouble(DbSave + "Max", textMaxRadius.Text.InvariantParseDouble(defaultmaximumradius));
+            SQLiteConnectionUser.PutSettingDouble(DbSave + "Min", MinRadius);
+            SQLiteConnectionUser.PutSettingDouble(DbSave + "Max", MaxRadius);
             SQLiteConnectionUser.PutSettingBool(DbSave + "Behaviour", checkBoxCube.Checked);
         }
 
@@ -90,12 +142,11 @@ namespace EDDiscovery.UserControls
                 last_he = he;
 
                 //System.Diagnostics.Debug.WriteLine("Star grid started, uctg selected, ask");
+
+                // Get nearby systems from the systems DB.
                 computer.CalculateClosestSystems(he.System, 
                     (s, d) => BeginInvoke((MethodInvoker)delegate { NewStarListComputed(s, d); }) , 
-                    maxitems,
-                    Math.Max(textMinRadius.Text.InvariantParseDouble(0), 8.0/128.0),     // min to exclude our star
-                    textMaxRadius.Text.InvariantParseDouble(defaultmaximumradius),
-                    !checkBoxCube.Checked
+                    maxitems, MinRadius, MaxRadius, !checkBoxCube.Checked
                     );     // hook here, force closes system update
             }
         }
@@ -104,11 +155,9 @@ namespace EDDiscovery.UserControls
         {
             System.Diagnostics.Debug.Assert(Application.MessageLoop);       // check!
 
+            // Get nearby systems from our travel history. This will filter out duplicates from the systems DB.
             discoveryform.history.CalculateSqDistances(list, sys.x, sys.y, sys.z,
-                                maxitems,
-                                Math.Max(textMinRadius.Text.InvariantParseDouble(0), 8.0/128.0),     // min to exclude our star
-                                textMaxRadius.Text.InvariantParseDouble(defaultmaximumradius),
-                                !checkBoxCube.Checked
+                                maxitems, MinRadius, MaxRadius, !checkBoxCube.Checked
                                 );
 
             FillGrid(sys.name, list);
@@ -116,36 +165,30 @@ namespace EDDiscovery.UserControls
 
         private void FillGrid(string name, SortedList<double, ISystem> csl)
         {
-            SetControlText("");
             dataGridViewNearest.Rows.Clear();
 
-            double? sphere = textMaxRadius.Text.InvariantParseDoubleNull();
-
-            if (csl.Count() > 0)
+            if (csl != null && csl.Any())
             {
                 SetControlText("From " + name);
                 foreach (KeyValuePair<double, ISystem> tvp in csl)
                 {
-                    int visits = discoveryform.history.GetVisitsCount(tvp.Value.name, tvp.Value.id_edsm);
-                    object[] rowobj = { tvp.Value.name, Math.Sqrt(tvp.Key).ToString("0.00"), visits.ToStringInvariant() };       // distances are stored squared for speed, back to normal.
+                    double dist = Math.Sqrt(tvp.Key);   // distances are stored squared for speed, back to normal.
 
-                    if (checkBoxCube.Checked || sphere == null )        // if cube, or sphere value incorrect, just add
+                    if (tvp.Value.name != name && (checkBoxCube.Checked || (dist >= MinRadius && dist <= MaxRadius)))
                     {
-                        int rowindex = dataGridViewNearest.Rows.Add(rowobj);
-                        dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
-                    }
-                    else if (Math.Sqrt(tvp.Key) <= sphere.Value)
-                    { 
+                        int visits = discoveryform.history.GetVisitsCount(tvp.Value.name, tvp.Value.id_edsm);
+                        object[] rowobj = { tvp.Value.name, $"{dist:0.00}", $"{visits:n0}" };
+
                         int rowindex = dataGridViewNearest.Rows.Add(rowobj);
                         dataGridViewNearest.Rows[rowindex].Tag = tvp.Value;
                     }
                 }
-                
+            }
+            else
+            {
+                SetControlText(string.Empty);
             }
         }
-
-        ISystem rightclicksystem = null;
-        int rightclickrow = -1;
 
         private void dataGridViewNearest_MouseDown(object sender, MouseEventArgs e)
         {
@@ -213,7 +256,7 @@ namespace EDDiscovery.UserControls
 
         private void dataGridViewNearest_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
         {
-            if (e.Column.Index >= 1)
+            if (colDistance.Equals(e.Column))
             {
                 double v1, v2;
                 string vs1 = e.CellValue1?.ToString();
@@ -224,28 +267,63 @@ namespace EDDiscovery.UserControls
                     e.Handled = true;
                 }
             }
+            else if (colVisited.Equals(e.Column))
+            {
+                int v1, v2;
+                string s1 = e.CellValue1?.ToString();
+                string s2 = e.CellValue2?.ToString();
+                if (!string.IsNullOrEmpty(s1) && !string.IsNullOrEmpty(s2) && int.TryParse(s1, out v1) && int.TryParse(s2, out v2))
+                {
+                    e.SortResult = v1.CompareTo(v2);
+                    e.Handled = true;
+                }
+            }
         }
 
 
         private void textMinRadius_TextChanged(object sender, EventArgs e)
         {
-            double? min = textMinRadius.Text.InvariantParseDoubleNull();
-            if (min != null)
-                KickComputation(uctg.GetCurrentHistoryEntry);
+            // Don't let others directly assigning to textMinRadius.Text result in parsing.
+            if (textMinRadius.ContainsFocus)
+            {
+                double? min = textMinRadius.Text.InvariantParseDoubleNull();
+                MinRadius = min ?? defaultMinRadius;
+            }
+        }
+
+        private void textMinRadius_Leave(object sender, EventArgs e)
+        {
+            if (pendingText != null)
+                textMinRadius.Text = pendingText;
+            pendingText = null;
         }
 
         private void textMaxRadius_TextChanged(object sender, EventArgs e)
         {
-            double? max = textMaxRadius.Text.InvariantParseDoubleNull();
-            if (max != null)
-                KickComputation(uctg.GetCurrentHistoryEntry);
+            // Don't let others directly assigning to textMaxRadius.Text result in parsing.
+            if (textMaxRadius.ContainsFocus)
+            {
+                double? max = textMaxRadius.Text.InvariantParseDoubleNull();
+                MaxRadius = max ?? defaultMaxRadius;
+            }
+        }
+
+        private void textMaxRadius_Leave(object sender, EventArgs e)
+        {
+            if (pendingText != null)
+                textMaxRadius.Text = pendingText;
+            pendingText = null;
+        }
+
+        private void checkBoxCube_CheckedChanged(object sender, EventArgs e)
+        {
+            KickComputation(last_he ?? uctg.GetCurrentHistoryEntry);
         }
 
 
         /// <summary>
         /// Computer
         /// </summary>
-
         public class StarDistanceComputer
         {
             private Thread backgroundStardistWorker;
@@ -338,11 +416,6 @@ namespace EDDiscovery.UserControls
                     return (result == 0) ? 1 : result;      // for this, equals just means greater than, to allow duplicate distance values to be added.
                 }
             }
-        }
-        
-        private void checkBoxCube_CheckedChanged(object sender, EventArgs e)
-        {
-            KickComputation(last_he ?? uctg.GetCurrentHistoryEntry);
         }
     }
 }

--- a/EDDiscovery/UserControls/UserControlStarDistance.resx
+++ b/EDDiscovery/UserControls/UserControlStarDistance.resx
@@ -120,13 +120,13 @@
   <metadata name="closestContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="Col1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="colName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Distance.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="colDistance.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Visited.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="colVisited.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
* Don't re-parse the text values for every change.
* Set the `DataGridView` columns read-only. No sense allowing people to rename systems...
* Fix a few *potential* NRE encounters.
* Update the `TextBox`es even if the parse result isn't valid.
* Filter out the current system instead of overriding the minimum value.
* Allow numeric sorting on number of visits column.

(cherry picked from commit 4a9d0be1b7768ca4c108a88e9d883605b58a96d1)

From #1641, with updates for the comments, and a rebase onto the da4f2d3a45d7dd77e00ecfa2a3ac73fb91053f3f fix for a clean merge.