### PR TITLE
Fix inverted json match in FindEntry

### DIFF
--- a/EliteDangerous/EliteDangerous/JournalEntry.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntry.cs
@@ -971,7 +971,7 @@ namespace EliteDangerousCore
                         while (reader.Read())
                         {
                             JournalEntry jent = CreateJournalEntry(reader);
-                            if (!AreSameEntry(ent, jent, entjo))
+                            if (AreSameEntry(ent, jent, entjo))
                             {
                                 entries.Add(jent);
                             }


### PR DESCRIPTION
This should fix #1853, at least for `DiscoveryScan` events with different numbers.

I don't know if it's worth trying to handle the edge case of two subsequent `DiscoveryScan` events coming in with the same number of bodies in the same second but in separate reader ticks.  Would probably have to group events by timestamp and keep the latest events read in the last tick around to be handled in the next tick.  This would add up to 2 seconds extra delay in recognizing events given a 2 second tick.  This would also require rewinding the reader to the start of the first event in that second in order to prevent missing events.