### PR TITLE
Slim memory requirements by fixing HE

### DIFF
--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -699,6 +699,8 @@ namespace EDDiscovery._3DMap
 
                     Vector3d? lastpos = null;
 
+                    Color drawcolour = Color.Green;
+
                     foreach (HistoryEntry sp in syslists)
                     {
                         if (sp.EntryType == JournalTypeEnum.Resurrect || sp.EntryType == JournalTypeEnum.Died)
@@ -707,14 +709,17 @@ namespace EDDiscovery._3DMap
                         }
                         else if (sp.IsLocOrJump && sp.System.HasCoordinate)
                         {
+                            if (sp.IsFSDJump)
+                            {
+                                drawcolour = Color.FromArgb((sp.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                                if (drawcolour.GetBrightness() < 0.05)
+                                    drawcolour = Color.Red;
+                            }
+
                             if (lastpos.HasValue)
                             {
-                                Color c = Color.FromArgb(255, Color.FromArgb(sp.MapColour));         // convert to colour, ensure alpha is 255 (some time in the past this value could have been screwed up)
-                                if (c.GetBrightness() < 0.05)                                        // and ensure it shows
-                                    c = Color.Red;
-
                                 datasetl.Add(new LineData(sp.System.X, sp.System.Y, sp.System.Z,
-                                                    lastpos.Value.X, lastpos.Value.Y , lastpos.Value.Z, c));
+                                                    lastpos.Value.X, lastpos.Value.Y , lastpos.Value.Z, drawcolour));
                             }
 
                             lastpos = new Vector3d(sp.System.X, sp.System.Y, sp.System.Z);
@@ -728,15 +733,20 @@ namespace EDDiscovery._3DMap
                 {
                     var datasetp = Data3DSetClass<PointData>.Create("visitedstarsdots", DotColour, 2.0f);
 
+                    Color drawcolour = Color.Green;
+
                     foreach (HistoryEntry vs in syslists)
                     {
                         if (vs.System.HasCoordinate)
                         {
-                            Color c = Color.FromArgb(255, Color.FromArgb(vs.MapColour));         // convert to colour, ensure alpha is 255 (some time in the past this value could have been screwed up)
-                            if (c.GetBrightness() < 0.05)                                        // and ensure it shows
-                                c = Color.Red;
+                            if (vs.IsFSDJump)
+                            {
+                                drawcolour = Color.FromArgb((vs.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                                if (drawcolour.GetBrightness() < 0.05)
+                                    drawcolour = Color.Red;
+                            }
 
-                            datasetp.Add(new PointData(vs.System.X, vs.System.Y, vs.System.Z, c));
+                            datasetp.Add(new PointData(vs.System.X, vs.System.Y, vs.System.Z, drawcolour));
                         }
                     }
 

--- a/EDDiscovery/Actions/ActionVars.cs
+++ b/EDDiscovery/Actions/ActionVars.cs
@@ -58,8 +58,10 @@ namespace EDDiscovery.Actions
                 vars[prefix + "MultiPlayer"] = he.MultiPlayer ? "1" : "0";
                 vars[prefix + "ContainsRares"] = he.ContainsRares() ? "1" : "0";
                 vars[prefix + "EventSummary"] = he.EventSummary;
-                vars[prefix + "EventDescription"] = he.EventDescription;
-                vars[prefix + "EventDetailedInfo"] = he.EventDetailedInfo;
+
+                he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+                vars[prefix + "EventDescription"] = EventDescription;
+                vars[prefix + "EventDetailedInfo"] = EventDetailedInfo;
 
                 vars.AddPropertiesFieldsOfClass(he.journalEntry, prefix + "Class_", new Type[] { typeof(System.Drawing.Icon), typeof(System.Drawing.Image), typeof(System.Drawing.Bitmap), typeof(Newtonsoft.Json.Linq.JObject) }, 5);      //depth seems good enough
 

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1335,8 +1335,7 @@ namespace EDDiscovery
         {
             comboBoxCommander.Enabled = false;
             comboBoxCommander.Items.Clear();            // comboBox is nicer with items
-            comboBoxCommander.Items.Add("Hidden Log");
-            comboBoxCommander.Items.AddRange((from EDCommander c in EDCommander.GetList() select c.Name).ToList());
+            comboBoxCommander.Items.AddRange((from EDCommander c in EDCommander.GetListInclHidden() select c.Name).ToList());
             if (history.CommanderId == -1)
             {
                 comboBoxCommander.SelectedIndex = 0;
@@ -1355,15 +1354,10 @@ namespace EDDiscovery
         {
             if (comboBoxCommander.SelectedIndex >= 0 && comboBoxCommander.Enabled)     // DONT trigger during LoadCommandersListBox
             {
-                if (comboBoxCommander.SelectedIndex == 0)
-                    Controller.RefreshHistoryAsync(currentcmdr: -1);                                   // which will cause DIsplay to be called as some point
-                else
-                {
-                    var itm = (from EDCommander c in EDCommander.GetList() where c.Name.Equals(comboBoxCommander.Text) select c).ToList();
+                var itm = (from EDCommander c in EDCommander.GetListInclHidden() where c.Name.Equals(comboBoxCommander.Text) select c).ToList();
 
-                    EDCommander.CurrentCmdrID = itm[0].Nr;
-                    Controller.RefreshHistoryAsync(currentcmdr: EDCommander.CurrentCmdrID);                                   // which will cause DIsplay to be called as some point
-                }
+                EDCommander.CurrentCmdrID = itm[0].Nr;
+                Controller.RefreshHistoryAsync(currentcmdr: EDCommander.CurrentCmdrID);                                   // which will cause DIsplay to be called as some point
             }
 
         }

--- a/EDDiscovery/Forms/Form2DMap.cs
+++ b/EDDiscovery/Forms/Form2DMap.cs
@@ -128,21 +128,23 @@ namespace EDDiscovery
 
             int currentcmdr = EDCommander.CurrentCmdrID;
 
-            var history = from systems in syslist where systems.EventTimeLocal > start && systems.EventTimeLocal<endDate && systems.System.HasCoordinate == true  orderby systems.EventTimeUTC  select systems;
-            List<HistoryEntry> listHistory = history.ToList();
+            List<HistoryEntry> jumps = (from systems in syslist where systems.EventTimeLocal > start && systems.EventTimeLocal < endDate && systems.IsLocOrJump orderby systems.EventTimeUTC select systems).ToList();
+
+            Color drawcolour = Color.Green;
 
             using (Graphics gfx = Graphics.FromImage(imageViewer.Image))
             {
-                if (listHistory.Count > 1)
+                for (int ii = 0; ii < jumps.Count-1; ii++)
                 {
-                    for (int ii = 1; ii < listHistory.Count; ii++)
+                    if (jumps[ii].IsFSDJump)
                     {
-                        Color a = Color.FromArgb(listHistory[ii].MapColour);
-                        Color b = (a.IsFullyTransparent()) ? Color.FromArgb(255, a) : a;
-
-                        using (Pen pen = new Pen(b, 2))
-                            DrawLine(gfx, pen, listHistory[ii - 1].System, listHistory[ii].System);
+                        drawcolour = Color.FromArgb((jumps[ii].journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                        if (drawcolour.GetBrightness() < 0.05)
+                            drawcolour = Color.Red;
                     }
+
+                    using (Pen pen = new Pen(drawcolour, 2))
+                        DrawLine(gfx, pen, jumps[ii].System, jumps[ii+1].System);
                 }
 
                 if (DisplayTestGrid)

--- a/EDDiscovery/Forms/MoveToCommander.cs
+++ b/EDDiscovery/Forms/MoveToCommander.cs
@@ -37,7 +37,7 @@ namespace EDDiscovery.Forms
 
         public bool Init()
         {
-            List<EDCommander> commanders = EDCommander.GetList();
+            List<EDCommander> commanders = EDCommander.GetListCommanders();
 
             comboBoxCommanders.DisplayMember = "Name";
             comboBoxCommanders.ValueMember = "Nr";

--- a/EDDiscovery/Forms/SetNoteForm.cs
+++ b/EDDiscovery/Forms/SetNoteForm.cs
@@ -28,8 +28,11 @@ namespace EDDiscovery.Forms
             this.textBoxNote.Text = this.NoteText ?? "";
             this.labelTimestamp.Text = he.EventTimeLocal.ToString();
             this.labelSystem.Text = he.System.Name;
+
+            he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
             this.labelSummary.Text = he.EventSummary;
-            this.labelDetails.Text = he.EventDescription;
+            this.labelDetails.Text = EventDescription;
 
             EDDiscovery.EDDTheme theme = EDDiscovery.EDDTheme.Instance;
             theme.ApplyToFormStandardFontSize(this);

--- a/EDDiscovery/UserControls/FilterHelpers.cs
+++ b/EDDiscovery/UserControls/FilterHelpers.cs
@@ -61,38 +61,38 @@ namespace EDDiscovery.UserControls
             }
         }
 
-        static public List<HistoryEntry> MarkHistory(List<HistoryEntry> he, Conditions.ConditionLists cond, Conditions.ConditionVariables othervars, out int count)       // Used for debugging it..
-        {
-            count = 0;
+        //static public List<HistoryEntry> MarkHistory(List<HistoryEntry> he, Conditions.ConditionLists cond, Conditions.ConditionVariables othervars, out int count)       // Used for debugging it..
+        //{
+        //    count = 0;
 
-            if (cond.Count == 0)       // no filters, all in
-                return he;
-            else
-            {
-                List<HistoryEntry> ret = new List<HistoryEntry>();
+        //    if (cond.Count == 0)       // no filters, all in
+        //        return he;
+        //    else
+        //    {
+        //        List<HistoryEntry> ret = new List<HistoryEntry>();
 
-                foreach (HistoryEntry s in he)
-                {
-                    List<Conditions.Condition> list = new List<Conditions.Condition>();    // don't want it
+        //        foreach (HistoryEntry s in he)
+        //        {
+        //            List<Conditions.Condition> list = new List<Conditions.Condition>();    // don't want it
 
-                    int mrk = s.EventDescription.IndexOf(":::");
-                    if (mrk >= 0)
-                        s.EventDescription = s.EventDescription.Substring(mrk + 3);
+        //            int mrk = s.EventDescription.IndexOf(":::");
+        //            if (mrk >= 0)
+        //                s.EventDescription = s.EventDescription.Substring(mrk + 3);
 
-                    string er;
+        //            string er;
 
-                    if (!cond.CheckFilterFalse(s.journalEntry, s.journalEntry.EventTypeStr, new Conditions.ConditionVariables[] { othervars, new Conditions.ConditionVariables("Note", s.snc?.Note ?? "") }, out er, list))
-                    {
-                        //System.Diagnostics.Debug.WriteLine("Filter out " + s.Journalid + " " + s.EntryType + " " + s.EventDescription);
-                        s.EventDescription = "!" + list[0].eventname + ":::" + s.EventDescription;
-                        count++;
-                    }
+        //            if (!cond.CheckFilterFalse(s.journalEntry, s.journalEntry.EventTypeStr, new Conditions.ConditionVariables[] { othervars, new Conditions.ConditionVariables("Note", s.snc?.Note ?? "") }, out er, list))
+        //            {
+        //                //System.Diagnostics.Debug.WriteLine("Filter out " + s.Journalid + " " + s.EntryType + " " + s.EventDescription);
+        //                s.EventDescription = "!" + list[0].eventname + ":::" + s.EventDescription;
+        //                count++;
+        //            }
 
-                    ret.Add(s);
-                }
+        //            ret.Add(s);
+        //        }
 
-                return ret;
-            }
-        }
+        //        return ret;
+        //    }
+        //}
     }
 }

--- a/EDDiscovery/UserControls/UserControlCombatPanel.cs
+++ b/EDDiscovery/UserControls/UserControlCombatPanel.cs
@@ -321,8 +321,11 @@ namespace EDDiscovery.UserControls
             if (CreateEntry(he, out string summarycol, out string descriptioncol, out string rewardcol))
             {
                 var rw = dataGridViewCombat.RowTemplate.Clone() as DataGridViewRow;
+                he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
                 rw.CreateCells(dataGridViewCombat, EDDiscoveryForm.EDDConfig.DisplayUTC ? he.EventTimeUTC : he.EventTimeLocal,
-                    he.EventSummary, he.EventDescription, rewardcol);
+                    he.EventSummary, EventDescription, rewardcol);
+
                 rw.Tag = he;
 
                 if (ins)
@@ -348,8 +351,11 @@ namespace EDDiscovery.UserControls
         bool CreateEntry( HistoryEntry he, out string summarycol, out string descriptioncol, out string rewardcol )
         {
             rewardcol = "";
+
+            he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
             summarycol = he.EventSummary;
-            descriptioncol = he.EventDescription;
+            descriptioncol = EventDescription;
 
             MissionState ml = current.MissionKey != null && he.MissionList.Missions.ContainsKey(current.MissionKey) ? he.MissionList.Missions[current.MissionKey] : null;
 
@@ -676,7 +682,8 @@ namespace EDDiscovery.UserControls
                 int ch = dataGridViewCombat.Rows[leftclickrow].Height;
                 bool toexpand = (ch <= DefaultRowHeight);
 
-                string infotext = leftclicksystem.EventDescription + ((toexpand && leftclicksystem.EventDetailedInfo.Length > 0) ? (Environment.NewLine + leftclicksystem.EventDetailedInfo) : "");
+                leftclicksystem.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+                string infotext = EventDescription + ((toexpand && EventDetailedInfo.Length > 0) ? (Environment.NewLine + EventDetailedInfo) : "");
 
                 int h = DefaultRowHeight;
 

--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -184,8 +184,10 @@ namespace EDDiscovery.UserControls
 
         private void AddNewJournalRow(bool insert, HistoryEntry item)            // second part of add history row, adds item to view.
         {
-            string detail = item.EventDescription;
-            detail = detail.AppendPrePad(item.EventDetailedInfo.LineLimit(15,Environment.NewLine + "..."), Environment.NewLine);
+            item.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
+            string detail = EventDescription;
+            detail = detail.AppendPrePad(EventDetailedInfo.LineLimit(15,Environment.NewLine + "..."), Environment.NewLine);
 
             var rw = dataGridViewJournal.RowTemplate.Clone() as DataGridViewRow;
             rw.CreateCells(dataGridViewJournal, EDDiscoveryForm.EDDConfig.DisplayUTC ? item.EventTimeUTC : item.EventTimeLocal, "", item.EventSummary, detail);
@@ -399,7 +401,8 @@ namespace EDDiscovery.UserControls
             if (leftclickrow >= 0)                                                   // Click expands it..
             {
                 ExtendedControls.InfoForm info = new ExtendedControls.InfoForm();
-                string infodetailed = leftclicksystem.EventDescription.AppendPrePad(leftclicksystem.EventDetailedInfo, Environment.NewLine);
+                leftclicksystem.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+                string infodetailed = EventDescription.AppendPrePad(EventDetailedInfo, Environment.NewLine);
                 info.Info("Journal Record: " + (EDDiscoveryForm.EDDConfig.DisplayUTC ? leftclicksystem.EventTimeUTC : leftclicksystem.EventTimeLocal) + ": " + leftclicksystem.EventSummary,
                     FindForm().Icon, infodetailed);
                 info.Size = new Size(1200, 800);

--- a/EDDiscovery/UserControls/UserControlSettings.cs
+++ b/EDDiscovery/UserControls/UserControlSettings.cs
@@ -93,7 +93,7 @@ namespace EDDiscovery.UserControls
             radioButtonCentreHome.Checked = !selectionCentre;
 
             dataGridViewCommanders.AutoGenerateColumns = false;             // BEFORE assigned to list..
-            dataGridViewCommanders.DataSource = EDCommander.GetList();
+            dataGridViewCommanders.DataSource = EDCommander.GetListCommanders();
 
             panel_defaultmapcolor.BackColor = Color.FromArgb(EDDConfig.Instance.DefaultMapColour);
 
@@ -152,7 +152,7 @@ namespace EDDiscovery.UserControls
         public void UpdateCommandersListBox()
         {
             dataGridViewCommanders.DataSource = null;
-            dataGridViewCommanders.DataSource = EDCommander.GetList();
+            dataGridViewCommanders.DataSource = EDCommander.GetListCommanders();
             dataGridViewCommanders.Update();
         }
 

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -333,6 +333,8 @@ namespace EDDiscovery.UserControls
             if (Config(Configuration.showIcon))
                 coldata.Add("`!!ICON!!");                // dummy place holder..
 
+            he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
             if (Config(Configuration.showDescription))
             {
                 tooltipattach.Add(coldata.Count);
@@ -342,7 +344,7 @@ namespace EDDiscovery.UserControls
             if (Config(Configuration.showInformation))
             {
                 tooltipattach.Add(coldata.Count);
-                coldata.Add(he.EventDescription.Replace("\r\n", " "));
+                coldata.Add(EventDescription.Replace("\r\n", " "));
             }
 
             if (layoutorder == 0 && Config(Configuration.showNotes))
@@ -381,7 +383,7 @@ namespace EDDiscovery.UserControls
                 edsm.SetAlternateImage(BaseUtils.BitMapHelpers.DrawTextIntoFixedSizeBitmapC("EDSM", edsm.img.Size, displayfont, backtext, textcolour.Multiply(1.2F), 0.5F, true), edsm.pos, true);
             }
 
-            string tooltip = he.EventSummary + Environment.NewLine + he.EventDescription + Environment.NewLine + he.EventDetailedInfo;
+            string tooltip = he.EventSummary + Environment.NewLine + EventDescription + Environment.NewLine + EventDetailedInfo;
 
             for (int i = 0; i < coldata.Count; i++)             // then we draw them, allowing them to overfill columns if required
             {

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -244,7 +244,9 @@ namespace EDDiscovery.UserControls
 
             dataGridViewStarList.Rows[rownr].DefaultCellStyle.ForeColor = (he.System.HasCoordinate || he.EntryType != JournalTypeEnum.FSDJump) ? discoveryform.theme.VisitedSystemColor : discoveryform.theme.NonVisitedSystemColor;
 
-            string tip = he.EventSummary + Environment.NewLine + he.EventDescription + Environment.NewLine + he.EventDetailedInfo;
+            he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
+            string tip = he.EventSummary + Environment.NewLine + EventDescription + Environment.NewLine + EventDetailedInfo;
 
             dataGridViewStarList.Rows[rownr].Cells[0].Tag = false;  //[0] records if checked EDSm
 
@@ -799,6 +801,8 @@ namespace EDDiscovery.UserControls
                                 tlist = tlist.AppendPrePad(syslist[i].EventTimeLocal.ToShortDateString() + " " + syslist[i].EventTimeLocal.ToShortTimeString(), ", ");
                         }
 
+                        he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
                         return new Object[] {
                             rw.Cells[0].Value,
                             rw.Cells[1].Value,
@@ -807,8 +811,8 @@ namespace EDDiscovery.UserControls
                             tlist,
                             he.WhereAmI ,
                             he.ShipInformation != null ? he.ShipInformation.Name : "Unknown",
-                            he.EventDescription,
-                            he.EventDetailedInfo,
+                            EventDescription,
+                            EventDetailedInfo,
                             he.isTravelling ? he.TravelledDistance.ToString("0.0") : "",
                             he.isTravelling ? he.TravelledSeconds.ToString() : "",
                             he.isTravelling ? he.Travelledjumps.ToStringInvariant() : "",

--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -153,7 +153,7 @@ namespace EDDiscovery.UserControls
 
                 HistoryEntry lastfsd = hl.GetLastHistoryEntry(x => x.journalEntry is EliteDangerousCore.JournalEvents.JournalFSDJump, he);
 
-                if (lastfsd != null && lastfsd.IsEDSMFirstDiscover)
+                if (lastfsd != null && (lastfsd.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).EDSMFirstDiscover)
                     name = "(FD)*" + name;
 
                 textBoxSystem.Text = name;

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -213,6 +213,8 @@ namespace EDDiscovery.UserControls
                 dataGridViewTravel.Columns[sortcol].HeaderCell.SortGlyphDirection = sortorder;
             }
 
+            System.Diagnostics.Debug.WriteLine(BaseUtils.AppTicks.TickCount100 + " GRID UP");
+
             FireChangeSelection();      // and since we repainted, we should fire selection, as we in effect may have selected a new one
         }
 

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -213,8 +213,6 @@ namespace EDDiscovery.UserControls
                 dataGridViewTravel.Columns[sortcol].HeaderCell.SortGlyphDirection = sortorder;
             }
 
-            System.Diagnostics.Debug.WriteLine(BaseUtils.AppTicks.TickCount100 + " GRID UP");
-
             FireChangeSelection();      // and since we repainted, we should fire selection, as we in effect may have selected a new one
         }
 
@@ -287,8 +285,16 @@ namespace EDDiscovery.UserControls
             //string debugt = item.Journalid + "  " + item.System.id_edsm + " " + item.System.GetHashCode() + " "; // add on for debug purposes to a field below
 
             var rw = dataGridViewTravel.RowTemplate.Clone() as DataGridViewRow;
+
+            item.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
+            string travelinfo = item.TravelInfo();
+            if (travelinfo != null)
+                EventDetailedInfo = travelinfo + Environment.NewLine + EventDetailedInfo;
+
             rw.CreateCells(dataGridViewTravel, EDDiscoveryForm.EDDConfig.DisplayUTC ? item.EventTimeUTC : item.EventTimeLocal, "", 
-                                item.EventSummary, item.EventDescription, (item.snc != null) ? item.snc.Note : "");
+                                item.EventSummary, EventDescription, (item.snc != null) ? item.snc.Note : "");
+
             rw.Cells[TravelHistoryColumns.HistoryTag].Tag = item;
 
             int rownr = 0;
@@ -305,7 +311,7 @@ namespace EDDiscovery.UserControls
 
             dataGridViewTravel.Rows[rownr].DefaultCellStyle.ForeColor = (item.System.HasCoordinate || item.EntryType != JournalTypeEnum.FSDJump) ? discoveryform.theme.VisitedSystemColor : discoveryform.theme.NonVisitedSystemColor;
 
-            string tip = item.EventSummary + Environment.NewLine + item.EventDescription + Environment.NewLine + item.EventDetailedInfo;
+            string tip = item.EventSummary + Environment.NewLine + EventDescription + Environment.NewLine + EventDetailedInfo;
 
             dataGridViewTravel.Rows[rownr].Cells[0].ToolTipText = tip;
             dataGridViewTravel.Rows[rownr].Cells[1].ToolTipText = tip;
@@ -522,7 +528,9 @@ namespace EDDiscovery.UserControls
 
             if (he.IsFSDJump && showfsdmapcolour)
             {
-                using (Brush b = new SolidBrush(Color.FromArgb(he.MapColour)))
+                Color c = Color.FromArgb((he.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+
+                using (Brush b = new SolidBrush(c))
                 {
                     e.Graphics.FillEllipse(b, new Rectangle(hstart + 2, top + 2, size - 6, size - 6));
                 }
@@ -592,7 +600,13 @@ namespace EDDiscovery.UserControls
         {
             if (leftclickrow >= 0)                                                   // Click expands it..
             {
-                string infodetailed = leftclicksystem.EventDescription.AppendPrePad(leftclicksystem.EventDetailedInfo,Environment.NewLine);
+                leftclicksystem.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+
+                string travelinfo = leftclicksystem.TravelInfo();
+                if (travelinfo != null)
+                    EventDetailedInfo = travelinfo + Environment.NewLine + EventDetailedInfo;
+
+                string infodetailed = EventDescription.AppendPrePad(EventDetailedInfo,Environment.NewLine);
 
                 if (infodetailed.Lines() >= 15) // too long for inline expansion
                 {
@@ -607,7 +621,7 @@ namespace EDDiscovery.UserControls
                     int ch = dataGridViewTravel.Rows[leftclickrow].Height;
                     bool toexpand = (ch <= DefaultRowHeight);
 
-                    string infotext = (toexpand) ? infodetailed : leftclicksystem.EventDescription;
+                    string infotext = (toexpand) ? infodetailed : EventDescription;
 
                     int h = DefaultRowHeight;
 
@@ -684,7 +698,7 @@ namespace EDDiscovery.UserControls
             mapColorDialog.AllowFullOpen = true;
             mapColorDialog.FullOpen = true;
             HistoryEntry sp2 = (HistoryEntry)selectedRows.First().Cells[TravelHistoryColumns.HistoryTag].Tag;
-            mapColorDialog.Color = Color.FromArgb(sp2.MapColour);
+            mapColorDialog.Color = Color.Red;
 
             if (mapColorDialog.ShowDialog(FindForm()) == DialogResult.OK)
             {
@@ -1183,15 +1197,16 @@ namespace EDDiscovery.UserControls
                     grd.GetLine += delegate (int r)
                     {
                         HistoryEntry he = (HistoryEntry)dataGridViewTravel.Rows[r].Cells[TravelHistoryColumns.HistoryTag].Tag;
+                        he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
                         return new Object[] {
                             dataGridViewTravel.Rows[r].Cells[0].Value,
-                            he.journalEntry.EventTypeStr,
+                            he.journalEntry.EventSummaryName,
                             (he.System != null) ? he.System.Name : "Unknown",    // paranoia
                             he.WhereAmI,
                             he.ShipInformation != null ? he.ShipInformation.Name : "Unknown",
                             he.EventSummary,
-                            he.EventDescription,
-                            he.EventDetailedInfo,
+                            EventDescription,
+                            EventDetailedInfo,
                             dataGridViewTravel.Rows[r].Cells[4].Value,
                             he.isTravelling ? he.TravelledDistance.ToString("0.0") : "",
                             he.isTravelling ? he.TravelledSeconds.ToString() : "",

--- a/EDDiscovery/UserControls/UserControlTrippanel.cs
+++ b/EDDiscovery/UserControls/UserControlTrippanel.cs
@@ -210,13 +210,12 @@ namespace EDDiscovery.UserControls
                     if (he.StartMarker)
                         return;
 
-                    he.StartMarker = true;
-                    JournalEntry.UpdateSyncFlagBit(he.Journalid, SyncFlags.StartMarker, he.StartMarker);
+                    he.journalEntry.UpdateSyncFlagBit(SyncFlags.StartMarker, true, SyncFlags.StopMarker, false);
+
                     if (list.Count() > 1 && he.isTravelling)
                     {
                         he = list.ToArray()[1];
-                        he.StopMarker = true;
-                        JournalEntry.UpdateSyncFlagBit(he.Journalid, SyncFlags.StopMarker, he.StopMarker);
+                        he.journalEntry.UpdateSyncFlagBit(SyncFlags.StopMarker, true , SyncFlags.StopMarker, false);
                     }
                     discoveryform.RefreshHistoryAsync();
                 }

--- a/EliteDangerous/EDSM/EDSMClass.cs
+++ b/EliteDangerous/EDSM/EDSMClass.cs
@@ -385,9 +385,9 @@ namespace EliteDangerousCore.EDSM
 
         #region Log Sync for log fetcher
 
-        public int GetLogs(DateTime? starttimeutc, DateTime? endtimeutc, out List<HistoryEntry> log, out DateTime logstarttime, out DateTime logendtime)
+        public int GetLogs(DateTime? starttimeutc, DateTime? endtimeutc, out List<JournalFSDJump> log, out DateTime logstarttime, out DateTime logendtime)
         {
-            log = new List<HistoryEntry>();
+            log = new List<JournalFSDJump>();
             logstarttime = DateTime.MaxValue;
             logendtime = DateTime.MinValue;
 
@@ -451,8 +451,8 @@ namespace EliteDangerousCore.EDSM
                             }
                         }
 
-                        HistoryEntry he = HistoryEntry.MakeVSEntry(sc, etutc, EliteConfigInstance.InstanceConfig.DefaultMapColour, "", "", firstdiscover: firstdiscover);       // FSD jump entry
-                        log.Add(he);
+                        JournalFSDJump fsd = new JournalFSDJump(etutc, sc , EliteConfigInstance.InstanceConfig.DefaultMapColour, firstdiscover, (int)SyncFlags.EDSM);
+                        log.Add(fsd);
                     }
                 }
             }

--- a/EliteDangerous/EDSM/EDSMJournalSync.cs
+++ b/EliteDangerous/EDSM/EDSMJournalSync.cs
@@ -455,7 +455,7 @@ namespace EliteDangerousCore.EDSM
                                     if (systemCreated)
                                     {
                                         System.Diagnostics.Debug.WriteLine("** EDSM indicates first entry for " + he.System.Name);
-                                        he.SetFirstDiscover(true, cn, txn);
+                                        (he.journalEntry as JournalFSDJump).UpdateFirstDiscover(true, cn, txn);
                                         firstdiscovers = firstdiscovers.AppendPrePad(he.System.Name, ";");
                                     }
                                 }

--- a/EliteDangerous/EliteDangerous/EDJournalClass.cs
+++ b/EliteDangerous/EliteDangerous/EDJournalClass.cs
@@ -193,7 +193,7 @@ namespace EliteDangerousCore
 
         public void ParseJournalFiles(Func<bool> cancelRequested, Action<int, string> updateProgress, bool forceReload = false)
         {
-            List<EDCommander> listCommanders = EDCommander.GetList();
+            List<EDCommander> listCommanders = EDCommander.GetListCommanders();
 
             // add the default frontier folder in
 

--- a/EliteDangerous/EliteDangerous/EDJournalReader.cs
+++ b/EliteDangerous/EliteDangerous/EDJournalReader.cs
@@ -120,23 +120,23 @@ namespace EliteDangerousCore
                     newname = "[BETA] " + newname;
                 }
 
-                EDCommander _commander = EDCommander.GetCommander(newname);
+                EDCommander commander = EDCommander.GetCommander(newname);
 
-                if (_commander == null )
+                if (commander == null )
                 {
-                    _commander = EDCommander.GetAll().FirstOrDefault();
-                    if (EDCommander.NumberOfCommanders == 1 && _commander != null && _commander.Name == "Jameson (Default)")
+                    commander = EDCommander.GetListCommanders().FirstOrDefault();
+                    if (EDCommander.NumberOfCommanders == 1 && commander != null && commander.Name == "Jameson (Default)")
                     {
-                        _commander.Name = newname;
-                        _commander.EdsmName = newname;
-                        EDCommander.Update(new List<EDCommander> { _commander }, false);
+                        commander.Name = newname;
+                        commander.EdsmName = newname;
+                        EDCommander.Update(new List<EDCommander> { commander }, false);
                     }
                     else
-                        _commander = EDCommander.Create(newname, null, EDJournalClass.GetDefaultJournalDir().Equals(TravelLogUnit.Path) ? "" : TravelLogUnit.Path);
+                        commander = EDCommander.Create(newname, null, EDJournalClass.GetDefaultJournalDir().Equals(TravelLogUnit.Path) ? "" : TravelLogUnit.Path);
 
                 }
 
-                cmdrid = _commander.Nr;
+                cmdrid = commander.Nr;
 
                 if (!TravelLogUnit.CommanderId.HasValue)
                 {

--- a/EliteDangerous/EliteDangerous/ShipModuleData.cs
+++ b/EliteDangerous/EliteDangerous/ShipModuleData.cs
@@ -87,7 +87,8 @@ namespace EliteDangerousCore
 
                 System.Diagnostics.Debug.WriteLine("**** Not known item.. synthesise response " + fdid + " >> " + m.ModName + "," + m.ModType);
                 synthesisedmodules.Add(lowername, m);                   // lets cache them for completeness..
-                //            string line = "{ \"" + lowername + "\", new ShipModule( -1, 0 , \"" + m.modname + "\",\"" + m.modtype + "\") },";
+                
+                //            string line = "{ \"" + lowername + "\", new ShipModule( -1, 0 , \"" + m.modname + "\",\"" + m.modtype + "\") },";     // DEBUG
                 //            if (!synthresponses.Contains(line))  synthresponses.Add(line);
             }
 

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore
 
         public int Indexno;            // for display purposes.
 
-        public JournalTypeEnum EntryType { get { return journalEntry?.EventTypeID ?? JournalTypeEnum.Unknown; } }
-        public long Journalid { get { return journalEntry?.Id ??0; } }
-        public JournalEntry journalEntry;
+        public JournalTypeEnum EntryType { get { return journalEntry.EventTypeID; } }
+        public long Journalid { get { return journalEntry.Id; } }
+        public JournalEntry journalEntry;       // MUST be present
         public EDCommander Commander;
 
         public ISystem System;         // Must be set! All entries, even if they are not FSD entries.
@@ -47,21 +47,16 @@ namespace EliteDangerousCore
                                        // SO the journal reader can just read data in that table only, does not need to do a system match
 
         public DateTime EventTimeLocal { get { return EventTimeUTC.ToLocalTime(); } }
-        public DateTime EventTimeUTC { get { return journalEntry?.EventTimeUTC.ToLocalTime() ?? DateTime.UtcNow; } }
+        public DateTime EventTimeUTC { get { return journalEntry.EventTimeUTC; } }
         public TimeSpan AgeOfEntry() { return DateTime.Now - EventTimeUTC; }
-        public string EventSummary { get { journalEntry.FillInformation(out string s, out string i, out string d); return s; } }
-        public string EventDescription { get { journalEntry.FillInformation(out string s, out string i, out string d); return s; } }
-        public string EventDetailedInfo { get { journalEntry.FillInformation(out string s, out string i, out string d); return s; } }
 
-        public int MapColour;
+        public string EventSummary { get { return journalEntry.EventSummaryName;} }
 
-        public bool IsStarPosFromEDSM;  // flag populated from journal entry when HE is made. Was the star position taken from EDSM?
-        public bool IsEDSMFirstDiscover;// Only on FSD JUMP
-        public bool EdsmSync;           // flag populated from journal entry when HE is made. Have we synced?
-        public bool EDDNSync;           // flag populated from journal entry when HE is made. Have we synced?
-        public bool EGOSync;            // flag populated from journal entry when HE is made. Have we synced?
-        public bool StartMarker;        // flag populated from journal entry when HE is made. Is this a system distance measurement system
-        public bool StopMarker;         // flag populated from journal entry when HE is made. Is this a system distance measurement stop point
+        public bool EdsmSync { get { return journalEntry.SyncedEDSM; } }           // flag populated from journal entry when HE is made. Have we synced?
+        public bool EDDNSync { get { return journalEntry.SyncedEDDN; } }
+        public bool EGOSync { get { return journalEntry.SyncedEGO; } }
+        public bool StartMarker { get { return journalEntry.StartMarker; } }
+        public bool StopMarker { get { return journalEntry.StopMarker; } }
         public bool IsFSDJump { get { return EntryType == JournalTypeEnum.FSDJump; } }
         public bool IsLocOrJump { get { return EntryType == JournalTypeEnum.FSDJump || EntryType == JournalTypeEnum.Location; } }
         public bool IsFuelScoop { get { return EntryType == JournalTypeEnum.FuelScoop; } }
@@ -136,42 +131,14 @@ namespace EliteDangerousCore
 
         private HistoryEntry()
         {
-
-        }
-        // for importing old events in from 2.1 - logs
-        public static HistoryEntry MakeVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info, int journalid = 0, bool firstdiscover = false)
-        {
-            return null;
-            //Debug.Assert(sys != null);
-
-            //Newtonsoft.Json.Linq.JObject evt = new Newtonsoft.Json.Linq.JObject();
-            //evt.Add("timestamp",new Newtonsoft.Json.J)
-
-            //return new HistoryEntry
-            //{
-            //    journalEntry = new JournalFSDJump(eventt),
-            //    EntryType = JournalTypeEnum.FSDJump,
-            //    System = sys,
-            //    EventTimeUTC = eventt,
-            //    EventSummary = "Jump to " + sys.Name,
-            //    EventDescription = dist,
-            //    EventDetailedInfo = info,
-            //    MapColour = m,
-            //    Journalid = journalid,
-            //    IsEDSMFirstDiscover = firstdiscover,
-            //    EdsmSync = true
-            //};
         }
 
-        public static HistoryEntry FromJournalEntry(JournalEntry je, HistoryEntry prev, out bool journalupdate, SQLiteConnectionSystem conn = null, EDCommander cmdr = null)
+        public static HistoryEntry FromJournalEntry(JournalEntry je, HistoryEntry prev, out bool journalupdate, SQLiteConnectionSystem conn = null)//, EDCommander cmdr = null)
         {
             ISystem isys = prev == null ? new SystemClass("Unknown") : prev.System;
             int indexno = prev == null ? 1 : prev.Indexno + 1;
 
-            int mapcolour = 0;
             journalupdate = false;
-            bool starposfromedsm = false;
-            bool firstdiscover = false;
 
             if (je.EventTypeID == JournalTypeEnum.Location || je.EventTypeID == JournalTypeEnum.FSDJump)
             {
@@ -252,30 +219,16 @@ namespace EliteDangerousCore
                         }
                     }
 
-                    mapcolour = jfsd.MapColor;
-                    firstdiscover = jfsd.EDSMFirstDiscover;
                 }
 
                 isys = newsys;
-                starposfromedsm = (jl != null && jl.HasCoordinate) ? jl.StarPosFromEDSM : newsys.HasCoordinate;
             }
-
-            string summary, info, detailed;
-            je.FillInformation(out summary, out info, out detailed);
 
             HistoryEntry he = new HistoryEntry
             {
                 Indexno = indexno,
                 journalEntry = je,
                 System = isys,
-                MapColour = mapcolour,
-                EdsmSync = je.SyncedEDSM,
-                EDDNSync = je.SyncedEDDN,
-                EGOSync = je.SyncedEGO,
-                StartMarker = je.StartMarker,
-                StopMarker = je.StopMarker,
-                IsStarPosFromEDSM = starposfromedsm,
-                IsEDSMFirstDiscover = firstdiscover,
                 Commander = cmdr ?? EDCommander.GetCommander(je.CommanderId)
             };
 
@@ -385,12 +338,31 @@ namespace EliteDangerousCore
             else if (je.EventTypeID == JournalTypeEnum.QuitACrew)
                 he.onCrewWithCaptain = null;
 
-            if (prev != null && prev.travelling)      // if we are travelling..
+            if (prev != null )
             {
-                he.travelled_distance = prev.travelled_distance;
-                he.travelled_missingjump = prev.travelled_missingjump;
-                he.travelled_jumps = prev.travelled_jumps;
+                if (prev.StopMarker)            // if we had a stop marker previously, means the next one needs to clear the counters
+                {
+                    he.travelling = false;               // still travelling if its a start marker
+                    he.travelled_distance = 0;
+                    he.travelled_seconds = new TimeSpan(0);
+                    he.travelled_missingjump = 0;
+                    he.travelled_jumps = 0;
+                }
+                else
+                {
+                    he.travelling = prev.travelling;
+                    he.travelled_distance = prev.travelled_distance;
+                    he.travelled_seconds = prev.travelled_seconds;
+                    he.travelled_missingjump = prev.travelled_missingjump;
+                    he.travelled_jumps = prev.travelled_jumps;
+                }
+            }
 
+            if (he.StartMarker)           // start marker, start travelling
+                he.travelling = true;
+
+            if ( he.travelling )
+            {
                 if (he.IsFSDJump && !he.MultiPlayer)   // if jump, and not multiplayer..
                 {
                     double dist = ((JournalFSDJump)je).JumpDist;
@@ -403,49 +375,17 @@ namespace EliteDangerousCore
                     }
                 }
 
-                he.travelled_seconds = prev.travelled_seconds;
-                TimeSpan diff = he.EventTimeUTC.Subtract(prev.EventTimeUTC);
-
-                if (he.EntryType != JournalTypeEnum.LoadGame && diff < new TimeSpan(2, 0, 0))   // time between last entry and load game is not real time
+                if (prev != null)
                 {
-                    he.travelled_seconds += diff;
-                }
+                    TimeSpan diff = he.EventTimeUTC.Subtract(prev.EventTimeUTC);
 
-                if (he.StopMarker || he.StartMarker)
-                {
-                    //Debug.WriteLine("Travelling stop at " + he.Indexno);
-                    he.travelling = false;
-//TBD                    
-                    //he.EventDetailedInfo += ((he.EventDetailedInfo.Length > 0) ? Environment.NewLine : "") + "Travelled " + he.travelled_distance.ToStringInvariant("0.0") + " LY"
-                    //                    + ", " + he.travelled_jumps + " jumps"
-                    //                    + ((he.travelled_missingjump > 0) ? ", " + he.travelled_missingjump + " unknown distance jumps" : "") +
-                    //                    ", time " + he.travelled_seconds;
-
-                    he.travelled_distance = 0;
-                    he.travelled_seconds = new TimeSpan(0);
-                }
-                else
-                {
-                    he.travelling = true;
-
-                    if (he.IsFSDJump)
+                    if (he.EntryType != JournalTypeEnum.LoadGame && diff < new TimeSpan(2, 0, 0))   // time between last entry and load game is not real time
                     {
-//TBD
-
-                        //he.EventDetailedInfo += ((he.EventDetailedInfo.Length > 0) ? Environment.NewLine : "") + "Travelling" +
-                        //                " distance " + he.travelled_distance.ToString("0.0") + " LY"
-                        //                + ", " + he.travelled_jumps + " jumps"
-                        //                + ((he.travelled_missingjump > 0) ? ", " + he.travelled_missingjump + " unknown distance jumps" : "") +
-                        //                ", time " + he.travelled_seconds;
+                        he.travelled_seconds += diff;
                     }
                 }
             }
 
-            if (he.StartMarker)
-            {
-                //Debug.WriteLine("Travelling start at " + he.Indexno);
-                he.travelling = true;
-            }
 
             return he;
         }
@@ -471,6 +411,26 @@ namespace EliteDangerousCore
 
         #endregion
 
+        public string TravelInfo()          // use to get a summary of travel info.. 
+        {
+            if (StopMarker)
+            {
+                return "Travelled " + travelled_distance.ToStringInvariant("0.0") + " LY"
+                                     + ", " + travelled_jumps + " jumps"
+                                     + ((travelled_missingjump > 0) ? ", " + travelled_missingjump + " unknown distance jumps" : "") +
+                                      ", time " + travelled_seconds;
+            }
+            else if (isTravelling && IsFSDJump)
+            {
+                return "Travelling distance " + travelled_distance.ToString("0.0") + " LY"
+                + ", " + travelled_jumps + " jumps"
+                + ((travelled_missingjump > 0) ? ", " + travelled_missingjump + " unknown distance jumps" : "") +
+                ", time " + travelled_seconds;
+            }
+            else
+                return null;
+        }
+
         public System.Drawing.Image GetIcon
         {
             get
@@ -488,61 +448,27 @@ namespace EliteDangerousCore
         public void UpdateMapColour(int v)
         {
             if (EntryType == JournalTypeEnum.FSDJump)
-            {
-                MapColour = v;
-                if (Journalid != 0)
-                    JournalEntry.UpdateMapColour(Journalid, v);
-            }
+                (journalEntry as JournalFSDJump).UpdateMapColour(v);
         }
 
         public void UpdateCommanderID(int v)
         {
-            if (Journalid != 0)
-            {
-                JournalEntry.UpdateCommanderID(Journalid, v);
-            }
+            journalEntry.UpdateCommanderID(v);
         }
 
         public void SetEdsmSync(SQLiteConnectionUser cn = null, DbTransaction txn = null)
         {
-            EdsmSync = true;
-            if (Journalid != 0)
-            {
-                JournalEntry.UpdateSyncFlagBit(Journalid, SyncFlags.EDSM, true, cn, txn);
-            }
+            journalEntry.UpdateSyncFlagBit(SyncFlags.EDSM, true, SyncFlags.NoBit, false, cn, txn);
         }
+
         public void SetEddnSync(SQLiteConnectionUser cn = null, DbTransaction txn = null)
         {
-            EDDNSync = true;
-            if (Journalid != 0)
-            {
-                JournalEntry.UpdateSyncFlagBit(Journalid, SyncFlags.EDDN, true, cn, txn);
-            }
+            journalEntry.UpdateSyncFlagBit(SyncFlags.EDDN, true, SyncFlags.NoBit, false, cn, txn);
         }
 
         public void SetEGOSync(SQLiteConnectionUser cn = null, DbTransaction txn = null)
         {
-            EGOSync = true;
-            if (Journalid != 0)
-            {
-                JournalEntry.UpdateSyncFlagBit(Journalid, SyncFlags.EGO, true, cn, txn);
-            }
-        }
-
-        public void SetFirstDiscover(bool firstdiscover, SQLiteConnectionUser cn = null, DbTransaction txnl = null) // only on FSD entries
-        {
-            IsEDSMFirstDiscover = firstdiscover;
-            if (journalEntry != null)
-            {
-                JournalFSDJump jl = journalEntry as JournalFSDJump;
-                if (jl != null)
-                {
-                    Newtonsoft.Json.Linq.JObject jo = jl.GetJson();
-                    jo["EDD_EDSMFirstDiscover"] = firstdiscover;
-                    jl.UpdateJsonEntry(jo, cn, txnl);
-                    jl.EDSMFirstDiscover = firstdiscover;
-                }
-            }
+            journalEntry.UpdateSyncFlagBit(SyncFlags.EGO, true, SyncFlags.NoBit, false, cn, txn);
         }
 
         public bool IsJournalEventInEventFilter(string[] events)

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -31,10 +31,7 @@ namespace EliteDangerousCore
 
         public int Indexno;            // for display purposes.
 
-        public JournalTypeEnum EntryType { get { return journalEntry.EventTypeID; } }
-        public long Journalid { get { return journalEntry.Id; } }
         public JournalEntry journalEntry;       // MUST be present
-        public EDCommander Commander;
 
         public ISystem System;         // Must be set! All entries, even if they are not FSD entries.
                                        // The Minimum is name and edsm_id 
@@ -46,6 +43,9 @@ namespace EliteDangerousCore
                                        //       if edsm_id=-1 a load from SystemTable will occur with the name used
                                        // SO the journal reader can just read data in that table only, does not need to do a system match
 
+        public JournalTypeEnum EntryType { get { return journalEntry.EventTypeID; } }
+        public long Journalid { get { return journalEntry.Id; } }
+        public EDCommander Commander { get { return EDCommander.GetCommander(journalEntry.CommanderId); } }
         public DateTime EventTimeLocal { get { return EventTimeUTC.ToLocalTime(); } }
         public DateTime EventTimeUTC { get { return journalEntry.EventTimeUTC; } }
         public TimeSpan AgeOfEntry() { return DateTime.Now - EventTimeUTC; }
@@ -133,7 +133,7 @@ namespace EliteDangerousCore
         {
         }
 
-        public static HistoryEntry FromJournalEntry(JournalEntry je, HistoryEntry prev, out bool journalupdate, SQLiteConnectionSystem conn = null)//, EDCommander cmdr = null)
+        public static HistoryEntry FromJournalEntry(JournalEntry je, HistoryEntry prev, out bool journalupdate, SQLiteConnectionSystem conn = null)
         {
             ISystem isys = prev == null ? new SystemClass("Unknown") : prev.System;
             int indexno = prev == null ? 1 : prev.Indexno + 1;
@@ -229,7 +229,6 @@ namespace EliteDangerousCore
                 Indexno = indexno,
                 journalEntry = je,
                 System = isys,
-                Commander = cmdr ?? EDCommander.GetCommander(je.CommanderId)
             };
 
 

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -31,8 +31,8 @@ namespace EliteDangerousCore
 
         public int Indexno;            // for display purposes.
 
-        public JournalTypeEnum EntryType;
-        public long Journalid;
+        public JournalTypeEnum EntryType { get { return journalEntry?.EventTypeID ?? JournalTypeEnum.Unknown; } }
+        public long Journalid { get { return journalEntry?.Id ??0; } }
         public JournalEntry journalEntry;
         public EDCommander Commander;
 
@@ -47,11 +47,11 @@ namespace EliteDangerousCore
                                        // SO the journal reader can just read data in that table only, does not need to do a system match
 
         public DateTime EventTimeLocal { get { return EventTimeUTC.ToLocalTime(); } }
-        public DateTime EventTimeUTC;
+        public DateTime EventTimeUTC { get { return journalEntry?.EventTimeUTC.ToLocalTime() ?? DateTime.UtcNow; } }
         public TimeSpan AgeOfEntry() { return DateTime.Now - EventTimeUTC; }
-        public string EventSummary;
-        public string EventDescription;
-        public string EventDetailedInfo;
+        public string EventSummary { get { journalEntry.FillInformation(out string s, out string i, out string d); return s; } }
+        public string EventDescription { get { journalEntry.FillInformation(out string s, out string i, out string d); return s; } }
+        public string EventDetailedInfo { get { journalEntry.FillInformation(out string s, out string i, out string d); return s; } }
 
         public int MapColour;
 
@@ -141,20 +141,26 @@ namespace EliteDangerousCore
         // for importing old events in from 2.1 - logs
         public static HistoryEntry MakeVSEntry(ISystem sys, DateTime eventt, int m, string dist, string info, int journalid = 0, bool firstdiscover = false)
         {
-            Debug.Assert(sys != null);
-            return new HistoryEntry
-            {
-                EntryType = JournalTypeEnum.FSDJump,
-                System = sys,
-                EventTimeUTC = eventt,
-                EventSummary = "Jump to " + sys.Name,
-                EventDescription = dist,
-                EventDetailedInfo = info,
-                MapColour = m,
-                Journalid = journalid,
-                IsEDSMFirstDiscover = firstdiscover,
-                EdsmSync = true
-            };
+            return null;
+            //Debug.Assert(sys != null);
+
+            //Newtonsoft.Json.Linq.JObject evt = new Newtonsoft.Json.Linq.JObject();
+            //evt.Add("timestamp",new Newtonsoft.Json.J)
+
+            //return new HistoryEntry
+            //{
+            //    journalEntry = new JournalFSDJump(eventt),
+            //    EntryType = JournalTypeEnum.FSDJump,
+            //    System = sys,
+            //    EventTimeUTC = eventt,
+            //    EventSummary = "Jump to " + sys.Name,
+            //    EventDescription = dist,
+            //    EventDetailedInfo = info,
+            //    MapColour = m,
+            //    Journalid = journalid,
+            //    IsEDSMFirstDiscover = firstdiscover,
+            //    EdsmSync = true
+            //};
         }
 
         public static HistoryEntry FromJournalEntry(JournalEntry je, HistoryEntry prev, out bool journalupdate, SQLiteConnectionSystem conn = null, EDCommander cmdr = null)
@@ -260,20 +266,14 @@ namespace EliteDangerousCore
             HistoryEntry he = new HistoryEntry
             {
                 Indexno = indexno,
-                EntryType = je.EventTypeID,
-                Journalid = je.Id,
                 journalEntry = je,
                 System = isys,
-                EventTimeUTC = je.EventTimeUTC,
                 MapColour = mapcolour,
                 EdsmSync = je.SyncedEDSM,
                 EDDNSync = je.SyncedEDDN,
                 EGOSync = je.SyncedEGO,
                 StartMarker = je.StartMarker,
                 StopMarker = je.StopMarker,
-                EventSummary = summary,
-                EventDescription = info,
-                EventDetailedInfo = detailed,
                 IsStarPosFromEDSM = starposfromedsm,
                 IsEDSMFirstDiscover = firstdiscover,
                 Commander = cmdr ?? EDCommander.GetCommander(je.CommanderId)
@@ -415,10 +415,11 @@ namespace EliteDangerousCore
                 {
                     //Debug.WriteLine("Travelling stop at " + he.Indexno);
                     he.travelling = false;
-                    he.EventDetailedInfo += ((he.EventDetailedInfo.Length > 0) ? Environment.NewLine : "") + "Travelled " + he.travelled_distance.ToStringInvariant("0.0") + " LY"
-                                        + ", " + he.travelled_jumps + " jumps"
-                                        + ((he.travelled_missingjump > 0) ? ", " + he.travelled_missingjump + " unknown distance jumps" : "") +
-                                        ", time " + he.travelled_seconds;
+//TBD                    
+                    //he.EventDetailedInfo += ((he.EventDetailedInfo.Length > 0) ? Environment.NewLine : "") + "Travelled " + he.travelled_distance.ToStringInvariant("0.0") + " LY"
+                    //                    + ", " + he.travelled_jumps + " jumps"
+                    //                    + ((he.travelled_missingjump > 0) ? ", " + he.travelled_missingjump + " unknown distance jumps" : "") +
+                    //                    ", time " + he.travelled_seconds;
 
                     he.travelled_distance = 0;
                     he.travelled_seconds = new TimeSpan(0);
@@ -429,11 +430,13 @@ namespace EliteDangerousCore
 
                     if (he.IsFSDJump)
                     {
-                        he.EventDetailedInfo += ((he.EventDetailedInfo.Length > 0) ? Environment.NewLine : "") + "Travelling" +
-                                        " distance " + he.travelled_distance.ToString("0.0") + " LY"
-                                        + ", " + he.travelled_jumps + " jumps"
-                                        + ((he.travelled_missingjump > 0) ? ", " + he.travelled_missingjump + " unknown distance jumps" : "") +
-                                        ", time " + he.travelled_seconds;
+//TBD
+
+                        //he.EventDetailedInfo += ((he.EventDetailedInfo.Length > 0) ? Environment.NewLine : "") + "Travelling" +
+                        //                " distance " + he.travelled_distance.ToString("0.0") + " LY"
+                        //                + ", " + he.travelled_jumps + " jumps"
+                        //                + ((he.travelled_missingjump > 0) ? ", " + he.travelled_missingjump + " unknown distance jumps" : "") +
+                        //                ", time " + he.travelled_seconds;
                     }
                 }
             }

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -885,7 +885,7 @@ namespace EliteDangerousCore
                 {
                     if (MergeEntries(jprev, je))        // if we merge.. we may have updated info, so reprint.
                     {
-                        jprev.FillInformation(out prev.EventSummary, out prev.EventDescription, out prev.EventDetailedInfo);    // need to keep this up to date..
+                        //jprev.FillInformation(out prev.EventSummary, out prev.EventDescription, out prev.EventDetailedInfo);    // need to keep this up to date..
                         continue;
                     }
 

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -748,25 +748,17 @@ namespace EliteDangerousCore
             {
                 if (hs == he)
                 {
-                    if (he.StartMarker)
+                    if (he.StartMarker || he.StopMarker)
                     {
-                        JournalEntry.UpdateSyncFlagBit(hs.Journalid, SyncFlags.StartMarker, false);
-                        he.StartMarker = false;
-                    }
-                    else if (he.StopMarker)
-                    {
-                        JournalEntry.UpdateSyncFlagBit(hs.Journalid, SyncFlags.StopMarker, false);
-                        he.StopMarker = false;
+                        hs.journalEntry.UpdateSyncFlagBit(SyncFlags.StartMarker, false, SyncFlags.StopMarker, false);
                     }
                     else if (started == false)
                     {
-                        JournalEntry.UpdateSyncFlagBit(hs.Journalid, SyncFlags.StartMarker, true);
-                        he.StartMarker = true;
+                        hs.journalEntry.UpdateSyncFlagBit(SyncFlags.StartMarker, true, SyncFlags.StopMarker, false);
                     }
                     else
                     {
-                        JournalEntry.UpdateSyncFlagBit(hs.Journalid, SyncFlags.StopMarker, true);
-                        he.StopMarker = true;
+                        hs.journalEntry.UpdateSyncFlagBit(SyncFlags.StartMarker, false, SyncFlags.StopMarker, true);
                     }
 
                     break;
@@ -970,7 +962,7 @@ namespace EliteDangerousCore
                     shipyards.Process(je, conn);
                     outfitting.Process(je, conn);
 
-                    Tuple<ShipInformation, ModulesInStore> ret = shipinformationlist.Process(je, conn,he.WhereAmI, he.System);  // the ships
+                    Tuple<ShipInformation, ModulesInStore> ret = shipinformationlist.Process(je, conn, he.WhereAmI, he.System);  // the ships
                     he.ShipInformation = ret.Item1;
                     he.StoredModules = ret.Item2;
 

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -848,11 +848,9 @@ namespace EliteDangerousCore
                                     bool Keepuievents = true)
         {
             HistoryList hist = new HistoryList();
-            EDCommander cmdr = null;
 
             if (CurrentCommander >= 0)
             {
-                cmdr = EDCommander.GetCommander(CurrentCommander);
                 journalmonitor.ParseJournalFiles(() => cancelRequested(), (p, s) => reportProgress(p, s), forceReload: ForceJournalReload);   // Parse files stop monitor..
 
                 if (NetLogPath != null)
@@ -888,7 +886,7 @@ namespace EliteDangerousCore
                     }
 
                     bool journalupdate = false;
-                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, out journalupdate, conn, cmdr);
+                    HistoryEntry he = HistoryEntry.FromJournalEntry(je, prev, out journalupdate, conn);
 
                     prev = he;
                     jprev = je;

--- a/EliteDangerous/JournalEvents/JournalAfmuRepair.cs
+++ b/EliteDangerous/JournalEvents/JournalAfmuRepair.cs
@@ -48,9 +48,9 @@ namespace EliteDangerousCore.JournalEvents
         public bool FullyRepaired { get; set; }
         public float Health { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", ModuleLocalised, "Health:;%", (int)Health, ";Fully Repaired", FullyRepaired);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalApproachBody.cs
+++ b/EliteDangerous/JournalEvents/JournalApproachBody.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
         public string BodyType { get { return "Planet"; } }
         public string BodyDesignation { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Body;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalApproachSettlement.cs
+++ b/EliteDangerous/JournalEvents/JournalApproachSettlement.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name_Localised { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Name_Localised;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalBounty.cs
+++ b/EliteDangerous/JournalEvents/JournalBounty.cs
@@ -61,9 +61,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, n);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("; cr;N0", TotalReward, "Target:", (string)Target, "Victim faction:", VictimFactionLocalised);
 
             detailed = "";

--- a/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
+++ b/EliteDangerous/JournalEvents/JournalBuyAmmo.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, "", -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("; cr;N0", Cost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalBuyDrones.cs
+++ b/EliteDangerous/JournalEvents/JournalBuyDrones.cs
@@ -44,9 +44,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Type + " " + Count + " drones", -TotalCost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Type:", Type, "Count:", Count, "Total Cost:; cr;N0", TotalCost, "each:; cr;N0", BuyPrice);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
+++ b/EliteDangerous/JournalEvents/JournalBuyExplorationData.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, System, -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("System:", System, "Cost:; cr;N0", Cost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
+++ b/EliteDangerous/JournalEvents/JournalBuyTradeData.cs
@@ -40,9 +40,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, System, -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("System:", System, "Cost:; cr;N0", Cost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCapShipBond.cs
+++ b/EliteDangerous/JournalEvents/JournalCapShipBond.cs
@@ -50,9 +50,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, AwardingFaction_Localised.Alt(AwardingFaction) + " " + Reward);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("; cr;N0", Reward, "< from ", AwardingFaction_Localised.Alt(AwardingFaction),
                 "< , due to ", VictimFaction_Localised.Alt(VictimFaction));
             detailed = "";

--- a/EliteDangerous/JournalEvents/JournalCargo.cs
+++ b/EliteDangerous/JournalEvents/JournalCargo.cs
@@ -57,9 +57,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public Cargo[] Inventory { get; set; }      // may be NULL
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "No Cargo";
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalCargoDepot.cs
+++ b/EliteDangerous/JournalEvents/JournalCargoDepot.cs
@@ -67,9 +67,9 @@ namespace EliteDangerousCore.JournalEvents
                 mc.Change(MaterialCommodities.CommodityCategory, CargoType, (UpdateEnum == UpdateTypeEnum.Collect) ? Count : -Count, 0, conn);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             if (UpdateEnum == UpdateTypeEnum.Collect)
             {
                 info = BaseUtils.FieldBuilder.Build("Collected:", Count, "< of " , FriendlyCargoType, "Total:", ItemsDelivered, "To Go:", ItemsToGo, "Progress:;%;N1", ProgressPercent);

--- a/EliteDangerous/JournalEvents/JournalChangeCrewRole.cs
+++ b/EliteDangerous/JournalEvents/JournalChangeCrewRole.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Role { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Role;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalClearSavedGame.cs
+++ b/EliteDangerous/JournalEvents/JournalClearSavedGame.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Name { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Name;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCockpitBreached.cs
+++ b/EliteDangerous/JournalEvents/JournalCockpitBreached.cs
@@ -28,9 +28,9 @@ namespace EliteDangerousCore.JournalEvents
 
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCollectCargo.cs
+++ b/EliteDangerous/JournalEvents/JournalCollectCargo.cs
@@ -49,9 +49,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, FriendlyType );
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Type_Localised, ";Stolen", Stolen);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCommander.cs
+++ b/EliteDangerous/JournalEvents/JournalCommander.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Name { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cmdr ", Name);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCommitCrime.cs
+++ b/EliteDangerous/JournalEvents/JournalCommitCrime.cs
@@ -62,9 +62,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, CrimeType + " on " + v);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", CrimeType, "< on faction ", Faction, "Against ", VictimLocalised, "Cost ; cr;N0", Fine, "Bounty ; cr;N0", Bounty);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCommunityGoal.cs
+++ b/EliteDangerous/JournalEvents/JournalCommunityGoal.cs
@@ -129,9 +129,9 @@ namespace EliteDangerousCore.JournalEvents
         public List<CommunityGoal> CommunityGoals;
         public string CommunityGoalList;
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = CommunityGoalList;
             detailed = "";
             if ( CommunityGoals!=null )

--- a/EliteDangerous/JournalEvents/JournalCommunityGoalDiscard.cs
+++ b/EliteDangerous/JournalEvents/JournalCommunityGoalDiscard.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name { get; set; }
         public string System { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name, "< at ; Star System", System);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCommunityGoalJoin.cs
+++ b/EliteDangerous/JournalEvents/JournalCommunityGoalJoin.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name { get; set; }
         public string System { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name, "< at ; Star System", System);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
+++ b/EliteDangerous/JournalEvents/JournalCommunityGoalReward.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Name + " " + System, Reward);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name, "< at ; Star System", System, "Reward ; cr;N0", Reward);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalContinued.cs
+++ b/EliteDangerous/JournalEvents/JournalContinued.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public int Part { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Part.ToString();
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewAssign.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewAssign.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name { get; set; }
         public string Role { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name, "< to role ;", Role);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewFire.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewFire.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
         public long NpcCrewID { get; set; }
         public string Name { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("; fired", Name);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewHire.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewHire.cs
@@ -47,9 +47,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Name + " " + Faction, -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Hired ;", Name, "< of faction ", Faction, " Rank ", CombatRank.ToString().SplitCapsWord(), "Cost ; cr;N0", Cost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewLaunchFighter.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewLaunchFighter.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Crew { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Crew;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewMemberJoins.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewMemberJoins.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Crew { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Crew;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewMemberQuits.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewMemberQuits.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Crew { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Crew;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalCrewMemberRoleChange.cs
+++ b/EliteDangerous/JournalEvents/JournalCrewMemberRoleChange.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Crew { get; set; }
         public string Role { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             //info = Crew;
             info = BaseUtils.FieldBuilder.Build("Crew:", Crew, "Role:", Role);
             detailed = "";

--- a/EliteDangerous/JournalEvents/JournalDataScanned.cs
+++ b/EliteDangerous/JournalEvents/JournalDataScanned.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Type { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Type;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDatalinkScan.cs
+++ b/EliteDangerous/JournalEvents/JournalDatalinkScan.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Message { get; set; }
         public string MessageLocalised { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = MessageLocalised;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
+++ b/EliteDangerous/JournalEvents/JournalDatalinkVoucher.cs
@@ -42,9 +42,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, PayeeFaction + " " + Reward.ToString("N0"));
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Reward ; cr;N0", Reward, "< from faction ", PayeeFaction, "against ", VictimFaction);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDied.cs
+++ b/EliteDangerous/JournalEvents/JournalDied.cs
@@ -83,9 +83,9 @@ namespace EliteDangerousCore.JournalEvents
         }
 
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             if (Killers != null)
             {

--- a/EliteDangerous/JournalEvents/JournalDiscoveryScan.cs
+++ b/EliteDangerous/JournalEvents/JournalDiscoveryScan.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
         public long SystemAddress { get; set; }
         public int Bodies { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("New bodies discovered:", Bodies);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDockFighter.cs
+++ b/EliteDangerous/JournalEvents/JournalDockFighter.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.DockFighter();
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDockSRV.cs
+++ b/EliteDangerous/JournalEvents/JournalDockSRV.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.DockSRV();
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDocked.cs
+++ b/EliteDangerous/JournalEvents/JournalDocked.cs
@@ -110,9 +110,10 @@ namespace EliteDangerousCore.JournalEvents
             public double Proportion;
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)      //V
+        public override string FillSummary { get { return $"At {StationName}"; } }
+
+        public override void FillInformation(out string info, out string detailed)      //V
         {
-            summary = $"At {StationName}";
             info = BaseUtils.FieldBuilder.Build("Type ", StationType, "< in system ", StarSystem, ";Wanted" , Wanted, "Faction:", Faction, "< in state ", FactionState);
             detailed = BaseUtils.FieldBuilder.Build("Allegiance:", Allegiance, "Economy:", Economy_Localised, "Government:", Government_Localised);
 

--- a/EliteDangerous/JournalEvents/JournalDockingCancelled.cs
+++ b/EliteDangerous/JournalEvents/JournalDockingCancelled.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationType { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = StationName;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDockingDenied.cs
+++ b/EliteDangerous/JournalEvents/JournalDockingDenied.cs
@@ -40,9 +40,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationType { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("At ", StationName, "", Reason);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDockingGranted.cs
+++ b/EliteDangerous/JournalEvents/JournalDockingGranted.cs
@@ -34,9 +34,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationType { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("At ", StationName, "< on pad ", LandingPad);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDockingRequested.cs
+++ b/EliteDangerous/JournalEvents/JournalDockingRequested.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationType { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = StationName;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalDockingTimeout.cs
+++ b/EliteDangerous/JournalEvents/JournalDockingTimeout.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationType { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = StationName;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalEDDCommodityPrices.cs
+++ b/EliteDangerous/JournalEvents/JournalEDDCommodityPrices.cs
@@ -58,9 +58,9 @@ namespace EliteDangerousCore.JournalEvents
         public long? MarketID { get; set; }
         public List<CCommodities> Commodities { get; protected set; }   // never null
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Prices on ; items", Commodities.Count, "< at " , Station , "< in " , StarSystem);
 
             int col = 0;

--- a/EliteDangerous/JournalEvents/JournalEDDItemSet.cs
+++ b/EliteDangerous/JournalEvents/JournalEDDItemSet.cs
@@ -46,9 +46,9 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             bool comma = false;
             if (Materials != null)

--- a/EliteDangerous/JournalEvents/JournalEjectCargo.cs
+++ b/EliteDangerous/JournalEvents/JournalEjectCargo.cs
@@ -58,9 +58,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, FriendlyType + " " + Count);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Type_Localised, "Count:", Count, ";Abandoned", Abandoned, "PowerPlay:", PowerplayOrigin);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalEndCrewSession.cs
+++ b/EliteDangerous/JournalEvents/JournalEndCrewSession.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public bool OnCrime { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build(";Crime", OnCrime);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalEngineerApply.cs
+++ b/EliteDangerous/JournalEvents/JournalEngineerApply.cs
@@ -40,9 +40,9 @@ namespace EliteDangerousCore.JournalEvents
         public int Level { get; set; }
         public string Override { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Engineer, "Blueprint:", Blueprint, "Level:", Level, "Override:", Override);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalEngineerContribution.cs
+++ b/EliteDangerous/JournalEvents/JournalEngineerContribution.cs
@@ -81,9 +81,9 @@ namespace EliteDangerousCore.JournalEvents
 
         protected override JournalTypeEnum IconEventType { get { return unknownType ? JournalTypeEnum.EngineerContribution_Unknown : JournalTypeEnum.EngineerContribution_MatCommod; } }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             if (unknownType==true)
                 info = "Report to EDDiscovery team an unknown EngineerContribution type: " + Type;
              else

--- a/EliteDangerous/JournalEvents/JournalEngineerCraft.cs
+++ b/EliteDangerous/JournalEvents/JournalEngineerCraft.cs
@@ -100,9 +100,9 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("In ", Slot , "" , Module, "By ", Engineering.Engineer, "Blueprint ", Engineering.FriendlyBlueprintName, "Level ", Engineering.Level);
 
             detailed = "";

--- a/EliteDangerous/JournalEvents/JournalEngineerProgress.cs
+++ b/EliteDangerous/JournalEvents/JournalEngineerProgress.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Progress { get; set; }
         public int? Rank { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Engineer, "Rank:", Rank, "Progress:", Progress);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalEscapeInterdiction.cs
+++ b/EliteDangerous/JournalEvents/JournalEscapeInterdiction.cs
@@ -34,9 +34,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Interdictor { get; set; }
         public bool IsPlayer { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("By ", Interdictor, "< (NPC);(Player)", IsPlayer);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -13,9 +13,11 @@
  *
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EliteDangerousCore.DB;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Drawing;
 using System.Linq;
 using System.Text;
@@ -128,6 +130,12 @@ Examples of trending states:
             EDSMFirstDiscover = evt["EDD_EDSMFirstDiscover"].Bool(false);
         }
 
+        public JournalFSDJump(DateTime utc, ISystem sys, int colour, bool first, int synced) : base(utc, sys, synced, JournalTypeEnum.FSDJump)
+        {
+            MapColor = colour;
+            EDSMFirstDiscover = first;
+        }
+
         public double JumpDist { get; set; }
         public double FuelUsed { get; set; }
         public double FuelLevel { get; set; }
@@ -137,9 +145,10 @@ Examples of trending states:
         public bool RealJournalEvent { get; private set; } // True if real ED 2.2+ journal event and not pre 2.2 imported.
         public bool EDSMFirstDiscover { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override string FillSummary { get { return "Jump to " + StarSystem; } }
+
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = "Jump to " + StarSystem;
             info = "";
             if (JumpDist > 0)
                 info += JumpDist.ToString("0.00") + " ly";
@@ -185,5 +194,45 @@ Examples of trending states:
         {
             shp.FSDJump(this);
         }
+
+        public void UpdateMapColour(int mapcolour)
+        {
+            using (SQLiteConnectionUser cn = new SQLiteConnectionUser(utc: true))
+            {
+                JObject jo = GetJson(Id, cn);
+
+                if (jo != null)
+                {
+                    jo["EDDMapColor"] = mapcolour;
+                    UpdateJsonEntry(jo, cn);
+                    MapColor = mapcolour;
+                }
+            }
+        }
+
+        public void UpdateFirstDiscover(bool value, SQLiteConnectionUser cn = null, DbTransaction txnl = null)
+        {
+            JObject jo = GetJson(Id,cn,txnl);
+
+            if (jo != null)
+            {
+                jo["EDD_EDSMFirstDiscover"] = value;
+                UpdateJsonEntry(jo, cn, txnl);
+                EDSMFirstDiscover = value;
+            }
+        }
+
+        public JObject CreateFSDJournalEntryJson()          // minimal version, not the whole schebang
+        {
+            JObject jo = new JObject();
+            jo["timestamp"] = EventTimeUTC.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'");
+            jo["event"] = "FSDJump";
+            jo["StarSystem"] = StarSystem;
+            jo["StarPos"] = new JArray(StarPos.X, StarPos.Y, StarPos.Z);
+            jo["EDDMapColor"] = MapColor;
+            jo["EDD_EDSMFirstDiscover"] = EDSMFirstDiscover;
+            return jo;
+        }
+
     }
 }

--- a/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
+++ b/EliteDangerous/JournalEvents/JournalFactionKillBond.cs
@@ -46,9 +46,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, AwardingFaction_Localised.Alt(AwardingFaction) + " " + Reward.ToString("N0"));
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Reward:;N0", Reward, "< from ", AwardingFaction_Localised.Alt(AwardingFaction),
                 "< , due to ", VictimFaction_Localised.Alt(VictimFaction));
             detailed = "";

--- a/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
+++ b/EliteDangerous/JournalEvents/JournalFetchRemoteModule.cs
@@ -65,9 +65,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, StoredItemLocalised + " on " + Ship, -TransferCost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", StoredItemLocalised, "Cost:", TransferCost, "into ship:", Ship, "Transfer Time:", FriendlyTransferTime);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalFighterDestroyed.cs
+++ b/EliteDangerous/JournalEvents/JournalFighterDestroyed.cs
@@ -26,9 +26,9 @@ namespace EliteDangerousCore.JournalEvents
         {
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalFighterRebuilt.cs
+++ b/EliteDangerous/JournalEvents/JournalFighterRebuilt.cs
@@ -29,9 +29,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Loadout { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Loadout);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalFileheader.cs
+++ b/EliteDangerous/JournalEvents/JournalFileheader.cs
@@ -51,9 +51,9 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Version:", GameVersion , "Build:" , Build , "Part:", Part);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalFriends.cs
+++ b/EliteDangerous/JournalEvents/JournalFriends.cs
@@ -58,9 +58,9 @@ namespace EliteDangerousCore.JournalEvents
         public int OnlineCount { get; set; }        // always counts
         public int OfflineCount { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             detailed = "";
 
             if (StatusList != null)

--- a/EliteDangerous/JournalEvents/JournalFuelScope.cs
+++ b/EliteDangerous/JournalEvents/JournalFuelScope.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         public double Scooped { get; set; }
         public double Total { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build(";t;0.0" , Scooped, "Total:;t;0.0" , Total);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalHeatDamage.cs
+++ b/EliteDangerous/JournalEvents/JournalHeatDamage.cs
@@ -30,9 +30,9 @@ namespace EliteDangerousCore.JournalEvents
         {
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalHeatWarning.cs
+++ b/EliteDangerous/JournalEvents/JournalHeatWarning.cs
@@ -27,9 +27,9 @@ namespace EliteDangerousCore.JournalEvents
         {
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalHullDamage.cs
+++ b/EliteDangerous/JournalEvents/JournalHullDamage.cs
@@ -30,9 +30,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public double Health { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build(";%",(int)(Health*100));
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalInterdicted.cs
+++ b/EliteDangerous/JournalEvents/JournalInterdicted.cs
@@ -47,9 +47,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Faction { get; set; }
         public string Power { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build(";Submitted", Submitted, "< To ", Interdictor, "< (NPC);(Player)", IsPlayer, "Rank:", CombatRank.ToString().SplitCapsWord(), "Faction:", Faction, "Power:", Power);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalInterdiction.cs
+++ b/EliteDangerous/JournalEvents/JournalInterdiction.cs
@@ -47,9 +47,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Faction { get; set; }
         public string Power { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Failed to interdict;Interdicted", Success, "< ", Interdicted, "< (NPC);(Player)", IsPlayer, "Rank:", CombatRank.ToString().SplitCapsWord(), "Faction:", Faction, "Power:", Power);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalJetConeBoost.cs
+++ b/EliteDangerous/JournalEvents/JournalJetConeBoost.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public double BoostValue { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Boost:;;0.0", BoostValue);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalJetConeDamage.cs
+++ b/EliteDangerous/JournalEvents/JournalJetConeDamage.cs
@@ -38,9 +38,9 @@ namespace EliteDangerousCore.JournalEvents
         public string ModuleFD { get; set; }
         public string ModuleLocalised { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = ModuleLocalised;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalJoinACrew.cs
+++ b/EliteDangerous/JournalEvents/JournalJoinACrew.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Captain { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Captain:" , Captain);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalKickCrewMember.cs
+++ b/EliteDangerous/JournalEvents/JournalKickCrewMember.cs
@@ -34,9 +34,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Crew { get; set; }
         public bool OnCrime { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("; removed", Crew , "; Crime", OnCrime);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalLaunchDrone.cs
+++ b/EliteDangerous/JournalEvents/JournalLaunchDrone.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Type { get; set; }
         public string FriendlyType { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Type:", FriendlyType);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalLaunchFighter.cs
+++ b/EliteDangerous/JournalEvents/JournalLaunchFighter.cs
@@ -38,9 +38,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.LaunchFighter(PlayerControlled);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Loadout:", Loadout);
             if (!PlayerControlled)
                 info += ", NPC Controlled";

--- a/EliteDangerous/JournalEvents/JournalLaunchSRV.cs
+++ b/EliteDangerous/JournalEvents/JournalLaunchSRV.cs
@@ -38,9 +38,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.LaunchSRV();
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Loadout:", Loadout);
             if (!PlayerControlled)
                 info += ", NPC Controlled";

--- a/EliteDangerous/JournalEvents/JournalLeaveBody.cs
+++ b/EliteDangerous/JournalEvents/JournalLeaveBody.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
         public string BodyDesignation { get; set; }
         public string BodyType { get { return "Planet"; } }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Body;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalLiftoff.cs
+++ b/EliteDangerous/JournalEvents/JournalLiftoff.cs
@@ -38,9 +38,9 @@ namespace EliteDangerousCore.JournalEvents
         public double Longitude { get; set; }
         public bool? PlayerControlled { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = JournalFieldNaming.RLat(Latitude) + " " + JournalFieldNaming.RLong(Longitude) + BaseUtils.FieldBuilder.Build(", NPC Controlled;", PlayerControlled);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalLoadGame.cs
+++ b/EliteDangerous/JournalEvents/JournalLoadGame.cs
@@ -64,9 +64,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public bool? Horizons { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cmdr ", LoadGameCommander, "Ship:", Ship, "Name:", ShipName, "Ident:", ShipIdent, "Credits:;;N0", Credits);
             detailed = BaseUtils.FieldBuilder.Build("Mode:", GameMode , "Group:" , Group , "Not Landed;Landed" , StartLanded , "Fuel Level:;;0.0", FuelLevel , "Capacity:;;0.0" , FuelCapacity);
         }

--- a/EliteDangerous/JournalEvents/JournalLoadout.cs
+++ b/EliteDangerous/JournalEvents/JournalLoadout.cs
@@ -90,9 +90,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.Loadout(ShipId, Ship, ShipFD, ShipName, ShipIdent, ShipModules, HullValue?? 0, ModulesValue ?? 0, Rebuy ?? 0);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Ship:", Ship, "Name:", ShipName, "Ident:", ShipIdent, "Modules:", ShipModules.Count , "Hull:; cr;N0", HullValue , "Modules:; cr;N0" , ModulesValue , "Rebuy:; cr;N0", Rebuy);
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalLocOrJump.cs
+++ b/EliteDangerous/JournalEvents/JournalLocOrJump.cs
@@ -71,6 +71,13 @@ namespace EliteDangerousCore.JournalEvents
             public int Trend { get; set; }
         }
 
+        protected JournalLocOrJump(DateTime utc, ISystem sys, int synced, JournalTypeEnum jtype) : base(utc, synced, jtype)
+        {
+            StarSystem = sys.Name;
+            StarPos = new EMK.LightGeometry.Vector3((float)sys.X, (float)sys.Y, (float)sys.Z);
+            EdsmID = sys.EDSMID;
+        }
+
         protected JournalLocOrJump(JObject evt, JournalTypeEnum jtype) : base(evt, jtype)
         {
             StarSystem = evt["StarSystem"].Str();

--- a/EliteDangerous/JournalEvents/JournalLocation.cs
+++ b/EliteDangerous/JournalEvents/JournalLocation.cs
@@ -68,11 +68,20 @@ namespace EliteDangerousCore.JournalEvents
 
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override string FillSummary { get
+            {
+                if (Docked)
+                    return "At " + StationName;
+                else if (Latitude.HasValue && Longitude.HasValue)
+                    return "Landed on " + Body;
+                else
+                    return "At " + StarSystem;
+            } }
+
+        public override void FillInformation(out string info, out string detailed) //V
         {
             if (Docked)
             {
-                summary = "At " + StationName;
                 info = BaseUtils.FieldBuilder.Build("Type ", StationType, "< in system ", StarSystem);
                 detailed = BaseUtils.FieldBuilder.Build(";Wanted", Wanted, "Allegiance:", Allegiance, "Economy:", Economy_Localised, "Government:", Government_Localised, "Security:", Security_Localised);
 
@@ -101,13 +110,11 @@ namespace EliteDangerousCore.JournalEvents
             }
             else if (Latitude.HasValue && Longitude.HasValue)
             {
-                summary = "Landed on " + Body;
                 info = "At " + JournalFieldNaming.RLat(Latitude.Value) + " " + JournalFieldNaming.RLong(Longitude.Value);
                 detailed = "";
             }
             else
             {
-                summary = "At " + StarSystem;
                 info = BaseUtils.FieldBuilder.Build("In space near ", Body, "< of type ", BodyType);
                 detailed = "";
             }

--- a/EliteDangerous/JournalEvents/JournalMarketBuy.cs
+++ b/EliteDangerous/JournalEvents/JournalMarketBuy.cs
@@ -57,9 +57,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, FriendlyType + " " + Count,-TotalCost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Type_Localised, "", Count, "< at ; cr;N0", BuyPrice, "Total:; cr;N0", TotalCost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalMarketSell.cs
+++ b/EliteDangerous/JournalEvents/JournalMarketSell.cs
@@ -70,9 +70,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, FriendlyType + " " + Count + " Avg " + AvgPricePaid, TotalSale, (double)(SellPrice - AvgPricePaid));
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             long profit = TotalSale - (AvgPricePaid * Count);
             info = BaseUtils.FieldBuilder.Build("", Type_Localised, "", Count, "< at ; cr;N0", SellPrice, "Total:; cr;N0", TotalSale, "Profit:; cr;N0", profit);
             detailed = BaseUtils.FieldBuilder.Build("Legal;Illegal", IllegalGoods, "Not Stolen;Stolen", StolenGoods, "Market;BlackMarket", BlackMarket);

--- a/EliteDangerous/JournalEvents/JournalMassModuleStore.cs
+++ b/EliteDangerous/JournalEvents/JournalMassModuleStore.cs
@@ -62,9 +62,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.MassModuleStore(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Total modules:", ModuleItems?.Count());
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialCollected.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
             mc.Change(Category, Name, Count, 0, conn);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", FriendlyName, "< ; items", Count);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialDiscarded.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
             mc.Change(Category, Name, -Count, 0, conn);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", FriendlyName, "< ; items", Count);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialDiscovered.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
         public string FriendlyName { get; set; }
         public int DiscoveryNumber { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", FriendlyName);
             if (DiscoveryNumber > 0)
                 info += ", Discovery " + DiscoveryNumber.ToStringInvariant();

--- a/EliteDangerous/JournalEvents/JournalMaterialTrade.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterialTrade.cs
@@ -73,9 +73,9 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = detailed = "";
 
             if (Paid != null && Received != null)

--- a/EliteDangerous/JournalEvents/JournalMaterials.cs
+++ b/EliteDangerous/JournalEvents/JournalMaterials.cs
@@ -69,9 +69,9 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
             if (Raw != null && Raw.Length>0)

--- a/EliteDangerous/JournalEvents/JournalMiningRefined.cs
+++ b/EliteDangerous/JournalEvents/JournalMiningRefined.cs
@@ -47,9 +47,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEventNoCash(Id, EventTimeUTC, EventTypeID, FriendlyType );
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Type_Localised;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalMissionAbandoned.cs
+++ b/EliteDangerous/JournalEvents/JournalMissionAbandoned.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public int MissionId { get; set; }
         public long? Fine { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name, "Fine:", Fine);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalMissionAccepted.cs
+++ b/EliteDangerous/JournalEvents/JournalMissionAccepted.cs
@@ -121,9 +121,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public bool? Wing { get; set; }     // 3.02
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
 
             DateTime exp = Expiry;
             if (exp != null && !EliteConfigInstance.InstanceConfig.DisplayUTC)

--- a/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
+++ b/EliteDangerous/JournalEvents/JournalMissionCompleted.cs
@@ -147,9 +147,9 @@ namespace EliteDangerousCore.JournalEvents
             mlist.Completed(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name,
                                         "< from ", Faction,
                                         "Reward:; cr;N0", Reward,

--- a/EliteDangerous/JournalEvents/JournalMissionFailed.cs
+++ b/EliteDangerous/JournalEvents/JournalMissionFailed.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public int MissionId { get; set; }
         public long? Fine { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Name,"Fine:",Fine);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalMissionRedirected.cs
+++ b/EliteDangerous/JournalEvents/JournalMissionRedirected.cs
@@ -50,9 +50,9 @@ namespace EliteDangerousCore.JournalEvents
         public int MissionId { get; set; }
         public string Name { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = info = BaseUtils.FieldBuilder.Build("Mission name:", Name,
                                       "From:", OldDestinationSystem,
                                       "", OldDestinationStation,

--- a/EliteDangerous/JournalEvents/JournalMissions.cs
+++ b/EliteDangerous/JournalEvents/JournalMissions.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
         public MissionItem[] FailedMissions { get; set; }
         public MissionItem[] CompletedMissions { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalModuleBuy.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleBuy.cs
@@ -91,9 +91,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ModuleBuy(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", BuyItemLocalised, "< into ", Slot, "Cost:; cr;N0", BuyPrice);
             if (SellItem.Length > 0)
                 info += ", " + BaseUtils.FieldBuilder.Build("Sold:", SellItemLocalised, "Price:; cr;N0", SellPrice);

--- a/EliteDangerous/JournalEvents/JournalModuleInfo.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleInfo.cs
@@ -85,9 +85,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public List<ShipModule> ShipModules;
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Modules:", ShipModules.Count);
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleRetrieve.cs
@@ -88,9 +88,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ModuleRetrieve(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", RetrievedItemLocalised, "< into ", Slot ,";Hot!", Hot );
             if ( Cost>0)
                 info += " " + BaseUtils.FieldBuilder.Build("Cost:; cr;N0", Cost);

--- a/EliteDangerous/JournalEvents/JournalModuleSell.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleSell.cs
@@ -67,9 +67,9 @@ namespace EliteDangerousCore.JournalEvents
         {
             shp.ModuleSell(this);
         }
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", SellItemLocalised, "< from ", Slot, "Price:; cr;N0", SellPrice);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleSellRemote.cs
@@ -65,9 +65,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ModuleSellRemote(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Item:", SellItemLocalised, "Price:; cr;N0", SellPrice);
             detailed = BaseUtils.FieldBuilder.Build("Ship:", Ship);
         }

--- a/EliteDangerous/JournalEvents/JournalModuleStore.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleStore.cs
@@ -87,9 +87,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ModuleStore(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", StoredItemLocalised, "< from ", Slot , ";Hot!", Hot, "Cost:" , Cost);
             if (ReplacementItem.Length > 0)
                 info = ", " + BaseUtils.FieldBuilder.Build("Replaced by:", ReplacementItemLocalised);

--- a/EliteDangerous/JournalEvents/JournalModuleSwap.cs
+++ b/EliteDangerous/JournalEvents/JournalModuleSwap.cs
@@ -73,9 +73,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ModuleSwap(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("From ", FromSlot , "< to " , ToSlot , "Item:" , FromItemLocalised);
             if (ToItem.Length > 0 )                         
                 info += ", Swapped with " + ToItemLocalised;

--- a/EliteDangerous/JournalEvents/JournalMusic.cs
+++ b/EliteDangerous/JournalEvents/JournalMusic.cs
@@ -51,9 +51,9 @@ Note: Other music track names may be used in future
         public string MusicTrack { get; set; }
         public EDMusicTrackEnum MusicTrackID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("MusicTrack:", MusicTrack);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalNavBeaconScan.cs
+++ b/EliteDangerous/JournalEvents/JournalNavBeaconScan.cs
@@ -37,9 +37,9 @@ namespace EliteDangerousCore.JournalEvents
         public int NumBodies { get; set; }           
         public long? SystemAddress{ get; set; }            
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Bodies:", NumBodies);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalNewCommander.cs
+++ b/EliteDangerous/JournalEvents/JournalNewCommander.cs
@@ -34,9 +34,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name { get; set; }
         public string Package { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cmdr ", Name , "Starting Package:", Package); 
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalNpcCrewPaidWage.cs
+++ b/EliteDangerous/JournalEvents/JournalNpcCrewPaidWage.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name { get; set; }
         public long Amount { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("<", Name , "; Cr" , Amount);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalNpcCrewRank.cs
+++ b/EliteDangerous/JournalEvents/JournalNpcCrewRank.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Name { get; set; }
         public CombatRank RankCombat { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("<", Name, "Rank:", RankCombat.ToString().SplitCapsWord());
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalOutfitting.cs
+++ b/EliteDangerous/JournalEvents/JournalOutfitting.cs
@@ -63,9 +63,9 @@ namespace EliteDangerousCore.JournalEvents
         public bool? Horizons { get; set; }
         public bool? AllowCobraMkIV { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalPVPKill.cs
+++ b/EliteDangerous/JournalEvents/JournalPVPKill.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Victim { get; set; }
         public CombatRank CombatRank { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",Victim, "Rank:" , CombatRank.ToString().SplitCapsWord());
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPassengers.cs
+++ b/EliteDangerous/JournalEvents/JournalPassengers.cs
@@ -66,9 +66,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public Passengers[] Manifest { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //U
+        public override void FillInformation(out string info, out string detailed) //U
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "No Passengers";
 
             if (Manifest != null && Manifest.Length > 0)

--- a/EliteDangerous/JournalEvents/JournalPayBounties.cs
+++ b/EliteDangerous/JournalEvents/JournalPayBounties.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, (Faction_Localised.Length > 0 ? "Faction " + Faction_Localised : "") + " Broker " + BrokerPercentage.ToString("0.0") + "%", -Amount);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cost:; cr;N0", Amount, "< To ", Faction_Localised);
             if (BrokerPercentage > 0)
                 info += ", Broker took " + BrokerPercentage.ToString("0") + "%";

--- a/EliteDangerous/JournalEvents/JournalPayFines.cs
+++ b/EliteDangerous/JournalEvents/JournalPayFines.cs
@@ -47,9 +47,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, (Faction_Localised.Length > 0 ? "Faction " + Faction_Localised : "") + " Broker " + BrokerPercentage.ToString("0.0") + "%", -Amount);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cost:; cr;N0", Amount, "< To ", Faction_Localised);
             if (BrokerPercentage > 0)
                 info += ", Broker took " + BrokerPercentage.ToString("0") + "%";

--- a/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
+++ b/EliteDangerous/JournalEvents/JournalPayLegacyFines.cs
@@ -38,9 +38,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, "Broker " + BrokerPercentage.ToString("0.0") + "%", -Amount);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cost:; cr;N0", Amount);
             if (BrokerPercentage > 0)
                 info += ", Broker took " + BrokerPercentage.ToString("0") + "%";

--- a/EliteDangerous/JournalEvents/JournalPowerplay.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplay.cs
@@ -45,9 +45,9 @@ namespace EliteDangerousCore.JournalEvents
         public TimeSpan TimePledgedSpan { get; set; }
         public string TimePledgedString { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Power, "Rank:", Rank, "Merits:", Merits, "Votes:", Votes, "Pledged:" , TimePledgedString);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayCollect.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayCollect.cs
@@ -37,9 +37,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Type { get; set; }
         public int Count { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Power, "Type:", Type, "Count:", Count);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayDefect.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayDefect.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string FromPower { get; set; }
         public string ToPower { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("From:", FromPower, "To:", ToPower);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayDeliver.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayDeliver.cs
@@ -37,9 +37,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Type { get; set; }
         public int Count { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Power, "Type:", Type, "Count:", Count);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayFastTrack.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Power, -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Power, "Cost:; cr;N0", Cost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayJoin.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayJoin.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Power { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Power;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayLeave.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayLeave.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Power { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)      //V
+        public override void FillInformation(out string info, out string detailed)      //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Power;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplaySalary.cs
@@ -38,9 +38,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Power, Amount);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Power, "Amount:; cr;N0", Amount);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayVote.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayVote.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
         public string System { get; set; }
         public int Votes { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Power, "System:", System, "Votes:", Votes);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalPowerplayVoucher.cs
+++ b/EliteDangerous/JournalEvents/JournalPowerplayVoucher.cs
@@ -34,9 +34,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Power { get; set; }
         public string[] Systems { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Power;
             if ( Systems!=null)
             {

--- a/EliteDangerous/JournalEvents/JournalProgress.cs
+++ b/EliteDangerous/JournalEvents/JournalProgress.cs
@@ -47,9 +47,9 @@ namespace EliteDangerousCore.JournalEvents
         public int Federation { get; set; }
         public int CQC { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Combat:;%", Combat,
                                       "Trade:;%", Trade,
                                       "Exploration:;%", Explore,

--- a/EliteDangerous/JournalEvents/JournalPromotion.cs
+++ b/EliteDangerous/JournalEvents/JournalPromotion.cs
@@ -62,9 +62,9 @@ namespace EliteDangerousCore.JournalEvents
         public FederationRank? Federation { get; set; }
         public EmpireRank? Empire { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Combat:", Combat.HasValue ? Combat.ToString() : null,
                                       "Trade:", Trade.HasValue ? Trade.ToString() : null,
                                       "Exploration:", Explore.HasValue ? Explore.ToString() : null,

--- a/EliteDangerous/JournalEvents/JournalQuitACrew.cs
+++ b/EliteDangerous/JournalEvents/JournalQuitACrew.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string Captain { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Captain:",Captain);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRank.cs
+++ b/EliteDangerous/JournalEvents/JournalRank.cs
@@ -55,9 +55,9 @@ namespace EliteDangerousCore.JournalEvents
         public FederationRank Federation { get; set; }
         public CQCRank CQC { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Combat.ToString().SplitCapsWord(),
                                       "", Trade.ToString().SplitCapsWord(),
                                       "", Explore.ToString().SplitCapsWord(),

--- a/EliteDangerous/JournalEvents/JournalRebootRepair.cs
+++ b/EliteDangerous/JournalEvents/JournalRebootRepair.cs
@@ -40,9 +40,9 @@ namespace EliteDangerousCore.JournalEvents
         public string[] Slots { get; set; }
         public string[] FriendlySlots { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             if (FriendlySlots != null)
                 info = string.Join(",", FriendlySlots);

--- a/EliteDangerous/JournalEvents/JournalReceiveText.cs
+++ b/EliteDangerous/JournalEvents/JournalReceiveText.cs
@@ -41,9 +41,9 @@ namespace EliteDangerousCore.JournalEvents
         public string MessageLocalised { get; set; }
         public string Channel { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("From:", FromLocalised, "Msg:", MessageLocalised, "Channel:", Channel);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
+++ b/EliteDangerous/JournalEvents/JournalRedeemVoucher.cs
@@ -44,9 +44,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Type + " Broker " + BrokerPercentage.ToString("0.0") + "%", Amount);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)      //V
+        public override void FillInformation(out string info, out string detailed)      //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Type:" , Type , "Amount:; cr;N0", Amount, "Faction:" , Faction);
             if (BrokerPercentage > 0)
                 info += ", Broker took " + BrokerPercentage.ToString("0") + "%";

--- a/EliteDangerous/JournalEvents/JournalRefuelAll.cs
+++ b/EliteDangerous/JournalEvents/JournalRefuelAll.cs
@@ -40,9 +40,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, "Amount " + Amount.ToString() + "t", -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cost:; cr;N0", Cost, "Fuel:; tons;0.0", Amount);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
+++ b/EliteDangerous/JournalEvents/JournalRefuelPartial.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, "Amount " + Amount.ToString() +"t", -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cost:; cr;N0", Cost, "Fuel:; tons;0.0", Amount);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRepair.cs
+++ b/EliteDangerous/JournalEvents/JournalRepair.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Item, -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",ItemLocalised, "Cost:; cr;N0" , Cost );
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRepairAll.cs
+++ b/EliteDangerous/JournalEvents/JournalRepairAll.cs
@@ -37,9 +37,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, "", -Cost);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Cost:; cr;N0",Cost);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRepairDrone.cs
+++ b/EliteDangerous/JournalEvents/JournalRepairDrone.cs
@@ -40,9 +40,9 @@ namespace EliteDangerousCore.JournalEvents
         public double CockpitRepaired { get; set; }
         public double CorrosionRepaired { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Hull:", HullRepaired.ToString("0.0"), "Cockpit:", CockpitRepaired.ToString("0.0"), "Corrosion:", CorrosionRepaired.ToString("0.0"));
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalReputation.cs
+++ b/EliteDangerous/JournalEvents/JournalReputation.cs
@@ -37,9 +37,9 @@ namespace EliteDangerousCore.JournalEvents
         public double? Independent { get; set; }
         public double? Alliance { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Federation:;;0.#",Federation , "Empire:;;0.#" , Empire, "Independent:;;0.#", Independent , "Alliance:;;0.#", Alliance);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
+++ b/EliteDangerous/JournalEvents/JournalRestockVehicle.cs
@@ -46,9 +46,9 @@ namespace EliteDangerousCore.JournalEvents
 
         protected override JournalTypeEnum IconEventType { get { return Type.Contains("SRV") ? JournalTypeEnum.RestockVehicle_SRV : JournalTypeEnum.RestockVehicle_Fighter; } }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",Type , "Cost:; cr;N0" , Cost , "Count:" , Count , "Loadout:" , Loadout);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalResurrect.cs
+++ b/EliteDangerous/JournalEvents/JournalResurrect.cs
@@ -48,9 +48,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.Resurrect();
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Option:",Option, "Cost:; cr;N0" , Cost, ";Bankrupt" , Bankrupt);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSRVDestroyed.cs
+++ b/EliteDangerous/JournalEvents/JournalSRVDestroyed.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.DockSRV();
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -338,10 +338,11 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
-        {
-            summary = $"Scan of {BodyName}";
 
+        public override string FillSummary { get { return "Scan of " + BodyName; } }
+
+        public override void FillInformation(out string info, out string detailed)  //V
+        {
             if (IsStar)
             {
                 double? r = nRadius;

--- a/EliteDangerous/JournalEvents/JournalScanned.cs
+++ b/EliteDangerous/JournalEvents/JournalScanned.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         }
         public string ScanType { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = ScanType;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalScientificResearch.cs
+++ b/EliteDangerous/JournalEvents/JournalScientificResearch.cs
@@ -34,9 +34,9 @@ namespace EliteDangerousCore.JournalEvents
         public string Category { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",Name, "Count:",  Count , "Category:", Category);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalScreenshot.cs
+++ b/EliteDangerous/JournalEvents/JournalScreenshot.cs
@@ -60,9 +60,9 @@ namespace EliteDangerousCore.JournalEvents
         public double? nAltitude { get; set; }
         public double? nHeading { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)  //V
+        public override void FillInformation(out string info, out string detailed)  //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("At " , Body , "< in " , System , "File:", Filename, "Width:", Width , "Height:", Height, "Latitude:", JournalFieldNaming.RLat(nLatitude), "Longitude:", JournalFieldNaming.RLong(nLongitude));
             detailed = "";
         }
@@ -131,7 +131,7 @@ namespace EliteDangerousCore.JournalEvents
                     Body = body
                 });
 
-                ss = JournalEntry.CreateJournalEntry(jo.ToString()) as JournalScreenshot;
+                ss = JournalEntry.CreateJournalEntry(jo) as JournalScreenshot;
                 ss.Add(jo);
             }
 

--- a/EliteDangerous/JournalEvents/JournalSearchAndRescue.cs
+++ b/EliteDangerous/JournalEvents/JournalSearchAndRescue.cs
@@ -43,9 +43,9 @@ namespace EliteDangerousCore.JournalEvents
         public long Reward { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",FriendlyName , "Num:" , Count, "Reward:" , Reward);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSelfDestruct.cs
+++ b/EliteDangerous/JournalEvents/JournalSelfDestruct.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
 
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "Boom!";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSellDrones.cs
+++ b/EliteDangerous/JournalEvents/JournalSellDrones.cs
@@ -44,9 +44,9 @@ namespace EliteDangerousCore.JournalEvents
             mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Count.ToString() + " drones", TotalSale);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",Type, "Count:" , Count , "Each:; cr;N0" , SellPrice, "Amount:; cr;N0" , TotalSale);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
+++ b/EliteDangerous/JournalEvents/JournalSellExplorationData.cs
@@ -50,9 +50,9 @@ namespace EliteDangerousCore.JournalEvents
                 mcl.AddEvent(Id, EventTimeUTC, EventTypeID, Systems.Length + " systems", TotalEarnings);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Amount:; cr;N0", BaseValue, "Bonus:; cr;N0", Bonus , "Total:; cr (inc any PVP bonus);N0", TotalEarnings);
             detailed = "";
             if (Systems != null)

--- a/EliteDangerous/JournalEvents/JournalSellShipOnRebuy.cs
+++ b/EliteDangerous/JournalEvents/JournalSellShipOnRebuy.cs
@@ -60,9 +60,9 @@ Example:
             shp.Sell(ShipType, SellShipId);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Ship:",ShipType, "System:" , System, "Price:" , ShipPrice);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSendText.cs
+++ b/EliteDangerous/JournalEvents/JournalSendText.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public string To_Localised { get; set; }
         public string Message { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("To:", To_Localised, "Msg:", Message);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSetUserShipName.cs
+++ b/EliteDangerous/JournalEvents/JournalSetUserShipName.cs
@@ -52,9 +52,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.SetUserShipName(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",ShipName,"", ShipIdent, "On:" , Ship);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalShieldState.cs
+++ b/EliteDangerous/JournalEvents/JournalShieldState.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
 
         protected override JournalTypeEnum IconEventType { get { return ShieldsUp ? JournalTypeEnum.ShieldState_ShieldsUp : JournalTypeEnum.ShieldState_ShieldsDown; } }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Shields Down;Shields Up",ShieldsUp);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalShipTargeted.cs
+++ b/EliteDangerous/JournalEvents/JournalShipTargeted.cs
@@ -74,9 +74,9 @@ namespace EliteDangerousCore.JournalEvents
         public string SubSystem { get; set; }           // 3 null
         public double? SubSystemHealth { get; set; }    // 3 null
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             if (TargetLocked)
             {
                 if (ScanStage == null)

--- a/EliteDangerous/JournalEvents/JournalShipyard.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyard.cs
@@ -60,9 +60,9 @@ namespace EliteDangerousCore.JournalEvents
         public bool? Horizons { get; set; }
         public bool? AllowCobraMkIV { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyardBuy.cs
@@ -95,9 +95,9 @@ namespace EliteDangerousCore.JournalEvents
                 shp.Sell(SellOldShipFD, SellOldShipId.Value);     
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", ShipType, "Amount:; cr;N0", ShipPrice);
             if (StoreOldShip != null)
                 info += ", " + BaseUtils.FieldBuilder.Build("Stored:", StoreOldShip);

--- a/EliteDangerous/JournalEvents/JournalShipyardNew.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyardNew.cs
@@ -45,9 +45,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ShipyardNew(ShipType, ShipFD, ShipId);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = ShipType;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalShipyardSell.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyardSell.cs
@@ -60,9 +60,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.Sell(ShipType, SellShipId);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", ShipType, "Amount:; cr;N0", ShipPrice , "At:" , System);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalShipyardSwap.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyardSwap.cs
@@ -61,9 +61,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.ShipyardSwap(this, whereami, system.Name);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Swap ",StoreOldShip, "< for a " , ShipType);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
+++ b/EliteDangerous/JournalEvents/JournalShipyardTransfer.cs
@@ -80,9 +80,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.Transfer(ShipType, ShipTypeFD, ShipId, FromSystem, system.Name, whereami, arrival);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Of ", ShipType, "< from " , FromSystem , "Distance:; ly;0.0" , Distance , "Price:; cr;N0", TransferPrice, "TransferTime:", FriendlyTransferTime);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalShutdown.cs
+++ b/EliteDangerous/JournalEvents/JournalShutdown.cs
@@ -28,9 +28,9 @@ namespace EliteDangerousCore.JournalEvents
 
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalStartJump.cs
+++ b/EliteDangerous/JournalEvents/JournalStartJump.cs
@@ -41,9 +41,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StarClass { get; set; }
         public string FriendlyStarClass { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("",JumpType , "< to " , StarSystem, "" , FriendlyStarClass);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalStatistics.cs
+++ b/EliteDangerous/JournalEvents/JournalStatistics.cs
@@ -56,9 +56,9 @@ namespace EliteDangerousCore.JournalEvents
         public MaterialTraderStatsClass MaterialTraderStats { get; set; }
         public CQCClass CQC { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalStoredModules.cs
+++ b/EliteDangerous/JournalEvents/JournalStoredModules.cs
@@ -48,9 +48,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.UpdateStoredModules(this);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Total:", ModuleItems?.Count());
             detailed = "";
 

--- a/EliteDangerous/JournalEvents/JournalStoredShips.cs
+++ b/EliteDangerous/JournalEvents/JournalStoredShips.cs
@@ -69,9 +69,9 @@ namespace EliteDangerousCore.JournalEvents
         public StoredShipInformation[] ShipsHere { get; set; }
         public StoredShipInformation[] ShipsRemote { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("At starport:",ShipsHere?.Count(),"Other locations:",ShipsRemote?.Count() );
             detailed = "";
             if (ShipsHere != null)

--- a/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
+++ b/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StarSystem { get; set; }
         public long? SystemAddress { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)//V
+        public override void FillInformation(out string info, out string detailed)//V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = StarSystem;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
+++ b/EliteDangerous/JournalEvents/JournalSupercruiseExit.cs
@@ -42,9 +42,9 @@ namespace EliteDangerousCore.JournalEvents
         public string BodyType { get; set; }
         public string BodyDesignation { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("At ", Body , "< in ", StarSystem, "Type:" , BodyType);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalSynthesis.cs
+++ b/EliteDangerous/JournalEvents/JournalSynthesis.cs
@@ -68,9 +68,9 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Name;
             if (Materials != null)
                 foreach (KeyValuePair<string, int> k in Materials)

--- a/EliteDangerous/JournalEvents/JournalSystemsShutdown.cs
+++ b/EliteDangerous/JournalEvents/JournalSystemsShutdown.cs
@@ -33,9 +33,9 @@ namespace EliteDangerousCore.JournalEvents
     {
         public JournalSystemsShutdown(JObject evt) : base(evt, JournalTypeEnum.SystemsShutdown) { }
 
-        public override void FillInformation(out string summary, out string info, out string detailed)
+        public override void FillInformation(out string info, out string detailed)
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalTechnologyBroker.cs
+++ b/EliteDangerous/JournalEvents/JournalTechnologyBroker.cs
@@ -78,9 +78,9 @@ namespace EliteDangerousCore.JournalEvents
             public int Count;
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Type:", BrokerType);
 
             if (ItemsUnlocked != null)

--- a/EliteDangerous/JournalEvents/JournalTouchdown.cs
+++ b/EliteDangerous/JournalEvents/JournalTouchdown.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
         public double Longitude { get; set; }
         public bool? PlayerControlled { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = JournalFieldNaming.RLat(Latitude) + " " + JournalFieldNaming.RLong(Longitude) + BaseUtils.FieldBuilder.Build(", NPC Controlled;", PlayerControlled);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalUSSDrop.cs
+++ b/EliteDangerous/JournalEvents/JournalUSSDrop.cs
@@ -35,9 +35,9 @@ namespace EliteDangerousCore.JournalEvents
         public int USSThreat { get; set; }
         public string USSTypeLocalised { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("Type:",USSTypeLocalised, "Threat:" , USSThreat);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalUnderAttack.cs
+++ b/EliteDangerous/JournalEvents/JournalUnderAttack.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Target { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", Target);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalUndocked.cs
+++ b/EliteDangerous/JournalEvents/JournalUndocked.cs
@@ -36,9 +36,9 @@ namespace EliteDangerousCore.JournalEvents
         public string StationType { get; set; }
         public long? MarketID { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = BaseUtils.FieldBuilder.Build("", StationName, "Type:", StationType);
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalUnknown.cs
+++ b/EliteDangerous/JournalEvents/JournalUnknown.cs
@@ -33,9 +33,8 @@ namespace EliteDangerousCore.JournalEvents
             eventname = evt["event"].Str("No event tag");
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = eventname.SplitCapsWord();
             info = "Unhandled Journal event, Report to EDDiscovery team. " + Environment.NewLine + json;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
+++ b/EliteDangerous/JournalEvents/JournalVehicleSwitch.cs
@@ -39,9 +39,9 @@ namespace EliteDangerousCore.JournalEvents
             shp.VehicleSwitch(To);
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = To; 
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalWingAdd.cs
+++ b/EliteDangerous/JournalEvents/JournalWingAdd.cs
@@ -32,9 +32,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Name { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Name;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalWingInvite.cs
+++ b/EliteDangerous/JournalEvents/JournalWingInvite.cs
@@ -30,9 +30,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string Name { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = Name;
             detailed = "";
         }

--- a/EliteDangerous/JournalEvents/JournalWingJoin.cs
+++ b/EliteDangerous/JournalEvents/JournalWingJoin.cs
@@ -31,9 +31,9 @@ namespace EliteDangerousCore.JournalEvents
 
         public string[] Others { get; set; }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             if (Others != null)
                 foreach (string s in Others)

--- a/EliteDangerous/JournalEvents/JournalWingLeave.cs
+++ b/EliteDangerous/JournalEvents/JournalWingLeave.cs
@@ -28,9 +28,9 @@ namespace EliteDangerousCore.JournalEvents
 
         }
 
-        public override void FillInformation(out string summary, out string info, out string detailed) //V
+        public override void FillInformation(out string info, out string detailed) //V
         {
-            summary = EventTypeStr.SplitCapsWord();
+            
             info = "";
             detailed = "";
         }


### PR DESCRIPTION
    WP2 HE more optimised
    
    Massive muck about
    HE now stripped of most data.
    FSD creation moved into FSD class, as is set map colour and first
    discover flag only in FSD entries.  Changed to 2d/3d maps to get colour
    now from journal
    Removed Description/Detailed info from he, UCs use FillInformation to
    get it dynamically - slower but less memory
    EDSM log fetch passes back FSD jump entries, and uses them instead of
    HEs
    Start/Stop travelled system altered to work with new system
    All the journal deltas were the removal of EventSummary from fill
    information, and a few additional overrides for FillSummary.
