### PR TITLE
Don't fail sync if history has beta events mixed

### DIFF
--- a/EliteDangerous/EDSM/EDSMJournalSync.cs
+++ b/EliteDangerous/EDSM/EDSMJournalSync.cs
@@ -169,19 +169,24 @@ namespace EliteDangerousCore.EDSM
             System.Diagnostics.Debug.WriteLine("Send " + helist.Count());
 
             int eventCount = 0;
+            bool hasbeta = false;
             foreach (HistoryEntry he in helist)     // push list of events to historylist queue..
             {
                 if (he.Commander.Name.StartsWith("[BETA]", StringComparison.InvariantCultureIgnoreCase) || he.IsBetaMessage)
                 {
-                    log?.Invoke("Cannot send Beta logs to EDSM");
-                    return false;
+                    hasbeta = true;
                 }
-
-                if (ShouldSendEvent(he))
+                else if (ShouldSendEvent(he))
                 {
                     historylist.Enqueue(new HistoryQueueEntry { HistoryEntry = he, Logger = log , ManualSync = manual });
                     eventCount++;
                 }
+            }
+
+            if (hasbeta && eventCount == 0)
+            {
+                log?.Invoke("Cannot send Beta logs to EDSM");
+                return false;
             }
 
             if (manual )    // if in manual mode, we want to tell the user the end, so push an end marker

--- a/EliteDangerous/EDSM/EDSMJournalSync.cs
+++ b/EliteDangerous/EDSM/EDSMJournalSync.cs
@@ -170,11 +170,13 @@ namespace EliteDangerousCore.EDSM
 
             int eventCount = 0;
             bool hasbeta = false;
+            DateTime betatime = DateTime.MinValue;
             foreach (HistoryEntry he in helist)     // push list of events to historylist queue..
             {
                 if (he.Commander.Name.StartsWith("[BETA]", StringComparison.InvariantCultureIgnoreCase) || he.IsBetaMessage)
                 {
                     hasbeta = true;
+                    betatime = he.EventTimeUTC;
                 }
                 else if (ShouldSendEvent(he))
                 {
@@ -185,7 +187,7 @@ namespace EliteDangerousCore.EDSM
 
             if (hasbeta && eventCount == 0)
             {
-                log?.Invoke("Cannot send Beta logs to EDSM");
+                log?.Invoke($"Cannot send Beta logs to EDSM - most recent timestamp: {betatime.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")}");
                 return false;
             }
 


### PR DESCRIPTION
Players can accidentally assign beta history to their real commander.

Filter out any such beta history rather than failing the sync.

This should help fix #1799