### PR TITLE
Fix a couple of issues with sending to EDDN

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -220,7 +220,7 @@ namespace EliteDangerousCore.EDDN
                 ["systemName"] = journal.StarSystem,
                 ["stationName"] = journal.StationName,
                 ["marketId"] = journal.MarketID,
-                ["modules"] = new JArray(journal.ModuleItems.Select(m => m.FDName))
+                ["modules"] = new JArray(journal.ModuleItems.Select(m => JournalFieldNaming.NormaliseFDItemName(m.FDName)))
             };
 
             //if (systemAddress != null)

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -219,12 +219,12 @@ namespace EliteDangerousCore.EDDN
                 ["timestamp"] = journal.EventTimeUTC.ToString("yyyy-MM-ddTHH:mm:ss'Z'"),
                 ["systemName"] = journal.StarSystem,
                 ["stationName"] = journal.StationName,
-                ["marketID"] = journal.MarketID,
-                ["modules"] = new JArray(journal.ModuleItems.Select(m => m.Name))
+                ["marketId"] = journal.MarketID,
+                ["modules"] = new JArray(journal.ModuleItems.Select(m => m.FDName))
             };
 
-            if (systemAddress != null)
-                message["systemAddress"] = systemAddress;
+            //if (systemAddress != null)
+            //    message["systemAddress"] = systemAddress;
 
             msg["message"] = message;
             return msg;
@@ -268,12 +268,12 @@ namespace EliteDangerousCore.EDDN
                 ["timestamp"] = journal.EventTimeUTC.ToString("yyyy-MM-ddTHH:mm:ss'Z'"),
                 ["systemName"] = journal.StarSystem,
                 ["stationName"] = journal.StationName,
-                ["marketID"] = journal.MarketID,
-                ["ships"] = new JArray(journal.ShipyardItems.Select(m => m.ShipType))
+                ["marketId"] = journal.MarketID,
+                ["ships"] = new JArray(journal.ShipyardItems.Select(m => m.FDShipType))
             };
 
-            if (systemAddress != null)
-                message["SystemAddress"] = systemAddress;
+            //if (systemAddress != null)
+            //    message["SystemAddress"] = systemAddress;
 
             msg["message"] = message;
             return msg;
@@ -345,7 +345,7 @@ namespace EliteDangerousCore.EDDN
 
             message["systemName"] = systemName;
             message["stationName"] = stationName;
-            message["marketID"] = marketID;
+            message["marketId"] = marketID;
             message["timestamp"] = time.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
 
             JArray JAcommodities = new JArray();
@@ -360,14 +360,14 @@ namespace EliteDangerousCore.EDDN
 
                 JObject jo = new JObject();
 
-                jo["demandBracket"] = commodity.demandBracket;
                 jo["name"] = commodity.name;
-                jo["buyPrice"] = commodity.buyPrice;
                 jo["meanPrice"] = commodity.meanPrice;
-                jo["stockBracket"] = commodity.stockBracket;
-                jo["demand"] = commodity.demand;
-                jo["sellPrice"] = commodity.sellPrice;
+                jo["buyPrice"] = commodity.buyPrice;
                 jo["stock"] = commodity.stock;
+                jo["stockBracket"] = commodity.stockBracket;
+                jo["sellPrice"] = commodity.sellPrice;
+                jo["demand"] = commodity.demand;
+                jo["demandBracket"] = commodity.demandBracket;
 
                 if (commodity.StatusFlags!=null && commodity.StatusFlags.Count > 0)
                 {
@@ -396,7 +396,16 @@ namespace EliteDangerousCore.EDDN
             catch (System.Net.WebException ex)
             {
                 System.Net.HttpWebResponse response = ex.Response as System.Net.HttpWebResponse;
-                System.Diagnostics.Trace.WriteLine($"EDDN message post failed - status: {response?.StatusCode.ToString() ?? ex.Status.ToString()}\nEDDN Message: {msg.ToString()}");
+                string responsetext = null;
+                using (var responsestream = response.GetResponseStream())
+                {
+                    using (var reader = new System.IO.StreamReader(responsestream))
+                    {
+                        responsetext = reader.ReadToEnd();
+                    }
+                }
+
+                System.Diagnostics.Trace.WriteLine($"EDDN message post failed - status: {response?.StatusCode.ToString() ?? ex.Status.ToString()}\nResponse: {responsetext}\nEDDN Message: {msg.ToString()}");
                 return false;
             }
         }

--- a/EliteDangerous/EliteDangerous/CommodityPrices.cs
+++ b/EliteDangerous/EliteDangerous/CommodityPrices.cs
@@ -84,7 +84,7 @@ namespace EliteDangerousCore
             try
             {
                 id = jo["id"].Int();
-                name = jo["Name"].Str();
+                name = JournalFieldNaming.FixCommodityName(jo["Name"].Str());
                 locName = jo["Name_Localised"].Str().Alt(name);
                 loctype = jo["Category_Localised"].Str();
                 type = jo["Category"].Str();

--- a/EliteDangerous/EliteDangerous/JournalFieldNaming.cs
+++ b/EliteDangerous/EliteDangerous/JournalFieldNaming.cs
@@ -297,8 +297,14 @@ namespace EliteDangerousCore
             //string x = s;
             if (s.StartsWith("$int_"))
                 s = s.Replace("$int_", "Int_");
+            if (s.StartsWith("int_"))
+                s = s.Replace("int_", "Int_");
             if (s.StartsWith("$hpt_"))
                 s = s.Replace("$hpt_", "Hpt_");
+            if (s.StartsWith("hpt_"))
+                s = s.Replace("hpt_", "Hpt_");
+            if (s.Contains("_armour_"))
+                s = s.Replace("_armour_", "_Armour_");
             if (s.EndsWith("_name;"))
                 s = s.Substring(0, s.Length - 6);
 

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -72,8 +72,8 @@ namespace EliteDangerousCore
             get
             {
                 DateTime ed22 = new DateTime(2016, 10, 25, 12, 0, 0);
-                if ((EntryType == JournalTypeEnum.Scan || 
-                     EntryType == JournalTypeEnum.Docked || 
+                if ((EntryType == JournalTypeEnum.Scan ||
+                     EntryType == JournalTypeEnum.Docked ||
                      EntryType == JournalTypeEnum.FSDJump ||
                      EntryType == JournalTypeEnum.Market ||
                      EntryType == JournalTypeEnum.Shipyard ||

--- a/EliteDangerous/JournalEvents/JournalOutfitting.cs
+++ b/EliteDangerous/JournalEvents/JournalOutfitting.cs
@@ -51,6 +51,7 @@ namespace EliteDangerousCore.JournalEvents
             {
                 foreach (OutfittingModuleItem i in ModuleItems)
                 {
+                    i.FDName = i.Name;
                     i.Name = JournalFieldNaming.GetBetterItemNameEvents(i.Name);
                 }
             }
@@ -98,6 +99,7 @@ namespace EliteDangerousCore.JournalEvents
         {
             public long id;
             public string Name;
+            public string FDName;
             public long BuyPrice;
         }
     }

--- a/EliteDangerous/JournalEvents/JournalShipyard.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyard.cs
@@ -50,6 +50,7 @@ namespace EliteDangerousCore.JournalEvents
             {
                 foreach (ShipyardItem i in ShipyardItems)
                 {
+                    i.FDShipType = i.ShipType;
                     i.ShipType = JournalFieldNaming.GetBetterShipName(i.ShipType);
                 }
             }
@@ -100,6 +101,7 @@ namespace EliteDangerousCore.JournalEvents
         public class ShipyardItem
         {
             public long id;
+            public string FDShipType;
             public string ShipType;
             public string ShipType_Localised;
             public long ShipPrice;


### PR DESCRIPTION
`marketID` -> `marketId`
`shipyard` and `outfitting` reject `systemAddress`
`outfitting` uses a case-sensitive match, so adjust the lower-case module names to match