### PR TITLE
Get systems in 3 hour blocks; limit update to 30 days

### DIFF
--- a/EliteDangerous/EDSM/SystemClassEDSM.cs
+++ b/EliteDangerous/EDSM/SystemClassEDSM.cs
@@ -671,6 +671,11 @@ namespace EliteDangerousCore.EDSM
                 System.Diagnostics.Debug.WriteLine("Reject partial sync, last record less than 1 hour old");
                 return updates;
             }
+            else if (DateTime.UtcNow.Subtract(lastrecordtime).TotalDays >= 30)
+            {
+                System.Diagnostics.Trace.WriteLine("Reject partial sync, last record too old");
+                return updates;
+            }
 
             // Go For SYNC
 
@@ -684,7 +689,7 @@ namespace EliteDangerousCore.EDSM
                 if (PendingClose())     
                     return updates;
 
-                DateTime enddate = lastrecordtime + TimeSpan.FromHours(12);
+                DateTime enddate = lastrecordtime + TimeSpan.FromHours(3);
                 if (enddate > DateTime.UtcNow)
                     enddate = DateTime.UtcNow;
 


### PR DESCRIPTION
Requesting more than 3 hours causes EDSM to kill the request after a random number of systems have been retrieved.