### PR TITLE
PR1900 and 1716

### DIFF
--- a/ActionLanguage/ActionsCore/ActionCoreController.cs
+++ b/ActionLanguage/ActionsCore/ActionCoreController.cs
@@ -120,11 +120,11 @@ namespace ActionLanguage
             programrunglobalvariables[name] = globalvariables[name] = value;
         }
 
-        public void DeleteVariable(string name)
+        public void DeleteVariableWildcard(string name)
         {
-            programrunglobalvariables.Delete(name);
-            persistentglobalvariables.Delete(name);
-            globalvariables.Delete(name);
+            programrunglobalvariables.DeleteWildcard(name);
+            persistentglobalvariables.DeleteWildcard(name);
+            globalvariables.DeleteWildcard(name);
         }
 
         public void TerminateAll()

--- a/ActionLanguage/ActionsCore/ActionFile.cs
+++ b/ActionLanguage/ActionsCore/ActionFile.cs
@@ -88,6 +88,11 @@ namespace ActionLanguage
             filevariables.Delete(n);
         }
 
+        public void DeleteFileVariableWildcard(string n)
+        {
+            filevariables.DeleteWildcard(n);
+        }
+
         public string Read(JObject jo , out bool readenable)            // KEEP JSON reader for backwards compatibility.
         {
             string errlist = "";

--- a/ActionLanguage/ActionsCore/ActionProgramRun.cs
+++ b/ActionLanguage/ActionsCore/ActionProgramRun.cs
@@ -83,7 +83,7 @@ namespace ActionLanguage
 
         public ConditionVariables variables { get { return currentvars; } }
         public string this[string s] { get { return currentvars[s]; } set { currentvars[s] = value; } }
-        public void DeleteVar(string v) { currentvars.Delete(v); }
+        public void DeleteVariableWildcard(string v) { currentvars.DeleteWildcard(v); }
         public bool VarExist(string v) { return currentvars.Exists(v); }
         public void Add(ConditionVariables v) { currentvars.Add(v); }
         public void AddDataOfType(Object o, Type t, string n) { currentvars.AddDataOfType(o, t, n, 5); }

--- a/ActionLanguage/ActionsCore/ActionRun.cs
+++ b/ActionLanguage/ActionsCore/ActionRun.cs
@@ -173,7 +173,7 @@ namespace ActionLanguage
                     if ( logtologline )
                         actioncontroller.LogLine(t + s);
                     if ( logger!= null )
-                        logger.Write(s);
+                        logger.WriteLine(s);
                 }
 
                 if (progcurrent.DoExecute(ac))       // execute is on.. 

--- a/ActionLanguage/ActionsCoreCmds/ActionSet.cs
+++ b/ActionLanguage/ActionsCoreCmds/ActionSet.cs
@@ -257,9 +257,9 @@ namespace ActionLanguage
                 while ((v = p.NextWord(", ")) != null)
                 {
                     v = ap.variables.Qualify(v);
-                    ap.actioncontroller.DeleteVariable(v);
-                    ap.actionfile.DeleteFileVariable(v);
-                    ap.DeleteVar(v);
+                    ap.actioncontroller.DeleteVariableWildcard(v);
+                    ap.actionfile.DeleteFileVariableWildcard(v);
+                    ap.DeleteVariableWildcard(v);
                     p.IsCharMoveOn(',');
                 }
             }

--- a/BaseUtils/Strings/StringParser.cs
+++ b/BaseUtils/Strings/StringParser.cs
@@ -83,6 +83,18 @@ namespace BaseUtils
                 return false;
         }
 
+        public bool IsAnyCharMoveOn(string t)
+        {
+            if (pos < line.Length && t.Contains(line[pos]))
+            {
+                pos++;
+                SkipSpace();
+                return true;
+            }
+            else
+                return false;
+        }
+
         // WORD defined by terminators. options to lowercase it and de-escape it
 
         public string NextWord(string terminators = " " , bool lowercase = false, bool replacescape = false)
@@ -203,25 +215,26 @@ namespace BaseUtils
                 return null;
         }
 
-        // Read a quoted word list off 
-
-        public List<string> NextQuotedWordList(bool lowercase = false , bool replaceescape = false , bool commaopt =  false)        // empty list on error
+        // Read a quoted word list off, delimiters definable, and with an optional move on char, and the lowercard/replaceescape options
+        // null list on error
+        public List<string> NextQuotedWordList(bool lowercase = false , bool replaceescape = false , 
+                                        string nonquoteterminators = ",", string itemterm = " ", bool termopt = false)
         {
             List<string> ret = new List<string>();
 
             do
             {
-                string v = NextQuotedWord(", ",lowercase,replaceescape);
+                string v = NextQuotedWord(nonquoteterminators + itemterm,lowercase,replaceescape);
                 if (v == null)
                     return null;
 
                 ret.Add(v);
 
-                if (commaopt)
+                if (termopt)
                 {
-                    IsCharMoveOn(',');   // remove it if its there
+                    IsAnyCharMoveOn(nonquoteterminators);   // remove it if its there
                 }
-                else if (!IsEOL && !IsCharMoveOn(','))   // either EOL, or its not a comma matey
+                else if (!IsEOL && !IsAnyCharMoveOn(nonquoteterminators))   // either EOL, or its not a terminator
                     return null;
 
             } while (!IsEOL);

--- a/Conditions/ConditionFunctionsBase.cs
+++ b/Conditions/ConditionFunctionsBase.cs
@@ -98,8 +98,8 @@ namespace Conditions
                 functions.Add("trim", new FuncEntry(Trim, FuncEntry.PT.MESE));
                 functions.Add("upper", new FuncEntry(Upper, 1, 20, FuncEntry.PT.MESE));
                 functions.Add("wordof", new FuncEntry(WordOf, 2, FuncEntry.PT.MESE, FuncEntry.PT.ImeSE, FuncEntry.PT.MESE));
-                functions.Add("wordlistcount", new FuncEntry(WordListCount, FuncEntry.PT.MESE));
-                functions.Add("wordlistentry", new FuncEntry(WordListEntry, FuncEntry.PT.MESE, FuncEntry.PT.ImeSE));
+                functions.Add("wordlistcount", new FuncEntry(WordListCount, 1, FuncEntry.PT.MESE, FuncEntry.PT.MESE));
+                functions.Add("wordlistentry", new FuncEntry(WordListEntry, 2, FuncEntry.PT.MESE, FuncEntry.PT.ImeSE, FuncEntry.PT.MESE));
                 #endregion
 
                 #region Files
@@ -376,8 +376,9 @@ namespace Conditions
         protected bool WordListCount(out string output)
         {
             BaseUtils.StringParser l = new BaseUtils.StringParser(paras[0].Value);
-            List<string> ll = l.NextQuotedWordList();
-            output = ll.Count.ToStringInvariant();
+            string splitchars = (paras.Count >= 2) ? paras[1].Value : ",";
+            List<string> ll = l.NextQuotedWordList(nonquoteterminators: splitchars);
+            output = ll != null ? ll.Count.ToStringInvariant() : "0";
             return true;
         }
 
@@ -386,13 +387,13 @@ namespace Conditions
         {
             BaseUtils.StringParser l = new BaseUtils.StringParser(paras[0].Value);
             int count = paras[1].Int;
+            string splitchars = (paras.Count >= 3) ? paras[2].Value : ",";
+
             output = "";
 
-            List<string> ll = l.NextQuotedWordList();
-            if (count >= 0 && count < ll.Count)
-            {
+            List<string> ll = l.NextQuotedWordList(nonquoteterminators: splitchars);
+            if (ll != null && count >= 0 && count < ll.Count)
                 output = ll[count];
-            }
             return true;
         }
 

--- a/Conditions/ConditionVariables.cs
+++ b/Conditions/ConditionVariables.cs
@@ -97,6 +97,23 @@ namespace Conditions
                 values.Remove(name);
         }
 
+        public void DeleteWildcard(string name)
+        { 
+            int wildcard = name.IndexOf('*');
+            if (wildcard >= 0)
+                name = name.Substring(0, wildcard);
+
+            List<string> removelist = new List<string>();
+            foreach (KeyValuePair<string, string> k in values)
+            {
+                if ((wildcard >= 0 && k.Key.StartsWith(name)) || k.Key.Equals(name))
+                    removelist.Add(k.Key);
+            }
+
+            foreach (string k in removelist)
+                values.Remove(k);
+        }
+
         public void Add(List<ConditionVariables> varlist)
         {
             if (varlist != null)

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionPerform.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionPerform.cs
@@ -32,7 +32,7 @@ namespace EDDiscovery.Actions
         List<string> FromString(string input)       // returns in raw esacped mode
         {
             StringParser sp = new StringParser(input);
-            List<string> s = sp.NextQuotedWordList(commaopt:true);
+            List<string> s = sp.NextQuotedWordList(termopt:true);
             return (s != null && s.Count >= 1 ) ? s : null;
         }
 

--- a/EDDiscovery/Actions/ConditionFunctionsEDD.cs
+++ b/EDDiscovery/Actions/ConditionFunctionsEDD.cs
@@ -91,7 +91,7 @@ namespace EDDiscovery.Actions
 
         static public string PhoneticShipName(string inname)
         {
-            return inname.Replace("Mk. IV", "Mark 4").Replace("Mk. III", "Mark 3");
+            return inname.Replace("Mk IV", "Mark 4").Replace("Mk III", "Mark 3").Replace("MkIV", "Mark 4").Replace("MkIII", "Mark 3");
         }
 
         protected bool Ship(out string output)

--- a/EDDiscovery/UserControls/UserControlCombatPanel.cs
+++ b/EDDiscovery/UserControls/UserControlCombatPanel.cs
@@ -254,7 +254,7 @@ namespace EDDiscovery.UserControls
 
             if ( current != null )
             {
-                System.Diagnostics.Debug.WriteLine("Filter {0} {1}", current.StartTime.ToStringZulu(), current.EndTime.ToStringZulu());
+                //System.Diagnostics.Debug.WriteLine("Filter {0} {1}", current.StartTime.ToStringZulu(), current.EndTime.ToStringZulu());
                 List<HistoryEntry> hel;
 
                 if (current.Type == FilterEntry.EntryType.Lastdock)
@@ -505,7 +505,7 @@ namespace EDDiscovery.UserControls
 
         private void SelectInitial()
         {
-            string sel = SQLiteConnectionUser.GetSettingString(DbSave + "Selected", "");
+            string sel = SQLiteConnectionUser.GetSettingString(DbSave + "Selected", "Since Last Dock");
 
             if (!sel.IsEmpty())
             {

--- a/EDDiscovery/UserControls/UserControlCombatPanel.cs
+++ b/EDDiscovery/UserControls/UserControlCombatPanel.cs
@@ -278,7 +278,7 @@ namespace EDDiscovery.UserControls
 
                 foreach ( HistoryEntry he in hel )
                 {
-                    System.Diagnostics.Debug.WriteLine("{0} {1} {2}", he.EventTimeUTC.ToStringZulu(), he.EventSummary, he.EventDescription);
+                    //System.Diagnostics.Debug.WriteLine("Combat Add {0} {1} {2}", he.EventTimeUTC.ToStringZulu(), he.EventSummary, he.EventDescription);
                     AddToGrid(he);
                 }
             }

--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -127,14 +127,15 @@ namespace EDDiscovery.UserControls
             Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
         }
 
-        private void Discoveryform_OnEDSMSyncComplete()     // EDSM ~MAY~ have updated the last discovery flag, so redisplay
+        private void Discoveryform_OnEDSMSyncComplete(int count, string syslist)     // EDSM ~MAY~ have updated the last discovery flag, so redisplay
         {
-            //System.Diagnostics.Debug.WriteLine("EDSM SYNC COMPLETED KICKING SYS INFO");
+            System.Diagnostics.Debug.WriteLine("EDSM SYNC COMPLETED with " + count + " '" + syslist + "'");
             Display(last_he, discoveryform.history);
         }
 
         bool neverdisplayed = true;
         HistoryEntry last_he = null;
+
         private void Display(HistoryEntry he, HistoryList hl)
         {
             if (neverdisplayed)

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -58,6 +58,18 @@ namespace EliteDangerousCore.EDDN
             return header;
         }
 
+        static public bool IsEDDNMessage( JournalTypeEnum EntryType, DateTime EventTimeUTC )
+        {
+            DateTime ed22 = new DateTime(2016, 10, 25, 12, 0, 0);
+            if ((EntryType == JournalTypeEnum.Scan ||
+                 EntryType == JournalTypeEnum.Docked ||
+                 EntryType == JournalTypeEnum.FSDJump ||
+                 EntryType == JournalTypeEnum.Location ||
+                 EntryType == JournalTypeEnum.Market ||
+                 EntryType == JournalTypeEnum.Shipyard ||
+                 EntryType == JournalTypeEnum.Outfitting) && EventTimeUTC > ed22) return true;
+            else return false;
+        }
 
         private string GetEDDNJournalSchemaRef()
         {

--- a/EliteDangerous/EGO/EGOClass.cs
+++ b/EliteDangerous/EGO/EGOClass.cs
@@ -27,7 +27,7 @@ using System.Management;
 using System.Reflection;
 using System.Text;
 
-namespace EDDiscoveryCore.EGO
+namespace EliteDangerousCore.EGO
 {
     public class EGOClass : BaseUtils.HttpCom
     {

--- a/EliteDangerous/EGO/EGOClass.cs
+++ b/EliteDangerous/EGO/EGOClass.cs
@@ -64,8 +64,10 @@ namespace EliteDangerousCore.EGO
             return msg;
         }
 
-        public bool PostMessage(JObject msg, ref bool recordSet)
+        public bool PostMessage(JObject msg, out bool recordSet)
         {
+            recordSet = false;
+
             try
             {
                 BaseUtils.ResponseData resp = RequestPost(msg.ToString(), "");

--- a/EliteDangerous/EliteDangerous/JournalFieldNaming.cs
+++ b/EliteDangerous/EliteDangerous/JournalFieldNaming.cs
@@ -35,6 +35,18 @@ namespace EliteDangerousCore
             return MaterialCommodityDB.FDNameTranslation(old);
         }
 
+        static public string NormaliseMaterialCategory(string cat)
+        {
+            if (cat.Contains("$"))
+            {
+                int i = cat.LastIndexOf('_');
+                if (i != -1 && i < cat.Length - 1)
+                    cat = cat.Substring(i + 1).Replace(";", "");
+            }
+
+            return cat;
+        }
+
         public static string RMat(string fdname)            // fix up fdname into a nicer name
         {
             MaterialCommodityDB mc = MaterialCommodityDB.GetCachedMaterial(fdname);

--- a/EliteDangerous/EliteDangerous/MaterialCommodities.cs
+++ b/EliteDangerous/EliteDangerous/MaterialCommodities.cs
@@ -29,7 +29,6 @@ namespace EliteDangerousCore
         public string type { get; set; }                    // and its type, for materials its rarity, for commodities its group ("Metals" etc).
         public string shortname { get; set; }               // short abv. name
         public Color colour { get; set; }                   // colour if its associated with one
-        public int flags { get; set; }                      // now out of date.. keep for now to limit code changes
 
         public static string CommodityCategory = "Commodity";
         public static string MaterialRawCategory = "Raw";
@@ -44,10 +43,12 @@ namespace EliteDangerousCore
         public static string MaterialFreqCommon = "Common";
         public static string MaterialFreqVeryCommon = "Very Common";
 
+        // name key is lower case normalised
         private static Dictionary<string, MaterialCommodityDB> cachelist = new Dictionary<string, MaterialCommodityDB>();
 
         public static MaterialCommodityDB GetCachedMaterial(string fdname)
         {
+            fdname = fdname.ToLower();
             return cachelist.ContainsKey(fdname) ? cachelist[fdname] : null;
         }
 
@@ -62,7 +63,7 @@ namespace EliteDangerousCore
         {
         }
 
-        public MaterialCommodityDB(string cs, string n, string fd, string t, string shortn, Color cl, int fl)
+        public MaterialCommodityDB(string cs, string n, string fd, string t, string shortn, Color cl)
         {
             category = cs;
             name = n;
@@ -70,7 +71,6 @@ namespace EliteDangerousCore
             type = t;
             shortname = shortn;
             colour = cl;
-            flags = fl;
         }
 
         public void SetCache()
@@ -82,7 +82,7 @@ namespace EliteDangerousCore
         {
             if (!cachelist.ContainsKey(fdname.ToLower()))
             {
-                MaterialCommodityDB mcdb = new MaterialCommodityDB(cat, fdname.SplitCapsWordFull(), fdname, "", "", Color.Green, 0);
+                MaterialCommodityDB mcdb = new MaterialCommodityDB(cat, fdname.SplitCapsWordFull(), fdname, "", "", Color.Green);
                 mcdb.SetCache();
                 System.Diagnostics.Debug.WriteLine("Material not present: " + cat + "," + fdname );
             }
@@ -167,7 +167,7 @@ namespace EliteDangerousCore
         private static bool Add(string catname, Color colour, string aliasname, string typeofit, string shortname = "", string fdName = "")
         {
             string fdn = (fdName.Length > 0) ? fdName : aliasname.FDName();
-            MaterialCommodityDB mc = new MaterialCommodityDB(catname, aliasname, fdn, typeofit, shortname, colour, 0);
+            MaterialCommodityDB mc = new MaterialCommodityDB(catname, aliasname, fdn, typeofit, shortname, colour);
             mc.SetCache();
             return true;
         }

--- a/EliteDangerous/EliteDangerous/MaterialCommoditiesList.cs
+++ b/EliteDangerous/EliteDangerous/MaterialCommoditiesList.cs
@@ -79,7 +79,6 @@ namespace EliteDangerousCore
         {
             MaterialCommoditiesList mcl = new MaterialCommoditiesList();
 
-            mcl.list = new List<MaterialCommodities>(list.Count);
             list.ForEach(item =>
             {
                 bool commodity = item.category.Equals(MaterialCommodities.CommodityCategory);
@@ -156,7 +155,7 @@ namespace EliteDangerousCore
         public void Change(string cat, string fdname, int num, long price, SQLiteConnectionUser conn, bool ignorecatonsearch = false)
         {
             MaterialCommodities mc = GetNewCopyOf(cat, fdname, conn, ignorecatonsearch);
-
+       
             double costprev = mc.count * mc.price;
             double costnew = num * price;
             mc.count = Math.Max(mc.count + num, 0);

--- a/EliteDangerous/EliteDangerous/MaterialCommoditiesList.cs
+++ b/EliteDangerous/EliteDangerous/MaterialCommoditiesList.cs
@@ -65,6 +65,8 @@ namespace EliteDangerousCore
     {
         private List<MaterialCommodities> list;
 
+        // static BaseUtils.LogToFile log = new BaseUtils.LogToFile("c:\\code"); // debug
+
         public MaterialCommoditiesList()
         {
             list = new List<MaterialCommodities>();
@@ -147,6 +149,9 @@ namespace EliteDangerousCore
                 MaterialCommodityDB mcdb = MaterialCommodityDB.EnsurePresent(cat,fdname, conn);    // get a MCDB of this
                 MaterialCommodities mc = new MaterialCommodities(mcdb);        // make a new entry
                 list.Add(mc);
+
+                //log.WriteLine("MC Made:" + cat + " " + fdname + " >> " + mc.fdname + mc.name );
+
                 return mc;
             }
         }
@@ -163,7 +168,7 @@ namespace EliteDangerousCore
             if (mc.count > 0 && num > 0)      // if bought (defensive with mc.count)
                 mc.price = (costprev + costnew) / mc.count;       // price is now a combination of the current cost and the new cost. in case we buy in tranches
 
-            //System.Diagnostics.Debug.WriteLine("Mat:" + cat + " " + fdname + " " + num + " " + mc.count);
+            //log.WriteLine("MC Change:" + cat + " " + fdname + " " + num + " " + mc.count);
         }
 
         public void Craft(string fdname, int num)
@@ -175,7 +180,8 @@ namespace EliteDangerousCore
                 MaterialCommodities mc = new MaterialCommodities(list[index]);      // new clone of
                 list[index] = mc;       // replace ours with new one
                 mc.count = Math.Max(mc.count - num, 0);
-                //System.Diagnostics.Debug.WriteLine("craft:" + fdname + " " + num + " " + mc.count);
+
+                //log.WriteLine("MC Craft:" + fdname + " " + num + " " + mc.count);
             }
         }
 
@@ -184,19 +190,20 @@ namespace EliteDangerousCore
             list.RemoveAll(x => x.category.Equals(MaterialCommodities.CommodityCategory));      // empty the list of all commodities
         }
 
-        public void Set(string cat, string fdname, int num, double price, SQLiteConnectionUser conn, bool ignorecatonsearch = false)
+        public void Set(string cat, string fdname, int num, double price, SQLiteConnectionUser conn)
         {
-            MaterialCommodities mc = GetNewCopyOf(cat, fdname, conn, ignorecatonsearch);
+            MaterialCommodities mc = GetNewCopyOf(cat, fdname, conn);
 
             mc.count = num;
             if (price > 0)
                 mc.price = price;
 
-            //System.Diagnostics.Debug.WriteLine("Set:" + cat + " " + fdname + " " + num + " " + mc.count);
+            //log.WriteLine("MC Set:" + cat + " " + fdname + " " + num + " " + mc.count);
         }
 
         public void Clear(bool commodity)
         {
+            //log.Write("MC Clear");
             for (int i = 0; i < list.Count; i++)
             {
                 MaterialCommodities mc = list[i];
@@ -204,9 +211,10 @@ namespace EliteDangerousCore
                 {
                     list[i] = new MaterialCommodities(list[i]);     // new clone of it we can change..
                     list[i].count = 0;  // and clear it
-                    //System.Diagnostics.Debug.WriteLine("Clear:" + mc.fdname);
+                    //log.Write(mc.fdname + ",");
                 }
             }
+            //log.Write("", true);
         }
 
         static public MaterialCommoditiesList Process(JournalEntry je, MaterialCommoditiesList oldml, SQLiteConnectionUser conn,

--- a/EliteDangerous/EliteDangerous/Outfitting.cs
+++ b/EliteDangerous/EliteDangerous/Outfitting.cs
@@ -125,7 +125,7 @@ namespace EliteDangerousCore
                     {
                         yards.Add(yard);
                         last = yard;
-                        System.Diagnostics.Debug.WriteLine("OF return " + yard.Ident(true) + " " + yard.Datetime.ToString());
+                        //System.Diagnostics.Debug.WriteLine("OF return " + yard.Ident(true) + " " + yard.Datetime.ToString());
                     }
                 }
             }

--- a/EliteDangerous/EliteDangerous/ShipModuleData.cs
+++ b/EliteDangerous/EliteDangerous/ShipModuleData.cs
@@ -60,35 +60,50 @@ namespace EliteDangerousCore
         {
             string lowername = fdid.ToLower();
 
+            ShipModule m = null;
+
             if (modules.ContainsKey(lowername))
             {
                 //System.Diagnostics.Debug.WriteLine("Module item " + fdid + " >> " + (modules[lowername] as ShipModule).modname + " " + (modules[lowername] as ShipModule).moduleid);
-                return modules[lowername] as ShipModule;
+                m = modules[lowername];
             }
             else if (noncorolismodules.ContainsKey(lowername))
             {
-                //System.Diagnostics.Debug.WriteLine("Module item " + fdid + " >> " + (modules[lowername] as ShipModule).modname + " " + (modules[lowername] as ShipModule).moduleid);
-                return noncorolismodules[lowername] as ShipModule;
+                m = noncorolismodules[lowername];
+            }
+            else if (synthesisedmodules.ContainsKey(lowername))
+            {
+                m = synthesisedmodules[lowername];
+            }
+            else
+            {                                                           // synthesise one
+                string candidatename = fdid;
+                candidatename = candidatename.Replace("weaponcustomisation", "WeaponCustomisation").Replace("testbuggy", "SRV").
+                                        Replace("enginecustomisation", "EngineCustomisation");
+
+                candidatename = candidatename.SplitCapsWordFull();
+
+                m = new ShipModule(-1, 0, candidatename, IsVanity(lowername) ? VanityType : UnknownType);
+
+                System.Diagnostics.Debug.WriteLine("**** Not known item.. synthesise response " + fdid + " >> " + m.ModName + "," + m.ModType);
+                synthesisedmodules.Add(lowername, m);                   // lets cache them for completeness..
+                //            string line = "{ \"" + lowername + "\", new ShipModule( -1, 0 , \"" + m.modname + "\",\"" + m.modtype + "\") },";
+                //            if (!synthresponses.Contains(line))  synthresponses.Add(line);
             }
 
-            // synthesise one - its probably a vanity item.. all the regular items should be in the list..
-
-            ShipModule m = new ShipModule(-1, 0, fdid.SplitCapsWordFull(), IsVanity(lowername) ? VanityType : UnknownType);
-            System.Diagnostics.Debug.WriteLine("**** Not known item.. synthesise response " + fdid + " >> " + m.ModName + "," + m.ModType);
-
-//            string line = "{ \"" + lowername + "\", new ShipModule( -1, 0 , \"" + m.modname + "\",\"" + m.modtype + "\") },";
-//            if (!synthresponses.Contains(line))  synthresponses.Add(line);
-
+            // System.Diagnostics.Debug.WriteLine("Module item " + fdid + " >> " + m.ModName + " " + m.ModType + " " + m.ModuleID);
             return m;
         }
 
-        List<string> synthresponses = new List<string>();               // for debugging and collecting new items, comment out above
-        public void DumpItems()
-        {
-            synthresponses.Sort();
-            foreach (var s in synthresponses)
-                System.Diagnostics.Debug.WriteLine(s);
-        }
+        //List<string> synthresponses = new List<string>();               // KEEP ..  for debugging and collecting new items, comment out above
+        //public void DumpItems()
+        //{
+        //    synthresponses.Sort();
+        //    foreach (var s in synthresponses)
+        //        System.Diagnostics.Debug.WriteLine(s);
+        //}
+
+        private Dictionary<string, ShipModule> synthesisedmodules = new Dictionary<string, ShipModule>();
 
         private const string VanityType =  "Vanity Item";
         private const string UnknownType = "Unknown Module";
@@ -304,7 +319,7 @@ namespace EliteDangerousCore
             { "modularcargobaydoor", new ShipModule( -1, 0 , "Modular Cargo Bay Door", CargoBayDoorType ) },
             { "modularcargobaydoorfdl", new ShipModule( -1, 0 , "FDL Cargo Bay Door", CargoBayDoorType ) },
 
-            // Vanities found in logs
+            // Vanities found in logs (not exaustive)
 
             { "asp_shipkit1_bumper1", new ShipModule( -1, 0 , "Asp Shipkit 1 Bumper 1", VanityType) },
             { "asp_shipkit1_bumper2", new ShipModule( -1, 0 , "Asp Shipkit 1 Bumper 2", VanityType) },
@@ -440,7 +455,7 @@ namespace EliteDangerousCore
 
 ///////////////////////////////////// FROM MODULE SCAN
 
-                        { "hpt_atdumbfiremissile_fixed_medium", new ShipModule(128788699, 4, 1.2F, "Ammo:64/8, Damage:64, Speed:750m/s, Reload:5s, ThermL:2.4","AX Dumbfire Missile Fixed Medium", "Missile Rack")},
+            { "hpt_atdumbfiremissile_fixed_medium", new ShipModule(128788699, 4, 1.2F, "Ammo:64/8, Damage:64, Speed:750m/s, Reload:5s, ThermL:2.4","AX Dumbfire Missile Fixed Medium", "Missile Rack")},
             { "hpt_atdumbfiremissile_turret_medium", new ShipModule(128788704, 4, 1.2F, "Ammo:64/8, Damage:50, Speed:750m/s, Reload:5s, ThermL:1.5","AX Dumbfire Missile Turret Medium", "Missile Rack")},
             { "hpt_atdumbfiremissile_fixed_large", new ShipModule(128788700, 8, 1.62F, "Ammo:128/12, Damage:64, Speed:750m/s, Reload:5s, ThermL:3.6","AX Dumbfire Missile Fixed Large", "Missile Rack")},
             { "hpt_atdumbfiremissile_turret_large", new ShipModule(128788705, 8, 1.75F, "Ammo:128/12, Damage:64, Speed:750m/s, Reload:5s, ThermL:1.9","AX Dumbfire Missile Turret Large", "Missile Rack")},
@@ -1061,41 +1076,6 @@ namespace EliteDangerousCore
             { "int_powerdistributor_size1_class3", new ShipModule(128064180, 1.3F, 0.4F, "Sys:0.5MW, Eng:0.5MW, Wep:1.5MW","Power Distributor Class 1 Rating C", "Power Distributor")},
             { "int_powerdistributor_size1_class4", new ShipModule(128064181, 2, 0.44F, "Sys:0.6MW, Eng:0.6MW, Wep:1.7MW","Power Distributor Class 1 Rating B", "Power Distributor")},
             { "int_powerdistributor_size1_class5", new ShipModule(128064182, 1.3F, 0.48F, "Sys:0.6MW, Eng:0.6MW, Wep:1.8MW","Power Distributor Class 1 Rating A", "Power Distributor")},
-            { "int_powerplant_size8_class1", new ShipModule(128064063, 160, 0, "Power:24MW","Powerplant Class 8 Rating E", "Powerplant")},
-            { "int_powerplant_size8_class2", new ShipModule(128064064, 64, 0, "Power:27MW","Powerplant Class 8 Rating D", "Powerplant")},
-            { "int_powerplant_size8_class3", new ShipModule(128064065, 80, 0, "Power:30MW","Powerplant Class 8 Rating C", "Powerplant")},
-            { "int_powerplant_size8_class4", new ShipModule(128064066, 128, 0, "Power:33MW","Powerplant Class 8 Rating B", "Powerplant")},
-            { "int_powerplant_size8_class5", new ShipModule(128064067, 80, 0, "Power:36MW","Powerplant Class 8 Rating A", "Powerplant")},
-            { "int_powerplant_size7_class1", new ShipModule(128064058, 80, 0, "Power:20MW","Powerplant Class 7 Rating E", "Powerplant")},
-            { "int_powerplant_size7_class2", new ShipModule(128064059, 32, 0, "Power:22.5MW","Powerplant Class 7 Rating D", "Powerplant")},
-            { "int_powerplant_size7_class3", new ShipModule(128064060, 40, 0, "Power:25MW","Powerplant Class 7 Rating C", "Powerplant")},
-            { "int_powerplant_size7_class4", new ShipModule(128064061, 64, 0, "Power:27.5MW","Powerplant Class 7 Rating B", "Powerplant")},
-            { "int_powerplant_size7_class5", new ShipModule(128064062, 40, 0, "Power:30MW","Powerplant Class 7 Rating A", "Powerplant")},
-            { "int_powerplant_size6_class1", new ShipModule(128064053, 40, 0, "Power:16.8MW","Powerplant Class 6 Rating E", "Powerplant")},
-            { "int_powerplant_size6_class2", new ShipModule(128064054, 16, 0, "Power:18.9MW","Powerplant Class 6 Rating D", "Powerplant")},
-            { "int_powerplant_size6_class3", new ShipModule(128064055, 20, 0, "Power:21MW","Powerplant Class 6 Rating C", "Powerplant")},
-            { "int_powerplant_size6_class4", new ShipModule(128064056, 32, 0, "Power:23.1MW","Powerplant Class 6 Rating B", "Powerplant")},
-            { "int_powerplant_size6_class5", new ShipModule(128064057, 20, 0, "Power:25.2MW","Powerplant Class 6 Rating A", "Powerplant")},
-            { "int_powerplant_size5_class1", new ShipModule(128064048, 20, 0, "Power:13.6MW","Powerplant Class 5 Rating E", "Powerplant")},
-            { "int_powerplant_size5_class2", new ShipModule(128064049, 8, 0, "Power:15.3MW","Powerplant Class 5 Rating D", "Powerplant")},
-            { "int_powerplant_size5_class3", new ShipModule(128064050, 10, 0, "Power:17MW","Powerplant Class 5 Rating C", "Powerplant")},
-            { "int_powerplant_size5_class4", new ShipModule(128064051, 16, 0, "Power:18.7MW","Powerplant Class 5 Rating B", "Powerplant")},
-            { "int_powerplant_size5_class5", new ShipModule(128064052, 10, 0, "Power:20.4MW","Powerplant Class 5 Rating A", "Powerplant")},
-            { "int_powerplant_size4_class1", new ShipModule(128064043, 10, 0, "Power:10.4MW","Powerplant Class 4 Rating E", "Powerplant")},
-            { "int_powerplant_size4_class2", new ShipModule(128064044, 4, 0, "Power:11.7MW","Powerplant Class 4 Rating D", "Powerplant")},
-            { "int_powerplant_size4_class3", new ShipModule(128064045, 5, 0, "Power:13MW","Powerplant Class 4 Rating C", "Powerplant")},
-            { "int_powerplant_size4_class4", new ShipModule(128064046, 8, 0, "Power:14.3MW","Powerplant Class 4 Rating B", "Powerplant")},
-            { "int_powerplant_size4_class5", new ShipModule(128064047, 5, 0, "Power:15.6MW","Powerplant Class 4 Rating A", "Powerplant")},
-            { "int_powerplant_size3_class1", new ShipModule(128064038, 5, 0, "Power:8MW","Powerplant Class 3 Rating E", "Powerplant")},
-            { "int_powerplant_size3_class2", new ShipModule(128064039, 2, 0, "Power:9MW","Powerplant Class 3 Rating D", "Powerplant")},
-            { "int_powerplant_size3_class3", new ShipModule(128064040, 2.5F, 0, "Power:10MW","Powerplant Class 3 Rating C", "Powerplant")},
-            { "int_powerplant_size3_class4", new ShipModule(128064041, 4, 0, "Power:11MW","Powerplant Class 3 Rating B", "Powerplant")},
-            { "int_powerplant_size3_class5", new ShipModule(128064042, 2.5F, 0, "Power:12MW","Powerplant Class 3 Rating A", "Powerplant")},
-            { "int_powerplant_size2_class1", new ShipModule(128064033, 2.5F, 0, "Power:6.4MW","Powerplant Class 2 Rating E", "Powerplant")},
-            { "int_powerplant_size2_class2", new ShipModule(128064034, 1, 0, "Power:7.2MW","Powerplant Class 2 Rating D", "Powerplant")},
-            { "int_powerplant_size2_class3", new ShipModule(128064035, 1.3F, 0, "Power:8MW","Powerplant Class 2 Rating C", "Powerplant")},
-            { "int_powerplant_size2_class4", new ShipModule(128064036, 2, 0, "Power:8.8MW","Powerplant Class 2 Rating B", "Powerplant")},
-            { "int_powerplant_size2_class5", new ShipModule(128064037, 1.3F, 0, "Power:9.6MW","Powerplant Class 2 Rating A", "Powerplant")},
             { "int_sensors_size8_class1", new ShipModule(128064253, 160, 0.55F, "Range:5.1km","Sensors Class 8 Rating E", "Sensors")},
             { "int_sensors_size8_class2", new ShipModule(128064254, 64, 0.62F, "Range:5.8km","Sensors Class 8 Rating D", "Sensors")},
             { "int_sensors_size8_class3", new ShipModule(128064255, 160, 0.69F, "Range:6.4km","Sensors Class 8 Rating C", "Sensors")},
@@ -1173,8 +1153,52 @@ namespace EliteDangerousCore
             { "int_engine_size2_class5", new ShipModule(128064072, 2.5F, 3, "OptMass:72t, MaxMass:108t, MinMass:36t","Thrusters Class 2 Rating A", "Thrusters")},
             { "int_engine_size3_class5_fast", new ShipModule(128682013, 5, 5, "OptMass:90t, MaxMass:200t, MinMass:70t","Thrusters Class 3 Rating A Fast", "Thrusters")},
             { "int_engine_size2_class5_fast", new ShipModule(128682014, 2.5F, 4, "OptMass:60t, MaxMass:120t, MinMass:50t","Thrusters Class 2 Rating A Fast", "Thrusters")},
+            { "hpt_guardian_gausscannon_fixed_medium", new ShipModule(128833687, 4, 2.61F, "Ammo:80/1, Damage:70, Range:3000m, Reload:1s, ThermL:25","Guardian Gauss Cannon Fixed Medium", "Guardian")},
+            { "hpt_guardian_plasmalauncher_fixed_medium", new ShipModule(128049466, 4, 2.13F, "Ammo:200/15, Damage:5, Range:3500m, Speed:1200m/s, Reload:3s, ThermL:5.2","Guardian Plasma Launcher Fixed Medium", "Guardian")},
+            { "hpt_guardian_plasmalauncher_turret_medium", new ShipModule(128049466, 4, 2.01F, "Ammo:200/15, Damage:4, Range:3500m, Speed:1200m/s, Reload:3s, ThermL:5.8","Guardian Plasma Launcher Turret Medium", "Guardian")},
+            { "int_powerplant_size8_class1", new ShipModule(128064063, 160, 0, "Power:24MW","Powerplant Class 8 Rating E", "Powerplant")},
+            { "int_powerplant_size8_class2", new ShipModule(128064064, 64, 0, "Power:27MW","Powerplant Class 8 Rating D", "Powerplant")},
+            { "int_powerplant_size8_class3", new ShipModule(128064065, 80, 0, "Power:30MW","Powerplant Class 8 Rating C", "Powerplant")},
+            { "int_powerplant_size8_class4", new ShipModule(128064066, 128, 0, "Power:33MW","Powerplant Class 8 Rating B", "Powerplant")},
+            { "int_powerplant_size8_class5", new ShipModule(128064067, 80, 0, "Power:36MW","Powerplant Class 8 Rating A", "Powerplant")},
+            { "int_powerplant_size7_class1", new ShipModule(128064058, 80, 0, "Power:20MW","Powerplant Class 7 Rating E", "Powerplant")},
+            { "int_powerplant_size7_class2", new ShipModule(128064059, 32, 0, "Power:22.5MW","Powerplant Class 7 Rating D", "Powerplant")},
+            { "int_powerplant_size7_class3", new ShipModule(128064060, 40, 0, "Power:25MW","Powerplant Class 7 Rating C", "Powerplant")},
+            { "int_powerplant_size7_class4", new ShipModule(128064061, 64, 0, "Power:27.5MW","Powerplant Class 7 Rating B", "Powerplant")},
+            { "int_powerplant_size7_class5", new ShipModule(128064062, 40, 0, "Power:30MW","Powerplant Class 7 Rating A", "Powerplant")},
+            { "int_powerplant_size6_class1", new ShipModule(128064053, 40, 0, "Power:16.8MW","Powerplant Class 6 Rating E", "Powerplant")},
+            { "int_powerplant_size6_class2", new ShipModule(128064054, 16, 0, "Power:18.9MW","Powerplant Class 6 Rating D", "Powerplant")},
+            { "int_powerplant_size6_class3", new ShipModule(128064055, 20, 0, "Power:21MW","Powerplant Class 6 Rating C", "Powerplant")},
+            { "int_powerplant_size6_class4", new ShipModule(128064056, 32, 0, "Power:23.1MW","Powerplant Class 6 Rating B", "Powerplant")},
+            { "int_powerplant_size6_class5", new ShipModule(128064057, 20, 0, "Power:25.2MW","Powerplant Class 6 Rating A", "Powerplant")},
+            { "int_powerplant_size5_class1", new ShipModule(128064048, 20, 0, "Power:13.6MW","Powerplant Class 5 Rating E", "Powerplant")},
+            { "int_powerplant_size5_class2", new ShipModule(128064049, 8, 0, "Power:15.3MW","Powerplant Class 5 Rating D", "Powerplant")},
+            { "int_powerplant_size5_class3", new ShipModule(128064050, 10, 0, "Power:17MW","Powerplant Class 5 Rating C", "Powerplant")},
+            { "int_powerplant_size5_class4", new ShipModule(128064051, 16, 0, "Power:18.7MW","Powerplant Class 5 Rating B", "Powerplant")},
+            { "int_powerplant_size5_class5", new ShipModule(128064052, 10, 0, "Power:20.4MW","Powerplant Class 5 Rating A", "Powerplant")},
+            { "int_powerplant_size4_class1", new ShipModule(128064043, 10, 0, "Power:10.4MW","Powerplant Class 4 Rating E", "Powerplant")},
+            { "int_powerplant_size4_class2", new ShipModule(128064044, 4, 0, "Power:11.7MW","Powerplant Class 4 Rating D", "Powerplant")},
+            { "int_powerplant_size4_class3", new ShipModule(128064045, 5, 0, "Power:13MW","Powerplant Class 4 Rating C", "Powerplant")},
+            { "int_powerplant_size4_class4", new ShipModule(128064046, 8, 0, "Power:14.3MW","Powerplant Class 4 Rating B", "Powerplant")},
+            { "int_powerplant_size4_class5", new ShipModule(128064047, 5, 0, "Power:15.6MW","Powerplant Class 4 Rating A", "Powerplant")},
+            { "int_powerplant_size3_class1", new ShipModule(128064038, 5, 0, "Power:8MW","Powerplant Class 3 Rating E", "Powerplant")},
+            { "int_powerplant_size3_class2", new ShipModule(128064039, 2, 0, "Power:9MW","Powerplant Class 3 Rating D", "Powerplant")},
+            { "int_powerplant_size3_class3", new ShipModule(128064040, 2.5F, 0, "Power:10MW","Powerplant Class 3 Rating C", "Powerplant")},
+            { "int_powerplant_size3_class4", new ShipModule(128064041, 4, 0, "Power:11MW","Powerplant Class 3 Rating B", "Powerplant")},
+            { "int_powerplant_size3_class5", new ShipModule(128064042, 2.5F, 0, "Power:12MW","Powerplant Class 3 Rating A", "Powerplant")},
+            { "int_powerplant_size2_class1", new ShipModule(128064033, 2.5F, 0, "Power:6.4MW","Powerplant Class 2 Rating E", "Powerplant")},
+            { "int_powerplant_size2_class2", new ShipModule(128064034, 1, 0, "Power:7.2MW","Powerplant Class 2 Rating D", "Powerplant")},
+            { "int_powerplant_size2_class3", new ShipModule(128064035, 1.3F, 0, "Power:8MW","Powerplant Class 2 Rating C", "Powerplant")},
+            { "int_powerplant_size2_class4", new ShipModule(128064036, 2, 0, "Power:8.8MW","Powerplant Class 2 Rating B", "Powerplant")},
+            { "int_powerplant_size2_class5", new ShipModule(128064037, 1.3F, 0, "Power:9.6MW","Powerplant Class 2 Rating A", "Powerplant")},
+            { "int_guardianpowerplant_size2", new ShipModule(128064037, 1.5F, 0, "Power:12.7MW","Guardian Powerplant Class 2", "Guardian Powerplant")},
+            { "int_guardianpowerplant_size3", new ShipModule(128064037, 2.9F, 0, "Power:15.8MW","Guardian Powerplant Class 3", "Guardian Powerplant")},
+            { "int_guardianpowerplant_size4", new ShipModule(128064037, 5.9F, 0, "Power:20.6MW","Guardian Powerplant Class 4", "Guardian Powerplant")},
+            { "int_guardianpowerplant_size5", new ShipModule(128064037, 11.7F, 0, "Power:26.9MW","Guardian Powerplant Class 5", "Guardian Powerplant")},
+            { "int_guardianpowerplant_size6", new ShipModule(128064037, 23.4F, 0, "Power:33.3MW","Guardian Powerplant Class 6", "Guardian Powerplant")},
+            { "int_guardianpowerplant_size7", new ShipModule(128064037, 46.8F, 0, "Power:39.6MW","Guardian Powerplant Class 7", "Guardian Powerplant")},
+            { "int_guardianpowerplant_size8", new ShipModule(128064037, 93.6F, 0, "Power:47.5MW","Guardian Powerplant Class 8", "Guardian Powerplant")},
 
-            
             ///////////////////////////////////// FROM SHIP DATA SCAN - Corolis has some module info in the ships folder
 
             { "adder_armour_grade1", new ShipModule(128049268,0,0,"Explosive:-40%, Kinetic:-20%, Thermal:0%","Adder Lightweight Armour","Armour")},

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -56,7 +56,7 @@ namespace EliteDangerousCore
         public int MapColour;
 
         public bool IsStarPosFromEDSM;  // flag populated from journal entry when HE is made. Was the star position taken from EDSM?
-        public bool IsEDSMFirstDiscover;// flag populated from journal entry when HE is made. Were we the first to report the system to EDSM?
+        public bool IsEDSMFirstDiscover;// Only on FSD JUMP
         public bool EdsmSync;           // flag populated from journal entry when HE is made. Have we synced?
         public bool EDDNSync;           // flag populated from journal entry when HE is made. Have we synced?
         public bool EGOSync;            // flag populated from journal entry when HE is made. Have we synced?
@@ -67,21 +67,6 @@ namespace EliteDangerousCore
         public bool IsFuelScoop { get { return EntryType == JournalTypeEnum.FuelScoop; } }
         public bool IsShipChange { get { return (EntryType == JournalTypeEnum.LoadGame || EntryType == JournalTypeEnum.Docked) && ShipInformation != null; } }
         public bool IsBetaMessage { get { return journalEntry?.Beta ?? false; } }
-        public bool ISEDDNMessage
-        {
-            get
-            {
-                DateTime ed22 = new DateTime(2016, 10, 25, 12, 0, 0);
-                if ((EntryType == JournalTypeEnum.Scan ||
-                     EntryType == JournalTypeEnum.Docked ||
-                     EntryType == JournalTypeEnum.FSDJump ||
-                     EntryType == JournalTypeEnum.Location ||
-                     EntryType == JournalTypeEnum.Market ||
-                     EntryType == JournalTypeEnum.Shipyard ||
-                     EntryType == JournalTypeEnum.Outfitting) && EventTimeUTC > ed22) return true;
-                else return false;
-            }
-        }
 
         public double TravelledDistance { get { return travelled_distance; } }
         public TimeSpan TravelledSeconds { get { return travelled_seconds; } }
@@ -262,11 +247,11 @@ namespace EliteDangerousCore
                     }
 
                     mapcolour = jfsd.MapColor;
+                    firstdiscover = jfsd.EDSMFirstDiscover;
                 }
 
                 isys = newsys;
                 starposfromedsm = (jl != null && jl.HasCoordinate) ? jl.StarPosFromEDSM : newsys.HasCoordinate;
-                firstdiscover = jl == null ? false : jl.EDSMFirstDiscover;
             }
 
             string summary, info, detailed;
@@ -541,12 +526,12 @@ namespace EliteDangerousCore
             }
         }
 
-        public void SetFirstDiscover(bool firstdiscover, SQLiteConnectionUser cn = null, DbTransaction txnl = null)
+        public void SetFirstDiscover(bool firstdiscover, SQLiteConnectionUser cn = null, DbTransaction txnl = null) // only on FSD entries
         {
             IsEDSMFirstDiscover = firstdiscover;
             if (journalEntry != null)
             {
-                JournalLocOrJump jl = journalEntry as JournalLocOrJump;
+                JournalFSDJump jl = journalEntry as JournalFSDJump;
                 if (jl != null)
                 {
                     Newtonsoft.Json.Linq.JObject jo = jl.GetJson();

--- a/EliteDangerous/JournalEvents/JournalCargo.cs
+++ b/EliteDangerous/JournalEvents/JournalCargo.cs
@@ -34,8 +34,15 @@ namespace EliteDangerousCore.JournalEvents
         public class Cargo
         {
             public string Name { get; set; }            // FDNAME
+            public string FriendlyName { get; set; }            // FDNAME
             public int Count { get; set; }
             public int Stolen { get; set; }
+
+            public void Normalise()
+            {
+                Name = JournalFieldNaming.FDNameTranslation(Name);
+                FriendlyName = JournalFieldNaming.RMat(Name);
+            }
         }
 
         public JournalCargo(JObject evt) : base(evt, JournalTypeEnum.Cargo)
@@ -44,7 +51,7 @@ namespace EliteDangerousCore.JournalEvents
             if (Inventory != null)
             {
                 foreach (Cargo c in Inventory)
-                    c.Name = JournalFieldNaming.FDNameTranslation(c.Name);
+                    c.Normalise();
             }
         }
 
@@ -72,7 +79,7 @@ namespace EliteDangerousCore.JournalEvents
                     int? stolen = null;
                     if (c.Stolen > 0)
                         stolen = c.Stolen;
-                    detailed += BaseUtils.FieldBuilder.Build("", JournalFieldNaming.RMat(c.Name), "; items", c.Count , "(;)" , stolen);
+                    detailed += BaseUtils.FieldBuilder.Build("", c.FriendlyName, "; items", c.Count , "(;)" , stolen);
                 }
             }
         }

--- a/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -124,6 +124,8 @@ Examples of trending states:
             MapColor = jm.Int(EliteDangerousCore.EliteConfigInstance.InstanceConfig.DefaultMapColour);
             if (jm.Empty())
                 evt["EDDMapColor"] = EliteDangerousCore.EliteConfigInstance.InstanceConfig.DefaultMapColour;      // new entries get this default map colour if its not already there
+
+            EDSMFirstDiscover = evt["EDD_EDSMFirstDiscover"].Bool(false);
         }
 
         public double JumpDist { get; set; }
@@ -133,6 +135,7 @@ Examples of trending states:
         public int BoostValue { get; set; }
         public int MapColor { get; set; }
         public bool RealJournalEvent { get; private set; } // True if real ED 2.2+ journal event and not pre 2.2 imported.
+        public bool EDSMFirstDiscover { get; set; }
 
         public override void FillInformation(out string summary, out string info, out string detailed)  //V
         {

--- a/EliteDangerous/JournalEvents/JournalLocOrJump.cs
+++ b/EliteDangerous/JournalEvents/JournalLocOrJump.cs
@@ -30,7 +30,6 @@ namespace EliteDangerousCore.JournalEvents
         public EMK.LightGeometry.Vector3 StarPos { get; set; }
         public long? SystemAddress { get; set; }
         public bool StarPosFromEDSM { get; set; }
-        public bool EDSMFirstDiscover { get; set; }
 
         public string Faction { get; set; }
         public string FactionState { get; set; }
@@ -76,7 +75,6 @@ namespace EliteDangerousCore.JournalEvents
         {
             StarSystem = evt["StarSystem"].Str();
             StarPosFromEDSM = evt["StarPosFromEDSM"].Bool(false);
-            EDSMFirstDiscover = evt["EDD_EDSMFirstDiscover"].Bool(false);
 
             EMK.LightGeometry.Vector3 pos = new EMK.LightGeometry.Vector3();
 

--- a/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
@@ -27,14 +27,14 @@ namespace EliteDangerousCore.JournalEvents
     {
         public JournalMaterialCollected(JObject evt ) : base(evt, JournalTypeEnum.MaterialCollected)
         {
-            Category = evt["Category"].Str();
-            Name = evt["Name"].Str();            // MUST BE FD NAME
-            Name = JournalFieldNaming.FDNameTranslation(Name);     // pre-mangle to latest names, in case we are reading old journal records
+            Category = JournalFieldNaming.NormaliseMaterialCategory(evt["Category"].Str());
+            Name = JournalFieldNaming.FDNameTranslation(evt["Name"].Str());     // pre-mangle to latest names, in case we are reading old journal records
             FriendlyName = JournalFieldNaming.RMat(Name);
             Count = evt["Count"].Int(1);
         }
         public string Category { get; set; }
         public string FriendlyName { get; set; }
+        public string FDName { get; set; }
         public string Name { get; set; }
         public int Count { get; set; }
 

--- a/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
@@ -23,9 +23,8 @@ namespace EliteDangerousCore.JournalEvents
     {
         public JournalMaterialDiscarded(JObject evt ) : base(evt, JournalTypeEnum.MaterialDiscarded)
         {
-            Category = evt["Category"].Str();
-            Name = evt["Name"].Str();           // FDNAME
-            Name = JournalFieldNaming.FDNameTranslation(Name);     // pre-mangle to latest names, in case we are reading old journal records
+            Category = JournalFieldNaming.NormaliseMaterialCategory(evt["Category"].Str());
+            Name = JournalFieldNaming.FDNameTranslation(evt["Name"].Str());     // pre-mangle to latest names, in case we are reading old journal records
             FriendlyName = JournalFieldNaming.RMat(Name);
             Count = evt["Count"].Int();
         }

--- a/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
@@ -28,8 +28,8 @@ namespace EliteDangerousCore.JournalEvents
     {
         public JournalMaterialDiscovered(JObject evt ) : base(evt, JournalTypeEnum.MaterialDiscovered)
         {
-            Category = evt["Category"].Str();
-            Name = evt["Name"].Str();
+            Category = JournalFieldNaming.NormaliseMaterialCategory(evt["Category"].Str());
+            Name = JournalFieldNaming.FDNameTranslation(evt["Name"].Str());     // pre-mangle to latest names, in case we are reading old journal records
             FriendlyName = JournalFieldNaming.RMat(Name);
             DiscoveryNumber = evt["DiscoveryNumber"].Int();
         }

--- a/EliteDangerous/JournalEvents/JournalMaterialTrade.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialTrade.cs
@@ -46,7 +46,7 @@ namespace EliteDangerousCore.JournalEvents
             public string Material;     //fdname
             public string FriendlyMaterial; // our name
             public string Material_Localised;   // their localised name if present
-            public string Category;
+            public string Category;     // journal says always there.  If not, use tradertype
             public string Category_Localised;
             public int Quantity;
 
@@ -55,7 +55,12 @@ namespace EliteDangerousCore.JournalEvents
                 Material = JournalFieldNaming.FDNameTranslation(Material);
                 FriendlyMaterial = JournalFieldNaming.RMat(Material);
                 Material_Localised = Material_Localised.Alt(FriendlyMaterial);       // ensure.
-                Category_Localised = Category_Localised.Alt(Category);
+
+                if (Category != null)       // some entries do not have this
+                {
+                    Category = JournalFieldNaming.NormaliseMaterialCategory(Category);  // fix up any strangeness
+                    Category_Localised = Category_Localised.Alt(Category);
+                }
             }
         }
 

--- a/EliteDangerous/JournalEvents/JournalMaterials.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterials.cs
@@ -36,7 +36,14 @@ namespace EliteDangerousCore.JournalEvents
         public class Material
         {
             public string Name { get; set; }        //FDNAME
+            public string FriendlyName { get; set; }        //friendly
             public int Count { get; set; }
+
+            public void Normalise()
+            {
+                Name = JournalFieldNaming.FDNameTranslation(Name);
+                FriendlyName = JournalFieldNaming.RMat(Name);
+            }
         }
 
         public JournalMaterials(JObject evt) : base(evt, JournalTypeEnum.Materials)
@@ -58,7 +65,7 @@ namespace EliteDangerousCore.JournalEvents
             if (a != null)
             {
                 foreach (Material m in a)
-                    m.Name = JournalFieldNaming.FDNameTranslation(m.Name);
+                    m.Normalise();
             }
         }
 
@@ -95,7 +102,7 @@ namespace EliteDangerousCore.JournalEvents
             foreach (Material m in mat)
             {
                 sb.Append(Environment.NewLine);
-                sb.Append(BaseUtils.FieldBuilder.Build(" ", JournalFieldNaming.RMat(m.Name), "; items", m.Count));
+                sb.Append(BaseUtils.FieldBuilder.Build(" ", m.FriendlyName, "; items", m.Count));
             }
             return sb.ToString();
         }

--- a/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
+++ b/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
@@ -234,7 +234,7 @@ namespace EliteDangerousCore.JournalEvents
         {
             public string Name; // fdname
             public string FriendlyName; // our conversion
-            public string Name_Localised;       // may be null
+            public string Name_Localised;       // may be null on reading
             public string Category; // may be null
             public string Category_Localised; // may be null
             public int Count;
@@ -244,6 +244,12 @@ namespace EliteDangerousCore.JournalEvents
                 Name = JournalFieldNaming.FDNameTranslation(Name);
                 FriendlyName = JournalFieldNaming.RMat(Name);
                 Name_Localised = Name_Localised.Alt(FriendlyName);
+
+                if (Category != null)
+                {
+                    Category = JournalFieldNaming.NormaliseMaterialCategory(Category);
+                    Category_Localised = Category_Localised.Alt(Category);
+                }
             }
         }
 

--- a/EliteDangerous/JournalEvents/JournalScientificResearch.cs
+++ b/EliteDangerous/JournalEvents/JournalScientificResearch.cs
@@ -23,9 +23,9 @@ namespace EliteDangerousCore.JournalEvents
     {
         public JournalScientificResearch(JObject evt) : base(evt, JournalTypeEnum.ScientificResearch)
         {
-            Name = evt["Name"].Str();
+            Name = JournalFieldNaming.FDNameTranslation(evt["Name"].Str());
             Count = evt["Count"].Int();
-            Category = evt["Category"].Str();
+            Category = JournalFieldNaming.NormaliseMaterialCategory(evt["Category"].Str());
             MarketID = evt["MarketID"].LongNull();
         }
 

--- a/EliteDangerous/JournalEvents/JournalTechnologyBroker.cs
+++ b/EliteDangerous/JournalEvents/JournalTechnologyBroker.cs
@@ -41,7 +41,10 @@ namespace EliteDangerousCore.JournalEvents
 
             if (MaterialList != null)
                 foreach (Materials m in MaterialList)
+                {
                     m.FriendlyName = JournalFieldNaming.RMat(m.Name);
+                    m.Category = JournalFieldNaming.NormaliseMaterialCategory(m.Category);
+                }
 
             string oldentry = evt["ItemUnlocked"].StrNull();        // 3.02 journal entry
             if (ItemsUnlocked == null && oldentry != null)


### PR DESCRIPTION
    PR1900 Materials dup and PR1716 EDSM plus fixes to other items
    
    Logtofile enhanced for threads and writing part of a line
    EGO,EDDN and EDSM Sync cleaned up and now calls a callback when
    complete.  that call back runs an action program and UI callback.
    System info uses this to indicate if star is Firstdiscovered.  Sync back
    provides star list and count of items sent.
    Fixed PR1900 for materials - category from materialtrade is incorrectly
    formatted by journal (Howard knows) so mangle it.  Ensure the category
    always goes thru the mangler.
    ShipModuleData updated again from coriolis develop branch.  Now keeps a
    cache of synthesised items so it can be quicker reporting it and limits
    the debug output to when created.
    Cargo gets friendlyname for item
    Materials gets friendlyname
    
    String parser enhanced to allow for IsCharMoveon of string and different
    separators for nextquotedwordlist
    wordlistcount and wordlistentry enhanced to take optional separator

    HTTP Com modernised to support ASYNC, Enhancements for VP
    
    Can delete wild card vars
    HTTP com rewitten and a async get put in there for example
    Phonetics for viper made better in PhoneticSHipname
    Combat panel selected last dock as default
    EDSM Class cleaned up and regionalised.. no code changes
    Material commds picked up non lower case search of cache items