### PR TITLE
Fix Some Issues Noted in #1657

### DIFF
--- a/EDDiscovery/3DMap/FormMap.Designer.cs
+++ b/EDDiscovery/3DMap/FormMap.Designer.cs
@@ -177,6 +177,7 @@ namespace EDDiscovery
             this.labelSystemCoords.TabIndex = 18;
             this.labelSystemCoords.Text = "Sol x=0.00";
             this.labelSystemCoords.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.labelSystemCoords.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // toolStripControls
             // 
@@ -787,6 +788,7 @@ namespace EDDiscovery
             this.panelAuxControls.Size = new System.Drawing.Size(506, 40);
             this.panelAuxControls.TabIndex = 27;
             this.panelAuxControls.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.panelAuxControls.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // panelTop
             // 
@@ -800,6 +802,7 @@ namespace EDDiscovery
             this.panelTop.Size = new System.Drawing.Size(1564, 40);
             this.panelTop.TabIndex = 0;
             this.panelTop.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.panelTop.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // panel_minimize
             // 

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1556,6 +1556,10 @@ namespace EDDiscovery
             OnCaptionMouseDown((Control)sender, e);
         }
 
+        private void panelTop_MouseUp(object sender, System.Windows.Forms.MouseEventArgs e)
+        {
+            OnCaptionMouseUp((Control)sender, e);
+        }
 
         #endregion
 

--- a/EDDiscovery/Forms/DraggableFormPos.Designer.cs
+++ b/EDDiscovery/Forms/DraggableFormPos.Designer.cs
@@ -37,11 +37,6 @@
             this.ClientSize = new System.Drawing.Size(284, 261);
             this.Name = "DraggableFormPos";
             this.Text = "DraggableFormPos";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.DraggableFormPos_FormClosing);
-            this.Load += new System.EventHandler(this.DraggableFormPos_Load);
-            this.Shown += new System.EventHandler(this.DraggableFormPos_Shown);
-            this.ResizeEnd += new System.EventHandler(this.DraggableFormPos_ResizeEnd);
-            this.Resize += new System.EventHandler(this.DraggableFormPos_Resize);
             this.ResumeLayout(false);
 
         }

--- a/EDDiscovery/Forms/DraggableFormPos.cs
+++ b/EDDiscovery/Forms/DraggableFormPos.cs
@@ -146,33 +146,43 @@ namespace EDDiscovery.Forms
             }
         }
 
-        private void DraggableFormPos_Load(object sender, EventArgs e)      // on load we restore
+        protected override void OnLoad(EventArgs e)         // on load we restore
         {
             RestoreFormPosition();
+
+            base.OnLoad(e);
         }
 
-        private void DraggableFormPos_Shown(object sender, EventArgs e)     // some classes need this to screen out stuff as well as us
+        protected override void OnShown(EventArgs e)        // some classes need this to screen out stuff as well as us
         {
+            base.OnShown(e);
+
             FormShownOnce = true;
         }
 
-        private void DraggableFormPos_Resize(object sender, EventArgs e)        // this is a resize or a max..
+        protected override void OnResize(EventArgs e)       // this is a resize or a max..
         {
+            base.OnResize(e);
+
             if (FormShownOnce && !IsTemporaryResized) // to make sure that we have been shown and we are saving size
                 RecordFormPosition();
         }
 
-        private void DraggableFormPos_ResizeEnd(object sender, EventArgs e)     // this is a resize of a location change.
+        protected override void OnResizeEnd(EventArgs e)    // this is a resize or a location change.
         {
+            base.OnResizeEnd(e);
+
             if (FormShownOnce && !IsTemporaryResized) // to make sure that we have been shown and we are saving size
                 RecordFormPosition();
         }
 
-        private void DraggableFormPos_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            SaveFormPosition();     // even if its cancelled, still s
-        }
+            base.OnFormClosing(e);
 
+            if (!e.Cancel)
+                SaveFormPosition();
+        }
 
         #endregion
     }

--- a/EDDiscovery/Forms/DraggableFormPos.cs
+++ b/EDDiscovery/Forms/DraggableFormPos.cs
@@ -13,7 +13,6 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
-
 using EliteDangerousCore.DB;
 using System;
 using System.Collections.Generic;
@@ -28,7 +27,6 @@ using System.Windows.Forms;
 namespace EDDiscovery.Forms
 {
     // inherit and it will save the form position for you. You supply the RestoreFormPositionRegKey in your constructor.
-
     public partial class DraggableFormPos : ExtendedControls.DraggableForm
     {
         protected bool FormIsMaximised { get { return formMax; } }                  
@@ -76,12 +74,12 @@ namespace EDDiscovery.Forms
 
         private void RestoreFormPosition()
         {
-            if (!EDDOptions.Instanced) // crap way of screening out designer
+            if (this.DesignMode)
                 return;
 
-            var top = SQLiteDBClass.GetSettingInt(RestoreFormPositionRegKey+"Top", -999);
+            var top = SQLiteDBClass.GetSettingInt(RestoreFormPositionRegKey+"Top", int.MinValue);
 
-            if (top != -999 && EDDOptions.Instance.NoWindowReposition == false)
+            if (top != int.MinValue && EDDOptions.Instance.NoWindowReposition == false)
             {
                 var left = SQLiteDBClass.GetSettingInt(RestoreFormPositionRegKey+"Left", 0);
                 var height = SQLiteDBClass.GetSettingInt(RestoreFormPositionRegKey+"Height", 800);

--- a/EDDiscovery/Forms/Form2DMap.Designer.cs
+++ b/EDDiscovery/Forms/Form2DMap.Designer.cs
@@ -218,6 +218,7 @@ namespace EDDiscovery
             this.panelTop.Size = new System.Drawing.Size(982, 32);
             this.panelTop.TabIndex = 2;
             this.panelTop.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.panelTop.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // panel_minimize
             // 

--- a/EDDiscovery/Forms/Form2DMap.cs
+++ b/EDDiscovery/Forms/Form2DMap.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright © 2015 - 2016 EDDiscovery development team
+ * Copyright © 2015 - 2017 EDDiscovery development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
-
+using BaseUtils;
 using EliteDangerousCore;
 using EliteDangerousCore.DB;
 using EMK.LightGeometry;
@@ -27,7 +27,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
-using BaseUtils;
 
 namespace EDDiscovery
 {
@@ -313,6 +312,11 @@ namespace EDDiscovery
         private void panelTop_MouseDown(object sender, MouseEventArgs e)
         {
             OnCaptionMouseDown((Control)sender, e);
+        }
+
+        private void panelTop_MouseUp(object sender, MouseEventArgs e)
+        {
+            OnCaptionMouseUp((Control)sender, e);
         }
 
         private void toolStripButtonSave_Click(object sender, EventArgs e)

--- a/EDDiscovery/Forms/GalaxySectorSelect.Designer.cs
+++ b/EDDiscovery/Forms/GalaxySectorSelect.Designer.cs
@@ -79,6 +79,7 @@
             this.panelTop.Size = new System.Drawing.Size(1182, 32);
             this.panelTop.TabIndex = 1;
             this.panelTop.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.panelTop.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // panel_close
             // 

--- a/EDDiscovery/Forms/GalaxySectorSelect.cs
+++ b/EDDiscovery/Forms/GalaxySectorSelect.cs
@@ -153,16 +153,7 @@ namespace EDDiscovery.Forms
 
             System.Diagnostics.Debug.WriteLine("Initial Sectors " + string.Join(",", initiallist));
             System.Diagnostics.Debug.WriteLine("Cur Sectors " + string.Join(",", currentsel));
-            bool added = false;
-
-            foreach (int i in currentsel)
-            {
-                if (!initiallist.Contains(i))       // if initial list does not include a current sel
-                {
-                    added = true;
-                    break;
-                }
-            }
+            bool added = currentsel.Except(initiallist).Any();  // if initial list does not include a current sel
 
             if (added)                            // we added some..
             {
@@ -180,15 +171,9 @@ namespace EDDiscovery.Forms
             }
             else
             {
-                Removed = new List<int>();
+                Removed = initiallist.Except(currentsel).ToList();  // if initial list does not include a current sel
 
-                foreach (int i in initiallist)
-                {
-                    if (!currentsel.Contains(i))       // if initial list does not include a current sel
-                        Removed.Add(i);
-                }
-
-                if (Removed.Count>0)
+                if (Removed.Any())
                 {
                     AllRemoveSectors = (from int i in GridId.AllId() where !currentsel.Contains(i) select i).ToList();
 

--- a/EDDiscovery/Forms/GalaxySectorSelect.cs
+++ b/EDDiscovery/Forms/GalaxySectorSelect.cs
@@ -1,4 +1,19 @@
-﻿using BaseUtils;
+﻿/*
+ * Copyright © 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using BaseUtils;
 using EliteDangerousCore.DB;
 using System;
 using System.Collections.Generic;
@@ -215,6 +230,10 @@ namespace EDDiscovery.Forms
             OnCaptionMouseDown((Control)sender, e);
         }
 
+        private void panelTop_MouseUp(object sender, MouseEventArgs e)
+        {
+            OnCaptionMouseUp((Control)sender, e);
+        }
     }
 
     public class ImageViewerWithGrid : ExtendedControls.ImageViewer

--- a/EDDiscovery/UserControls/UserControlRoute.cs
+++ b/EDDiscovery/UserControls/UserControlRoute.cs
@@ -107,16 +107,16 @@ namespace EDDiscovery.UserControls
 
         string SystemNameOnly(string s)             // removes @ at end.
         {
-            int atpos = s.IndexOf('@');
+            int atpos = s?.IndexOf('@') ?? -1;
             if (s != null && atpos != -1)
                 s = s.Substring(0, atpos);
-            s = s.Trim();
+            s = s?.Trim();
             return s;
         }
 
         private void textBox_Clicked(object sender, EventArgs e)
         {
-            ((ExtendedControls.TextBoxBorder)sender).Select(0, 1000); // clicking highlights everything
+            ((ExtendedControls.TextBoxBorder)sender).SelectAll(); // clicking highlights everything
         }
 
         #region router

--- a/ExtendedControls/Forms/DraggableForm.cs
+++ b/ExtendedControls/Forms/DraggableForm.cs
@@ -38,11 +38,11 @@ namespace ExtendedControls
 
         /// <summary>
         /// The number of pixels from the top of the <see cref="SmartSysMenuForm"/> that will be interpreted as caption
-        /// area when the <see cref="SmartSysMenuForm"/> is unframed.
+        /// area when the <see cref="SmartSysMenuForm"/> is unframed. The default value is <c>28</c>.
         /// </summary>
         /// <seealso cref="OnCaptionMouseDown"/>
         /// <seealso cref="OnCaptionMouseUp"/>
-        [DefaultValue(20), Description("The number of pixels from the top of the Form that will be interpreted as the Form's caption area.")]
+        [DefaultValue(28), Description("The number of pixels from the top of the Form that will be interpreted as the Form's caption area.")]
         public uint CaptionHeight { get; set; } = 28;
 
 

--- a/ExtendedControls/Forms/InfoForm.Designer.cs
+++ b/ExtendedControls/Forms/InfoForm.Designer.cs
@@ -100,7 +100,8 @@ namespace ExtendedControls
             this.labelCaption.Size = new System.Drawing.Size(98, 13);
             this.labelCaption.TabIndex = 6;
             this.labelCaption.Text = "Captiony thing here";
-            this.labelCaption.MouseDown += new System.Windows.Forms.MouseEventHandler(this.labelCaption_MouseDown);
+            this.labelCaption.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.labelCaption.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // panel_close
             // 
@@ -138,6 +139,7 @@ namespace ExtendedControls
             this.panelTop.Size = new System.Drawing.Size(824, 30);
             this.panelTop.TabIndex = 30;
             this.panelTop.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseDown);
+            this.panelTop.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelTop_MouseUp);
             // 
             // panelBottom
             // 

--- a/ExtendedControls/Forms/InfoForm.cs
+++ b/ExtendedControls/Forms/InfoForm.cs
@@ -91,9 +91,9 @@ namespace ExtendedControls
             OnCaptionMouseDown((Control)sender, e);
         }
 
-        private void labelCaption_MouseDown(object sender, MouseEventArgs e)
+        private void panelTop_MouseUp(object sender, MouseEventArgs e)
         {
-            OnCaptionMouseDown((Control)sender, e);
+            OnCaptionMouseUp((Control)sender, e);
         }
 
         private void InfoForm_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
* Add `MouseUp` handlers to match `MouseDown` handlers for caption controls.
* Add copyright to `EDDiscovery/Forms/GalaxySectorSelect.cs`.
* Bump copyright year in `EDDiscovery/Forms/Form2DMap.cs`.
* Also sort the using directives in `EDDiscovery/Forms/Form2DMap.cs`.
* `DraggableFormPos`:
  * Default the `top` value to `int.MinValue` instead of `-999` to prevent collisions.
  * Use `this.DesignMode` instead of checking if options are instanced.
  * `Event` -> `OnEvent`, as it's cheaper and we can override/change behavior.
  * Don't save `Form` position if the close was cancelled.
    * Not sure why it was the way it was, but eventually it's going to get closed and that's the time to capture the info.
* Linq-ify some GalaxySectorSelect `foreach` blocks that weren't concerned about the items being iterated.
* Fix a couple NRE possibilities in `UserControlRoute`
* Use `SelectAll` in `UserControlRoute` instead of `Select(0,1000)` to select *all* of the text.
* Fix the `DefaultValue` attrib on `DraggableForm.CaptionHeight`, and add the default value to the XML doc for the property.

Not addressed in this PR but will handle separately:
* The revised theme handling code for missing fonts isn't ideal.
* `if (!string.IsNullOrEmpty(x))` is cheaper than `if (x != null && x.Length > 0)`, and easier to read.