### PR TITLE
Fix issue with roll down panel

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -802,7 +802,7 @@ namespace EDDiscovery
             this.removeTabToolStripMenuItem,
             this.renameTabToolStripMenuItem});
             this.contextMenuStripTabs.Name = "contextMenuStripTabs";
-            this.contextMenuStripTabs.Size = new System.Drawing.Size(190, 92);
+            this.contextMenuStripTabs.Size = new System.Drawing.Size(190, 70);
             this.contextMenuStripTabs.Opening += new System.ComponentModel.CancelEventHandler(this.ContextMenuStripTabs_Opening);
             // 
             // addTabToolStripMenuItem
@@ -845,6 +845,7 @@ namespace EDDiscovery
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.EDDiscoveryForm_FormClosing);
             this.Load += new System.EventHandler(this.EDDiscoveryForm_Load);
             this.Shown += new System.EventHandler(this.EDDiscoveryForm_Shown);
+            this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.EDDiscoveryForm_MouseDown);
             this.Resize += new System.EventHandler(this.EDDiscoveryForm_Resize);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -353,7 +353,9 @@ namespace EDDiscovery
             {
                 if (e.Button == MouseButtons.Right)
                 {
-                    contextMenuStripTabs.Show(tabControlMain.PointToScreen(e.Location));
+                    Point p = tabControlMain.PointToScreen(e.Location);
+                    p.Offset(0, -8);
+                    contextMenuStripTabs.Show(p);
                 }
                 else if (e.Button == MouseButtons.Middle && !IsNonRemovableTab(tabControlMain.LastTabClicked))
                 {
@@ -377,6 +379,17 @@ namespace EDDiscovery
             bool uch = tabControlMain.TabPages[n].Controls[0] is UserControls.UserControlHistory;
             bool sel = tabControlMain.TabPages[n].Controls[0] is UserControls.UserControlPanelSelector;
             return uch || sel;
+        }
+
+        private void EDDiscoveryForm_MouseDown(object sender, MouseEventArgs e)     // use the form to detect the click on the empty tab area.. it passes thru
+        {
+            if (e.Button == MouseButtons.Right && e.Y >= tabControlMain.Top)
+            {
+                tabControlMain.ClearLastTab();      // this sets LastTab to -1, which thankfully means insert at last but one position to the AddTab function
+                Point p = this.PointToScreen(e.Location);
+                p.Offset(0, -8);
+                contextMenuStripTabs.Show(p);
+            }
         }
 
         #endregion

--- a/EDDiscovery/MajorTabControl.cs
+++ b/EDDiscovery/MajorTabControl.cs
@@ -59,7 +59,7 @@ namespace EDDiscovery
                 int nameindex = (i - 1) / 2;
                 string name = majortabnames != null && nameindex < majortabnames.Length && majortabnames[nameindex].Length>0 ? majortabnames[nameindex] : null;
 
-                if (tabctrl[i] != -1)
+                if (tabctrl[i] != -1)       // this means UserControlHistory, which is a special one
                 {
                     try
                     {
@@ -84,6 +84,8 @@ namespace EDDiscovery
                 TabPages.Add(history); // add back in right place
                 userhistory.Init(eddiscovery, null, UserControls.UserControlCommonBase.DisplayNumberHistoryGrid); // and init at this point with 0 as dn
             }
+
+            EnsureMajorTabIsPresent(PanelInformation.PanelIDs.PanelSelector, true);     // just in case it disappears due to weirdness or debugging
 
             if (tabctrl.Length > 0 && tabctrl[0] >= 0 && tabctrl[0] < TabPages.Count)
                 SelectedIndex = tabctrl[0];  // make sure external data does not crash us

--- a/ExtendedControls/Controls/RollUpPanel.cs
+++ b/ExtendedControls/Controls/RollUpPanel.cs
@@ -30,7 +30,7 @@ namespace ExtendedControls
         public int UnrolledHeight { get; set; } = 32;
         public int RolledUpHeight { get; set; } = 5;
         public int RollUpAnimationTime { get; set; } = 500;            // animation time
-        public bool ShowHiddenMarker { get { return hiddenmarkershow; } set { hiddenmarkershow = value; SetHMViz();} }
+        public bool ShowHiddenMarker { get { return hiddenmarkershow; } set { hiddenmarkershow = value; SetHMViz(); } }
 
         public int HiddenMarkerWidth { get; set; } = 0;   //0 = full width
 
@@ -49,7 +49,7 @@ namespace ExtendedControls
 
         Action<RollUpPanel, CheckBoxCustom> PinStateChanged = null;
 
-        enum Mode { None, PauseBeforeRollDown, PauseBeforeRollUp, RollUp, RollDown};
+        enum Mode { None, PauseBeforeRollDown, PauseBeforeRollUp, RollUp, RollDown };
         Mode mode;
         Timer timer;
         bool hiddenmarkershow = true;           // if to show it at all.
@@ -85,7 +85,7 @@ namespace ExtendedControls
 
             ResumeLayout();
 
-            mode = Mode.None; 
+            mode = Mode.None;
             timer = new Timer();
             timer.Tick += Timer_Tick;
 
@@ -101,7 +101,7 @@ namespace ExtendedControls
 
         private void Hiddenmarker_Click(object sender, EventArgs e)
         {
-            if ( mode == Mode.PauseBeforeRollDown )
+            if (mode == Mode.PauseBeforeRollDown)
             {
                 //System.Diagnostics.Debug.WriteLine("Cancel roll down pause and expand now");
                 timer.Stop();
@@ -118,7 +118,7 @@ namespace ExtendedControls
         {
             if (ttpin == null)
                 ttpin = "Pin to stop this menu bar disappearing automatically";
-            if ( ttmarker == null )
+            if (ttmarker == null)
                 ttmarker = "Click or hover over this to unroll the menu bar";
             t.SetToolTip(pinbutton, ttpin);
             t.SetToolTip(hiddenmarker, ttmarker);
@@ -139,7 +139,7 @@ namespace ExtendedControls
         }
 
 
-        public void SetPinImages(Image up , Image down)
+        public void SetPinImages(Image up, Image down)
         {
             pinbutton.Image = up;
             pinbutton.ImageUnchecked = down;
@@ -221,7 +221,7 @@ namespace ExtendedControls
                 mode = Mode.PauseBeforeRollDown;
                 //System.Diagnostics.Debug.WriteLine(Environment.TickCount + " begin wait for unroll");
             }
-            else if ( mode == Mode.PauseBeforeRollUp )      // if in a roll up.. we stop it
+            else if (mode == Mode.PauseBeforeRollUp)      // if in a roll up.. we stop it
             {
                 timer.Stop();
                 mode = Mode.None;
@@ -275,7 +275,7 @@ namespace ExtendedControls
                 if (hmwidth == 0)
                     hmwidth = ClientRectangle.Width;
 
-                hiddenmarker.Left = (HiddenMarkerWidth<0) ? ((ClientRectangle.Width - hmwidth)/2) : 0;
+                hiddenmarker.Left = (HiddenMarkerWidth < 0) ? ((ClientRectangle.Width - hmwidth) / 2) : 0;
                 hiddenmarker.Width = hmwidth;
             }
         }
@@ -352,14 +352,5 @@ namespace ExtendedControls
                 }
             }
         }
-
-        // NOT IN USE
-        #region Icon Replacement
-        public void ReplaceIconsNOTINUSE(Func<string, Image> getIcon)
-        {
-            pinbutton.Image = getIcon("PinDown");
-            pinbutton.ImageUnchecked = getIcon("PinUp");
-        }
-        #endregion
     }
 }

--- a/ExtendedControls/Controls/TabControlCustom.cs
+++ b/ExtendedControls/Controls/TabControlCustom.cs
@@ -66,6 +66,7 @@ namespace ExtendedControls
         public bool AllowDragReorder { get; set; } = false;
         // Tab clicked.. reports last tab clicked
         public int LastTabClicked { get; private set; } = -1;
+        public void ClearLastTab() { LastTabClicked = -1; }
 
         #endregion
 

--- a/TestExtendedControls/Program.cs
+++ b/TestExtendedControls/Program.cs
@@ -55,7 +55,7 @@ namespace DialogTest
                     th.SetThemeByName("Elite Verdana");
                     ExtendedControls.ThemeableFormsInstance.Instance = th;
                     ExtendedControls.InfoForm inf = new ExtendedControls.InfoForm();
-                    inf.Info("Info form", Properties.Resources._3x3_grid, "This is a nice test\r\nOf the info form\r\n", null, new int[] { 0, 100, 200, 300, 400, 500, 600 }, true);
+                    inf.Info("Info form", Properties.Resources._3x3_grid, "This is a nice test\r\nOf the info form\r\n", new int[] { 0, 100, 200, 300, 400, 500, 600 }, true);
                     sel = inf;
                     break;
 


### PR DESCRIPTION
Forms did not like tab control in panel with docking, for some reason.
Notice it does not do a resize until the roll up is complete, minimising
the flashing.. hmmm

Anyway, use the form to detect the mouse click on the empty tab area and
process