### PR TITLE
Fix version checking system

### DIFF
--- a/BaseUtils/HTTP/GitHubRelease.cs
+++ b/BaseUtils/HTTP/GitHubRelease.cs
@@ -36,9 +36,12 @@ namespace BaseUtils
         public string ReleaseVersion {
             get
             {
-                string str = jo["name"].Str();
-
-                return new string(str.Where(p => char.IsDigit(p) || p=='.').ToArray());
+                string str = jo["tag_name"].Str();
+                int indexof = str.IndexOfAny("0123456789".ToCharArray());
+                if (indexof >= 0)
+                    return str.Substring(indexof);
+                else
+                    return "";
             }
         }
 

--- a/BaseUtils/Numbers/NumberObjectExtensions.cs
+++ b/BaseUtils/Numbers/NumberObjectExtensions.cs
@@ -210,11 +210,16 @@ public static class ObjectExtensionsNumbersBool
         return 0;
     }
 
-    static public int[] GetVersion(this System.Reflection.Assembly aw)
+    static public int[] GetVersionInts(this System.Reflection.Assembly aw)
     {
-        string v = aw.FullName.Split(',')[1].Split('=')[1];
-        string[] list = v.Split('.');
-        return VersionFromStringArray(list);
+        System.Reflection.AssemblyName an = new System.Reflection.AssemblyName(aw.FullName);            // offical way to split it
+        return new int[4] { an.Version.Major, an.Version.Minor, an.Version.Build, an.Version.Revision };
+    }
+
+    static public string GetVersionString(this System.Reflection.Assembly aw)
+    {
+        System.Reflection.AssemblyName an = new System.Reflection.AssemblyName(aw.FullName);
+        return an.Version.Major.ToStringInvariant() + "." + an.Version.Minor.ToStringInvariant() + "." + an.Version.Build.ToStringInvariant() + "." + an.Version.Revision.ToStringInvariant();
     }
 
     #endregion

--- a/EDDiscovery/Actions/ConditionFunctionsEDD.cs
+++ b/EDDiscovery/Actions/ConditionFunctionsEDD.cs
@@ -69,7 +69,7 @@ namespace EDDiscovery.Actions
 
         protected bool Version(out string output)
         {
-            int[] edversion = System.Reflection.Assembly.GetExecutingAssembly().GetVersion();
+            int[] edversion = System.Reflection.Assembly.GetExecutingAssembly().GetVersionInts();
 
             int para;
             if (paras[0].value.InvariantParse(out para) && para >= 0 && para <= edversion.Length)

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -317,13 +317,11 @@ namespace EDDiscovery
 
                 if (rel != null)
                 {
-                    //string newInstaller = jo["Filename"].Value<string>();
+                    var currentVersion = System.Reflection.Assembly.GetExecutingAssembly().GetVersionString();
+                    var releaseVersion = rel.ReleaseVersion;
 
-                    var currentVersion = Application.ProductVersion;
-
-                    Version v1, v2;
-                    v1 = new Version(rel.ReleaseVersion);
-                    v2 = new Version(currentVersion);
+                    Version v1 = new Version(releaseVersion);
+                    Version v2 = new Version(currentVersion);
 
                     if (v1.CompareTo(v2) > 0) // Test if newer installer exists:
                     {

--- a/EDDiscovery/Forms/AddOnManagerForm.cs
+++ b/EDDiscovery/Forms/AddOnManagerForm.cs
@@ -158,7 +158,7 @@ namespace EDDiscovery.Forms
 
             mgr = new VersioningManager();
 
-            int[] edversion = System.Reflection.Assembly.GetExecutingAssembly().GetVersion();
+            int[] edversion = System.Reflection.Assembly.GetExecutingAssembly().GetVersionInts();
             System.Diagnostics.Debug.Assert(edversion != null);
 
             ReadLocalFiles(mgr, managedownloadmode);


### PR DESCRIPTION
Use correct Assembly name splitter class to find out numbers
Use executing assembly to find current vnumber instead of product
version.
Fix github to use release tag and allow for crap in front of it.