### PR TITLE
Starlist and Scangrid materials fix

### DIFF
--- a/EDDiscovery/UserControls/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/UserControlScanGrid.cs
@@ -213,11 +213,11 @@ namespace EDDiscovery.UserControls
                         if (sn.ScanData.HasMaterials)
                         {
                             string MaterialsBrief = sn.ScanData.DisplayMaterials(4).ToString();
-                            // jumponium materials: Arsenic (As), Cadmium (Cd), Germanium (Ge), Niobium (Nb), Polonium (Po), Vanadium (V), Yttrium (Y)
+                            // jumponium materials: Arsenic (As), Cadmium (Cd), Carbon (C), Germanium (Ge), Niobium (Nb), Polonium (Po), Vanadium (V), Yttrium (Y)
                             
-                            if (MaterialsBrief.Contains("Arsenic") || MaterialsBrief.Contains("Cadmium") || MaterialsBrief.Contains("Germanium")
-                                || MaterialsBrief.Contains("Niobium") || MaterialsBrief.Contains("Polonium") || MaterialsBrief.Contains("Vanadium")
-                                || MaterialsBrief.Contains("Yttrium"))
+                            if (MaterialsBrief.Contains("Arsenic") || MaterialsBrief.Contains("Cadmium") || MaterialsBrief.Contains("Carbon")
+                                || MaterialsBrief.Contains("Germanium") || MaterialsBrief.Contains("Niobium") || MaterialsBrief.Contains("Polonium")
+                                || MaterialsBrief.Contains("Vanadium") || MaterialsBrief.Contains("Yttrium"))
                             {
                                 bdDetails.Append("\n" + "This body contains: ");
                             }

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -28,6 +28,7 @@ using EliteDangerousCore;
 using EliteDangerousCore.EDSM;
 using EliteDangerousCore.EDDN;
 using EliteDangerousCore.JournalEvents;
+using static EDDiscovery.UserControls.Recipes;
 
 namespace EDDiscovery.UserControls
 {
@@ -49,7 +50,6 @@ namespace EDDiscovery.UserControls
         #endregion
 
         #region Init
-
         private class StarHistoryColumns
         {
             public const int LastVisit = 0;
@@ -69,7 +69,7 @@ namespace EDDiscovery.UserControls
         private Dictionary<string, List<HistoryEntry>> systemsentered = new Dictionary<string, List<HistoryEntry>>();
         private Dictionary<long, DataGridViewRow> rowsbyjournalid = new Dictionary<long, DataGridViewRow>();
         private HistoryList current_historylist;
-                
+        
         public UserControlStarList()
         {
             InitializeComponent();
@@ -101,9 +101,10 @@ namespace EDDiscovery.UserControls
             this.checkBoxJumponium.CheckedChanged += new System.EventHandler(this.buttonJumponium_CheckedChanged);
 
             discoveryform.OnHistoryChange += HistoryChanged;
-            discoveryform.OnNewEntry += AddNewEntry;            
+            discoveryform.OnNewEntry += AddNewEntry;                        
         }
-               
+        
+                
         public override void LoadLayout()
         {
             DGVLoadColumnLayout(dataGridViewStarList, DbColumnSave);
@@ -237,13 +238,15 @@ namespace EDDiscovery.UserControls
         {
             string infostr = "";
             string jumponium = "";
-            int hasmaterials = 0;
+            bool hasMaterials = false;
 
             if (syslist.Count > 1)
                 infostr = "First visit " + syslist.Last().EventTimeLocal.ToShortDateString();
 
             HistoryEntry he = syslist[0];
             StarScan.SystemNode node = discoveryform.history.starscan?.FindSystem(he.System,false);
+
+            #region information
 
             if (node != null)
             {
@@ -354,10 +357,13 @@ namespace EDDiscovery.UserControls
                         // Landable bodies with valuable materials
                         if (sn.ScanData != null && sn.ScanData.IsLandable == true && sn.ScanData.HasMaterials && checkBoxJumponium.Checked == true)
                         {
-                            hasmaterials = 1;
+                            hasMaterials = true;
 
                             string MaterialsBrief = sn.ScanData.DisplayMaterials(4).ToString();
                             // jumponium materials: Arsenic (As), Cadmium (Cd), Carbon (C), Germanium (Ge), Niobium (Nb), Polonium (Po), Vanadium (V), Yttrium (Y)
+                            // "Premium","1C,1Ge,1Nb,1As,1Po,1Y" ),
+                            // "Standard", "1C,1V,1Ge,1Cd,1Nb"),
+                            // "Basic", "1C,1V,1Ge"),
 
                             int jump1 = 0;
                             int jump2 = 0;
@@ -381,6 +387,8 @@ namespace EDDiscovery.UserControls
                             if (MaterialsBrief.Contains("Germanium"))
                             {
                                 jump1 += 1;
+                                jump2 += 1;
+                                jump3 += 1;
                             }
                             if (MaterialsBrief.Contains("Niobium"))
                             {
@@ -457,7 +465,7 @@ namespace EDDiscovery.UserControls
                     {   // we need this to allow the panel to scan also through systems which has only stars
                         infostr = infostr.AppendPrePad(extrainfo, prefix);
                     }
-                    if (hasmaterials != 0 && checkBoxJumponium.Checked == true)
+                    if (hasMaterials == true && checkBoxJumponium.Checked == true)
                     {
                         infostr = infostr.AppendPrePad("\nThis system has jumponium materials: ");
                         infostr = infostr.AppendPrePad(jumponium);
@@ -467,6 +475,8 @@ namespace EDDiscovery.UserControls
 
             return infostr;
         }
+
+        #endregion
 
         Tuple<long, int> CurrentGridPosByJID()          // Returns JID, column index.  JID = -1 if cell is not defined
         {

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -357,7 +357,7 @@ namespace EDDiscovery.UserControls
                             hasmaterials = 1;
 
                             string MaterialsBrief = sn.ScanData.DisplayMaterials(4).ToString();
-                            // jumponium materials: Arsenic (As), Cadmium (Cd), Germanium (Ge), Niobium (Nb), Polonium (Po), Vanadium (V), Yttrium (Y)
+                            // jumponium materials: Arsenic (As), Cadmium (Cd), Carbon (C), Germanium (Ge), Niobium (Nb), Polonium (Po), Vanadium (V), Yttrium (Y)
 
                             int jump1 = 0;
                             int jump2 = 0;
@@ -371,6 +371,12 @@ namespace EDDiscovery.UserControls
                             if (MaterialsBrief.Contains("Cadmium"))
                             {
                                 jump2 += 1;
+                            }
+                            if (MaterialsBrief.Contains("Carbon"))
+                            {
+                                jump1 += 1;
+                                jump2 += 1;
+                                jump3 += 1;
                             }
                             if (MaterialsBrief.Contains("Germanium"))
                             {

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -365,92 +365,92 @@ namespace EDDiscovery.UserControls
                             // "Standard", "1C,1V,1Ge,1Cd,1Nb"),
                             // "Basic", "1C,1V,1Ge"),
 
-                            int jump1 = 0;
-                            int jump2 = 0;
-                            int jump3 = 0;
-                            int njump = 0;
+                            int basic = 0;
+                            int standard = 0;
+                            int premium = 0;
+                            int totalMterials = 0;
 
                             if (MaterialsBrief.Contains("Arsenic"))
                             {
-                                jump3 += 1;
+                                premium += 1;
                             }
                             if (MaterialsBrief.Contains("Cadmium"))
                             {
-                                jump2 += 1;
+                                standard += 1;
                             }
                             if (MaterialsBrief.Contains("Carbon"))
                             {
-                                jump1 += 1;
-                                jump2 += 1;
-                                jump3 += 1;
+                                basic += 1;
+                                standard += 1;
+                                premium += 1;
                             }
                             if (MaterialsBrief.Contains("Germanium"))
                             {
-                                jump1 += 1;
-                                jump2 += 1;
-                                jump3 += 1;
+                                basic += 1;
+                                standard += 1;
+                                premium += 1;
                             }
                             if (MaterialsBrief.Contains("Niobium"))
                             {
-                                jump2 += 1;
-                                jump3 += 1;
+                                standard += 1;
+                                premium += 1;
                             }
                             if (MaterialsBrief.Contains("Polonium"))
                             {
-                                jump3 += 1;
+                                premium += 1;
                             }
                             if (MaterialsBrief.Contains("Vanadium"))
                             {
-                                jump1 += 1;
+                                basic += 1;
                             }
                             if (MaterialsBrief.Contains("Yttrium"))
                             {
-                                jump3 += 1;
+                                premium += 1;
                             }
 
-                            if (jump1 > 0 || jump2 > 0 || jump3 > 0)
+                            if (basic > 0 || standard > 0 || premium > 0)
                             {
-                                njump = jump1 + jump2 + jump3;
+                                totalMterials = basic + standard + premium;
 
                                 StringBuilder jumpLevel = new StringBuilder();
 
                                 // level I
-                                if (jump1 != 0 && jump2 == 0 && jump3 == 0)
+                                if (basic != 0 && standard == 0 && premium == 0)
                                 {
-                                    jumpLevel.Append(jump1 + " level I");
+                                    jumpLevel.Append(basic + " Basic");
                                 }
                                 // level I and II
-                                if (jump1 != 0 && jump2 != 0 && jump3 == 0)
+                                if (basic != 0 && standard != 0 && premium == 0)
                                 {
-                                    jumpLevel.Append(jump1 + " level I and " + jump2 + " level II");
+                                    jumpLevel.Append(basic + " Basic " + standard + " Standard");
                                 }
                                 // level I
-                                if (jump1 == 0 && jump2 != 0 && jump3 == 0)
+                                if (basic == 0 && standard != 0 && premium == 0)
                                 {
-                                    jumpLevel.Append(jump2 + " level II");
+                                    jumpLevel.Append(standard + " Standard");
                                 }
                                 // level II and III
-                                if (jump1 == 0 && jump2 != 0 && jump3 != 0)
+                                if (basic == 0 && standard != 0 && premium != 0)
                                 {
-                                    jumpLevel.Append(jump2 + " level II and " + jump3 + " level III");
+                                    jumpLevel.Append(standard + " Standard and " + premium + " Premium");
                                 }
                                 // level III
-                                if (jump1 == 0 && jump2 == 0 && jump3 != 0)
+                                if (basic == 0 && standard == 0 && premium != 0)
                                 {
-                                    jumpLevel.Append(jump3 + " level III");
+                                    jumpLevel.Append(premium + " Premium");
                                 }
                                 // level I and III
-                                if (jump1 != 0 && jump2 == 0 && jump3 != 0)
+                                if (basic != 0 && standard == 0 && premium != 0)
                                 {
-                                    jumpLevel.Append(jump1 + " level I and " + jump3 + " level III");
+                                    jumpLevel.Append(basic + " Basic and " + premium + " Premium");
                                 }
                                 // all levels
-                                if (jump1 != 0 && jump2 != 0 && jump3 != 0)
+                                if (basic != 0 && standard != 0 && premium != 0)
                                 {
-                                    jumpLevel.Append(jump1 + " level I, " + jump2 + " level II and " + jump3 + " level III");
+                                    jumpLevel.Append(basic + " Basic, " + standard + " Standard and " + premium + " Premium");
                                 }
 
-                                jumponium = jumponium.AppendPrePad("\n" + sn.ScanData.BodyName + " has " + jumpLevel);
+                                jumponium = jumponium.AppendPrePad("\n" + sn.ScanData.BodyName + " has " + jumpLevel + " level elements.");
                             }
                         }
                     }
@@ -467,7 +467,7 @@ namespace EDDiscovery.UserControls
                     }
                     if (hasMaterials == true && checkBoxJumponium.Checked == true)
                     {
-                        infostr = infostr.AppendPrePad("\nThis system has jumponium materials: ");
+                        infostr = infostr.AppendPrePad("\n\nThis system has materials for FSD boost: ");
                         infostr = infostr.AppendPrePad(jumponium);
                     }
                 }


### PR DESCRIPTION
Still working on the same logic as before, yet updated to the last 3.0 materials for FSD boost:

- added Carbon
- added Germanium to Standard and Premium requirements
- reworked some notification string

---

As soon as I can, I'll rework it using the recipes logic from elitedangerouscore and synthesis planner: a filter to enable display for bodies which has the wanted materials or wanted recipes requirements.