### PR TITLE
Don't crash if the notes field is null

### DIFF
--- a/EDDiscovery/Forms/BookmarkForm.cs
+++ b/EDDiscovery/Forms/BookmarkForm.cs
@@ -108,8 +108,10 @@ namespace EDDiscovery.Forms
             if (!bk.isRegion)
             {
                 ISystem s = SystemClassDB.GetSystem(bk.StarName);
-                if ( s != null )    // paranoia
+                if (s != null)    // paranoia
                     InitialisePos(s);
+                else
+                    InitialisePos(bk.x, bk.y, bk.z);
 
                 SystemNoteClass sn = SystemNoteClass.GetNoteOnSystem(bk.StarName);
                 note = (sn != null) ? sn.Note : "";

--- a/EDDiscovery/UserControls/UserControlBookmarks.cs
+++ b/EDDiscovery/UserControls/UserControlBookmarks.cs
@@ -115,7 +115,11 @@ namespace EDDiscovery.UserControls
             if (currentedit != null)
             {
                 BookmarkClass bk = (BookmarkClass)currentedit.Tag;
-                string newNote = currentedit.Cells[2].Value.ToString();
+                string newNote = "";
+                if (null != currentedit.Cells[2].Value)
+                {
+                    newNote = currentedit.Cells[2].Value.ToString();
+                }
                 //System.Diagnostics.Debug.WriteLine("Checking for save " + currentedit.Index);
 
                 if (!newNote.Equals(bk.Note) || userControlSurfaceBookmarks.Edited)     // notes or planet marks changed


### PR DESCRIPTION
Fixes issues #2118 and #2120 

If a bookmark has a note and we clear it out, it will try to null it out. Set it to an empty string in this case, instead.

Also, if a bookmark's system cannot be found in the system DB, then we don't set the position in the bookmark editing dialog, which throws when we try to update the bookmark. The solution here is simply to fall back to the bookmark's position data if we can't find the system.