### PR TITLE
SRVs and Fighters don't have FSDs

### DIFF
--- a/EliteDangerous/EliteDangerous/ShipInformation.cs
+++ b/EliteDangerous/EliteDangerous/ShipInformation.cs
@@ -522,6 +522,7 @@ namespace EliteDangerousCore
         {
             ShipInformation sm = this.ShallowClone();
             sm.State = ShipState.Sold;
+            sm.SubVehicle = SubVehicleType.None;
             sm.ClearStorage();
             return sm;
         }
@@ -530,6 +531,7 @@ namespace EliteDangerousCore
         {
             ShipInformation sm = this.ShallowClone();
             //if (sm.StoredAtSystem != null) { if (sm.StoredAtSystem.Equals(system)) System.Diagnostics.Debug.WriteLine("..Previous known stored at" + sm.StoredAtSystem + ":" + sm.StoredAtStation); else System.Diagnostics.Debug.WriteLine("************************ DISGREEE..Previous known stored at" + sm.StoredAtSystem + ":" + sm.StoredAtStation); }
+            sm.SubVehicle = SubVehicleType.None;
             sm.StoredAtSystem = system;
             sm.StoredAtStation = station ?? sm.StoredAtStation;     // we may get one with just the system, so use the previous station if we have one
             //System.Diagnostics.Debug.WriteLine(".." + ShipFD + " Stored at " + sm.StoredAtSystem + ":" + sm.StoredAtStation);

--- a/EliteDangerous/EliteDangerous/ShipInformationList.cs
+++ b/EliteDangerous/EliteDangerous/ShipInformationList.cs
@@ -431,11 +431,20 @@ namespace EliteDangerousCore
             VerifyList();
         }
 
+        public void SupercruiseEntry(JournalSupercruiseEntry e)
+        {
+            if (HaveCurrentShip)
+            {
+                Ships[currentid] = CurrentShip.SetSubVehicle(ShipInformation.SubVehicleType.None);
+            }
+            VerifyList();
+        }
+
         public void FSDJump(JournalFSDJump e)
         {
             if (HaveCurrentShip)
             {
-                Ships[currentid] = CurrentShip.SetFuelLevel(e.FuelLevel);
+                Ships[currentid] = CurrentShip.SetFuelLevel(e.FuelLevel).SetSubVehicle(ShipInformation.SubVehicleType.None);
             }
             VerifyList();
         }

--- a/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
+++ b/EliteDangerous/JournalEvents/JournalSupercruiseEntry.cs
@@ -13,6 +13,7 @@
  *
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EliteDangerousCore.DB;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 
@@ -22,7 +23,7 @@ namespace EliteDangerousCore.JournalEvents
     //Parameters:
     //•	Starsystem
     [JournalEntryType(JournalTypeEnum.SupercruiseEntry)]
-    public class JournalSupercruiseEntry : JournalEntry
+    public class JournalSupercruiseEntry : JournalEntry, IShipInformation
     {
         public JournalSupercruiseEntry(JObject evt ) : base(evt, JournalTypeEnum.SupercruiseEntry)
         {
@@ -38,6 +39,11 @@ namespace EliteDangerousCore.JournalEvents
             
             info = StarSystem;
             detailed = "";
+        }
+
+        public void ShipInformation(ShipInformationList shp, string whereami, ISystem system, SQLiteConnectionUser conn)
+        {
+            shp.SupercruiseEntry(this);
         }
     }
 }


### PR DESCRIPTION
This should fix the edge case where an inactive ship is in SRV due to the `DockSRV` or `SRVDestroyed` event being missed.
This was discovered in #1994