### PR TITLE
Make UI responsive when loading grids

### DIFF
--- a/EDDiscovery/UserControls/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/UserControlJournalGrid.cs
@@ -171,6 +171,8 @@ namespace EDDiscovery.UserControls
             dataGridViewJournal.Rows.Clear();
             rowsbyjournalid.Clear();
 
+            dataGridViewJournal.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
+
             List<HistoryEntry[]> chunks = new List<HistoryEntry[]>();
 
             for (int i = 0; i < result.Count; i += 1000)
@@ -186,7 +188,17 @@ namespace EDDiscovery.UserControls
 
             foreach (var chunk in chunks)
             {
-                todo.Enqueue(() => dataGridViewJournal.Rows.AddRange(CreateHistoryRows(chunk, filtertext).ToArray()));
+                todo.Enqueue(() =>
+                {
+                    dataGridViewJournal.SuspendLayout();
+                    foreach (var item in chunk)
+                    {
+                        var row = CreateHistoryRow(item, filtertext);
+                        if (row != null)
+                            dataGridViewJournal.Rows.Add(row);
+                    }
+                    dataGridViewJournal.ResumeLayout();
+                });
             }
 
             todo.Enqueue(() =>
@@ -199,8 +211,6 @@ namespace EDDiscovery.UserControls
                 {
                     dataGridViewJournal.CurrentCell = dataGridViewJournal.Rows[rowno].Cells[pos.Item2];       // its the current cell which needs to be set, moves the row marker as well            currentGridRow = (rowno!=-1) ? 
                 }
-
-                dataGridViewJournal.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
 
                 System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCount100 + " JG " + displaynumber + " Load Finish");
 
@@ -329,16 +339,6 @@ namespace EDDiscovery.UserControls
 
             rowsbyjournalid[item.Journalid] = rw;
             return rw;
-        }
-
-        private List<DataGridViewRow> CreateHistoryRows(IEnumerable<HistoryEntry> items, string search)
-        {
-            List<DataGridViewRow> rows = new List<DataGridViewRow>();
-            foreach (var item in items)
-            {
-                rows.Add(CreateHistoryRow(item, search));
-            }
-            return rows;
         }
 
         private void UpdateToolTipsForFilter()

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -71,8 +71,11 @@ namespace EDDiscovery.UserControls
 
         Timer searchtimer;
         Timer autoupdateedsm;
+        Timer todotimer;
         int autoupdaterowstart = 0;
         int autoupdaterowoffset = 0;
+        Queue<Action> todo = new Queue<Action>();
+        bool loadcomplete = false;
 
         public UserControlStarList()
         {
@@ -111,6 +114,8 @@ namespace EDDiscovery.UserControls
             searchtimer.Tick += Searchtimer_Tick;
             autoupdateedsm = new Timer() { Interval = 2000 };
             autoupdateedsm.Tick += Autoupdateedsm_Tick;
+            todotimer = new Timer() { Interval = 20 };
+            todotimer.Tick += Todotimer_Tick;
 
             BaseUtils.Translator.Instance.Translate(this);
             BaseUtils.Translator.Instance.Translate(contextMenuStrip, this);
@@ -124,6 +129,9 @@ namespace EDDiscovery.UserControls
 
         public override void Closing()
         {
+            todo.Clear();
+            todotimer.Stop();
+            searchtimer.Stop();
             DGVSaveColumnLayout(dataGridViewStarList, DbColumnSave);
             discoveryform.OnHistoryChange -= HistoryChanged;
             discoveryform.OnNewEntry -= AddNewEntry;
@@ -144,12 +152,15 @@ namespace EDDiscovery.UserControls
 
         public void HistoryChanged(HistoryList hl, bool disablesorting)           // on History change
         {
-            autoupdateedsm.Stop();
-
             if (hl == null)     // just for safety
                 return;
 
+            loadcomplete = false;
+
+            autoupdateedsm.Stop();
+
             Tuple<long, int> pos = CurrentGridPosByJID();
+            string filtertext = textBoxFilter.Text;
 
             current_historylist = hl;
 
@@ -172,7 +183,6 @@ namespace EDDiscovery.UserControls
             List<HistoryEntry> result = filter.Filter(hl);      // last entry, first in list
             result = HistoryList.FilterHLByTravel(result);      // keep only travel entries (location after death, FSD jumps)
 
-
             foreach (HistoryEntry he in result)        // last first..
             {
                 if (!systemsentered.ContainsKey(he.System.Name))
@@ -181,51 +191,90 @@ namespace EDDiscovery.UserControls
                 systemsentered[he.System.Name].Add(he);     // first entry is newest jump to, second is next last, etc
             }
 
-            foreach( List<HistoryEntry> syslist in systemsentered.Values ) // will be in order of entry..
+            List<List<HistoryEntry>> syslists = systemsentered.Values.ToList();
+            List<List<HistoryEntry>[]> syslistchunks = new List<List<HistoryEntry>[]>();
+
+            for (int i = 0; i < syslists.Count; i += 1000)
             {
-                DataGridViewRow rw = CreateHistoryRow(syslist, textBoxFilter.Text);
-                if (rw != null)
-                    dataGridViewStarList.Rows.Add(rw);
+                List<HistoryEntry>[] syslistchunk = new List<HistoryEntry>[i + 1000 > syslists.Count ? syslists.Count - i : 1000];
+                syslists.CopyTo(i, syslistchunk, 0, syslistchunk.Length);
+                syslistchunks.Add(syslistchunk);
             }
 
-            dataGridViewStarList.FilterGridView(textBoxFilter.Text);
+            todo.Clear();
 
-            int rowno = FindGridPosByJID(pos.Item1, true);     // find row.. must be visible..  -1 if not found/not visible
-
-            if (rowno >= 0)
+            foreach (var syslistchunk in syslistchunks)
             {
-                dataGridViewStarList.CurrentCell = dataGridViewStarList.Rows[rowno].Cells[pos.Item2];       // its the current cell which needs to be set, moves the row marker as well currentGridRow = (rowno!=-1) ? 
-            }
-            else if (dataGridViewStarList.Rows.GetRowCount(DataGridViewElementStates.Visible) > 0)
-            {
-                rowno = dataGridViewStarList.Rows.GetFirstRow(DataGridViewElementStates.Visible);
-                dataGridViewStarList.CurrentCell = dataGridViewStarList.Rows[rowno].Cells[StarHistoryColumns.StarName];
-            }
-            else
-                rowno = -1;
-
-            dataGridViewStarList.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
-
-            System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCount100 + " SL " + displaynumber + " Load Finish");
-
-            if (sortcol >= 0)
-            {
-                dataGridViewStarList.Sort(dataGridViewStarList.Columns[sortcol], (sortorder == SortOrder.Descending) ? ListSortDirection.Descending : ListSortDirection.Ascending);
-                dataGridViewStarList.Columns[sortcol].HeaderCell.SortGlyphDirection = sortorder;
+                todo.Enqueue(() => dataGridViewStarList.Rows.AddRange(CreateHistoryRows(syslistchunk, filtertext).ToArray()));
             }
 
-            //System.Diagnostics.Debug.WriteLine("Fire HC");
+            todo.Enqueue(() =>
+            {
+                dataGridViewStarList.FilterGridView(filtertext);
 
-            autoupdaterowoffset = autoupdaterowstart = 0;
-            autoupdateedsm.Start();
+                int rowno = FindGridPosByJID(pos.Item1, true);     // find row.. must be visible..  -1 if not found/not visible
 
-            FireChangeSelection();      // and since we repainted, we should fire selection, as we in effect may have selected a new one
+                if (rowno >= 0)
+                {
+                    dataGridViewStarList.CurrentCell = dataGridViewStarList.Rows[rowno].Cells[pos.Item2];       // its the current cell which needs to be set, moves the row marker as well currentGridRow = (rowno!=-1) ? 
+                }
+                else if (dataGridViewStarList.Rows.GetRowCount(DataGridViewElementStates.Visible) > 0)
+                {
+                    rowno = dataGridViewStarList.Rows.GetFirstRow(DataGridViewElementStates.Visible);
+                    dataGridViewStarList.CurrentCell = dataGridViewStarList.Rows[rowno].Cells[StarHistoryColumns.StarName];
+                }
+                else
+                    rowno = -1;
+
+                dataGridViewStarList.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
+
+                System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCount100 + " SL " + displaynumber + " Load Finish");
+
+                if (sortcol >= 0)
+                {
+                    dataGridViewStarList.Sort(dataGridViewStarList.Columns[sortcol], (sortorder == SortOrder.Descending) ? ListSortDirection.Descending : ListSortDirection.Ascending);
+                    dataGridViewStarList.Columns[sortcol].HeaderCell.SortGlyphDirection = sortorder;
+                }
+
+                //System.Diagnostics.Debug.WriteLine("Fire HC");
+
+                autoupdaterowoffset = autoupdaterowstart = 0;
+                autoupdateedsm.Start();
+
+                FireChangeSelection();      // and since we repainted, we should fire selection, as we in effect may have selected a new one
+
+                loadcomplete = true;
+            });
+
+            todotimer.Start();
         }
 
+        private void Todotimer_Tick(object sender, EventArgs e)
+        {
+            ProcessTodo();
+        }
 
+        private void ProcessTodo()
+        {
+            if (todo.Count != 0)
+            {
+                var act = todo.Dequeue();
+                act();
+            }
+            else
+            {
+                todotimer.Stop();
+            }
+        }
 
         private void AddNewEntry(HistoryEntry he, HistoryList hl)           // on new entry from discovery system
         {
+            if (!loadcomplete)
+            {
+                todo.Enqueue(new Action(() => AddNewEntry(he, hl)));
+                return;
+            }
+
             if ( he.IsFSDJump )     // FSD jumps mean move system.. so
                 HistoryChanged(hl); // just recalc all..
 
@@ -274,7 +323,7 @@ namespace EDDiscovery.UserControls
 
             he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
 
-            string tip = he.EventSummary + Environment.NewLine + EventDescription + Environment.NewLine + EventDetailedInfo;
+            string tip = String.Join(Environment.NewLine, he.EventSummary, EventDescription, EventDetailedInfo);
 
             rw.Cells[0].ToolTipText = tip;
             rw.Cells[1].ToolTipText = tip;
@@ -282,6 +331,20 @@ namespace EDDiscovery.UserControls
             rw.Cells[3].ToolTipText = tip;
 
             return rw;
+        }
+
+        private List<DataGridViewRow> CreateHistoryRows(IEnumerable<List<HistoryEntry>> syslists, string search)
+        {
+            List<DataGridViewRow> rows = new List<DataGridViewRow>();
+
+            foreach (List<HistoryEntry> syslist in syslists) // will be in order of entry..
+            {
+                DataGridViewRow rw = CreateHistoryRow(syslist, search);
+                if (rw != null)
+                    rows.Add(rw);
+            }
+
+            return rows;
         }
 
         string Infoline(List<HistoryEntry> syslist)

--- a/EDDiscovery/UserControls/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/UserControlStarList.cs
@@ -178,6 +178,8 @@ namespace EDDiscovery.UserControls
             systemsentered.Clear();
             dataGridViewStarList.Rows.Clear();
 
+            dataGridViewStarList.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
+
             var filter = (TravelHistoryFilter)comboBoxHistoryWindow.SelectedItem ?? TravelHistoryFilter.NoFilter;
 
             List<HistoryEntry> result = filter.Filter(hl);      // last entry, first in list
@@ -205,7 +207,17 @@ namespace EDDiscovery.UserControls
 
             foreach (var syslistchunk in syslistchunks)
             {
-                todo.Enqueue(() => dataGridViewStarList.Rows.AddRange(CreateHistoryRows(syslistchunk, filtertext).ToArray()));
+                todo.Enqueue(() =>
+                {
+                    dataGridViewStarList.SuspendLayout();
+                    foreach (var syslist in syslistchunk)
+                    {
+                        var row = CreateHistoryRow(syslist, filtertext);
+                        if (row != null)
+                            dataGridViewStarList.Rows.Add(row);
+                    }
+                    dataGridViewStarList.Rows.AddRange(CreateHistoryRows(syslistchunk, filtertext).ToArray());
+                });
             }
 
             todo.Enqueue(() =>
@@ -225,8 +237,6 @@ namespace EDDiscovery.UserControls
                 }
                 else
                     rowno = -1;
-
-                dataGridViewStarList.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
 
                 System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCount100 + " SL " + displaynumber + " Load Finish");
 

--- a/EDDiscovery/UserControls/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/UserControlTravelGrid.cs
@@ -89,6 +89,10 @@ namespace EDDiscovery.UserControls
         EventFilterSelector cfs = new EventFilterSelector();
 
         Timer searchtimer;
+        Timer todotimer;
+
+        private Queue<Action> todo = new Queue<Action>();
+        private bool loadcomplete = false;
 
         public UserControlTravelGrid()
         {
@@ -122,6 +126,9 @@ namespace EDDiscovery.UserControls
             searchtimer = new Timer() { Interval = 500 };
             searchtimer.Tick += Searchtimer_Tick;
 
+            todotimer = new Timer { Interval = 20 };
+            todotimer.Tick += Todotimer_Tick;
+
             discoveryform.OnHistoryChange += HistoryChanged;
             discoveryform.OnNewEntry += AddNewEntry;
             discoveryform.OnNoteChanged += OnNoteChanged;
@@ -137,6 +144,9 @@ namespace EDDiscovery.UserControls
 
         public override void Closing()
         {
+            todo.Clear();
+            todotimer.Stop();
+            searchtimer.Stop();
             DGVSaveColumnLayout(dataGridViewTravel, DbColumnSave);
             discoveryform.OnHistoryChange -= HistoryChanged;
             discoveryform.OnNewEntry -= AddNewEntry;
@@ -162,6 +172,7 @@ namespace EDDiscovery.UserControls
             if (hl == null)     // just for safety
                 return;
 
+            loadcomplete = false;
             current_historylist = hl;
             this.Cursor = Cursors.WaitCursor;
 
@@ -189,46 +200,87 @@ namespace EDDiscovery.UserControls
             dataGridViewTravel.Rows.Clear();
             rowsbyjournalid.Clear();
 
-            for (int ii = 0; ii < result.Count; ii++)
+            List<HistoryEntry[]> chunks = new List<HistoryEntry[]>();
+
+            for (int i = 0; i < result.Count; i += 1000)
             {
-                DataGridViewRow rw = CreateHistoryRow(result[ii], textBoxFilter.Text);
-                if (rw != null)
-                    dataGridViewTravel.Rows.Add(rw);
+                HistoryEntry[] chunk = new HistoryEntry[i + 1000 > result.Count ? result.Count - i : 1000];
+
+                result.CopyTo(i, chunk, 0, chunk.Length);
+                chunks.Add(chunk);
             }
 
-            UpdateToolTipsForFilter();
+            todo.Clear();
+            string filtertext = textBoxFilter.Text;
 
-            int rowno = FindGridPosByJID(pos.Item1, true);     // find row.. must be visible..  -1 if not found/not visible
-
-            if (rowno >= 0)
+            foreach (var chunk in chunks)
             {
-                dataGridViewTravel.CurrentCell = dataGridViewTravel.Rows[rowno].Cells[pos.Item2];       // its the current cell which needs to be set, moves the row marker as well            currentGridRow = (rowno!=-1) ?
+                todo.Enqueue(() => dataGridViewTravel.Rows.AddRange(CreateHistoryRows(chunk, filtertext).ToArray()));
             }
-            else if (dataGridViewTravel.Rows.GetRowCount(DataGridViewElementStates.Visible) > 0)
+
+            todo.Enqueue(() =>
             {
-                rowno = dataGridViewTravel.Rows.GetFirstRow(DataGridViewElementStates.Visible);
-                dataGridViewTravel.CurrentCell = dataGridViewTravel.Rows[rowno].Cells[TravelHistoryColumns.Description];
+                UpdateToolTipsForFilter();
+
+                int rowno = FindGridPosByJID(pos.Item1, true);     // find row.. must be visible..  -1 if not found/not visible
+
+                if (rowno >= 0)
+                {
+                    dataGridViewTravel.CurrentCell = dataGridViewTravel.Rows[rowno].Cells[pos.Item2];       // its the current cell which needs to be set, moves the row marker as well            currentGridRow = (rowno!=-1) ? 
+                }
+                else if (dataGridViewTravel.Rows.GetRowCount(DataGridViewElementStates.Visible) > 0)
+                {
+                    rowno = dataGridViewTravel.Rows.GetFirstRow(DataGridViewElementStates.Visible);
+                    dataGridViewTravel.CurrentCell = dataGridViewTravel.Rows[rowno].Cells[TravelHistoryColumns.Description];
+                }
+                else
+                    rowno = -1;
+
+                dataGridViewTravel.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
+
+                System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCount100 + " TG " + displaynumber + " Load Finish");
+
+                if (sortcol >= 0)
+                {
+                    dataGridViewTravel.Sort(dataGridViewTravel.Columns[sortcol], (sortorder == SortOrder.Descending) ? ListSortDirection.Descending : ListSortDirection.Ascending);
+                    dataGridViewTravel.Columns[sortcol].HeaderCell.SortGlyphDirection = sortorder;
+                }
+
+                FireChangeSelection();      // and since we repainted, we should fire selection, as we in effect may have selected a new one
+
+                this.Cursor = Cursors.Default;
+                loadcomplete = true;
+            });
+
+            todotimer.Start();
+        }
+
+        private void Todotimer_Tick(object sender, EventArgs e)
+        {
+            ProcessTodo();
+        }
+
+        private void ProcessTodo()
+        {
+            if (todo.Count != 0)
+            {
+                var act = todo.Dequeue();
+                act();
             }
             else
-                rowno = -1;
-
-            dataGridViewTravel.Columns[0].HeaderText = EDDiscoveryForm.EDDConfig.DisplayUTC ? "Game Time".Tx() : "Time".Tx();
-
-            System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCount100 + " TG " + displaynumber + " Load Finish");
-
-            if (sortcol >= 0)
             {
-                dataGridViewTravel.Sort(dataGridViewTravel.Columns[sortcol], (sortorder == SortOrder.Descending) ? ListSortDirection.Descending : ListSortDirection.Ascending);
-                dataGridViewTravel.Columns[sortcol].HeaderCell.SortGlyphDirection = sortorder;
+                todotimer.Stop();
             }
-
-            FireChangeSelection();      // and since we repainted, we should fire selection, as we in effect may have selected a new one
-
-            this.Cursor = Cursors.Default;
         }
 
         private void AddNewEntry(HistoryEntry he, HistoryList hl)           // on new entry from discovery system
         {
+            if (!loadcomplete)
+            {
+                todo.Enqueue(() => AddNewEntry(he, hl));
+                return;
+            }
+
             bool add = he.IsJournalEventInEventFilter(SQLiteDBClass.GetSettingString(DbFilterSave, "All"));
 
             if (!add)                   // filtered out, update filter total and display
@@ -333,6 +385,16 @@ namespace EDDiscovery.UserControls
             rowsbyjournalid[item.Journalid] = rw;
             return rw;
 
+        }
+
+        private List<DataGridViewRow> CreateHistoryRows(IEnumerable<HistoryEntry> items, string search)
+        {
+            List<DataGridViewRow> rows = new List<DataGridViewRow>();
+            foreach (var item in items)
+            {
+                rows.Add(CreateHistoryRow(item, search));
+            }
+            return rows;
         }
 
         private void UpdateToolTipsForFilter()
@@ -443,6 +505,12 @@ namespace EDDiscovery.UserControls
 
         private void OnNoteChanged(Object sender,HistoryEntry he, bool committed)
         {
+            if (!loadcomplete)
+            {
+                todo.Enqueue(() => OnNoteChanged(sender, he, committed));
+                return;
+            }
+
             if (rowsbyjournalid.ContainsKey(he.Journalid) ) // if we can find the grid entry
             {
                 string s = (he.snc != null) ? he.snc.Note : "";     // snc may have gone null, so cope with it
@@ -461,6 +529,11 @@ namespace EDDiscovery.UserControls
 
         private void Searchtimer_Tick(object sender, EventArgs e)
         {
+            if (!loadcomplete)
+            {
+                return;
+            }
+
             searchtimer.Stop();
             this.Cursor = Cursors.WaitCursor;
             HistoryChanged(current_historylist);

--- a/EliteDangerous/EliteDangerous/MaterialRecipes.cs
+++ b/EliteDangerous/EliteDangerous/MaterialRecipes.cs
@@ -231,13 +231,10 @@ namespace EliteDangerousCore
 
         public static string UsedInSynthesisAbv(string abv)
         {
-            string usedin = "";
-            foreach (var x in SynthesisRecipes)
-            {
-                if (x.ingredients.Contains(abv))
-                    usedin = usedin.AppendPrePad(x.name + "-" + x.level, ",");
-            }
-            return usedin;
+            if (SynthesisRecipesByMaterial.ContainsKey(abv))
+                return String.Join(",", SynthesisRecipesByMaterial[abv].Select(x => x.name + "-" + x.level));
+            else
+                return "";
         }
 
         public static SynthesisRecipe FindSynthesis(string name, string level)
@@ -335,6 +332,11 @@ namespace EliteDangerousCore
             new SynthesisRecipe("AX Explosive Munitions", "Standard", "6S,6P,2Hg,4UKOC,4PE"),
             new SynthesisRecipe("AX Explosive Munitions", "Premium", "5W,4Hg,2Po,5BMC,5PE,6SFD"),
         };
+
+        public static Dictionary<string, List<SynthesisRecipe>> SynthesisRecipesByMaterial =
+            SynthesisRecipes.SelectMany(r => r.ingredients.Select(i => new { mat = i, recipe = r }))
+                            .GroupBy(a => a.mat)
+                            .ToDictionary(g => g.Key, g => g.Select(a => a.recipe).ToList());
 
         public static List<EngineeringRecipe> EngineeringRecipes = new List<EngineeringRecipe>()
         {
@@ -1149,6 +1151,11 @@ namespace EliteDangerousCore
 
 #endregion
         };
+
+        public static Dictionary<string, List<EngineeringRecipe>> EngineeringRecipesByMaterial =
+            EngineeringRecipes.SelectMany(r => r.ingredients.Select(i => new { mat = i, recipe = r }))
+                              .GroupBy(a => a.mat)
+                              .ToDictionary(g => g.Key, g => g.Select(a => a.recipe).ToList());
 
         #region Use the netlogentry frontierdata to update this
 

--- a/EliteDangerous/JournalEvents/JournalFSDJump.cs
+++ b/EliteDangerous/JournalEvents/JournalFSDJump.cs
@@ -66,45 +66,49 @@ namespace EliteDangerousCore.JournalEvents
 
         public override void FillInformation(out string info, out string detailed)  //V
         {
-            info = "";
+            StringBuilder sb = new StringBuilder();
             if (JumpDist > 0)
-                info += JumpDist.ToString("0.00") + " ly";
+                sb.Append(JumpDist.ToString("0.00") + " ly");
             if (FuelUsed > 0)
-                info += ", Fuel " + FuelUsed.ToString("0.0") + "t";
+                sb.Append(", Fuel " + FuelUsed.ToString("0.0") + "t");
             if (FuelLevel > 0)
-                info += " left " + FuelLevel.ToString("0.0") + "t";
+                sb.Append(" left " + FuelLevel.ToString("0.0") + "t");
 
             string econ = Economy_Localised.Alt(Economy);
             if (econ.Equals("None"))
                 econ = "";
 
-            info += " ";
-            info += BaseUtils.FieldBuilder.Build("Faction:", Faction, "<;(Wanted) ", Wanted, "State:", FactionState, "Allegiance:", Allegiance, "Economy:", econ, "Population:", Population);
-            detailed = "";
+            sb.Append(" ");
+            sb.Append(BaseUtils.FieldBuilder.Build("Faction:", Faction, "<;(Wanted) ", Wanted, "State:", FactionState, "Allegiance:", Allegiance, "Economy:", econ, "Population:", Population));
+            info = sb.ToString();
+
+            sb.Clear();
 
             if ( Factions != null )
             {
                 foreach (FactionInformation i in Factions)
                 {
-                    detailed += BaseUtils.FieldBuilder.Build("", i.Name, "State:", i.FactionState, "Gov:", i.Government, "Inf:;%", (i.Influence * 100.0).ToString("0.0"), "Alg:", i.Allegiance) ;
+                    sb.Append(BaseUtils.FieldBuilder.Build("", i.Name, "State:", i.FactionState, "Gov:", i.Government, "Inf:;%", (i.Influence * 100.0).ToString("0.0"), "Alg:", i.Allegiance));
                     if (i.PendingStates != null)
                     {
-                        detailed += BaseUtils.FieldBuilder.Build(",", "Pending State:");
+                        sb.Append(BaseUtils.FieldBuilder.Build(",", "Pending State:"));
                         foreach (JournalLocation.PowerStatesInfo state in i.PendingStates)
-                            detailed += BaseUtils.FieldBuilder.Build(",", state.State, "", state.Trend);
+                            sb.Append(BaseUtils.FieldBuilder.Build(",", state.State, "", state.Trend));
 
                     }
 
                     if (i.RecoveringStates != null)
                     {
-                        detailed += BaseUtils.FieldBuilder.Build(",", "Recovering State:");
+                        sb.Append(BaseUtils.FieldBuilder.Build(",", "Recovering State:"));
                         foreach (JournalLocation.PowerStatesInfo state in i.RecoveringStates)
-                            detailed += BaseUtils.FieldBuilder.Build(",", state.State, "", state.Trend);
+                            sb.Append(BaseUtils.FieldBuilder.Build(",", state.State, "", state.Trend));
                     }
-                    detailed += Environment.NewLine;
+                    sb.Append(Environment.NewLine);
 
                 }
             }
+
+            detailed = sb.ToString();
         }
 
         public void ShipInformation(ShipInformationList shp, string whereami, ISystem system, DB.SQLiteConnectionUser conn)


### PR DESCRIPTION
These use windows timers to process the creation of rows in chunks.  As WM_TIMER events are only generated when no other events are in the queue (see https://blogs.msdn.microsoft.com/oldnewthing/20111219-00/?p=8863/), this will allow the UI to process events between the processing of grid chunks.

Real-time journal events are queued while the grid is loading, and dispatched once the grid is loaded.

In order to reduce the time before anything is displayed, rows are added in chunks to the grids rather than being kept in a collection and added all at once after the are all created.  Note that row creation is the slowest part of the grid population - it takes about 20s for 40k rows to be created and filled, while it takes a couple of hundred ms to put those rows into the grid and filter them. 