### PR TITLE
Fix incorrect CQC progress

### DIFF
--- a/EliteDangerous/Inara/InaraSync.cs
+++ b/EliteDangerous/Inara/InaraSync.cs
@@ -278,7 +278,7 @@ namespace EliteDangerousCore.Inara
                             eventstosend.Add(InaraClass.setCommanderRankPilot("explore", (int)rank.Explore, progress?.Explore ?? -1, rank.EventTimeUTC));
                             eventstosend.Add(InaraClass.setCommanderRankPilot("empire", (int)rank.Empire, progress?.Empire ?? -1, rank.EventTimeUTC));
                             eventstosend.Add(InaraClass.setCommanderRankPilot("federation", (int)rank.Federation, progress?.Federation ?? -1, rank.EventTimeUTC));
-                            eventstosend.Add(InaraClass.setCommanderRankPilot("cqc", (int)rank.CQC, progress?.Combat ?? -1, rank.EventTimeUTC));
+                            eventstosend.Add(InaraClass.setCommanderRankPilot("cqc", (int)rank.CQC, progress?.CQC ?? -1, rank.EventTimeUTC));
                         }
 
                         break;


### PR DESCRIPTION
Issue reported on Discord:
> I don't know if this is an Inara problem or a EDD problem, but if I set EDD up to sync, my CQC rank syncs as "Legend 25%" which is the equivalent of my current combat rank (Deadly 25%) - if I upload a journal directly to Inara it goes in as Legend 92% (which is correct)