### PR TITLE
Add marketID to commodity; add market etc. to EDDN filter

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -681,7 +681,7 @@ namespace EDDiscovery
                 if (he.Commander.Name.StartsWith("[BETA]", StringComparison.InvariantCultureIgnoreCase) || he.IsBetaMessage)
                     eddn.isBeta = true;
 
-                JObject msg = eddn.CreateEDDNCommodityMessage(market.commodities, Capi.Profile.CurrentStarSystem.name, Capi.Profile.StarPort.name, DateTime.UtcNow);
+                JObject msg = eddn.CreateEDDNCommodityMessage(market.commodities, Capi.Profile.CurrentStarSystem.name, Capi.Profile.StarPort.name, market.id, DateTime.UtcNow);
 
                 if (msg != null)
                 {

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -331,7 +331,7 @@ namespace EliteDangerousCore.EDDN
         }
 
 
-        public JObject CreateEDDNCommodityMessage(List<CCommodities> commodities, string systemName, string stationName, DateTime time)
+        public JObject CreateEDDNCommodityMessage(List<CCommodities> commodities, string systemName, string stationName, long? marketID, DateTime time)
         {
             if (commodities == null || commodities.Count == 0)
                 return null;
@@ -345,6 +345,7 @@ namespace EliteDangerousCore.EDDN
 
             message["systemName"] = systemName;
             message["stationName"] = stationName;
+            message["marketID"] = marketID;
             message["timestamp"] = time.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
 
             JArray JAcommodities = new JArray();

--- a/EliteDangerous/EDDN/EDDNSync.cs
+++ b/EliteDangerous/EDDN/EDDNSync.cs
@@ -185,7 +185,7 @@ namespace EliteDangerousCore.EDDN
             {
                 JournalMarket jm = je as JournalMarket;
                 msg2 = eddn.CreateEDDNJournalMessage(jm, he.System.X, he.System.Y, he.System.Z, he.System.SystemAddress);
-                msg = eddn.CreateEDDNCommodityMessage(jm.Commodities, jm.StarSystem, jm.Station, DateTime.UtcNow);      // if its devoid of data, null returned
+                msg = eddn.CreateEDDNCommodityMessage(jm.Commodities, jm.StarSystem, jm.Station, jm.MarketID, DateTime.UtcNow);      // if its devoid of data, null returned
             }
 
             if (msg != null)

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -72,7 +72,12 @@ namespace EliteDangerousCore
             get
             {
                 DateTime ed22 = new DateTime(2016, 10, 25, 12, 0, 0);
-                if ((EntryType == JournalTypeEnum.Scan || EntryType == JournalTypeEnum.Docked || EntryType == JournalTypeEnum.FSDJump) && EventTimeUTC > ed22) return true; else return false;
+                if ((EntryType == JournalTypeEnum.Scan || 
+                     EntryType == JournalTypeEnum.Docked || 
+                     EntryType == JournalTypeEnum.FSDJump ||
+                     EntryType == JournalTypeEnum.Market ||
+                     EntryType == JournalTypeEnum.Shipyard ||
+                     EntryType == JournalTypeEnum.Outfitting) && EventTimeUTC > ed22) return true; else return false;
             }
         }
 


### PR DESCRIPTION
Market / Shipyard / Outfitting events weren't actually being sent to EDDN, as we hadn't updated the EDDN filter.

Also add the `marketID` attribute as discussed on the EDDN channel of the EDCD discord.