### PR TITLE
Fix filename case in TestNetLogEntry Resources.resx

### DIFF
--- a/TestNetLogEntry/Properties/Resources.resx
+++ b/TestNetLogEntry/Properties/Resources.resx
@@ -119,15 +119,15 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Market" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\market.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\Market.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="ModulesInfo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\modulesinfo.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\ModulesInfo.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="Outfitting" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\outfitting.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\Outfitting.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="Shipyard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\shipyard.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Resources\Shipyard.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes f7389dedab9ced3bcaa46bb24f2e0a6b51f8472d