### PR TITLE
Remove Lat/Lon from Location submitted to EDDN (9.0.x)

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -131,6 +131,14 @@ namespace EliteDangerousCore.EDDN
 
             message = RemoveCommonKeys(message);
             message.Remove("StarPosFromEDSM");
+            message.Remove("Latitude");
+            message.Remove("Longitude");
+            if (!journal.Docked)
+            {
+                message.Remove("Body");
+                message.Remove("BodyType");
+                message.Remove("BodyID");
+            }
 
             msg["message"] = message;
             return msg;


### PR DESCRIPTION
Latitude and Longitude fields are disallowed in the EDDN journal schema, so any events that have these fields set (i.e. any undocked Location entries below about 2/3 of orbital cruise altitude) would have been rejected by EDDN.