### PR TITLE
Check text is not empty or whitespace

### DIFF
--- a/EDDiscovery/UserControls/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/UserControlSysInfo.cs
@@ -396,7 +396,7 @@ namespace EDDiscovery.UserControls
         private void clickTextBox(object sender, EventArgs e)
         {
             string text = ((Control)sender).Text;
-            if (text != null)
+            if (!String.IsNullOrWhiteSpace(text))
                 Clipboard.SetText(text);
         }
 


### PR DESCRIPTION
Fixes: f1a8d97 Check control text not null before setting clipboard
This should fix #2076