### PR TITLE
Last hour fixes. SORRY!!! :(

### DIFF
--- a/EDDiscovery/UserControls/UserControlPlot.cs
+++ b/EDDiscovery/UserControls/UserControlPlot.cs
@@ -145,9 +145,6 @@ namespace EDDiscovery.UserControls
                         var curX = centerSystem.X;
                         var curY = centerSystem.Y;
                         var curZ = centerSystem.Z;
-
-                        double totalMass = 0;
-                        double knownMagnitude = 0;
                         
                         // reset charts axis
                         chartBubble.ChartAreas[0].AxisY.IsStartedFromZero = false;
@@ -164,7 +161,7 @@ namespace EDDiscovery.UserControls
                             int visits = discoveryform.history.GetVisitsCount(tvp.Value.Name, tvp.Value.EDSMID);
 
                             StringBuilder label = new StringBuilder();
-                            label.Append(theISystemInQuestion.Name + " / " + visits + " visits" + "\n" + distFromCurrentSys + "; " + "Known masses: " + totalMass + "; " + "Known absolute magnitude: " + knownMagnitude);
+                            label.Append(theISystemInQuestion.Name + " / " + visits + " visits" + "\n" + distFromCurrentSys);
 
                             double dx = curX - sysX;
                             double dy = curY - sysY;
@@ -222,7 +219,9 @@ namespace EDDiscovery.UserControls
         {
             int maxMarker = Convert.ToInt32(6 * (markerReduction[zoomIndex]));
             int defMarker = Convert.ToInt32(4 * (markerReduction[zoomIndex]));
-            int minMarker = Convert.ToInt32(2 * (markerReduction[zoomIndex]));
+                        
+            int minMarkAbsolute = Convert.ToInt32(2 * (markerReduction[zoomIndex]));
+            int minMarker = minMarkAbsolute < 1 ? minMarker = 1: minMarker = 2; // avoid zero values or less than 1 pixel marker when zooming
 
             // Min and Max size for Current system
             foreach (int serie in seriesIsCurrent)

--- a/EDDiscovery/UserControls/UserControlPlot.cs
+++ b/EDDiscovery/UserControls/UserControlPlot.cs
@@ -168,7 +168,7 @@ namespace EDDiscovery.UserControls
                             double dz = curZ - sysZ;
 
                             int px = Convert.ToInt32(dx) * -1;
-                            int py = Convert.ToInt32(dy) * -1;
+                            int py = Convert.ToInt32(dy);
                             int pz = Convert.ToInt32(dz);
 
                             // visited systems go to series #1, #4 and #7; unvisited to series #2, #5 and #8. 


### PR DESCRIPTION
Avoid markers less than 1 pixel when zooming Plot; fixed a test forgotten string in toolTip.