### PR TITLE
ScanData dirty hack.

### DIFF
--- a/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
@@ -133,7 +133,7 @@ namespace EDDiscovery.UserControls
             this.surfaceScanDetailsToolStripMenuItem,
             this.showInPositionToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStripConfig";
-            this.contextMenuStrip.Size = new System.Drawing.Size(347, 466);
+            this.contextMenuStrip.Size = new System.Drawing.Size(347, 444);
             // 
             // showSystemInformationToolStripMenuItem
             // 

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -254,10 +254,14 @@ namespace EDDiscovery.UserControls
 
                     if (Config(Configuration.showNothingWhenDocked) && (hl.IsCurrentlyDocked || hl.IsCurrentlyLanded))
                     {
+                        scantext = null;
+                        HideScanData(null, null);
                         AddColText(0, 0, rowpos, rowheight, (hl.IsCurrentlyDocked) ? "Docked" : "Landed", textcolour, backcolour, null);
                     }
                     else if ( ( uistate == UIState.GalMap && Config(Configuration.showNothingWhenGalmap)) || ( uistate == UIState.SystemMap && Config(Configuration.showNothingWhenSysmap)))
                     {
+                        scantext = null;
+                        HideScanData(null, null);
                         AddColText(0, 0, rowpos, rowheight, (uistate == UIState.GalMap) ? "Galaxy Map" : "System Map", textcolour, backcolour, null);
                     }
                     else


### PR DESCRIPTION
ScanData now disappear along with the main content if entered System/Galaxy map or Docked, if preferred.