### PR TITLE
Don't feed EDSM back to EDDN

### DIFF
--- a/EliteDangerous/DB/SystemCache.cs
+++ b/EliteDangerous/DB/SystemCache.cs
@@ -45,7 +45,7 @@ namespace EliteDangerousCore
             if (find.HasCoordinate && foundlist.Count > 0)           // if sys has a co-ord, find the best match within 0.5 ly
                 found = NearestTo(foundlist, find , 0.5);
 
-            if (found == null && foundlist.Count == 1)              // if we did not find one, but we have only 1 candidate, use it.
+            if (found == null && foundlist.Count == 1 && !find.HasCoordinate) // if we did not find one, but we have only 1 candidate, use it.
                 found = foundlist[0];
 
             if ( found == null )                                    // nope, no cache, so use the db

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -493,15 +493,51 @@ namespace EliteDangerousCore
 
             if (edsmsys != null)
             {
+                ISystem oldsys = syspos.System;
+
+                bool updateedsmid = oldsys.EDSMID <= 0 && edsmsys.EDSMID > 0;
+                bool updatesyspos = !oldsys.HasCoordinate && edsmsys.HasCoordinate;
+                bool updatename = oldsys.HasCoordinate && edsmsys.HasCoordinate &&
+                                  oldsys.Distance(edsmsys) < 0.1 &&
+                                  !String.Equals(edsmsys.Name, oldsys.Name, StringComparison.InvariantCultureIgnoreCase) &&
+                                  edsmsys.UpdateDate > syspos.EventTimeUTC;
+
+                ISystem newsys = new SystemClass
+                {
+                    Name = updatename ? edsmsys.Name : oldsys.Name,
+                    X = updatesyspos ? edsmsys.X : oldsys.X,
+                    Y = updatesyspos ? edsmsys.Y : oldsys.Y,
+                    Z = updatesyspos ? edsmsys.Z : oldsys.Z,
+                    EDSMID = updateedsmid ? edsmsys.EDSMID : oldsys.EDSMID,
+                    SystemAddress = oldsys.SystemAddress ?? edsmsys.SystemAddress,
+                    Allegiance = oldsys.Allegiance == EDAllegiance.Unknown ? edsmsys.Allegiance : oldsys.Allegiance,
+                    Government = oldsys.Government == EDGovernment.Unknown ? edsmsys.Government : oldsys.Government,
+                    Population = oldsys.Government == EDGovernment.Unknown ? edsmsys.Population : oldsys.Population,
+                    PrimaryEconomy = oldsys.PrimaryEconomy == EDEconomy.Unknown ? edsmsys.PrimaryEconomy : oldsys.PrimaryEconomy,
+                    Security = oldsys.Security == EDSecurity.Unknown ? edsmsys.Security : oldsys.Security,
+                    State = oldsys.State == EDState.Unknown ? edsmsys.State : oldsys.State,
+                    Faction = oldsys.Faction ?? edsmsys.Faction,
+                    CommanderCreate = edsmsys.CommanderCreate,
+                    CommanderUpdate = edsmsys.CommanderUpdate,
+                    CreateDate = edsmsys.CreateDate,
+                    EDDBID = edsmsys.EDDBID,
+                    EDDBUpdatedAt = edsmsys.EDDBUpdatedAt,
+                    GridID = edsmsys.GridID,
+                    NeedsPermit = edsmsys.NeedsPermit,
+                    RandomID = edsmsys.RandomID,
+                    UpdateDate = edsmsys.UpdateDate,
+                    SystemNote = edsmsys.SystemNote,
+                    status = SystemStatusEnum.EDSM
+                };
+
                 foreach (HistoryEntry he in alsomatching)       // list of systems in historylist using the same system object
                 {
-                    bool updateedsmid = he.System.EDSMID <= 0 && edsmsys.EDSMID>0;
-                    bool updatepos = (he.EntryType == JournalTypeEnum.FSDJump || he.EntryType == JournalTypeEnum.Location) && !syspos.System.HasCoordinate && edsmsys.HasCoordinate;
+                    bool updatepos = (he.EntryType == JournalTypeEnum.FSDJump || he.EntryType == JournalTypeEnum.Location) && updatesyspos;
 
                     if (updatepos || updateedsmid)
                         JournalEntry.UpdateEDSMIDPosJump(he.Journalid, edsmsys, updatepos, -1, uconn , utn);  // update pos and edsmid, jdist not updated
 
-                    he.System = edsmsys;
+                    he.System = newsys;
                 }
             }
             else


### PR DESCRIPTION
* If only one cached system is found, only match it if the seached system has no coordinate
* Only override the system fields that should be overridden from the EDSM system

This should fix the bug that resulted in bad data being sent to EDDN.

This was reported on January 18 on the EDSM discord that multiple bodies were assigned to the wrong system.

> [10:50 AM] Irisa Nyira: I've visited and scanned both 2MASS J02324756+6127000 systems for the first time today, both in the same session. The celestial bodies I've scanned in one system seem to be appearing on both.
> [11:17 AM] RapidfireCRH: Do you have your journal entries for each star
> [11:17 AM] RapidfireCRH: that will help in splitting them up
> [12:11 PM] Irisa Nyira: Yes, I do. What should I do with it?
> [12:14 PM] RapidfireCRH: keep it handy if Anthor needs it
> [12:14 PM] Irisa Nyira: Will do
> [12:14 PM] RapidfireCRH: After i said that i thought he might just look at timestamps
> [12:14 PM] RapidfireCRH: but you never know
> [12:22 PM] Irisa Nyira: I'll keep them handy. If it helps, the 2MASS J02324756+6127000 at [-4267.281,96.781,-4228.125] is a binary system and both stars have planets, whereas the one at [-4232.500,96.000,-4193.656] is a quinternary system and no planets orbit A or B. There are a bunch orbiting ABCD, and some more orbiting E.

I then investigated the EDDB entries and reported in the Developers channel on the EDDiscovery discord

> [7:15 PM] Bravada Cadelanne: https://ross.eddb.io/eddn/log/6397337 it looks like the data from EDSM is overriding the position sometimes - the associated FSDJump is https://ross.eddb.io/eddn/log/6392198, while it looks like the sent Scan event took the system info from https://ross.eddb.io/eddn/log/6300094
> [7:16 PM] Bravada Cadelanne: Interestingly, a few minutes later, it took the correct system: https://ross.eddb.io/eddn/log/6399733
> [7:24 PM] Bravada Cadelanne: In fact, both systems are fairly old, so if it picked up the wrong system, either the system matching is faulty, or matching the body to the FSDJump didn't work properly.