### PR TITLE
Fix rare case where EdsmSystems doesn't exist

### DIFF
--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -546,6 +546,7 @@ namespace EDDiscovery
         {
             StarScan.LoadBodyDesignationMap();
 
+            SQLiteConnectionSystem.RenameOrCreateSystemsTables();
             SQLiteConnectionSystem.CreateSystemsTableIndexes();     // just make sure they are there..
 
             Debug.WriteLine(BaseUtils.AppTicks.TickCountLap() + " Check systems");


### PR DESCRIPTION
Transactions don't actually protect DROP statements, as those statements
are always auto-committed.
Therefore we need to handle the case where the DROP statements executed,
but the RENAME statements failed to execute.

This PR should fix #2136 