### PR TITLE
Prefer EDSM scans over basic scans

### DIFF
--- a/EliteDangerous/EliteDangerous/StarScan.cs
+++ b/EliteDangerous/EliteDangerous/StarScan.cs
@@ -97,7 +97,7 @@ namespace EliteDangerousCore
 
                     if (scandata == null)
                         scandata = value;
-                    else if (!value.IsEDSMBody) // Always overwrtite if its a journalscan.
+                    else if ((!value.IsEDSMBody && value.ScanType != "Basic") || scandata.ScanType == "Basic") // Always overwrtite if its a journalscan (except basic scans)
                         scandata = value;
                 }
             }


### PR DESCRIPTION
A common complaint is that when the commander has forgotten to equip a DSS, bodies lose their materials when they scan the body.  Fix this by preferring anything else over basic scans.