### PR TITLE
Triage and fix whole bookmark system

### DIFF
--- a/BaseUtils/Numbers/NumberObjectExtensions.cs
+++ b/BaseUtils/Numbers/NumberObjectExtensions.cs
@@ -126,6 +126,15 @@ public static class ObjectExtensionsNumbersBool
             return null;
     }
 
+    static public double? ParseDoubleNull(this string s)
+    {
+        double i;
+        if (s != null && double.TryParse(s, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.CurrentCulture, out i))
+            return i;
+        else
+            return null;
+    }
+
     #endregion
 
     #region Float

--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -102,7 +102,7 @@ namespace EDDiscovery._3DMap
 
             foreach (BookmarkClass bc in GlobalBookMarkList.Instance.Bookmarks)
             {
-                Bitmap touse = (bc.id == bookmarktarget) ? maptarget : (bc.isRegion ? mapregion : (bc.hasSurfaceMarks ? mapsurface : mapstar));
+                Bitmap touse = (bc.id == bookmarktarget) ? maptarget : (bc.isRegion ? mapregion : (bc.hasPlanetaryMarks ? mapsurface : mapstar));
                 TexturedQuadData newtexture = TexturedQuadData.FromBitmap(touse, new PointData(bc.x, bc.y, bc.z), rotation, widthly, heightly,  0, heightly / 2);
                 newtexture.Tag = bc;
                 newtexture.Tag2 = 0;        // bookmark

--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -1047,6 +1047,12 @@ namespace EDDiscovery
                 labelSystemCoords.Text = "No centre system";
         }
 
+        public bool MoveTo(float x, float y, float z)
+        {
+            posdir.StartCameraSlew(new Vector3(x,y,z), -1F);
+            return true;
+        }
+
         public bool SetCenterSystemTo(string name)
         {
             if (Is3DMapsRunning)                         // if null, we are not up and running
@@ -1345,7 +1351,7 @@ namespace EDDiscovery
             BookmarkForm frm = new BookmarkForm();
             frm.InitialisePos(posdir.Position.X, posdir.Position.Y, posdir.Position.Z);
             DateTime tme = DateTime.Now;
-            frm.RegionBookmark(tme.ToString());
+            frm.NewRegionBookmark(tme);
             DialogResult res = frm.ShowDialog(this);
 
             if (res == DialogResult.OK)

--- a/EDDiscovery/3DMap/MapManager.cs
+++ b/EDDiscovery/3DMap/MapManager.cs
@@ -68,6 +68,11 @@ namespace EDDiscovery._3DMap
             return _formMap?.SetCenterSystemTo(system) ?? true;
         }
 
+        public bool MoveTo(float x, float y, float z)
+        {
+            return _formMap?.MoveTo(x, y, z) ?? true;
+        }
+
         public void Show()
         {
             // TODO: set Opacity to match EDDiscoveryForm

--- a/EDDiscovery/Forms/BookmarkForm.Designer.cs
+++ b/EDDiscovery/Forms/BookmarkForm.Designer.cs
@@ -47,7 +47,7 @@ namespace EDDiscovery.Forms
             this.label2 = new System.Windows.Forms.Label();
             this.labelBookmarkNotes = new System.Windows.Forms.Label();
             this.labelTimeMade = new System.Windows.Forms.Label();
-            this.textBoxNotes = new ExtendedControls.RichTextBoxScroll();
+            this.textBoxBookmarkNotes = new ExtendedControls.RichTextBoxScroll();
             this.textBoxX = new ExtendedControls.TextBoxBorder();
             this.textBoxY = new ExtendedControls.TextBoxBorder();
             this.textBoxZ = new ExtendedControls.TextBoxBorder();
@@ -63,11 +63,11 @@ namespace EDDiscovery.Forms
             this.textBoxTravelNote = new ExtendedControls.TextBoxBorder();
             this.checkBoxTarget = new ExtendedControls.CheckBoxCustom();
             this.buttonEDSM = new ExtendedControls.ButtonExt();
-            this.panel1 = new System.Windows.Forms.Panel();
+            this.panelOuter = new System.Windows.Forms.Panel();
             this.labelBadSystem = new System.Windows.Forms.Label();
             this.textBoxName = new ExtendedControls.AutoCompleteTextBox();
-            this.userControlSurfaceBookmarks1 = new EDDiscovery.UserControls.SurfaceBookmarksForm();
-            this.panel1.SuspendLayout();
+            this.userControlSurfaceBookmarks = new EDDiscovery.UserControls.SurfaceBookmarksForm();
+            this.panelOuter.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
@@ -90,7 +90,7 @@ namespace EDDiscovery.Forms
             // 
             // labelBookmarkNotes
             // 
-            this.labelBookmarkNotes.Location = new System.Drawing.Point(9, 147);
+            this.labelBookmarkNotes.Location = new System.Drawing.Point(9, 104);
             this.labelBookmarkNotes.Name = "labelBookmarkNotes";
             this.labelBookmarkNotes.Size = new System.Drawing.Size(121, 69);
             this.labelBookmarkNotes.TabIndex = 0;
@@ -105,32 +105,32 @@ namespace EDDiscovery.Forms
             this.labelTimeMade.TabIndex = 0;
             this.labelTimeMade.Text = "Time Made";
             // 
-            // textBoxNotes
+            // textBoxBookmarkNotes
             // 
-            this.textBoxNotes.BorderColor = System.Drawing.Color.Transparent;
-            this.textBoxNotes.BorderColorScaling = 0.5F;
-            this.textBoxNotes.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.textBoxNotes.HideScrollBar = true;
-            this.textBoxNotes.Location = new System.Drawing.Point(139, 147);
-            this.textBoxNotes.Name = "textBoxNotes";
-            this.textBoxNotes.ReadOnly = false;
-            this.textBoxNotes.ScrollBarArrowBorderColor = System.Drawing.Color.LightBlue;
-            this.textBoxNotes.ScrollBarArrowButtonColor = System.Drawing.Color.LightGray;
-            this.textBoxNotes.ScrollBarBackColor = System.Drawing.SystemColors.Control;
-            this.textBoxNotes.ScrollBarBorderColor = System.Drawing.Color.White;
-            this.textBoxNotes.ScrollBarFlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.textBoxNotes.ScrollBarForeColor = System.Drawing.SystemColors.ControlText;
-            this.textBoxNotes.ScrollBarMouseOverButtonColor = System.Drawing.Color.Green;
-            this.textBoxNotes.ScrollBarMousePressedButtonColor = System.Drawing.Color.Red;
-            this.textBoxNotes.ScrollBarSliderColor = System.Drawing.Color.DarkGray;
-            this.textBoxNotes.ScrollBarThumbBorderColor = System.Drawing.Color.Yellow;
-            this.textBoxNotes.ScrollBarThumbButtonColor = System.Drawing.Color.DarkBlue;
-            this.textBoxNotes.ScrollBarWidth = 20;
-            this.textBoxNotes.ShowLineCount = false;
-            this.textBoxNotes.Size = new System.Drawing.Size(726, 103);
-            this.textBoxNotes.TabIndex = 0;
-            this.textBoxNotes.TextBoxBackColor = System.Drawing.SystemColors.Control;
-            this.textBoxNotes.TextBoxForeColor = System.Drawing.SystemColors.ControlText;
+            this.textBoxBookmarkNotes.BorderColor = System.Drawing.Color.Transparent;
+            this.textBoxBookmarkNotes.BorderColorScaling = 0.5F;
+            this.textBoxBookmarkNotes.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBoxBookmarkNotes.HideScrollBar = true;
+            this.textBoxBookmarkNotes.Location = new System.Drawing.Point(139, 104);
+            this.textBoxBookmarkNotes.Name = "textBoxBookmarkNotes";
+            this.textBoxBookmarkNotes.ReadOnly = false;
+            this.textBoxBookmarkNotes.ScrollBarArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.textBoxBookmarkNotes.ScrollBarArrowButtonColor = System.Drawing.Color.LightGray;
+            this.textBoxBookmarkNotes.ScrollBarBackColor = System.Drawing.SystemColors.Control;
+            this.textBoxBookmarkNotes.ScrollBarBorderColor = System.Drawing.Color.White;
+            this.textBoxBookmarkNotes.ScrollBarFlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.textBoxBookmarkNotes.ScrollBarForeColor = System.Drawing.SystemColors.ControlText;
+            this.textBoxBookmarkNotes.ScrollBarMouseOverButtonColor = System.Drawing.Color.Green;
+            this.textBoxBookmarkNotes.ScrollBarMousePressedButtonColor = System.Drawing.Color.Red;
+            this.textBoxBookmarkNotes.ScrollBarSliderColor = System.Drawing.Color.DarkGray;
+            this.textBoxBookmarkNotes.ScrollBarThumbBorderColor = System.Drawing.Color.Yellow;
+            this.textBoxBookmarkNotes.ScrollBarThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.textBoxBookmarkNotes.ScrollBarWidth = 20;
+            this.textBoxBookmarkNotes.ShowLineCount = false;
+            this.textBoxBookmarkNotes.Size = new System.Drawing.Size(726, 103);
+            this.textBoxBookmarkNotes.TabIndex = 0;
+            this.textBoxBookmarkNotes.TextBoxBackColor = System.Drawing.SystemColors.Control;
+            this.textBoxBookmarkNotes.TextBoxForeColor = System.Drawing.SystemColors.ControlText;
             // 
             // textBoxX
             // 
@@ -256,7 +256,7 @@ namespace EDDiscovery.Forms
             // 
             // buttonOK
             // 
-            this.buttonOK.Location = new System.Drawing.Point(790, 564);
+            this.buttonOK.Location = new System.Drawing.Point(790, 521);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 1;
@@ -266,7 +266,7 @@ namespace EDDiscovery.Forms
             // 
             // buttonCancel
             // 
-            this.buttonCancel.Location = new System.Drawing.Point(698, 564);
+            this.buttonCancel.Location = new System.Drawing.Point(698, 521);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 2;
@@ -276,7 +276,7 @@ namespace EDDiscovery.Forms
             // 
             // buttonDelete
             // 
-            this.buttonDelete.Location = new System.Drawing.Point(13, 564);
+            this.buttonDelete.Location = new System.Drawing.Point(13, 521);
             this.buttonDelete.Name = "buttonDelete";
             this.buttonDelete.Size = new System.Drawing.Size(75, 23);
             this.buttonDelete.TabIndex = 9;
@@ -286,7 +286,7 @@ namespace EDDiscovery.Forms
             // 
             // labelTravelNote
             // 
-            this.labelTravelNote.Location = new System.Drawing.Point(6, 254);
+            this.labelTravelNote.Location = new System.Drawing.Point(6, 211);
             this.labelTravelNote.Name = "labelTravelNote";
             this.labelTravelNote.Size = new System.Drawing.Size(124, 49);
             this.labelTravelNote.TabIndex = 0;
@@ -294,7 +294,7 @@ namespace EDDiscovery.Forms
             // 
             // labelTravelNoteEdit
             // 
-            this.labelTravelNoteEdit.Location = new System.Drawing.Point(9, 312);
+            this.labelTravelNoteEdit.Location = new System.Drawing.Point(9, 269);
             this.labelTravelNoteEdit.Name = "labelTravelNoteEdit";
             this.labelTravelNoteEdit.Size = new System.Drawing.Size(121, 46);
             this.labelTravelNoteEdit.TabIndex = 0;
@@ -311,7 +311,7 @@ namespace EDDiscovery.Forms
             this.textBoxTravelNote.ClearOnFirstChar = false;
             this.textBoxTravelNote.ControlBackground = System.Drawing.SystemColors.Control;
             this.textBoxTravelNote.InErrorCondition = false;
-            this.textBoxTravelNote.Location = new System.Drawing.Point(139, 256);
+            this.textBoxTravelNote.Location = new System.Drawing.Point(139, 213);
             this.textBoxTravelNote.Multiline = true;
             this.textBoxTravelNote.Name = "textBoxTravelNote";
             this.textBoxTravelNote.ReadOnly = true;
@@ -331,7 +331,7 @@ namespace EDDiscovery.Forms
             this.checkBoxTarget.CheckColor = System.Drawing.Color.DarkBlue;
             this.checkBoxTarget.FontNerfReduction = 0.5F;
             this.checkBoxTarget.ImageButtonDisabledScaling = 0.5F;
-            this.checkBoxTarget.Location = new System.Drawing.Point(298, 112);
+            this.checkBoxTarget.Location = new System.Drawing.Point(584, 19);
             this.checkBoxTarget.MouseOverColor = System.Drawing.Color.CornflowerBlue;
             this.checkBoxTarget.Name = "checkBoxTarget";
             this.checkBoxTarget.Size = new System.Drawing.Size(87, 17);
@@ -342,7 +342,7 @@ namespace EDDiscovery.Forms
             // 
             // buttonEDSM
             // 
-            this.buttonEDSM.Location = new System.Drawing.Point(139, 106);
+            this.buttonEDSM.Location = new System.Drawing.Point(488, 16);
             this.buttonEDSM.Name = "buttonEDSM";
             this.buttonEDSM.Size = new System.Drawing.Size(75, 23);
             this.buttonEDSM.TabIndex = 11;
@@ -350,38 +350,38 @@ namespace EDDiscovery.Forms
             this.buttonEDSM.UseVisualStyleBackColor = true;
             this.buttonEDSM.Click += new System.EventHandler(this.buttonEDSM_Click);
             // 
-            // panel1
+            // panelOuter
             // 
-            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panel1.Controls.Add(this.labelBadSystem);
-            this.panel1.Controls.Add(this.textBoxName);
-            this.panel1.Controls.Add(this.userControlSurfaceBookmarks1);
-            this.panel1.Controls.Add(this.buttonEDSM);
-            this.panel1.Controls.Add(this.label1);
-            this.panel1.Controls.Add(this.checkBoxTarget);
-            this.panel1.Controls.Add(this.label2);
-            this.panel1.Controls.Add(this.buttonDelete);
-            this.panel1.Controls.Add(this.label3);
-            this.panel1.Controls.Add(this.buttonCancel);
-            this.panel1.Controls.Add(this.label6);
-            this.panel1.Controls.Add(this.buttonOK);
-            this.panel1.Controls.Add(this.label7);
-            this.panel1.Controls.Add(this.textBoxZ);
-            this.panel1.Controls.Add(this.labelBookmarkNotes);
-            this.panel1.Controls.Add(this.textBoxY);
-            this.panel1.Controls.Add(this.labelTravelNote);
-            this.panel1.Controls.Add(this.textBoxX);
-            this.panel1.Controls.Add(this.labelTravelNoteEdit);
-            this.panel1.Controls.Add(this.textBoxTime);
-            this.panel1.Controls.Add(this.labelTimeMade);
-            this.panel1.Controls.Add(this.textBoxNotes);
-            this.panel1.Controls.Add(this.textBoxTravelNote);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(881, 615);
-            this.panel1.TabIndex = 12;
-            this.panel1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel1_MouseDown);
+            this.panelOuter.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelOuter.Controls.Add(this.labelBadSystem);
+            this.panelOuter.Controls.Add(this.textBoxName);
+            this.panelOuter.Controls.Add(this.userControlSurfaceBookmarks);
+            this.panelOuter.Controls.Add(this.buttonEDSM);
+            this.panelOuter.Controls.Add(this.label1);
+            this.panelOuter.Controls.Add(this.checkBoxTarget);
+            this.panelOuter.Controls.Add(this.label2);
+            this.panelOuter.Controls.Add(this.buttonDelete);
+            this.panelOuter.Controls.Add(this.label3);
+            this.panelOuter.Controls.Add(this.buttonCancel);
+            this.panelOuter.Controls.Add(this.label6);
+            this.panelOuter.Controls.Add(this.buttonOK);
+            this.panelOuter.Controls.Add(this.label7);
+            this.panelOuter.Controls.Add(this.textBoxZ);
+            this.panelOuter.Controls.Add(this.labelBookmarkNotes);
+            this.panelOuter.Controls.Add(this.textBoxY);
+            this.panelOuter.Controls.Add(this.labelTravelNote);
+            this.panelOuter.Controls.Add(this.textBoxX);
+            this.panelOuter.Controls.Add(this.labelTravelNoteEdit);
+            this.panelOuter.Controls.Add(this.textBoxTime);
+            this.panelOuter.Controls.Add(this.labelTimeMade);
+            this.panelOuter.Controls.Add(this.textBoxBookmarkNotes);
+            this.panelOuter.Controls.Add(this.textBoxTravelNote);
+            this.panelOuter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelOuter.Location = new System.Drawing.Point(0, 0);
+            this.panelOuter.Name = "panelOuter";
+            this.panelOuter.Size = new System.Drawing.Size(874, 564);
+            this.panelOuter.TabIndex = 12;
+            this.panelOuter.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel1_MouseDown);
             // 
             // labelBadSystem
             // 
@@ -422,27 +422,27 @@ namespace EDDiscovery.Forms
             this.textBoxName.TabIndex = 13;
             this.textBoxName.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
             this.textBoxName.WordWrap = true;
-            this.textBoxName.Validated += new System.EventHandler(this.textBoxName_Validated);
+            this.textBoxName.TextChanged += new System.EventHandler(this.textBox_TextChanged);
             // 
             // userControlSurfaceBookmarks1
             // 
-            this.userControlSurfaceBookmarks1.Location = new System.Drawing.Point(13, 362);
-            this.userControlSurfaceBookmarks1.Name = "userControlSurfaceBookmarks1";
-            this.userControlSurfaceBookmarks1.Size = new System.Drawing.Size(852, 174);
-            this.userControlSurfaceBookmarks1.TabIndex = 12;
+            this.userControlSurfaceBookmarks.Location = new System.Drawing.Point(13, 310);
+            this.userControlSurfaceBookmarks.Name = "userControlSurfaceBookmarks1";
+            this.userControlSurfaceBookmarks.Size = new System.Drawing.Size(852, 205);
+            this.userControlSurfaceBookmarks.TabIndex = 12;
             // 
             // BookmarkForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(881, 615);
-            this.Controls.Add(this.panel1);
+            this.ClientSize = new System.Drawing.Size(874, 564);
+            this.Controls.Add(this.panelOuter);
             this.Icon = global::EDDiscovery.Properties.Resources.edlogo_3mo_icon;
             this.Name = "BookmarkForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Create New Bookmark";
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
+            this.panelOuter.ResumeLayout(false);
+            this.panelOuter.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -453,7 +453,7 @@ namespace EDDiscovery.Forms
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label labelBookmarkNotes;
         private System.Windows.Forms.Label labelTimeMade;
-        private ExtendedControls.RichTextBoxScroll textBoxNotes;
+        private ExtendedControls.RichTextBoxScroll textBoxBookmarkNotes;
         private ExtendedControls.TextBoxBorder textBoxX;
         private ExtendedControls.TextBoxBorder textBoxY;
         private ExtendedControls.TextBoxBorder textBoxZ;
@@ -469,8 +469,8 @@ namespace EDDiscovery.Forms
         private ExtendedControls.TextBoxBorder textBoxTravelNote;
         private ExtendedControls.CheckBoxCustom checkBoxTarget;
         private ExtendedControls.ButtonExt buttonEDSM;
-        private System.Windows.Forms.Panel panel1;
-        private UserControls.SurfaceBookmarksForm userControlSurfaceBookmarks1;
+        private System.Windows.Forms.Panel panelOuter;
+        private UserControls.SurfaceBookmarksForm userControlSurfaceBookmarks;
         private ExtendedControls.AutoCompleteTextBox textBoxName;
         private System.Windows.Forms.Label labelBadSystem;
     }

--- a/EDDiscovery/UserControls/SurfaceBookmarksForm.Designer.cs
+++ b/EDDiscovery/UserControls/SurfaceBookmarksForm.Designer.cs
@@ -31,46 +31,25 @@ namespace EDDiscovery.UserControls
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.dataGridViewMarks = new System.Windows.Forms.DataGridView();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.sendToCompassToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.labelSurface = new ExtendedControls.LabelExt();
-            this.buttonSave = new ExtendedControls.ButtonExt();
+            this.labelSurface = new System.Windows.Forms.Label();
             this.panelTop = new System.Windows.Forms.Panel();
             this.dataViewScrollerPanel1 = new ExtendedControls.DataViewScrollerPanel();
             this.vScrollBarCustom1 = new ExtendedControls.VScrollBarCustom();
+            this.dataGridViewMarks = new System.Windows.Forms.DataGridView();
             this.BodyName = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.SurfaceName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SurfaceDesc = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Latitude = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Longitude = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Valid = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewMarks)).BeginInit();
+            this.contextMenuStrip2 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.contextMenuStrip1.SuspendLayout();
             this.panelTop.SuspendLayout();
             this.dataViewScrollerPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewMarks)).BeginInit();
             this.SuspendLayout();
-            // 
-            // dataGridViewMarks
-            // 
-            this.dataGridViewMarks.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
-            this.dataGridViewMarks.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewMarks.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.BodyName,
-            this.SurfaceName,
-            this.SurfaceDesc,
-            this.Latitude,
-            this.Longitude,
-            this.Valid});
-            this.dataGridViewMarks.ContextMenuStrip = this.contextMenuStrip1;
-            this.dataGridViewMarks.Location = new System.Drawing.Point(0, 0);
-            this.dataGridViewMarks.Name = "dataGridViewMarks";
-            this.dataGridViewMarks.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewMarks.Size = new System.Drawing.Size(637, 168);
-            this.dataGridViewMarks.TabIndex = 3;
-            this.dataGridViewMarks.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewMarks_CellEndEdit);
-            this.dataGridViewMarks.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewMarks_CellValidating);
-            this.dataGridViewMarks.UserDeletingRow += new System.Windows.Forms.DataGridViewRowCancelEventHandler(this.dataGridViewMarks_UserDeletingRow);
             // 
             // contextMenuStrip1
             // 
@@ -94,22 +73,10 @@ namespace EDDiscovery.UserControls
             this.labelSurface.Size = new System.Drawing.Size(149, 13);
             this.labelSurface.TabIndex = 2;
             this.labelSurface.Text = "Surface Bookmarks In System";
-            this.labelSurface.TextBackColor = System.Drawing.Color.Transparent;
-            // 
-            // buttonSave
-            // 
-            this.buttonSave.Location = new System.Drawing.Point(173, 3);
-            this.buttonSave.Name = "buttonSave";
-            this.buttonSave.Size = new System.Drawing.Size(64, 24);
-            this.buttonSave.TabIndex = 4;
-            this.buttonSave.Text = "Save";
-            this.buttonSave.UseVisualStyleBackColor = true;
-            this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
             // 
             // panelTop
             // 
             this.panelTop.Controls.Add(this.labelSurface);
-            this.panelTop.Controls.Add(this.buttonSave);
             this.panelTop.Dock = System.Windows.Forms.DockStyle.Top;
             this.panelTop.Location = new System.Drawing.Point(0, 0);
             this.panelTop.Name = "panelTop";
@@ -121,7 +88,7 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel1.Controls.Add(this.vScrollBarCustom1);
             this.dataViewScrollerPanel1.Controls.Add(this.dataGridViewMarks);
             this.dataViewScrollerPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataViewScrollerPanel1.InternalMargin = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            this.dataViewScrollerPanel1.InternalMargin = new System.Windows.Forms.Padding(0);
             this.dataViewScrollerPanel1.Location = new System.Drawing.Point(0, 32);
             this.dataViewScrollerPanel1.Name = "dataViewScrollerPanel1";
             this.dataViewScrollerPanel1.ScrollBarWidth = 20;
@@ -140,13 +107,13 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom1.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.vScrollBarCustom1.HideScrollBar = false;
             this.vScrollBarCustom1.LargeChange = 1;
-            this.vScrollBarCustom1.Location = new System.Drawing.Point(637, 34);
+            this.vScrollBarCustom1.Location = new System.Drawing.Point(637, 21);
             this.vScrollBarCustom1.Maximum = 0;
             this.vScrollBarCustom1.Minimum = 0;
             this.vScrollBarCustom1.MouseOverButtonColor = System.Drawing.Color.Green;
             this.vScrollBarCustom1.MousePressedButtonColor = System.Drawing.Color.Red;
             this.vScrollBarCustom1.Name = "vScrollBarCustom1";
-            this.vScrollBarCustom1.Size = new System.Drawing.Size(20, 134);
+            this.vScrollBarCustom1.Size = new System.Drawing.Size(20, 147);
             this.vScrollBarCustom1.SliderColor = System.Drawing.Color.DarkGray;
             this.vScrollBarCustom1.SmallChange = 1;
             this.vScrollBarCustom1.TabIndex = 7;
@@ -157,6 +124,27 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom1.ThumbDrawAngle = 0F;
             this.vScrollBarCustom1.Value = 0;
             this.vScrollBarCustom1.ValueLimited = 0;
+            // 
+            // dataGridViewMarks
+            // 
+            this.dataGridViewMarks.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewMarks.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewMarks.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.BodyName,
+            this.SurfaceName,
+            this.SurfaceDesc,
+            this.Latitude,
+            this.Longitude,
+            this.Valid});
+            this.dataGridViewMarks.ContextMenuStrip = this.contextMenuStrip1;
+            this.dataGridViewMarks.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewMarks.Name = "dataGridViewMarks";
+            this.dataGridViewMarks.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewMarks.Size = new System.Drawing.Size(637, 168);
+            this.dataGridViewMarks.TabIndex = 3;
+            this.dataGridViewMarks.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewMarks_CellEndEdit);
+            this.dataGridViewMarks.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.dataGridViewMarks_CellValidating);
+            this.dataGridViewMarks.UserDeletingRow += new System.Windows.Forms.DataGridViewRowCancelEventHandler(this.dataGridViewMarks_UserDeletingRow);
             // 
             // BodyName
             // 
@@ -194,19 +182,24 @@ namespace EDDiscovery.UserControls
             this.Valid.Name = "Valid";
             this.Valid.ReadOnly = true;
             // 
-            // UserControlSurfaceBookmarks
+            // contextMenuStrip2
+            // 
+            this.contextMenuStrip2.Name = "contextMenuStrip2";
+            this.contextMenuStrip2.Size = new System.Drawing.Size(153, 26);
+            // 
+            // SurfaceBookmarksForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.dataViewScrollerPanel1);
             this.Controls.Add(this.panelTop);
-            this.Name = "UserControlSurfaceBookmarks";
+            this.Name = "SurfaceBookmarksForm";
             this.Size = new System.Drawing.Size(657, 200);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewMarks)).EndInit();
             this.contextMenuStrip1.ResumeLayout(false);
             this.panelTop.ResumeLayout(false);
             this.panelTop.PerformLayout();
             this.dataViewScrollerPanel1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewMarks)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -214,8 +207,7 @@ namespace EDDiscovery.UserControls
         #endregion
 
         private System.Windows.Forms.DataGridView dataGridViewMarks;
-        private ExtendedControls.LabelExt labelSurface;
-        private ExtendedControls.ButtonExt buttonSave;
+        private System.Windows.Forms.Label labelSurface;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem sendToCompassToolStripMenuItem;
         private System.Windows.Forms.DataGridViewComboBoxColumn BodyName;
@@ -227,5 +219,6 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.Panel panelTop;
         private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel1;
         private ExtendedControls.VScrollBarCustom vScrollBarCustom1;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip2;
     }
 }

--- a/EDDiscovery/UserControls/SurfaceBookmarksForm.cs
+++ b/EDDiscovery/UserControls/SurfaceBookmarksForm.cs
@@ -14,102 +14,69 @@ using EDDiscovery.Forms;
 
 namespace EDDiscovery.UserControls
 {
+    // now a leaf class - does not know about callers data.. much easier to understand
+
     public partial class SurfaceBookmarksForm : UserControl
     {
-        public bool Edited = false;
+        public bool Edited = false;         // set if edit taken
+        public PlanetMarks PlanetMarks { get { return planetmarks; } }      // current set..
 
-        public PlanetMarks PlanetMarks
-        {
-            get { return internalPlanetMarks; }
-            private set { internalPlanetMarks = value; }
-        }
+        public Action<PlanetMarks> Changed;     // if a change to data is made
+        public Action<string, string> CompassSeleted; // when compass is clicked
 
-        PlanetMarks internalPlanetMarks;
-        BookmarkClass thisBookmark;
+        private PlanetMarks planetmarks;
+
+        #region Initialisation
 
         public SurfaceBookmarksForm()
         {
             InitializeComponent();
         }
 
-        #region Bookmark Form
-
-        public void NewForSystem(string systemName)     // from bookmark form
+        public void Init(string systemName)     // from bookmark form.  new system or update with name..  name can be blank
         {
-            Edited = false;
-            PlanetMarks = new PlanetMarks();
+            planetmarks = new PlanetMarks();
+
+            dataGridViewMarks.CancelEdit();
             dataGridViewMarks.Rows.Clear();
-            SetSystem(systemName);
-            buttonSave.Hide();
+            dataGridViewMarks.Enabled = true;
             sendToCompassToolStripMenuItem.Enabled = false;
+            dataGridViewMarks.ColumnHeadersDefaultCellStyle.BackColor = dataGridViewMarks.RowHeadersDefaultCellStyle.BackColor = EDDTheme.Instance.GridBorderBack;
+
+            if (!string.IsNullOrEmpty(systemName))
+                UpdateComboBox(systemName);
+
+            Edited = false;
         }
 
-        public void AddSurfaceLocation(string planet, double latitude, double longitude)
-        {
-            using (DataGridViewRow dr = dataGridViewMarks.Rows[dataGridViewMarks.Rows.Add()])
-            {
-                dr.Cells[0].Value = planet;
-                dr.Cells[0].ReadOnly = true;
-                dr.Cells[1].Value = "Enter a name";
-                dr.Cells[2].Value = "";
-                dr.Cells[3].Value = latitude.ToString("F4");
-                dr.Cells[4].Value = longitude.ToString("F4");
-                ((DataGridViewCheckBoxCell)dr.Cells[5]).Value = false;
-                dr.Cells[1].Selected = true;
-            }
-        }
-
-        #endregion
-
-        void SetSystem(string systemName)
-        {
-            ISystem thisSystem = EDDApplicationContext.EDDMainForm.history.FindSystem(systemName);
-            ((DataGridViewComboBoxColumn)dataGridViewMarks.Columns["BodyName"]).Items.Clear();
-            ((DataGridViewComboBoxColumn)dataGridViewMarks.Columns["BodyName"]).Items.Add("");
-            if (thisSystem != null)
-            {
-                var landables = EDDApplicationContext.EDDMainForm.history.starscan.FindSystem(thisSystem, true)?.Bodies?.Where(b => b.ScanData != null && b.ScanData.IsLandable)?.Select(b => b.fullname);
-                if (landables != null)
-                {
-                    foreach (string s in landables)
-                    {
-                        ((DataGridViewComboBoxColumn)dataGridViewMarks.Columns["BodyName"]).Items.Add(s);
-                    }
-                }
-            }
-        }
-
-        #region Display Interface to Form/Bookmarks
-
-        public void DisplayPlanetMarks(BookmarkClass bk)
+        public void Disable()
         {
             Edited = false;
+            planetmarks = null;
+            dataGridViewMarks.CancelEdit();
+            dataGridViewMarks.ColumnHeadersDefaultCellStyle.BackColor = dataGridViewMarks.RowHeadersDefaultCellStyle.BackColor = EDDTheme.Instance.GridBorderBack.Multiply(0.5F);
             dataGridViewMarks.Rows.Clear();
+            dataGridViewMarks.Enabled = false;
+        }
 
-            if (bk == null)
-            {
-                dataGridViewMarks.AllowUserToAddRows = false;
-                buttonSave.Hide();
-                return;
-            }
+        public void Init(string systemName, PlanetMarks pm)          // from UCB or Bookmark form, Init with a bookmark
+        {
+            Edited = false;
+            planetmarks = pm!=null ? pm : new PlanetMarks();
 
-            if(bk.isRegion)
-            {
-                dataGridViewMarks.AllowUserToAddRows = false;
-                buttonSave.Hide();
-                return;
-            }
+            dataGridViewMarks.CancelEdit();
+            dataGridViewMarks.ColumnHeadersDefaultCellStyle.BackColor = dataGridViewMarks.RowHeadersDefaultCellStyle.BackColor = EDDTheme.Instance.GridBorderBack;
+            dataGridViewMarks.Rows.Clear();
+            dataGridViewMarks.Enabled = true;
 
             dataGridViewMarks.SuspendLayout();
 
-            dataGridViewMarks.AllowUserToAddRows = true;
-            SetSystem(bk.StarName);
-            thisBookmark = bk;
-            PlanetMarks = bk.PlanetaryMarks == null ? new PlanetMarks() : bk.PlanetaryMarks;
+            if (!string.IsNullOrEmpty(systemName))
+                UpdateComboBox(systemName);
 
-            if (PlanetMarks.Planets != null)
+            if (planetmarks.Planets != null)
             {
-                foreach (Planet pl in PlanetMarks.Planets)
+                foreach (Planet pl in planetmarks.Planets)
                 {
                     foreach (Location loc in pl.Locations)
                     {
@@ -137,67 +104,116 @@ namespace EDDiscovery.UserControls
             dataGridViewMarks.ResumeLayout();
         }
 
+        public void AddSurfaceLocation(string planet, double latitude, double longitude)    // call After Reset to add a surface bookmark
+        {
+            using (DataGridViewRow dr = dataGridViewMarks.Rows[dataGridViewMarks.Rows.Add()])
+            {
+                dr.Cells[0].Value = planet;
+                dr.Cells[0].ReadOnly = true;
+                dr.Cells[1].Value = "Enter a name";
+                dr.Cells[2].Value = "";
+                dr.Cells[3].Value = latitude.ToString("F4");
+                dr.Cells[4].Value = longitude.ToString("F4");
+                ((DataGridViewCheckBoxCell)dr.Cells[5]).Value = false;
+                dr.Cells[1].Selected = true;
+            }
+        }
+
+        private void UpdateComboBox(string systemName)
+        {
+            ISystem thisSystem = EDDApplicationContext.EDDMainForm.history.FindSystem(systemName);
+
+            DataGridViewComboBoxColumn c = (DataGridViewComboBoxColumn)dataGridViewMarks.Columns["BodyName"];
+
+            c.Items.Clear();
+            if (thisSystem != null)
+            {
+                var landables = EDDApplicationContext.EDDMainForm.history.starscan.FindSystem(thisSystem, true)?.Bodies?.Where(b => b.ScanData != null && b.ScanData.IsLandable)?.Select(b => b.fullname);
+
+                if (landables != null)
+                {
+                    foreach (string s in landables)
+                    {
+                        System.Diagnostics.Debug.WriteLine("Drop " + s);
+                        c.Items.Add(s);
+                    }
+                }
+            }
+        }
+
         #endregion
 
         #region UI
 
+        private void dataGridViewMarks_UserDeletingRow(object sender, DataGridViewRowCancelEventArgs e)
+        {
+            if(e.Row.Tag != null)
+            {
+                planetmarks.DeleteLocation(e.Row.Cells[0].Value.ToString(), ((Location)e.Row.Tag).Name);
+                Edited = true;
+                Changed?.Invoke(planetmarks);
+            }
+        }
+
+        private void sendToCompassToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DataGridViewRow c = dataGridViewMarks.CurrentRow;
+
+            if (c != null && c.Tag != null)
+            {
+                CompassSeleted?.Invoke(c.Cells[0].Value.ToString(), ((Location)c.Tag).Name);
+            }
+        }
+
+        #endregion
+
+
+        private void dataGridViewMarks_CellEndEdit(object sender, DataGridViewCellEventArgs e)
+        {
+            DataGridViewRow rw = dataGridViewMarks.Rows[e.RowIndex];
+            bool valid = ValidRow(rw);
+            ((DataGridViewCheckBoxCell)rw.Cells[5]).Value = valid;
+
+            if (valid)
+            {
+                Edited = true;
+                //System.Diagnostics.Debug.WriteLine("Commit " + rw.Cells[0].Value.ToString());
+
+                Location newLoc = rw.Tag != null ? (Location)rw.Tag : new Location();
+                newLoc.Name = rw.Cells[1].Value.ToString();
+                newLoc.Comment = rw.Cells[2].Value?.ToString();
+                newLoc.Latitude = Double.Parse(rw.Cells[3].Value.ToString());
+                newLoc.Longitude = Double.Parse(rw.Cells[4].Value.ToString());
+                planetmarks.AddOrUpdateLocation(rw.Cells[0].Value.ToString(), newLoc);
+                rw.Tag = newLoc;
+                rw.Cells[0].ReadOnly = true;    // can't change the planet or location name once it's in the collection or we'll not be able to look it up again
+                rw.Cells[1].ReadOnly = true;
+                Changed?.Invoke(planetmarks);
+            }
+        }
+
         private void dataGridViewMarks_CellValidating(object sender, DataGridViewCellValidatingEventArgs e)
         {
-            if(e.ColumnIndex == 3 || e.ColumnIndex == 4)
+            if (e.ColumnIndex == 3 || e.ColumnIndex == 4)
             {
-                //latitude or longitude
-                if (Double.TryParse(e.FormattedValue.ToString(), out double parsed))
+                string s = e.FormattedValue.ToString();
+
+                dataGridViewMarks.Rows[e.RowIndex].ErrorText = "";
+
+                if (s.Length > 0)
                 {
-                    if (parsed < -180 || parsed > 180)
+                    double? v = s.ParseDoubleNull();
+                    double lm = e.ColumnIndex == 3 ? 90 : 180;
+
+                    if (v == null || v.Value < -lm || v.Value > lm)
                     {
                         e.Cancel = true;
                         dataGridViewMarks.Rows[e.RowIndex].ErrorText = "Invalid coordinate";
                     }
-                    else
-                        dataGridViewMarks.Rows[e.RowIndex].ErrorText = "";
-                }
-                else
-                {
-                    if (dataGridViewMarks.Rows[e.RowIndex].Cells[0].Value != null)
-                    {
-                        e.Cancel = true;
-                        dataGridViewMarks.Rows[e.RowIndex].ErrorText = "Invalid number";
-                    }
                 }
             }
         }
 
-        private void dataGridViewMarks_CellEndEdit(object sender, DataGridViewCellEventArgs e)
-        {
-            if(e.ColumnIndex == 3 || e.ColumnIndex == 4)
-            {
-                Double parsed = Double.Parse(dataGridViewMarks[e.ColumnIndex, e.RowIndex].Value.ToString());
-                dataGridViewMarks[e.ColumnIndex, e.RowIndex].Value = parsed.ToString("F4");
-            }
-            DataGridViewRow dr = dataGridViewMarks.Rows[e.RowIndex];
-            if (ValidRow(dr))
-            {
-                SaveLocation(dr);
-            }
-            else
-                ((DataGridViewCheckBoxCell)dr.Cells[5]).Value = false;
-        }
-
-        private void SaveLocation(DataGridViewRow dr)
-        {
-            Location newLoc = dr.Tag != null ? (Location)dr.Tag : new Location();
-            newLoc.Name = dr.Cells[1].Value.ToString();
-            newLoc.Comment = dr.Cells[2].Value?.ToString();
-            newLoc.Latitude = Double.Parse(dr.Cells[3].Value.ToString());
-            newLoc.Longitude = Double.Parse(dr.Cells[4].Value.ToString());
-            internalPlanetMarks.AddOrUpdateLocation(dr.Cells[0].Value.ToString(), newLoc);
-            dr.Tag = newLoc;
-            dr.Cells[0].ReadOnly = true;    // can't change the planet or location name once it's in the collection or we'll not be able to look it up again
-            dr.Cells[1].ReadOnly = true;
-            ((DataGridViewCheckBoxCell)dr.Cells[5]).Value = true;
-            Edited = true;
-        }
-        
         private bool ValidRow(DataGridViewRow dr)
         {
             if (dr.Cells[3].Value == null || dr.Cells[4].Value == null) return false;
@@ -206,48 +222,5 @@ namespace EDDiscovery.UserControls
 
             return dr.Cells[0].Value?.ToString() != "" && dr.Cells[1].Value?.ToString() != "" && lat >= -180 && lat <= 180 && lon >= -180 && lon <= 180;
         }
-
-        private void dataGridViewMarks_UserDeletingRow(object sender, DataGridViewRowCancelEventArgs e)
-        {
-            if(e.Row.Tag != null)
-            {
-                internalPlanetMarks.DeleteLocation(e.Row.Cells[0].Value.ToString(), ((Location)e.Row.Tag).Name);
-                Edited = true;
-            }
-        }
-
-        private void buttonSave_Click(object sender, EventArgs e)
-        {
-            if(Edited)
-            {
-                GlobalBookMarkList.Instance.AddOrUpdateBookmark(thisBookmark, true, thisBookmark.StarName, thisBookmark.x, thisBookmark.y, thisBookmark.z, thisBookmark.Time, thisBookmark.Note, internalPlanetMarks);
-                Edited = false;
-            }
-        }
-
-        private void sendToCompassToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            DataGridViewRow dr = dataGridViewMarks.SelectedCells.Cast<DataGridViewCell>()
-                                                                        .Select(cell => cell.OwningRow)
-                                                                        .FirstOrDefault();
-            if (dr != null)
-            {
-                if (dr.Tag == null && ValidRow(dr)) SaveLocation(dr);
-
-                if (thisBookmark != null && dr.Tag != null)
-                {
-                    if (Edited)
-                    {
-                        GlobalBookMarkList.Instance.AddOrUpdateBookmark(thisBookmark, true, thisBookmark.StarName, thisBookmark.x, thisBookmark.y, thisBookmark.z, thisBookmark.Time, thisBookmark.Note, internalPlanetMarks);
-                        Edited = false;
-                    }
-
-                    UserControlCompass comp = (UserControlCompass)EDDApplicationContext.EDDMainForm.PopOuts.PopOut(PanelInformation.PanelIDs.Compass);
-                    comp.SetSurfaceBookmark(thisBookmark, dr.Cells[0].Value.ToString(), dr.Cells[1].Value.ToString());
-                }
-            }
-        }
-
-        #endregion
     }
 }

--- a/EDDiscovery/UserControls/SurfaceBookmarksForm.resx
+++ b/EDDiscovery/UserControls/SurfaceBookmarksForm.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="BodyName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -135,7 +138,7 @@
   <metadata name="Valid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="contextMenuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>172, 17</value>
   </metadata>
 </root>

--- a/EDDiscovery/UserControls/UserControlBookmarks.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlBookmarks.Designer.cs
@@ -45,6 +45,8 @@
             this.X = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Y = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Z = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.contextMenuStripBookmarks = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItemGotoStar3dmap = new System.Windows.Forms.ToolStripMenuItem();
             this.userControlSurfaceBookmarks = new EDDiscovery.UserControls.SurfaceBookmarksForm();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.panelButtons.SuspendLayout();
@@ -54,6 +56,7 @@
             this.splitContainer1.SuspendLayout();
             this.dataViewScrollerPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewBookMarks)).BeginInit();
+            this.contextMenuStripBookmarks.SuspendLayout();
             this.SuspendLayout();
             // 
             // panelButtons
@@ -110,6 +113,7 @@
             this.textBoxFilter.BorderColor = System.Drawing.Color.Transparent;
             this.textBoxFilter.BorderColorScaling = 0.5F;
             this.textBoxFilter.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBoxFilter.ClearOnFirstChar = false;
             this.textBoxFilter.ControlBackground = System.Drawing.SystemColors.Control;
             this.textBoxFilter.InErrorCondition = false;
             this.textBoxFilter.Location = new System.Drawing.Point(50, 6);
@@ -207,6 +211,7 @@
             this.X,
             this.Y,
             this.Z});
+            this.dataGridViewBookMarks.ContextMenuStrip = this.contextMenuStripBookmarks;
             this.dataGridViewBookMarks.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridViewBookMarks.Location = new System.Drawing.Point(0, 0);
             this.dataGridViewBookMarks.Name = "dataGridViewBookMarks";
@@ -216,6 +221,7 @@
             this.dataGridViewBookMarks.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewBookMarks_CellDoubleClick);
             this.dataGridViewBookMarks.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewBookMarks_CellEndEdit);
             this.dataGridViewBookMarks.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewBookMarks_SortCompare);
+            this.dataGridViewBookMarks.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewBookMarks_MouseDown);
             // 
             // Type
             // 
@@ -254,6 +260,20 @@
             this.Z.Name = "Z";
             this.Z.ReadOnly = true;
             // 
+            // contextMenuStripBookmarks
+            // 
+            this.contextMenuStripBookmarks.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemGotoStar3dmap});
+            this.contextMenuStripBookmarks.Name = "contextMenuStripBookmarks";
+            this.contextMenuStripBookmarks.Size = new System.Drawing.Size(158, 26);
+            // 
+            // toolStripMenuItemGotoStar3dmap
+            // 
+            this.toolStripMenuItemGotoStar3dmap.Name = "toolStripMenuItemGotoStar3dmap";
+            this.toolStripMenuItemGotoStar3dmap.Size = new System.Drawing.Size(157, 22);
+            this.toolStripMenuItemGotoStar3dmap.Text = "Goto in 3D Map";
+            this.toolStripMenuItemGotoStar3dmap.Click += new System.EventHandler(this.toolStripMenuItemGotoStar3dmap_Click);
+            // 
             // userControlSurfaceBookmarks
             // 
             this.userControlSurfaceBookmarks.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -278,6 +298,7 @@
             this.splitContainer1.ResumeLayout(false);
             this.dataViewScrollerPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewBookMarks)).EndInit();
+            this.contextMenuStripBookmarks.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -302,5 +323,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn Y;
         private System.Windows.Forms.DataGridViewTextBoxColumn Z;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripBookmarks;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemGotoStar3dmap;
     }
 }

--- a/EDDiscovery/UserControls/UserControlBookmarks.resx
+++ b/EDDiscovery/UserControls/UserControlBookmarks.resx
@@ -138,4 +138,7 @@
   <metadata name="Z.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="contextMenuStripBookmarks.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>114, 17</value>
+  </metadata>
 </root>

--- a/EDDiscovery/UserControls/UserControlCompass.cs
+++ b/EDDiscovery/UserControls/UserControlCompass.cs
@@ -378,11 +378,11 @@ namespace EDDiscovery.UserControls
             {
                 if (latitude.HasValue)
                 {
-                    frm.NewSystemBookmark(last_he.System, "", tme.ToString(), last_he.WhereAmI, latitude.Value, longitude.Value);
+                    frm.NewSystemBookmark(last_he.System, "", tme, last_he.WhereAmI, latitude.Value, longitude.Value);
                 }
                 else
                 {
-                    frm.NewSystemBookmark(last_he.System, "", tme.ToString());
+                    frm.NewSystemBookmark(last_he.System, "", tme);
                 }
             }
             else

--- a/EDDiscovery/UserControls/UserControlEDSM.cs
+++ b/EDDiscovery/UserControls/UserControlEDSM.cs
@@ -262,34 +262,40 @@ namespace EDDiscovery.UserControls
 
         private void viewOnEDSMToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            this.Cursor = Cursors.WaitCursor;
-            EDSMClass edsm = new EDSMClass();
-            long? id_edsm = rightclicksystem.EDSMID;
-
-            if (id_edsm == 0)
+            if (rightclicksystem != null)
             {
-                id_edsm = null;
+                this.Cursor = Cursors.WaitCursor;
+                EDSMClass edsm = new EDSMClass();
+                long? id_edsm = rightclicksystem.EDSMID;
+
+                if (id_edsm == 0)
+                {
+                    id_edsm = null;
+                }
+
+                if (!edsm.ShowSystemInEDSM(rightclicksystem.Name, id_edsm))
+                    ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
+
+                this.Cursor = Cursors.Default;
             }
-
-            if (!edsm.ShowSystemInEDSM(rightclicksystem.Name, id_edsm))
-                ExtendedControls.MessageBoxTheme.Show(FindForm(), "System could not be found - has not been synched or EDSM is unavailable");
-
-            this.Cursor = Cursors.Default;
         }
 
         private void mapGotoStartoolStripMenuItem_Click(object sender, EventArgs e)
         {
-            this.Cursor = Cursors.WaitCursor;
-
-            if (!discoveryform.Map.Is3DMapsRunning)            // if not running, click the 3dmap button
-                discoveryform.Open3DMap(null);
-
-            this.Cursor = Cursors.Default;
-
-            if (discoveryform.Map.Is3DMapsRunning)             // double check here! for paranoia.
+            if (rightclicksystem != null)
             {
-                if (discoveryform.Map.MoveToSystem(rightclicksystem))
-                    discoveryform.Map.Show();
+                this.Cursor = Cursors.WaitCursor;
+
+                if (!discoveryform.Map.Is3DMapsRunning)            // if not running, click the 3dmap button
+                    discoveryform.Open3DMap(null);
+
+                this.Cursor = Cursors.Default;
+
+                if (discoveryform.Map.Is3DMapsRunning)             // double check here! for paranoia.
+                {
+                    if (discoveryform.Map.MoveToSystem(rightclicksystem))
+                        discoveryform.Map.Show();
+                }
             }
         }
 

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -939,7 +939,7 @@ namespace EDDiscovery.UserControls
                 else
                 {
                     tme = DateTime.Now;
-                    bookmarkForm.NewSystemBookmark(rightclicksystem.System, "", tme.ToString());
+                    bookmarkForm.NewSystemBookmark(rightclicksystem.System, "", tme);
                 }
                 DialogResult dr = bookmarkForm.ShowDialog();
                 if (dr == DialogResult.OK)

--- a/EliteDangerous/DB/BookmarkClass.cs
+++ b/EliteDangerous/DB/BookmarkClass.cs
@@ -39,7 +39,9 @@ namespace EliteDangerousCore.DB
             public List<Location> Locations;
         }
 
-        public List<Planet> Planets;
+        public List<Planet> Planets;            // may be null
+
+        public bool hasMarks { get { return Planets != null && Planets.Count > 0 && Planets.Where(pl => pl.Locations.Count > 0).Any(); } }
 
         public PlanetMarks(string json)
         {
@@ -165,14 +167,11 @@ namespace EliteDangerousCore.DB
         public PlanetMarks PlanetaryMarks;   // may be null
         
         public bool isRegion { get { return Heading != null; } }
-        public bool hasSurfaceMarks
-        { get {
-                return PlanetaryMarks != null &&
-                    PlanetaryMarks.Planets.Count > 0 &&
-                    PlanetaryMarks.Planets.Where(pl => pl.Locations.Count > 0).Any();
-            } }
         public bool isStar { get { return Heading == null; } }
         public string Name { get { return Heading == null ? StarName : Heading; } }
+
+        public bool hasPlanetaryMarks
+        { get { return PlanetaryMarks != null && PlanetaryMarks.hasMarks; } }
 
         public BookmarkClass()
         {
@@ -192,6 +191,7 @@ namespace EliteDangerousCore.DB
             Note = (string)dr["Note"];
             if (System.DBNull.Value != dr["PlanetMarks"])
             {
+                System.Diagnostics.Debug.WriteLine("Planet mark {0} {1}", StarName, (string)dr["PlanetMarks"]);
                 PlanetaryMarks = new PlanetMarks((string)dr["PlanetMarks"]);
             }
         }

--- a/ExtendedControls/Themes/ThemeStandard.cs
+++ b/ExtendedControls/Themes/ThemeStandard.cs
@@ -153,6 +153,8 @@ namespace ExtendedControls
         public Color ButtonBorderColor { get { return currentsettings.colors[Settings.CI.button_border]; } set { SetCustom(); currentsettings.colors[Settings.CI.button_border] = value; } }
         public Color ButtonTextColor { get { return currentsettings.colors[Settings.CI.button_text]; } set { SetCustom(); currentsettings.colors[Settings.CI.button_text] = value; } }
 
+        public Color GridCellBack { get { return currentsettings.colors[Settings.CI.grid_cellbackground]; } set { SetCustom(); currentsettings.colors[Settings.CI.grid_cellbackground] = value; } }
+        public Color GridBorderBack { get { return currentsettings.colors[Settings.CI.grid_borderback]; } set { SetCustom(); currentsettings.colors[Settings.CI.grid_borderback] = value; } }
         public Color GridCellText { get { return currentsettings.colors[Settings.CI.grid_celltext]; } set { SetCustom(); currentsettings.colors[Settings.CI.grid_celltext] = value; } }
         public Color GridBorderLines { get { return currentsettings.colors[Settings.CI.grid_borderlines]; } set { SetCustom(); currentsettings.colors[Settings.CI.grid_borderlines] = value; } }
         


### PR DESCRIPTION
Multiple problems introduced by planetary bookmarks broke parts of the
current 3dmap functionality.
Reworked bookmark form, planetary form, tried to split dependencies out
- use call backs instead of explicit data sharing
Right click on bookmark in BMF can go directly to 3dmap point - cool
Creating bookmarks is via the target class helper so the target works
properly.
Bookmarks recoded to work with system