### PR TITLE
Fill summary in EDDCommodityPrices

### DIFF
--- a/EliteDangerous/EliteDangerous/JournalEntry.cs
+++ b/EliteDangerous/EliteDangerous/JournalEntry.cs
@@ -681,6 +681,7 @@ namespace EliteDangerousCore
                 jo["faction"] = faction;
                 jo["commodities"] = jcommodities;
                 JournalEDDCommodityPrices jis = new JournalEDDCommodityPrices(jo);
+                jis.EventSummaryName = jis.FillSummary;
                 jis.CommanderId = cmdrid;
                 jis.Add(jo, cn);
 


### PR DESCRIPTION
Fix another place where `EventSummaryName` was not set.
This should hopefully plug #2016 (though the proper fix would be #1992)