### PR TITLE
Add BodyID processing to StarScan; process other events with body name/id

### DIFF
--- a/EDDiscovery/UserControls/UserControlScan.cs
+++ b/EDDiscovery/UserControls/UserControlScan.cs
@@ -195,7 +195,7 @@ namespace EDDiscovery.UserControls
 
                         StarScan.ScanNode lastbelt = belts.Count != 0 ? belts.Dequeue() : null;
 
-                        foreach (StarScan.ScanNode planetnode in starnode.children.Values.Where(s => s.type != StarScan.ScanNodeType.belt))
+                        foreach (StarScan.ScanNode planetnode in starnode.children.Values.Where(s => s.type != StarScan.ScanNodeType.belt && s.type != StarScan.ScanNodeType.barycentre))
                         {
                             while (lastbelt != null && planetnode.ScanData != null && (lastbelt.BeltData == null || lastbelt.BeltData.OuterRad < planetnode.ScanData.nSemiMajorAxis))
                             {
@@ -307,7 +307,7 @@ namespace EDDiscovery.UserControls
 
                 Point moonpos = new Point(curpos.X + offset, maxtreepos.Y + itemsepar.Height);    // moon pos
 
-                foreach (StarScan.ScanNode moonnode in planetnode.children.Values)
+                foreach (StarScan.ScanNode moonnode in planetnode.children.Values.Where(n => n.type != StarScan.ScanNodeType.barycentre))
                 {
                     bool nonedsmscans = moonnode.DoesNodeHaveNonEDSMScansBelow();     // is there any scans here, either at this node or below?
 

--- a/EliteDangerous/EliteDangerous/JournalEntryInterfaces.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntryInterfaces.cs
@@ -38,6 +38,16 @@ namespace EliteDangerousCore
         void ShipInformation(ShipInformationList shp, SQLiteConnectionUser conn);
     }
 
+    public interface IBodyNameAndID
+    {
+        string Body { get; }
+        string BodyType { get; }
+        int? BodyID { get; }
+        string BodyDesignation { get; set; }
+        string StarSystem { get; }
+        long? SystemAddress { get; }
+    }
+
     public interface IMissions
     {
         void UpdateMissions(MissionListAccumulator mlist, ISystem sys, string body, SQLiteConnectionUser conn);

--- a/EliteDangerous/EliteDangerous/StarScan.cs
+++ b/EliteDangerous/EliteDangerous/StarScan.cs
@@ -548,7 +548,7 @@ namespace EliteDangerousCore
             starscannodetype = ScanNodeType.star;
             isbeltcluster = false;
             List<string> elements;
-            string rest = IsStarNameRelatedReturnRest(sys.Name, sc.Body, sc.BodyType);
+            string rest = IsStarNameRelatedReturnRest(sys.Name, sc.Body, sc.BodyDesignation);
 
             if (rest != null)                                   // if we have a relationship..
             {
@@ -800,6 +800,11 @@ namespace EliteDangerousCore
                     {
                         node.BodyID = sc.BodyID;
                     }
+
+                    if (sc.BodyType == "" || sc.BodyType == "Null")
+                        node.type = ScanNodeType.barycentre;
+                    else if (sc.BodyType == "Belt")
+                        node.type = ScanNodeType.belt;
                 }
             }
 

--- a/EliteDangerous/EliteDangerous/StarScan.cs
+++ b/EliteDangerous/EliteDangerous/StarScan.cs
@@ -649,7 +649,8 @@ namespace EliteDangerousCore
             SortedList<string, ScanNode> cnodes = sn.starnodes;
             ScanNode node = null;
             List<JournalScan.BodyParent> ancestors = sc.Parents?.AsEnumerable()?.ToList();
-            List<JournalScan.BodyParent> ancestorbodies = ancestors?.Where(a => a.Type == "Star" || a.Type == "Planet")?.ToList();
+            List<JournalScan.BodyParent> ancestorbodies = ancestors?.Where(a => a.Type == "Star" || a.Type == "Planet" || a.Type == "Belt")?.Reverse()?.ToList();
+            ScanNode toplevelnode = null;
 
             if ((ancestorbodies != null) && (starscannodetype != ScanNodeType.star))
             {
@@ -698,18 +699,6 @@ namespace EliteDangerousCore
                         sublv.BodyID = ancestorbodies[lvl].BodyID;
                         sn.NodesByID[(int)sublv.BodyID] = sublv;
                     }
-
-                    if (sublv.BodyID != null)
-                    {
-                        if (lvl == 0 && sublv.BodyID > sn.MaxTopLevelBodyID)
-                        {
-                            sn.MaxTopLevelBodyID = (int)sublv.BodyID;
-                        }
-                        else if (lvl > 0 && sublv.BodyID < sn.MinPlanetBodyID)
-                        {
-                            sn.MinPlanetBodyID = (int)sublv.BodyID;
-                        }
-                    }
                 }
 
                 node = sublv;
@@ -723,6 +712,35 @@ namespace EliteDangerousCore
                     if (sc.BodyID != null)
                     {
                         node.BodyID = sc.BodyID;
+                    }
+                }
+
+                if (lvl == 0)
+                {
+                    toplevelnode = node;
+                }
+
+                if (node.BodyID != null)
+                {
+                    if (lvl == 0 && node.BodyID > sn.MaxTopLevelBodyID)
+                    {
+                        sn.MaxTopLevelBodyID = (int)node.BodyID;
+                    }
+                    else if (lvl > 0 && node.BodyID < sn.MinPlanetBodyID)
+                    {
+                        sn.MinPlanetBodyID = (int)node.BodyID;
+                    }
+                }
+            }
+
+            if (ancestors != null && ancestorbodies != null && ancestorbodies[0] == null && toplevelnode.BodyID == null)
+            {
+                for (int lvl = 1; lvl < ancestors.Count; lvl++)
+                {
+                    if (ancestors[lvl - 1].BodyID >= sn.MinPlanetBodyID && ancestors[lvl].BodyID <= sn.MaxTopLevelBodyID)
+                    {
+                        toplevelnode.BodyID = ancestors[lvl].BodyID;
+                        sn.NodesByID[(int)toplevelnode.BodyID] = toplevelnode;
                     }
                 }
             }

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -808,6 +808,12 @@ namespace EliteDangerousCore
                     }
                 }
             }
+            else if (je is IBodyNameAndID)
+            {
+                JournalLocOrJump jl;
+                HistoryEntry jlhe;
+                starscan.AddBodyToBestSystem((IBodyNameAndID)je, Count - 1, EntryOrder, out jlhe, out jl);
+            }
 
             return he;
         }
@@ -943,6 +949,10 @@ namespace EliteDangerousCore
                         {
                             System.Diagnostics.Debug.WriteLine("******** Cannot add scan to system " + (je as JournalScan).BodyName + " in " + he.System.Name);
                         }
+                    }
+                    else if (je is IBodyNameAndID)
+                    {
+                        this.starscan.AddBodyToBestSystem((IBodyNameAndID)je, i, hl);
                     }
                 }
             }

--- a/EliteDangerous/JournalEvents/JournalApproachBody.cs
+++ b/EliteDangerous/JournalEvents/JournalApproachBody.cs
@@ -26,20 +26,22 @@ namespace EliteDangerousCore.JournalEvents
     // •	BodyID
 
     [JournalEntryType(JournalTypeEnum.ApproachBody)]
-    public class JournalApproachBody : JournalEntry
+    public class JournalApproachBody : JournalEntry, IBodyNameAndID
     {
         public JournalApproachBody(JObject evt) : base(evt, JournalTypeEnum.ApproachBody)
         {
             StarSystem = evt["StarSystem"].Str();
-            SystemAddress = evt["SystemAddress"].Long();
+            SystemAddress = evt["SystemAddress"].LongNull();
             Body = evt["Body"].Str();
-            BodyID = evt["BodyID"].Int();
+            BodyID = evt["BodyID"].IntNull();
         }
 
         public string StarSystem { get; set; }
-        public long SystemAddress { get; set; }
+        public long? SystemAddress { get; set; }
         public string Body { get; set; }
-        public int BodyID { get; set; }
+        public int? BodyID { get; set; }
+        public string BodyType { get { return "Planet"; } }
+        public string BodyDesignation { get; set; }
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {

--- a/EliteDangerous/JournalEvents/JournalLeaveBody.cs
+++ b/EliteDangerous/JournalEvents/JournalLeaveBody.cs
@@ -26,20 +26,22 @@ namespace EliteDangerousCore.JournalEvents
     // •	BodyID
 
     [JournalEntryType(JournalTypeEnum.LeaveBody)]
-    public class JournalLeaveBody : JournalEntry
+    public class JournalLeaveBody : JournalEntry, IBodyNameAndID
     {
         public JournalLeaveBody(JObject evt) : base(evt, JournalTypeEnum.LeaveBody)
         {
             StarSystem = evt["StarSystem"].Str();
-            SystemAddress = evt["SystemAddress"].Long();
+            SystemAddress = evt["SystemAddress"].LongNull();
             Body = evt["Body"].Str();
-            BodyID = evt["BodyID"].Int();
+            BodyID = evt["BodyID"].IntNull();
         }
 
         public string StarSystem { get; set; }
-        public long SystemAddress { get; set; }
+        public long? SystemAddress { get; set; }
         public string Body { get; set; }
-        public int BodyID { get; set; }
+        public int? BodyID { get; set; }
+        public string BodyDesignation { get; set; }
+        public string BodyType { get { return "Planet"; } }
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {

--- a/EliteDangerous/JournalEvents/JournalLocation.cs
+++ b/EliteDangerous/JournalEvents/JournalLocation.cs
@@ -36,7 +36,7 @@ namespace EliteDangerousCore.JournalEvents
     //•	Government
     //•	Security
     [JournalEntryType(JournalTypeEnum.Location)]
-    public class JournalLocation : JournalLocOrJump, ISystemStationEntry
+    public class JournalLocation : JournalLocOrJump, ISystemStationEntry, IBodyNameAndID
     {
         public JournalLocation(JObject evt) : base(evt, JournalTypeEnum.Location)      // all have evidence 16/3/2017
         {
@@ -57,8 +57,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationName { get; set; }
         public string StationType { get; set; }
         public string Body { get; set; }
-        public long? BodyID { get; set; }
+        public int? BodyID { get; set; }
         public string BodyType { get; set; }
+        public string BodyDesignation { get; set; }
 
         public double? Latitude { get; set; }
         public double? Longitude { get; set; }

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -76,6 +76,7 @@ namespace EliteDangerousCore.JournalEvents
         public bool HasRings { get { return Rings != null && Rings.Length > 0; } }
         public StarPlanetRing[] Rings { get; set; }
         public int EstimatedValue { get; set; }
+        public List<BodyParent> Parents { get; set; }
 
         // STAR
         public string StarType { get; set; }                        // null if no StarType, direct from journal, K, A, B etc
@@ -196,6 +197,12 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
+        public class BodyParent
+        {
+            public string Type;
+            public int BodyID;
+        }
+
         public JournalScan(JObject evt) : base(evt, JournalTypeEnum.Scan)
         {
             ScanType = evt["ScanType"].Str();
@@ -307,6 +314,16 @@ namespace EliteDangerousCore.JournalEvents
             IsEDSMBody = evt["EDDFromEDSMBodie"].Bool(false);
 
             EstimatedValue = CalculateEstimatedValue();
+
+            if (evt["Parents"] != null)
+            {
+                Parents = new List<BodyParent>();
+                foreach (JObject parent in evt["Parents"])
+                {
+                    JProperty prop = parent.Properties().First();
+                    Parents.Add(new BodyParent { Type = prop.Name, BodyID = prop.Value.Int() });
+                }
+            }
         }
 
         public override void FillInformation(out string summary, out string info, out string detailed)  //V

--- a/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
+++ b/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
@@ -23,7 +23,7 @@ namespace EliteDangerousCore.JournalEvents
     //•	Starsystem
     //•	Body
     [JournalEntryType(JournalTypeEnum.SupercruiseExit)]
-    public class JournalSupercruiseExit : JournalEntry
+    public class JournalSupercruiseExit : JournalEntry, IBodyNameAndID
     {
         public JournalSupercruiseExit(JObject evt ) : base(evt, JournalTypeEnum.SupercruiseExit)
         {
@@ -40,6 +40,7 @@ namespace EliteDangerousCore.JournalEvents
         public string Body { get; set; }
         public int? BodyID { get; set; }
         public string BodyType { get; set; }
+        public string BodyDesignation { get; set; }
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {


### PR DESCRIPTION
This does not yet handle barycentres, as it is difficult to determine if a barycentre is a top-level barycentre or a planet-level barycentre, and what the names of those top-level barycentres are unless all top-level stars have been scanned.