### PR TITLE
Fix `UserControlExpedition` `SQLiteException`

### DIFF
--- a/EDDiscovery/UserControls/UserControlExpedition.cs
+++ b/EDDiscovery/UserControls/UserControlExpedition.cs
@@ -13,7 +13,6 @@
  *
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
-using EDDiscovery.UserControls;
 using EliteDangerousCore;
 using EliteDangerousCore.DB;
 using EliteDangerousCore.EDSM;
@@ -325,11 +324,18 @@ namespace EDDiscovery.UserControls
             {
                 if (currentroute.Id >= 0)
                 {
-                    currentroute.Deleted = true;
-                    currentroute.Update();
+                    if (currentroute.EDSM)
+                    {
+                        currentroute.Deleted = true;
+                        currentroute.Update();
+                        UpdateUndeleteMenu();
+                    }
+                    else
+                    {
+                        currentroute.Delete();
+                    }
 
                     savedroute.Remove(currentroute);
-                    UpdateUndeleteMenu();
                     UpdateComboBox();
                 }
 

--- a/EliteDangerous/DB/SavedRouteClass.cs
+++ b/EliteDangerous/DB/SavedRouteClass.cs
@@ -424,8 +424,8 @@ namespace EliteDangerousCore.DB
                                     }
                                     else if (storedentry.EndDate != newentry.EndDate || storedentry.StartDate != newentry.StartDate)    // times change, just update
                                     {
-                                        storedentry.StartDate = newentry.StartDate.Value;      // update time and date but keep the expedition ID
-                                        storedentry.EndDate = newentry.EndDate.Value;
+                                        storedentry.StartDate = newentry.StartDate;             // update time and date but keep the expedition ID
+                                        storedentry.EndDate = newentry.EndDate;
                                         storedentry.EDSM = true;
                                         storedentry.Update();
                                         changed = true;

--- a/EliteDangerous/DB/SavedRouteClass.cs
+++ b/EliteDangerous/DB/SavedRouteClass.cs
@@ -394,15 +394,21 @@ namespace EliteDangerousCore.DB
 
                         foreach (SavedRouteClass newentry in array)
                         {
-                            newentry.StartDate = newentry.StartDate.Value.ToLocalTime();      // supplied, and respected by JSON, as zulu time. the stupid database holds local times. Convert.
-                            newentry.EndDate = newentry.EndDate.Value.ToLocalTime();
+                            newentry.EDSM = true;
+                            if (newentry.StartDate.HasValue)
+                                newentry.StartDate = newentry.StartDate.Value.ToLocalTime();      // supplied, and respected by JSON, as zulu time. the stupid database holds local times. Convert.
+                            if (newentry.EndDate.HasValue)
+                                newentry.EndDate = newentry.EndDate.Value.ToLocalTime();
 
                             SavedRouteClass storedentry = stored.Find(x => x.Name.Equals(newentry.Name));
 
                             if (newentry.Systems.Count == 0)              // no systems, means delete the database entry.. use with caution
                             {
-                                if ( storedentry != null )                  // if we have it in the DB, delete it
+                                if (storedentry != null)                // if we have it in the DB, delete it
+                                {
                                     storedentry.Delete();
+                                    changed = true;
+                                }
                             }
                             else
                             {
@@ -410,12 +416,13 @@ namespace EliteDangerousCore.DB
                                 {
                                     if (!storedentry.Systems.SequenceEqual(newentry.Systems)) // systems changed, we need to reset..
                                     {
+                                        bool wasDel = storedentry.Deleted;
                                         storedentry.Delete();   // delete the old one.. systems may be in a different order, and there is no ordering except by ID in the DB
-                                        newentry.EDSM = true;
+                                        newentry.Deleted = wasDel;
                                         newentry.Add();        // add to db..
-                                        changed = true;
+                                        changed = changed || !wasDel;   // If it was marked deleted, don't report it as being changed.
                                     }
-                                    else if (storedentry.EndDate == null || storedentry.StartDate == null || storedentry.EndDate.Value != newentry.EndDate.Value || storedentry.StartDate.Value != newentry.StartDate.Value)    // times change, just update
+                                    else if (storedentry.EndDate != newentry.EndDate || storedentry.StartDate != newentry.StartDate)    // times change, just update
                                     {
                                         storedentry.StartDate = newentry.StartDate.Value;      // update time and date but keep the expedition ID
                                         storedentry.EndDate = newentry.EndDate.Value;
@@ -432,7 +439,6 @@ namespace EliteDangerousCore.DB
                                 }
                                 else
                                 {                   // not there, add it..
-                                    newentry.EDSM = true;
                                     newentry.Add();        // add to db..
                                     changed = true;
                                 }


### PR DESCRIPTION
* `SavedRouteClass.UpdateDBFromExpeditionFiles`:
  * Fix several `InvalidOperationException`s if no `Start`/`End` `DateTime?` values are set.
  * Deleted routes now stay deleted even if they get updated upstream.
  * Deleting a route now sets the `changed` flag for consumers to see.
* `UserControlExpedition`:
  * Delete custom routes added by the user when clicking delete.
  * Only mark routes as faux-"deleted" if they come from EDSM.
  * Fix #1837