### PR TITLE
Move icon init to EDDiscoveryController.Initialize

### DIFF
--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -120,6 +120,13 @@ namespace EDDiscovery
 
             msg.Invoke("Locating Crew Members");
             EDDConfig.Instance.Update(false);
+
+            msg.Invoke("Decoding Symbols");
+            Icons.IconSet.ResetIcons();     // start with a clean slate loaded up from default icons
+
+            string path = EDDOptions.Instance.IconsPath ?? (EDDOptions.Instance.AppDataDirectory + "\\Icons\\*.zip");
+
+            Icons.IconSet.LoadIconPack(path, EDDOptions.Instance.AppDataDirectory, AppDomain.CurrentDomain.BaseDirectory);
         }
 
         public void Init()      // ED Discovery calls this during its init
@@ -131,12 +138,6 @@ namespace EDDiscovery
                     LogLineHighlight($"Log Writer Exception: {ex}");
                 };
             }
-
-            Icons.IconSet.ResetIcons();     // start with a clean slate loaded up from default icons
-
-            string path = EDDOptions.Instance.IconsPath ?? (EDDOptions.Instance.AppDataDirectory+"\\Icons\\*.zip");
-
-            Icons.IconSet.LoadIconPack(path, EDDOptions.Instance.AppDataDirectory , AppDomain.CurrentDomain.BaseDirectory);
 
             backgroundWorker = new Thread(BackgroundWorkerThread);
             backgroundWorker.IsBackground = true;

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -151,6 +151,7 @@ namespace EDDiscovery
             Debug.WriteLine(BaseUtils.AppTicks.TickCount100 + " ED init");
             msg.Invoke("Modulating Shields");
             Controller.Init();
+            PanelInformation.InitIcons();
 
             // Some components require the controller to be initialized
             // obsolete remove IconSet.SetPanelImageListGetter(PanelInformation.GetPanelImages);

--- a/EDDiscovery/PanelAndPopOuts.cs
+++ b/EDDiscovery/PanelAndPopOuts.cs
@@ -111,7 +111,12 @@ namespace EDDiscovery.Forms
             { new PanelInfo( PanelIDs.PanelSelector, typeof(UserControlPanelSelector), "+", "Selector", "") },       // no description, not presented to user
         };
 
-        public static IReadOnlyDictionary<PanelIDs, Image> PanelTypeIcons { get; } = new IconGroup<PanelIDs>("Panels");
+        public static IReadOnlyDictionary<PanelIDs, Image> PanelTypeIcons { get; private set; } = new IconGroup<PanelIDs>("Panels");
+
+        public static void InitIcons()
+        {
+            PanelTypeIcons = new IconGroup<PanelIDs>("Panels");
+        }
 
         public class PanelInfo
         {


### PR DESCRIPTION
The optimizer is apparently hoisting some static constructors to run at the start of the referencing method, and so was retrieving them before they had been initialized.