### PR TITLE
Include Location in messages sent to EDDN

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -149,12 +149,15 @@ namespace EliteDangerousCore.EDDN
             message.Remove("StarPosFromEDSM");
             message.Remove("Latitude");
             message.Remove("Longitude");
+
+            /*
             if (!journal.Docked)
             {
                 message.Remove("Body");
                 message.Remove("BodyType");
                 message.Remove("BodyID");
             }
+             */
 
             msg["message"] = message;
             return msg;

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -75,6 +75,7 @@ namespace EliteDangerousCore
                 if ((EntryType == JournalTypeEnum.Scan ||
                      EntryType == JournalTypeEnum.Docked ||
                      EntryType == JournalTypeEnum.FSDJump ||
+                     EntryType == JournalTypeEnum.Location ||
                      EntryType == JournalTypeEnum.Market ||
                      EntryType == JournalTypeEnum.Shipyard ||
                      EntryType == JournalTypeEnum.Outfitting) && EventTimeUTC > ed22) return true; else return false;


### PR DESCRIPTION
EDDN Sync was set to send Location events, but they were not included in the types of events to send to EDDN.