### PR TITLE
Fix some NOP `string.Trim()` calls, trim down a couple others

### DIFF
--- a/ActionLanguage/ActionsCore/ActionFile.cs
+++ b/ActionLanguage/ActionsCore/ActionFile.cs
@@ -185,7 +185,7 @@ namespace ActionLanguage
                         {
                             lineno++;       // on line of read..
 
-                            line.Trim();
+                            line = line.Trim();
                             if (line.StartsWith("ENABLED", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 line = line.Substring(7).Trim().ToLower();

--- a/Audio/SpeechSythesizerWindows.cs
+++ b/Audio/SpeechSythesizerWindows.cs
@@ -81,7 +81,7 @@ namespace AudioExtensions
                 string[] ssmlstart = new string[] { "<say-as ", "<emphasis" , "<phoneme" , "<sub" , "<prosody"};
                 string[] ssmlend = new string[] { "</say-as>", "</emphasis>" , "</phoneme>" , "</sub>" , "</prosody>" };
 
-                phrase.Trim();
+                phrase = phrase.Trim();
 
                 while (phrase.Length > 0)
                 {

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1890,12 +1890,12 @@ namespace EDDiscovery
                 }
 
                 SystemNoteClass sn = SystemNoteClass.GetNoteOnSystem(sysname, hoversystem == null ? 0 : hoversystem.EDSMID);   // may be null
-                if (sn != null && sn.Note.Trim().Length>0 )
+                if (!string.IsNullOrWhiteSpace(sn?.Note))
                 {
                     info += Environment.NewLine + "Notes: " + sn.Note.Trim();
                 }
 
-                if (curbookmark != null && curbookmark.Note != null && curbookmark.Note.Trim().Length>0 )
+                if (!string.IsNullOrWhiteSpace(curbookmark?.Note))
                     info += Environment.NewLine + "Bookmark Notes: " + curbookmark.Note.Trim();
 
                 _mousehovertooltip = new System.Windows.Forms.ToolTip();

--- a/EDDiscovery/UserControls/UserControlTrilateration.cs
+++ b/EDDiscovery/UserControls/UserControlTrilateration.cs
@@ -236,9 +236,9 @@ namespace EDDiscovery.UserControls
             }
             else if (e.ColumnIndex == 1)
             {
-                if (dataGridViewDistances[1, e.RowIndex].Value != null && !string.IsNullOrEmpty(dataGridViewDistances[1, e.RowIndex].Value.ToString().Trim()))
+                var value = dataGridViewDistances[1, e.RowIndex].Value?.ToString().Trim();
+                if (!string.IsNullOrEmpty(value))
                 {
-                    var value = dataGridViewDistances[1, e.RowIndex].Value.ToString().Trim();
                     var parsedDistance = BaseUtils.DistanceParser.ParseInterstellarDistance(value);
                     if (parsedDistance.HasValue)
                     {

--- a/EliteDangerous/CompanionAPI/CompanionAPIClass.cs
+++ b/EliteDangerous/CompanionAPI/CompanionAPIClass.cs
@@ -481,8 +481,8 @@ namespace EliteDangerousCore.CompanionAPI
 
             Trace.WriteLine("Reading response");
             using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream, encoding))
             {
-                var reader = new StreamReader(stream, encoding);
                 string data = reader.ReadToEnd();
                 if (string.IsNullOrWhiteSpace(data))
                 {

--- a/EliteDangerous/CompanionAPI/CompanionAPIClass.cs
+++ b/EliteDangerous/CompanionAPI/CompanionAPIClass.cs
@@ -484,7 +484,7 @@ namespace EliteDangerousCore.CompanionAPI
             {
                 var reader = new StreamReader(stream, encoding);
                 string data = reader.ReadToEnd();
-                if (data == null || data.Trim() == "")
+                if (string.IsNullOrWhiteSpace(data))
                 {
                     BaseUtils.HttpCom.WriteLog("Companion No data returned", "");
                     return null;

--- a/EliteDangerous/EliteDangerous/VisitingStarsCacheFolder.cs
+++ b/EliteDangerous/EliteDangerous/VisitingStarsCacheFolder.cs
@@ -49,7 +49,7 @@ namespace EliteDangerousCore
                 folder = Path.GetDirectoryName(allFiles[0]);
             }
 
-            if (folder == null || folder.Trim().Length == 0)
+            if (string.IsNullOrWhiteSpace(folder))
                 return null;
 
             return folder;


### PR DESCRIPTION
* Fix `ActionFile` and `SpeechSynthesizerWindows` that were using a NOP `string.Trim(...)` syntax.
* Rewrote a few other (repeated!) `string.Trim(...)` calls to use `string.IsNullOrWhiteSpace(...)`.