### PR TITLE
SPanel now includes current material levels in scan info

### DIFF
--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -745,7 +745,7 @@ namespace EDDiscovery.UserControls
         {
             if ( IsSurfaceScanOn )
             {
-                scantext = scan.DisplayString();
+                scantext = scan.DisplayString(historicmatlist: discoveryform.history.GetLast?.MaterialCommodity);
                 Display(current_historylist);
                 SetSurfaceScanBehaviour(null);  // set up timers etc.
             }

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -609,10 +609,10 @@ namespace EliteDangerousCore.JournalEvents
 
             MaterialCommodityDB mc = MaterialCommodityDB.GetCachedMaterial(name);
 
-            if (mc != null)
+            if (mc != null && (historicmatlist != null || currentmatlist != null))
             {
                 MaterialCommodities historic = historicmatlist?.Find(mc.name);
-                MaterialCommodities current = Object.ReferenceEquals(historicmatlist,currentmatlist) ? null : currentmatlist?.Find(mc.name);
+                MaterialCommodities current = ReferenceEquals(historicmatlist,currentmatlist) ? null : currentmatlist?.Find(mc.name);
                 int? limit = MaterialCommodityDB.MaterialLimit(mc);
 
                 string matinfo = historic?.count.ToString() ?? "0";


### PR DESCRIPTION
Journal scan display string no longer shows 0/# for all mats when no material list is passed in.