### PR TITLE
 Fix queued events being held too long

### DIFF
--- a/EliteDangerous/EliteDangerous/EDJournalReader.cs
+++ b/EliteDangerous/EliteDangerous/EDJournalReader.cs
@@ -211,14 +211,6 @@ namespace EliteDangerousCore
         {
             jent = new List<JournalReaderEntry>();
 
-            if (StartEntries.Count != 0 && this.TravelLogUnit.CommanderId != null && this.TravelLogUnit.CommanderId >= 0)
-            {
-                jent.Add(StartEntries.Dequeue());
-                //System.Diagnostics.Debug.WriteLine("*** UnDelay " + jent[0].JournalEntry.EventTypeStr);
-                jent[0].JournalEntry.CommanderId = (int)TravelLogUnit.CommanderId;
-                return true;
-            }
-
             bool readanything = false;
 
             while (ReadLine(out JournalReaderEntry newentry, l => ProcessLine(l, resetOnError)))
@@ -236,6 +228,17 @@ namespace EliteDangerousCore
                     {
                         //System.Diagnostics.Debug.WriteLine("*** Send  " + newentry.JournalEntry.EventTypeStr);
                         jent.Add(newentry);                     // else pass back
+                    }
+                }
+
+                if (StartEntries.Count != 0 && this.TravelLogUnit.CommanderId != null && this.TravelLogUnit.CommanderId >= 0)
+                {
+                    while (StartEntries.Count != 0)
+                    {
+                        var dentry = StartEntries.Dequeue();
+                        dentry.JournalEntry.CommanderId = (int)TravelLogUnit.CommanderId;
+                        //System.Diagnostics.Debug.WriteLine("*** UnDelay " + jent[0].JournalEntry.EventTypeStr);
+                        jent.Add(dentry);
                     }
                 }
             }

--- a/EliteDangerous/EliteDangerous/ShipInformationList.cs
+++ b/EliteDangerous/EliteDangerous/ShipInformationList.cs
@@ -86,6 +86,8 @@ namespace EliteDangerousCore
 
             ShipInformation newsm = null;       // if we change anything, we need a new clone..
 
+            Dictionary<string, ShipModule> moduleSlots = sm.Modules.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
             foreach (ShipModule m in modulelist)
             {
                 if (!sm.Contains(m.Slot) || !sm.Same(m))  // no slot, or not the same data.. (ignore localised item)
@@ -104,6 +106,27 @@ namespace EliteDangerousCore
 
                     newsm.SetModule(m);                   // update entry only.. rest will still point to same entries
                 }
+
+                moduleSlots.Remove(m.Slot);
+            }
+
+            // Remove modules not in loadout
+            if (moduleSlots.Count != 0)
+            {
+                List<ShipModule> modulesToRemove = moduleSlots.Values.ToList();
+
+                if (newsm == null)
+                {
+                    newsm = sm.ShallowClone();
+                }
+
+                foreach (ShipModule m in modulesToRemove)
+                {
+                    System.Diagnostics.Trace.WriteLine($"Warning: Module {m.Item} in slot {m.Slot} is missing from loadout");
+                    newsm = newsm.RemoveModule(m.Slot, m.Item);
+                }
+
+                Ships[sid] = newsm;
             }
         }
 


### PR DESCRIPTION
This bug is resulting in any events read before `LoadGame` being placed after the last entry read.

Fixes: 99850a0206735f2a8087d556345ac9048f7a2376