### PR TITLE
ShipYard and Remove multiple entries when reading journal

### DIFF
--- a/BaseUtils/BaseUtils.csproj
+++ b/BaseUtils/BaseUtils.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Collections\CollectionStaticHelpers.cs" />
     <Compile Include="Collections\SortedListDuplicates.cs" />
     <Compile Include="Dates\DateObjectExtensions.cs" />
     <Compile Include="EMK\Point3D.cs" />

--- a/BaseUtils/Collections/CollectionStaticHelpers.cs
+++ b/BaseUtils/Collections/CollectionStaticHelpers.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Copyright © 2015 - 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+
+using System.Collections.Generic;
+
+public static class CollectionStaticHelpers
+{
+    static public bool Equals<T>(T[] left, T[] right) where T : System.IEquatable<T>        // equals, calling null/null true..
+    {
+        if (left == null && right == null)
+            return true;
+
+        if (left == null || right == null || left.Length != right.Length)
+            return false;
+
+        for (int i = 0; i < left.Length; i++)
+        {
+            if (!left[i].Equals(right[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    static public bool Equals<T>(List<T> left, List<T> right) where T : System.IEquatable<T>
+    {
+        if (left == null && right == null)
+            return true;
+
+        if (left == null || right == null || left.Count != right.Count)
+            return false;
+
+        for (int i = 0; i < left.Count; i++)
+        {
+            if (!left[i].Equals(right[i]))
+                return false;
+        }
+
+        return true;
+    }
+}
+

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -368,6 +368,12 @@
     <Compile Include="UserControls\UserControlCombatPanel.Designer.cs">
       <DependentUpon>UserControlCombatPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="UserControls\UserControlShipYards.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\UserControlShipYards.Designer.cs">
+      <DependentUpon>UserControlShipYards.cs</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\UserControlPanelSelector.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -636,6 +642,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\UserControlCombatPanel.resx">
       <DependentUpon>UserControlCombatPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserControls\UserControlShipYards.resx">
+      <DependentUpon>UserControlShipYards.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\UserControlPanelSelector.resx">
       <DependentUpon>UserControlPanelSelector.cs</DependentUpon>

--- a/EDDiscovery/PanelAndPopOuts.cs
+++ b/EDDiscovery/PanelAndPopOuts.cs
@@ -65,8 +65,9 @@ namespace EDDiscovery.Forms
             LocalMap,               // 32
             Plot,                   // 33
             PanelSelector,          // 34
-            BookmarkManager,
-            CombatPanel,
+            BookmarkManager,        // 35
+            CombatPanel,            // 36
+            ShipYardPanel,          // 37
             // ****** ADD More here DO NOT REORDER *****
         };
 
@@ -94,6 +95,7 @@ namespace EDDiscovery.Forms
             { new PanelInfo( PanelIDs.ScanGrid, typeof(UserControlScanGrid), "Scan Grid", "ScanGrid", "Scan data on system in a grid", transparent: false) },
             { new PanelInfo( PanelIDs.EstimatedValues, typeof(UserControlEstimatedValues),"Estimated Values", "EstimatedValues", "Estimated scan values of bodies in system", transparent: false) },
             { new PanelInfo( PanelIDs.Modules, typeof(UserControlModules), "Ships/Loadout", "Modules", "Ships and their loadouts plus stored modules") },
+            { new PanelInfo( PanelIDs.ShipYardPanel, typeof(UserControlShipYards), "Ship Yards", "ShipYards", "Information on ship yards you have visited") },
             { new PanelInfo( PanelIDs.LocalMap, typeof(UserControlLocalMap), "Local Map", "LocalMap", "3D Map of systems in range", transparent: false) },
             { new PanelInfo( PanelIDs.Plot, typeof(UserControlPlot), "2D Plot", "Plot", "2D Plot of systems in range", transparent: false) },
             { new PanelInfo( PanelIDs.Exploration, typeof(UserControlExploration), "Exploration", "Exploration", "Exploration Information") },

--- a/EDDiscovery/UserControls/UserControlShipYards.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlShipYards.Designer.cs
@@ -1,0 +1,234 @@
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+namespace EDDiscovery.UserControls
+{
+    partial class UserControlShipYards
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.dataViewScrollerPanel = new ExtendedControls.DataViewScrollerPanel();
+            this.dataGridViewShips = new System.Windows.Forms.DataGridView();
+            this.ItemLocalised = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ItemCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Distance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.vScrollBarCustomMC = new ExtendedControls.VScrollBarCustom();
+            this.panelButtons = new System.Windows.Forms.Panel();
+            this.labelYard = new System.Windows.Forms.Label();
+            this.labelYardSel = new System.Windows.Forms.Label();
+            this.comboBoxYards = new ExtendedControls.ComboBoxCustom();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.dataViewScrollerPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewShips)).BeginInit();
+            this.panelButtons.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // dataViewScrollerPanel
+            // 
+            this.dataViewScrollerPanel.Controls.Add(this.dataGridViewShips);
+            this.dataViewScrollerPanel.Controls.Add(this.vScrollBarCustomMC);
+            this.dataViewScrollerPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataViewScrollerPanel.InternalMargin = new System.Windows.Forms.Padding(0);
+            this.dataViewScrollerPanel.Location = new System.Drawing.Point(0, 32);
+            this.dataViewScrollerPanel.Name = "dataViewScrollerPanel";
+            this.dataViewScrollerPanel.ScrollBarWidth = 20;
+            this.dataViewScrollerPanel.Size = new System.Drawing.Size(800, 540);
+            this.dataViewScrollerPanel.TabIndex = 0;
+            this.dataViewScrollerPanel.VerticalScrollBarDockRight = true;
+            // 
+            // dataGridViewShips
+            // 
+            this.dataGridViewShips.AllowUserToAddRows = false;
+            this.dataGridViewShips.AllowUserToDeleteRows = false;
+            this.dataGridViewShips.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewShips.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewShips.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.ItemLocalised,
+            this.ItemCol,
+            this.Distance});
+            this.dataGridViewShips.Location = new System.Drawing.Point(0, 0);
+            this.dataGridViewShips.Name = "dataGridViewShips";
+            this.dataGridViewShips.RowHeadersVisible = false;
+            this.dataGridViewShips.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.dataGridViewShips.Size = new System.Drawing.Size(780, 540);
+            this.dataGridViewShips.TabIndex = 1;
+            this.dataGridViewShips.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.dataGridViewModules_SortCompare);
+            // 
+            // ItemLocalised
+            // 
+            this.ItemLocalised.HeaderText = "Type";
+            this.ItemLocalised.MinimumWidth = 50;
+            this.ItemLocalised.Name = "ItemLocalised";
+            this.ItemLocalised.ReadOnly = true;
+            // 
+            // ItemCol
+            // 
+            this.ItemCol.FillWeight = 50F;
+            this.ItemCol.HeaderText = "Price";
+            this.ItemCol.MinimumWidth = 50;
+            this.ItemCol.Name = "ItemCol";
+            this.ItemCol.ReadOnly = true;
+            // 
+            // Distance
+            // 
+            this.Distance.HeaderText = "Distance";
+            this.Distance.MinimumWidth = 50;
+            this.Distance.Name = "Distance";
+            this.Distance.ReadOnly = true;
+            // 
+            // vScrollBarCustomMC
+            // 
+            this.vScrollBarCustomMC.ArrowBorderColor = System.Drawing.Color.LightBlue;
+            this.vScrollBarCustomMC.ArrowButtonColor = System.Drawing.Color.LightGray;
+            this.vScrollBarCustomMC.ArrowColorScaling = 0.5F;
+            this.vScrollBarCustomMC.ArrowDownDrawAngle = 270F;
+            this.vScrollBarCustomMC.ArrowUpDrawAngle = 90F;
+            this.vScrollBarCustomMC.BorderColor = System.Drawing.Color.White;
+            this.vScrollBarCustomMC.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.vScrollBarCustomMC.HideScrollBar = false;
+            this.vScrollBarCustomMC.LargeChange = 0;
+            this.vScrollBarCustomMC.Location = new System.Drawing.Point(780, 21);
+            this.vScrollBarCustomMC.Maximum = -1;
+            this.vScrollBarCustomMC.Minimum = 0;
+            this.vScrollBarCustomMC.MouseOverButtonColor = System.Drawing.Color.Green;
+            this.vScrollBarCustomMC.MousePressedButtonColor = System.Drawing.Color.Red;
+            this.vScrollBarCustomMC.Name = "vScrollBarCustomMC";
+            this.vScrollBarCustomMC.Size = new System.Drawing.Size(20, 519);
+            this.vScrollBarCustomMC.SliderColor = System.Drawing.Color.DarkGray;
+            this.vScrollBarCustomMC.SmallChange = 1;
+            this.vScrollBarCustomMC.TabIndex = 0;
+            this.vScrollBarCustomMC.Text = "vScrollBarCustom1";
+            this.vScrollBarCustomMC.ThumbBorderColor = System.Drawing.Color.Yellow;
+            this.vScrollBarCustomMC.ThumbButtonColor = System.Drawing.Color.DarkBlue;
+            this.vScrollBarCustomMC.ThumbColorScaling = 0.5F;
+            this.vScrollBarCustomMC.ThumbDrawAngle = 0F;
+            this.vScrollBarCustomMC.Value = -1;
+            this.vScrollBarCustomMC.ValueLimited = -1;
+            // 
+            // panelButtons
+            // 
+            this.panelButtons.Controls.Add(this.labelYard);
+            this.panelButtons.Controls.Add(this.labelYardSel);
+            this.panelButtons.Controls.Add(this.comboBoxYards);
+            this.panelButtons.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelButtons.Location = new System.Drawing.Point(0, 0);
+            this.panelButtons.Name = "panelButtons";
+            this.panelButtons.Size = new System.Drawing.Size(800, 32);
+            this.panelButtons.TabIndex = 2;
+            // 
+            // labelYard
+            // 
+            this.labelYard.AutoSize = true;
+            this.labelYard.Location = new System.Drawing.Point(246, 7);
+            this.labelYard.Name = "labelYard";
+            this.labelYard.Size = new System.Drawing.Size(53, 13);
+            this.labelYard.TabIndex = 28;
+            this.labelYard.Text = "Unknown";
+            // 
+            // labelYardSel
+            // 
+            this.labelYardSel.AutoSize = true;
+            this.labelYardSel.Location = new System.Drawing.Point(6, 7);
+            this.labelYardSel.Name = "labelYardSel";
+            this.labelYardSel.Size = new System.Drawing.Size(29, 13);
+            this.labelYardSel.TabIndex = 26;
+            this.labelYardSel.Text = "Yard";
+            // 
+            // comboBoxYards
+            // 
+            this.comboBoxYards.ArrowWidth = 1;
+            this.comboBoxYards.BorderColor = System.Drawing.Color.Red;
+            this.comboBoxYards.ButtonColorScaling = 0.5F;
+            this.comboBoxYards.DataSource = null;
+            this.comboBoxYards.DisableBackgroundDisabledShadingGradient = false;
+            this.comboBoxYards.DisplayMember = "";
+            this.comboBoxYards.DropDownBackgroundColor = System.Drawing.Color.Gray;
+            this.comboBoxYards.DropDownHeight = 400;
+            this.comboBoxYards.DropDownWidth = 500;
+            this.comboBoxYards.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.comboBoxYards.ItemHeight = 13;
+            this.comboBoxYards.Location = new System.Drawing.Point(52, 4);
+            this.comboBoxYards.MouseOverBackgroundColor = System.Drawing.Color.Silver;
+            this.comboBoxYards.Name = "comboBoxYards";
+            this.comboBoxYards.ScrollBarButtonColor = System.Drawing.Color.LightGray;
+            this.comboBoxYards.ScrollBarColor = System.Drawing.Color.LightGray;
+            this.comboBoxYards.ScrollBarWidth = 16;
+            this.comboBoxYards.SelectedIndex = -1;
+            this.comboBoxYards.SelectedItem = null;
+            this.comboBoxYards.SelectedValue = null;
+            this.comboBoxYards.Size = new System.Drawing.Size(188, 21);
+            this.comboBoxYards.TabIndex = 0;
+            this.comboBoxYards.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.toolTip.SetToolTip(this.comboBoxYards, "Select ship to view");
+            this.comboBoxYards.ValueMember = "";
+            this.comboBoxYards.SelectedIndexChanged += new System.EventHandler(this.comboBoxHistoryWindow_SelectedIndexChanged);
+            // 
+            // UserControlShipYards
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.dataViewScrollerPanel);
+            this.Controls.Add(this.panelButtons);
+            this.Name = "UserControlShipYards";
+            this.Size = new System.Drawing.Size(800, 572);
+            this.dataViewScrollerPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewShips)).EndInit();
+            this.panelButtons.ResumeLayout(false);
+            this.panelButtons.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private ExtendedControls.DataViewScrollerPanel dataViewScrollerPanel;
+        private System.Windows.Forms.DataGridView dataGridViewShips;
+        private ExtendedControls.VScrollBarCustom vScrollBarCustomMC;
+        private System.Windows.Forms.Panel panelButtons;
+        internal ExtendedControls.ComboBoxCustom comboBoxYards;
+        private System.Windows.Forms.Label labelYardSel;
+        private System.Windows.Forms.Label labelYard;
+        private System.Windows.Forms.ToolTip toolTip;
+        private System.Windows.Forms.DataGridViewTextBoxColumn LocationOf;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ItemLocalised;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ItemCol;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Distance;
+    }
+}

--- a/EDDiscovery/UserControls/UserControlShipYards.cs
+++ b/EDDiscovery/UserControls/UserControlShipYards.cs
@@ -1,0 +1,225 @@
+﻿/*
+ * Copyright © 2016 - 2017 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using EDDiscovery.Controls;
+using System.IO;
+using EliteDangerousCore;
+using EliteDangerousCore.DB;
+
+namespace EDDiscovery.UserControls
+{
+    public partial class UserControlShipYards : UserControlCommonBase
+    {
+        private string DbColumnSave { get { return ("ShipYardsGrid") + ((displaynumber > 0) ? displaynumber.ToString() : "") + "DGVCol"; } }
+        private string DbYardSave { get { return "ShipYardGridSelect" + ((displaynumber > 0) ? displaynumber.ToString() : ""); } }
+
+        #region Init
+
+        public UserControlShipYards()
+        {
+            InitializeComponent();
+            var corner = dataGridViewShips.TopLeftHeaderCell; // work around #1487
+        }
+
+        public override void Init()
+        {
+            dataGridViewShips.MakeDoubleBuffered();
+            dataGridViewShips.DefaultCellStyle.WrapMode = DataGridViewTriState.False;
+            dataGridViewShips.RowTemplate.Height = 26;
+
+            discoveryform.OnHistoryChange += Discoveryform_OnHistoryChange; ;
+            discoveryform.OnNewEntry += Discoveryform_OnNewEntry;
+            uctg.OnTravelSelectionChanged += Display;
+        }
+
+        public override void ChangeCursorType(IHistoryCursor thc)
+        {
+            uctg.OnTravelSelectionChanged -= Display;
+            uctg = thc;
+            uctg.OnTravelSelectionChanged += Display;
+        }
+
+        #endregion
+
+        #region Display
+
+        private void Discoveryform_OnNewEntry(HistoryEntry he, HistoryList hl)
+        {
+            Discoveryform_OnHistoryChange(hl);
+        }
+
+        private void Discoveryform_OnHistoryChange(HistoryList hl)
+        {
+            UpdateComboBox(hl);
+        }
+
+        private void UpdateComboBox(HistoryList hl)
+        {
+            ShipYardList shm = hl.shipyards;
+            string cursel = comboBoxYards.Text;
+
+            comboBoxYards.Items.Clear();
+            comboBoxYards.Items.Add("Travel History Entry");
+
+            comboBoxYards.Items.AddRange(shm.ShipList());
+
+            var list = (from ShipYard x in shm.YardListWithoutRepeats() orderby x.Datetime descending select x.Ident(EDDiscoveryForm.EDDConfig.DisplayUTC)).ToList();
+            comboBoxYards.Items.AddRange(list);
+
+            if (cursel == "")
+                cursel = SQLiteDBClass.GetSettingString(DbYardSave, "");
+
+            if (cursel == "" || !comboBoxYards.Items.Contains(cursel))
+                cursel = "Travel History Entry";
+
+            comboBoxYards.Enabled = false;
+            comboBoxYards.SelectedItem = cursel;
+            comboBoxYards.Enabled = true;
+        }
+
+        public override void InitialDisplay()
+        {
+            Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
+        }
+
+        HistoryEntry last_he = null;
+
+        private void Display(HistoryEntry he, HistoryList hl)
+        {
+            if ( comboBoxYards.Items.Count == 0 )
+                UpdateComboBox(hl);
+
+            last_he = he;
+            Display();
+        }
+
+        private void Display()
+        {
+            DataGridViewColumn sortcol = dataGridViewShips.SortedColumn != null ? dataGridViewShips.SortedColumn : dataGridViewShips.Columns[0];
+            SortOrder sortorder = dataGridViewShips.SortOrder;
+
+            dataGridViewShips.Rows.Clear();
+
+            labelYard.Visible = false;
+
+            ShipYard yard = null;
+
+            if (comboBoxYards.Text.Contains("Travel") || comboBoxYards.Text.Length == 0)  // second is due to the order History gets called vs this on start
+            {
+                HistoryEntry lastshipyard = discoveryform.history.GetLastHistoryEntry(x => x.EntryType == JournalTypeEnum.Shipyard, last_he);
+                if (lastshipyard != null)
+                    yard = (lastshipyard.journalEntry as EliteDangerousCore.JournalEvents.JournalShipyard).Yard;
+            }
+            else
+            {
+                yard = discoveryform.history.shipyards.YardListWithoutRepeats().Find(x => x.Ident(EDDiscoveryForm.EDDConfig.DisplayUTC).Equals(comboBoxYards.Text));
+            }
+
+            if (yard != null)
+            {
+                DisplayYard(yard);
+            }
+            else
+            {
+                List<Tuple<ShipYard, ShipYard.ShipyardItem>> shiplist = discoveryform.history.shipyards.GetShipLocationsFromYardsWithoutRepeat(comboBoxYards.Text);
+                if ( shiplist.Count > 0 )
+                    DisplayShips(shiplist, comboBoxYards.Text);
+            }
+
+            dataGridViewShips.Sort(sortcol, (sortorder == SortOrder.Descending) ? ListSortDirection.Descending : ListSortDirection.Ascending);
+            dataGridViewShips.Columns[sortcol.Index].HeaderCell.SortGlyphDirection = sortorder;
+        }
+
+        private void DisplayShips(List<Tuple<ShipYard, ShipYard.ShipyardItem>> shiplist,string ship)
+        {
+            ISystem cursys = discoveryform.history.CurrentSystem;
+
+            foreach (Tuple<ShipYard, ShipYard.ShipyardItem> i in shiplist)
+            {
+                double distance = discoveryform.history.DistanceCurrentTo(i.Item1.StarSystem);
+                object[] rowobj = { i.Item1.Location, i.Item2.ShipPrice.ToString("N1") + "cr" , (distance>-1) ? (distance.ToString("N1") + "ly") : "Unknown" };
+                dataGridViewShips.Rows.Add(rowobj);
+            }
+
+            labelYard.Text = ship + " locations";
+            labelYard.Visible = true;
+            dataGridViewShips.Columns[0].HeaderText = "Shipyard";
+            dataGridViewShips.Columns[2].Visible = true;
+        }
+
+        private void DisplayYard(ShipYard yard)    
+        {
+            foreach (ShipYard.ShipyardItem i in yard.Ships)
+            {
+                object[] rowobj = { i.ShipType_Localised, i.ShipPrice.ToString("N1") + "cr" };
+
+                dataGridViewShips.Rows.Add(rowobj);
+            }
+
+            double distance = discoveryform.history.DistanceCurrentTo(yard.StarSystem);
+
+            labelYard.Text = yard.Ident(EDDiscoveryForm.EDDConfig.DisplayUTC) + (distance>-1 ? (" @ " + distance.ToString("N1") + "ly") : "");
+            labelYard.Visible = true;
+            dataGridViewShips.Columns[0].HeaderText = "Ship";
+            dataGridViewShips.Columns[2].Visible = false;
+        }
+
+        #endregion
+
+        #region Layout
+
+        public override void LoadLayout()
+        {
+            DGVLoadColumnLayout(dataGridViewShips, DbColumnSave);
+        }
+
+        public override void Closing()
+        {
+            DGVSaveColumnLayout(dataGridViewShips, DbColumnSave);
+            uctg.OnTravelSelectionChanged -= Display;
+            discoveryform.OnNewEntry -= Discoveryform_OnNewEntry;
+            discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
+        }
+
+        #endregion
+
+        private void comboBoxHistoryWindow_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (comboBoxYards.Enabled)
+            {
+                SQLiteDBClass.PutSettingString(DbYardSave, comboBoxYards.Text);
+                Display();
+            }
+        }
+
+        private void dataGridViewModules_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
+        {
+            if (e.Column.Index == 1)
+                e.SortDataGridViewColumnNumeric("cr");
+            else if (e.Column.Index == 2)
+                e.SortDataGridViewColumnNumeric("ly");
+        }
+
+    }
+}

--- a/EDDiscovery/UserControls/UserControlShipYards.resx
+++ b/EDDiscovery/UserControls/UserControlShipYards.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="ItemLocalised.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ItemCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ItemLocalised.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ItemCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -239,7 +239,7 @@ namespace EliteDangerousCore.EDDN
 
         public JObject CreateEDDNJournalMessage(JournalShipyard journal, double x, double y, double z, long? systemAddress)
         {
-            if (journal.ShipyardItems == null)
+            if (journal.Yard.Ships == null)
                 return null;
 
             JObject msg = new JObject();
@@ -262,7 +262,7 @@ namespace EliteDangerousCore.EDDN
 
         public JObject CreateEDDNShipyardMessage(JournalShipyard journal, ISystem system = null)
         {
-            if (journal.ShipyardItems == null)
+            if (journal.Yard.Ships == null)
                 return null;
 
             JObject msg = new JObject();
@@ -273,10 +273,10 @@ namespace EliteDangerousCore.EDDN
             JObject message = new JObject
             {
                 ["timestamp"] = journal.EventTimeUTC.ToString("yyyy-MM-ddTHH:mm:ss'Z'"),
-                ["systemName"] = journal.StarSystem,
-                ["stationName"] = journal.StationName,
+                ["systemName"] = journal.Yard.StarSystem,
+                ["stationName"] = journal.Yard.StationName,
                 ["marketId"] = journal.MarketID,
-                ["ships"] = new JArray(journal.ShipyardItems.Select(m => m.FDShipType))
+                ["ships"] = new JArray(journal.Yard.Ships.Select(m => m.FDShipType))
             };
 
             //if (systemAddress != null)

--- a/EliteDangerous/EliteDangerous.csproj
+++ b/EliteDangerous/EliteDangerous.csproj
@@ -126,6 +126,7 @@
     <Compile Include="EliteDangerous\MaterialCommodities.cs" />
     <Compile Include="EliteDangerous\MaterialCommoditiesList.cs" />
     <Compile Include="EliteDangerous\MissionList.cs" />
+    <Compile Include="EliteDangerous\ShipModulesInStore.cs" />
     <Compile Include="EliteDangerous\ShipInformationList.cs" />
     <Compile Include="EliteDangerous\ShipModule.cs" />
     <Compile Include="EliteDangerous\ShipModuleData.cs" />
@@ -134,6 +135,8 @@
     <Compile Include="EliteDangerous\Ranks.cs" />
     <Compile Include="EliteDangerous\RoutePlotter.cs" />
     <Compile Include="EliteDangerous\ShipInformation.cs" />
+    <Compile Include="EliteDangerous\ShipStored.cs" />
+    <Compile Include="EliteDangerous\ShipYard.cs" />
     <Compile Include="EliteDangerous\StarScan.cs" />
     <Compile Include="DB\SystemCache.cs" />
     <Compile Include="EliteDangerous\SystemClass.cs" />

--- a/EliteDangerous/EliteDangerous/CommodityPrices.cs
+++ b/EliteDangerous/EliteDangerous/CommodityPrices.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace EliteDangerousCore
 {
-    public class CCommodities
+    public class CCommodities : System.IEquatable<CCommodities>
     {
         public int id { get; private set; }
 
@@ -56,6 +56,14 @@ namespace EliteDangerousCore
             StatusFlags = new List<string>(other.StatusFlags);
 
             ComparisionLR = ComparisionRL = "";
+        }
+
+        public bool Equals(CCommodities other)
+        {
+            return (id == other.id && string.Compare(fdname, other.fdname) == 0 && string.Compare(locName, other.locName) == 0 &&
+                     string.Compare(category, other.category) == 0 && string.Compare(loccategory, other.loccategory) == 0 &&
+                     buyPrice == other.buyPrice && sellPrice == other.sellPrice && meanPrice == other.meanPrice &&
+                     demandBracket == other.demandBracket && stockBracket == other.stockBracket && stock == other.stock && demand == other.demand);
         }
 
         public bool FromJsonCAPI(JObject jo)

--- a/EliteDangerous/EliteDangerous/JournalFieldNaming.cs
+++ b/EliteDangerous/EliteDangerous/JournalFieldNaming.cs
@@ -306,7 +306,7 @@ namespace EliteDangerousCore
             if (s.StartsWith("hpt_"))
                 s = s.Replace("hpt_", "Hpt_");
             if (s.Contains("_armour_"))
-                s = s.Replace("_Armour_", "_armour_");      // normalise Armour to now lower case.. as done in journals
+                s = s.Replace("_armour_", "_Armour_");      // normalise to Armour upper cas.. its a bit over the place with case..
             if (s.EndsWith("_name;"))
                 s = s.Substring(0, s.Length - 6);
 

--- a/EliteDangerous/EliteDangerous/ShipInformationList.cs
+++ b/EliteDangerous/EliteDangerous/ShipInformationList.cs
@@ -1,4 +1,22 @@
-﻿using EliteDangerousCore.JournalEvents;
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ *
+ * Data courtesy of Coriolis.IO https://github.com/EDCD/coriolis , data is intellectual property and copyright of Frontier Developments plc ('Frontier', 'Frontier Developments') and are subject to their terms and conditions.
+ */
+
+using EliteDangerousCore.JournalEvents;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -228,7 +246,7 @@ namespace EliteDangerousCore
             }
         }
 
-        public void StoredShips(JournalStoredShips.StoredShipInformation[] ships)
+        public void StoredShips(StoredShipInformation[] ships)
         {
             foreach (var i in ships)
             {
@@ -435,110 +453,4 @@ namespace EliteDangerousCore
     }
 
 
-    public class ModulesInStore
-    {
-        public class StoredModule               // storage used by journal event..
-        {
-            public int StorageSlot;
-            public string Name;
-            public string Name_Localised;
-            public string StarSystem;       // not while in transit
-            public long MarketID;       // not while in transit
-            public long TransferCost;   // not while in transit
-            public int TransferTime;    // not while in transit
-            public string EngineerModifications;    // null if none present
-            public double Quality;      // may not be there
-            public int Level;           // may not be there
-            public bool Hot;
-            public bool InTransit;
-            public int BuyPrice;
-
-            public System.TimeSpan TransferTimeSpan;        // computed
-            public string TransferTimeString; // computed, empty if not in tranfer (time<=0)
-
-            public double Mass
-            {
-                get
-                {
-                    ShipModuleData.ShipModule smd = ShipModuleData.Instance.GetModuleProperties(Name);
-                    return smd?.mass ?? 0;
-                }
-            }
-
-            public void Normalise()
-            {
-                Name = JournalFieldNaming.GetBetterItemNameEvents(Name);
-                Name_Localised = Name_Localised.Alt(Name);
-                TransferTimeSpan = new System.TimeSpan((int)(TransferTime / 60 / 60), (int)((TransferTime / 60) % 60), (int)(TransferTime % 60));
-                TransferTimeString = TransferTime > 0 ? TransferTimeSpan.ToString() : "";
-            }
-
-            public StoredModule(string item, string item_localised)
-            {
-                Name = item;
-                Name_Localised = item_localised.Alt(Name);
-                //System.Diagnostics.Debug.WriteLine("Store module '" + item + "' '" + item_localised + "'");
-            }
-
-            public StoredModule()
-            {
-            }
-        }
-
-        public List<StoredModule> StoredModules { get; private set; }       // by STORE id
-
-        public ModulesInStore()
-        {
-            StoredModules = new List<StoredModule>();
-        }
-
-        public ModulesInStore(List<StoredModule> list)
-        {
-            StoredModules = new List<StoredModule>(list);
-        }
-
-        public ModulesInStore StoreModule(string item, string itemlocalised)
-        {
-            ModulesInStore mis = this.ShallowClone();
-            mis.StoredModules.Add(new StoredModule(item, itemlocalised));
-            return mis;
-        }
-
-        public ModulesInStore StoreModule(JournalMassModuleStore.ModuleItem[] items, Dictionary<string, string> itemlocalisation)
-        {
-            ModulesInStore mis = this.ShallowClone();
-            foreach (var it in items)
-            {
-                string local = itemlocalisation.ContainsKey(it.Name) ? itemlocalisation[it.Name] : "";
-                mis.StoredModules.Add(new StoredModule(it.Name, local));
-            }
-            return mis;
-        }
-
-        public ModulesInStore RemoveModule(string item)
-        {
-            int index = StoredModules.FindIndex(x => x.Name.Equals(item, StringComparison.InvariantCultureIgnoreCase));  // if we have an item of this name
-            if (index != -1)
-            {
-                //System.Diagnostics.Debug.WriteLine("Remove module '" + item + "'  '" + StoredModules[index].Name_Localised + "'");
-                ModulesInStore mis = this.ShallowClone();
-                mis.StoredModules.RemoveAt(index);
-                return mis;
-            }
-            else
-                return this;
-        }
-
-        public ModulesInStore UpdateStoredModules(StoredModule[] newlist)
-        {
-            ModulesInStore mis = new ModulesInStore(newlist.ToList());      // copy constructor ..
-            return mis;
-        }
-
-        public ModulesInStore ShallowClone()          // shallow clone.. does not clone the ship modules, just the dictionary
-        {
-            ModulesInStore mis = new ModulesInStore(this.StoredModules);
-            return mis;
-        }
-    }
 }

--- a/EliteDangerous/EliteDangerous/ShipModule.cs
+++ b/EliteDangerous/EliteDangerous/ShipModule.cs
@@ -313,5 +313,25 @@ namespace EliteDangerousCore
         }
 
         #endregion
+
+        #region Outfitting Module
+
+        public class OutfittingEntry : IEquatable<OutfittingEntry>
+        {
+            public long id;
+            public string Name;
+            public string FDName;
+            public long BuyPrice;
+
+            public bool Equals(OutfittingEntry other)
+            {
+                return (id == other.id && string.Compare(Name, other.Name) == 0 && string.Compare(FDName, other.FDName) == 0 &&
+                         BuyPrice == other.BuyPrice);
+            }
+
+        }
+
+        #endregion
+
     }
 }

--- a/EliteDangerous/EliteDangerous/ShipModulesInStore.cs
+++ b/EliteDangerous/EliteDangerous/ShipModulesInStore.cs
@@ -1,0 +1,142 @@
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ *
+ * Data courtesy of Coriolis.IO https://github.com/EDCD/coriolis , data is intellectual property and copyright of Frontier Developments plc ('Frontier', 'Frontier Developments') and are subject to their terms and conditions.
+ */
+
+using EliteDangerousCore;
+using EliteDangerousCore.JournalEvents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EliteDangerousCore
+{
+    public class ModulesInStore
+    {
+        public class StoredModule: IEquatable<StoredModule> // storage used by journal event..
+        {
+            public int StorageSlot;
+            public string Name;
+            public string Name_Localised;
+            public string StarSystem;       // not while in transit
+            public long MarketID;       // not while in transit
+            public long TransferCost;   // not while in transit
+            public int TransferTime;    // not while in transit
+            public string EngineerModifications;    // null if none present
+            public double Quality;      // may not be there
+            public int Level;           // may not be there
+            public bool Hot;
+            public bool InTransit;
+            public int BuyPrice;
+
+            public System.TimeSpan TransferTimeSpan;        // computed
+            public string TransferTimeString; // computed, empty if not in tranfer (time<=0)
+
+            public double Mass
+            {
+                get
+                {
+                    ShipModuleData.ShipModule smd = ShipModuleData.Instance.GetModuleProperties(Name);
+                    return smd?.mass ?? 0;
+                }
+            }
+
+            public void Normalise()
+            {
+                Name = JournalFieldNaming.GetBetterItemNameEvents(Name);
+                Name_Localised = Name_Localised.Alt(Name);
+                TransferTimeSpan = new System.TimeSpan((int)(TransferTime / 60 / 60), (int)((TransferTime / 60) % 60), (int)(TransferTime % 60));
+                TransferTimeString = TransferTime > 0 ? TransferTimeSpan.ToString() : "";
+            }
+
+            public StoredModule(string item, string item_localised)
+            {
+                Name = item;
+                Name_Localised = item_localised.Alt(Name);
+                //System.Diagnostics.Debug.WriteLine("Store module '" + item + "' '" + item_localised + "'");
+            }
+
+            public StoredModule()
+            {
+            }
+
+            public bool Equals(StoredModule other)
+            {
+                return (StorageSlot == other.StorageSlot && string.Compare(Name, other.Name) == 0 && string.Compare(Name_Localised, other.Name_Localised) == 0 &&
+                         string.Compare(StarSystem, other.StarSystem) == 0 && MarketID == other.MarketID && TransferCost == other.TransferCost &&
+                         TransferTime == other.TransferTime && string.Compare(EngineerModifications, other.EngineerModifications) == 0 &&
+                         Quality == other.Quality && Level == other.Level && Hot == other.Hot && InTransit == other.InTransit && BuyPrice == other.BuyPrice);
+            }
+        }
+
+
+        public List<StoredModule> StoredModules { get; private set; }       // by STORE id
+
+        public ModulesInStore()
+        {
+            StoredModules = new List<StoredModule>();
+        }
+
+        public ModulesInStore(List<StoredModule> list)
+        {
+            StoredModules = new List<StoredModule>(list);
+        }
+
+        public ModulesInStore StoreModule(string item, string itemlocalised)
+        {
+            ModulesInStore mis = this.ShallowClone();
+            mis.StoredModules.Add(new StoredModule(item, itemlocalised));
+            return mis;
+        }
+
+        public ModulesInStore StoreModule(JournalMassModuleStore.ModuleItem[] items, Dictionary<string, string> itemlocalisation)
+        {
+            ModulesInStore mis = this.ShallowClone();
+            foreach (var it in items)
+            {
+                string local = itemlocalisation.ContainsKey(it.Name) ? itemlocalisation[it.Name] : "";
+                mis.StoredModules.Add(new StoredModule(it.Name, local));
+            }
+            return mis;
+        }
+
+        public ModulesInStore RemoveModule(string item)
+        {
+            int index = StoredModules.FindIndex(x => x.Name.Equals(item, StringComparison.InvariantCultureIgnoreCase));  // if we have an item of this name
+            if (index != -1)
+            {
+                //System.Diagnostics.Debug.WriteLine("Remove module '" + item + "'  '" + StoredModules[index].Name_Localised + "'");
+                ModulesInStore mis = this.ShallowClone();
+                mis.StoredModules.RemoveAt(index);
+                return mis;
+            }
+            else
+                return this;
+        }
+
+        public ModulesInStore UpdateStoredModules(StoredModule[] newlist)
+        {
+            ModulesInStore mis = new ModulesInStore(newlist.ToList());      // copy constructor ..
+            return mis;
+        }
+
+        public ModulesInStore ShallowClone()          // shallow clone.. does not clone the ship modules, just the dictionary
+        {
+            ModulesInStore mis = new ModulesInStore(this.StoredModules);
+            return mis;
+        }
+    }
+}

--- a/EliteDangerous/EliteDangerous/ShipStored.cs
+++ b/EliteDangerous/EliteDangerous/ShipStored.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * Copyright © 2016 EDDiscovery development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * EDDiscovery is not affiliated with Frontier Developments plc.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EliteDangerousCore
+{
+    public class StoredShipInformation : IEquatable<StoredShipInformation>
+    {
+        public int ShipID;      // both
+        public string ShipType; // both
+        public string ShipType_Localised; // both
+        public string Name;     // Both
+        public long Value;      // both
+        public bool Hot;        // both
+
+        public string StarSystem;   // remote only and when not in transit, but filled in for local
+        public long ShipMarketID;   //remote
+        public long TransferPrice;  //remote
+        public long TransferTime;   //remote
+        public bool InTransit;      //remote, and that means StarSystem is not there.
+
+        public string StationName;  // local only, null otherwise, not compared due to it being computed
+        public string ShipTypeFD; // both, computed
+        public System.TimeSpan TransferTimeSpan;        // computed
+        public string TransferTimeString; // computed
+
+        public void Normalise()
+        {
+            ShipTypeFD = JournalFieldNaming.NormaliseFDShipName(ShipType);
+            ShipType = JournalFieldNaming.GetBetterShipName(ShipTypeFD);
+            ShipType_Localised = ShipType_Localised.Alt(ShipType);
+            TransferTimeSpan = new System.TimeSpan((int)(TransferTime / 60 / 60), (int)((TransferTime / 60) % 60), (int)(TransferTime % 60));
+            TransferTimeString = TransferTimeSpan.ToString();
+        }
+
+        public bool Equals(StoredShipInformation other)
+        {
+            return ShipID == other.ShipID && string.Compare(ShipType, other.ShipType) == 0 &&
+                        string.Compare(ShipType_Localised, other.ShipType_Localised) == 0 && string.Compare(Name, other.Name) == 0 &&
+                        Value == other.Value && Hot == other.Hot &&
+                        string.Compare(StarSystem, other.StarSystem) == 0 && ShipMarketID == other.ShipMarketID && TransferPrice == other.TransferPrice &&
+                        InTransit == other.InTransit;
+        }
+    }
+}

--- a/EliteDangerous/EliteDangerous/ShipYard.cs
+++ b/EliteDangerous/EliteDangerous/ShipYard.cs
@@ -1,0 +1,133 @@
+﻿using EliteDangerousCore.DB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EliteDangerousCore
+{
+    public class ShipYard : IEquatable<ShipYard>
+    {
+        public class ShipyardItem : IEquatable<ShipyardItem>
+        {
+            public long id;
+            public string FDShipType;
+            public string ShipType;
+            public string ShipType_Localised;
+            public long ShipPrice;
+
+            public void Normalise()
+            {
+                FDShipType = ShipType;
+                ShipType = JournalFieldNaming.GetBetterShipName(ShipType);
+                ShipType_Localised = ShipType_Localised.Alt(ShipType);
+            }
+
+            public bool Equals(ShipyardItem other)
+            {
+                return id == other.id && string.Compare(FDShipType, other.FDShipType) == 0 &&
+                            string.Compare(ShipType_Localised, other.ShipType_Localised) == 0 && ShipPrice == other.ShipPrice;
+            }
+        }
+
+        public ShipyardItem[] Ships { get; private set; }
+        public string StationName { get; private set; }
+        public string StarSystem { get; private set; }
+        public DateTime Datetime { get; private set; }
+
+        public ShipYard()
+        {
+        }
+
+        public ShipYard(string st, string sy, DateTime dt , ShipyardItem[] it  )
+        {
+            StationName = st;
+            StarSystem = sy;
+            Datetime = dt;
+            Ships = it;
+            if ( Ships != null )
+                foreach (ShipYard.ShipyardItem i in Ships)
+                    i.Normalise();
+        }
+
+        public bool Equals(ShipYard other)
+        {
+            return string.Compare(StarSystem, other.StarSystem) == 0 && string.Compare(StationName, other.StationName) == 0 &&
+                CollectionStaticHelpers.Equals(Ships,other.Ships);
+        }
+
+        public string Location { get { return StarSystem + ":" + StationName; } }
+
+        public string Ident(bool utc) { return StarSystem + ":" + StationName + " on " +
+                ((utc) ? Datetime.ToString() : Datetime.ToLocalTime().ToString());
+        }
+
+        public List<string> ShipList() { return (from x1 in Ships select x1.ShipType_Localised).ToList(); }
+
+        public ShipyardItem Find(string shiplocname) { return Array.Find(Ships, x => x.ShipType_Localised.Equals(shiplocname)); }
+
+    }
+
+    public class ShipYardList
+    {
+        public List<ShipYard> ShipYards { get; private set; }
+
+        public ShipYardList()
+        {
+            ShipYards = new List<ShipYard>();
+        }
+
+        public List<string> ShipList()
+        {
+            List<string> ships = new List<string>();
+            foreach (ShipYard yard in ShipYards)
+                ships.AddRange(yard.ShipList());
+            return (from x in ships select x).Distinct().ToList();
+        }
+
+        public List<ShipYard> YardListWithoutRepeats()
+        {
+            ShipYard last = null;
+            List<ShipYard> yards = new List<ShipYard>();
+
+            foreach (var x1 in ShipYards)
+            {
+                if (last == null || !x1.Location.Equals(last.Location) || (x1.Datetime - last.Datetime).Seconds > 60 * 5)
+                {
+                    yards.Add(x1);
+                    last = x1;
+                }
+            }
+
+            return yards;
+        }
+
+        public List<Tuple<ShipYard, ShipYard.ShipyardItem>> GetShipLocationsFromYardsWithoutRepeat(string ship)       // without repeats note
+        {
+            List<Tuple<ShipYard, ShipYard.ShipyardItem>> list = new List<Tuple<ShipYard, ShipYard.ShipyardItem>>();
+            
+            foreach ( ShipYard yard in YardListWithoutRepeats())
+            {
+                ShipYard.ShipyardItem i = yard.Find(ship);
+                if (i != null)
+                    list.Add(new Tuple<ShipYard, ShipYard.ShipyardItem>(yard, i));
+            }
+
+            return list;
+        }
+
+        public void Process(JournalEntry je, SQLiteConnectionUser conn)
+        {
+            if ( je.EventTypeID == JournalTypeEnum.Shipyard)
+            {
+                JournalEvents.JournalShipyard js = je as JournalEvents.JournalShipyard;
+                if (js.Yard.Ships != null)     // just in case we get a bad shipyard with no ship data
+                {
+                    //System.Diagnostics.Debug.WriteLine("Add yard data for " + js.Yard.StarSystem + ":" + js.Yard.StationName);
+                    ShipYards.Add(js.Yard);
+                }
+            }
+        }
+    }
+}

--- a/EliteDangerous/JournalEvents/JournalMarket.cs
+++ b/EliteDangerous/JournalEvents/JournalMarket.cs
@@ -65,6 +65,11 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
+        public bool Equals(JournalMarket other)
+        {
+            return string.Compare(Station, other.Station) == 0 && string.Compare(StarSystem, other.StarSystem) == 0 && CollectionStaticHelpers.Equals(Commodities, other.Commodities);
+        }
+
         public bool ReadAdditionalFiles(string directory, ref JObject jo)
         {
             JObject jnew = ReadAdditionalFile(System.IO.Path.Combine(directory, "Market.json"));

--- a/EliteDangerous/JournalEvents/JournalOutfitting.cs
+++ b/EliteDangerous/JournalEvents/JournalOutfitting.cs
@@ -13,6 +13,8 @@
  *
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+
+using EliteDangerousCore;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 
@@ -45,11 +47,11 @@ namespace EliteDangerousCore.JournalEvents
             Horizons = evt["Horizons"].BoolNull();
             AllowCobraMkIV = evt["AllowCobraMkIV"].BoolNull();
 
-            ModuleItems = evt["Items"]?.ToObjectProtected<OutfittingModuleItem[]>();
+            ModuleItems = evt["Items"]?.ToObjectProtected<ShipModule.OutfittingEntry[]>();
 
             if ( ModuleItems != null )
             {
-                foreach (OutfittingModuleItem i in ModuleItems)
+                foreach (ShipModule.OutfittingEntry i in ModuleItems)
                 {
                     i.FDName = i.Name;
                     i.Name = JournalFieldNaming.GetBetterItemNameEvents(i.Name);
@@ -74,7 +76,7 @@ namespace EliteDangerousCore.JournalEvents
         public bool? Horizons { get; set; }
         public bool? AllowCobraMkIV { get; set; }
 
-        public OutfittingModuleItem[] ModuleItems { get; set; }
+        public ShipModule.OutfittingEntry[] ModuleItems { get; set; }
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {
@@ -86,21 +88,13 @@ namespace EliteDangerousCore.JournalEvents
             {
                 info = ModuleItems.Length.ToString() + " items available";
                 int itemno = 0;
-                foreach (OutfittingModuleItem m in ModuleItems)
+                foreach (ShipModule.OutfittingEntry m in ModuleItems)
                 {
                     detailed = detailed.AppendPrePad(m.Name + ":" + m.BuyPrice.ToString("N0"), (itemno % 3 < 2) ? ", " : System.Environment.NewLine);
                     itemno++;
                 }
             }
                 
-        }
-
-        public class OutfittingModuleItem
-        {
-            public long id;
-            public string Name;
-            public string FDName;
-            public long BuyPrice;
         }
     }
 }

--- a/EliteDangerous/JournalEvents/JournalShipyard.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyard.cs
@@ -38,19 +38,10 @@ namespace EliteDangerousCore.JournalEvents
 
         public void Rescan(JObject evt)
         {
-            StationName = evt["StationName"].Str();
-            StarSystem = evt["StarSystem"].Str();
+            Yard = new ShipYard(evt["StationName"].Str(), evt["StarSystem"].Str(), EventTimeUTC, evt["PriceList"]?.ToObjectProtected<ShipYard.ShipyardItem[]>());
             MarketID = evt["MarketID"].LongNull();
             Horizons = evt["Horizons"].BoolNull();
             AllowCobraMkIV = evt["AllowCobraMkIV"].BoolNull();
-
-            ShipyardItems = evt["PriceList"]?.ToObjectProtected<ShipyardItem[]>();
-
-            if (ShipyardItems != null)
-            {
-                foreach (ShipyardItem i in ShipyardItems)
-                    i.Normalise();
-            }
         }
 
         public bool ReadAdditionalFiles(string directory, ref JObject jo)
@@ -64,13 +55,10 @@ namespace EliteDangerousCore.JournalEvents
             return jnew != null;
         }
 
-        public string StationName { get; set; }
-        public string StarSystem { get; set; }
+        public ShipYard Yard { get; set; }
         public long? MarketID { get; set; }
         public bool? Horizons { get; set; }
         public bool? AllowCobraMkIV { get; set; }
-
-        public ShipyardItem[] ShipyardItems { get; set; }
 
         public override void FillInformation(out string summary, out string info, out string detailed) //V
         {
@@ -78,37 +66,22 @@ namespace EliteDangerousCore.JournalEvents
             info = "";
             detailed = "";
 
-            if (ShipyardItems != null)
+            if (Yard.Ships != null)
             {
-                if (ShipyardItems.Length < 5)
+                if (Yard.Ships.Length < 5)
                 {
-                    foreach (ShipyardItem m in ShipyardItems)
+                    foreach (ShipYard.ShipyardItem m in Yard.Ships)
                         info = info.AppendPrePad(m.ShipType_Localised.Alt(m.ShipType), ", ");
                 }
                 else
-                    info = ShipyardItems.Length.ToString() + " ships";
+                    info = Yard.Ships.Length.ToString() + " ships";
 
-                foreach (ShipyardItem m in ShipyardItems)
+                foreach (ShipYard.ShipyardItem m in Yard.Ships)
                 {
                     detailed = detailed.AppendPrePad(BaseUtils.FieldBuilder.Build("",m.ShipType_Localised.Alt(m.ShipType), "; cr;N0", m.ShipPrice), System.Environment.NewLine);
                 }
             }
         }
 
-        public class ShipyardItem
-        {
-            public long id;
-            public string FDShipType;
-            public string ShipType;
-            public string ShipType_Localised;
-            public long ShipPrice;
-
-            public void Normalise()
-            {
-                FDShipType = ShipType;
-                ShipType = JournalFieldNaming.GetBetterShipName(ShipType);
-                ShipType_Localised = ShipType_Localised.Alt(ShipType);
-            }
-        }
     }
 }

--- a/EliteDangerous/JournalEvents/JournalStoredShips.cs
+++ b/EliteDangerous/JournalEvents/JournalStoredShips.cs
@@ -123,34 +123,5 @@ namespace EliteDangerousCore.JournalEvents
                 shp.StoredShips(ShipsRemote);
         }
 
-        public class StoredShipInformation
-        {
-            public int ShipID;      // both
-            public string ShipType; // both
-            public string ShipType_Localised; // both
-            public string Name;     // Both
-            public long Value;      // both
-            public bool Hot;        // both
-
-            public string StarSystem;   // remote only and when not in transit, but filled in for local
-            public long ShipMarketID;   //remote
-            public long TransferPrice;  //remote
-            public long TransferTime;   //remote
-            public bool InTransit;      //remote, and that means StarSystem is not there.
-
-            public string StationName;  // local only, null otherwise
-            public string ShipTypeFD; // both, computed
-            public System.TimeSpan TransferTimeSpan;        // computed
-            public string TransferTimeString; // computed
-
-            public void Normalise()
-            {
-                ShipTypeFD = JournalFieldNaming.NormaliseFDShipName(ShipType);
-                ShipType = JournalFieldNaming.GetBetterShipName(ShipTypeFD);
-                ShipType_Localised = ShipType_Localised.Alt(ShipType);
-                TransferTimeSpan = new System.TimeSpan((int)(TransferTime / 60 / 60), (int)((TransferTime / 60) % 60), (int)(TransferTime % 60));
-                TransferTimeString = TransferTimeSpan.ToString();
-            }
-        }
     }
 }


### PR DESCRIPTION
Shipyard introduced to find ships - new UC.  Icon not ready yet but will
be soon
Classes moved to first class which are used in more than just the
journal entry
Reader now screens out multiple repeats of shipyard, storedships,stored
modules, outfitting, market so that we don't blam the journal with
repeated entries.  On undock, all repeats are cleared.
Change to form to make sure the TLU gets updated even if we don't create
a JR.. this was a fault, and caused re-reading of old entries in the
journal if you restarted.