### PR TITLE
Make CommandArgs debuggable; re-enable AppFolder in options.txt

### DIFF
--- a/BaseUtils/Misc/CommandArgs.cs
+++ b/BaseUtils/Misc/CommandArgs.cs
@@ -34,9 +34,11 @@ namespace BaseUtils
         }
 
         public string Peek { get { return (pos < args.Length) ? args[pos] : null; } }
-        public string Next { get { return (pos < args.Length) ? args[pos++] : null; } }
-        public string NextEmpty { get { return (pos < args.Length) ? args[pos++] : ""; } }
-        public int Int { get { return (pos < args.Length) ? args[pos++].InvariantParseInt(0) : 0; } }
+
+        public string Next() { return (pos < args.Length) ? args[pos++] : null; }
+        public string NextEmpty() { return (pos < args.Length) ? args[pos++] : ""; }
+        public int Int() { return (pos < args.Length) ? args[pos++].InvariantParseInt(0) : 0; }
+
         public string this[int v] { get { int left = args.Length - pos; return (v < left) ? args[pos + v] : null; } }
         public bool More { get { return args.Length > pos; } }
         public int Left { get { return args.Length - pos; } }

--- a/BaseUtils/Misc/CommandArgs.cs
+++ b/BaseUtils/Misc/CommandArgs.cs
@@ -38,6 +38,7 @@ namespace BaseUtils
         public string Next() { return (pos < args.Length) ? args[pos++] : null; }
         public string NextEmpty() { return (pos < args.Length) ? args[pos++] : ""; }
         public int Int() { return (pos < args.Length) ? args[pos++].InvariantParseInt(0) : 0; }
+        public string Rest(string sep = " ") { return string.Join(sep, args, pos, args.Length - pos); }
 
         public string this[int v] { get { int left = args.Length - pos; return (v < left) ? args[pos + v] : null; } }
         public bool More { get { return args.Length > pos; } }

--- a/EDDiscovery/EDDOptions.cs
+++ b/EDDiscovery/EDDOptions.cs
@@ -93,7 +93,7 @@ namespace EDDiscovery
 
         private void SetAppDataDirectory()
         {
-            ProcessCommandLineOptions((optname, ca) =>              //FIRST pass thru command line options looking
+            ProcessCommandLineOptions((optname, ca, toeol) =>              //FIRST pass thru command line options looking
             {                                                           //JUST for -appfolder
                 if (optname == "-appfolder" && ca.More)
                 {
@@ -165,10 +165,10 @@ namespace EDDiscovery
             UserDatabasePath = appsettings["UserDatabasePath"];
         }
 
-        private void ProcessCommandLineForOptionsFile(string basefolder, Action<string, BaseUtils.CommandArgs> getopt)     // command line -optionsfile
+        private void ProcessCommandLineForOptionsFile(string basefolder, Action<string, BaseUtils.CommandArgs, bool> getopt)     // command line -optionsfile
         {
             //System.Diagnostics.Debug.WriteLine("OptionFile -optionsfile ");
-            ProcessCommandLineOptions((optname, ca) =>              //FIRST pass thru command line options looking
+            ProcessCommandLineOptions((optname, ca, toeol) =>              //FIRST pass thru command line options looking
             {                                                           //JUST for -optionsfile
                 if (optname == "-optionsfile" && ca.More)
                 {
@@ -185,7 +185,7 @@ namespace EDDiscovery
             });
         }
 
-        private void ProcessOptionFile(string filepath, Action<string, BaseUtils.CommandArgs> getopt)       // read file and process options
+        private void ProcessOptionFile(string filepath, Action<string, BaseUtils.CommandArgs, bool> getopt)       // read file and process options
         {
             //System.Diagnostics.Debug.WriteLine("Read File " + filepath);
             foreach (string line in File.ReadAllLines(filepath))
@@ -195,23 +195,23 @@ namespace EDDiscovery
                     //string[] cmds = line.Split(new char[] { ' ' }, 2).Select(s => s.Trim()).ToArray();    // old version..
                     string[] cmds = BaseUtils.StringParser.ParseWordList(line, separ: ' ').ToArray();
                     BaseUtils.CommandArgs ca = new BaseUtils.CommandArgs(cmds);
-                    getopt("-" + ca.Next().ToLowerInvariant(), ca);
+                    getopt("-" + ca.Next().ToLowerInvariant(), ca, true);
                 }
             }
         }
 
-        private void ProcessCommandLineOptions(Action<string, BaseUtils.CommandArgs> getopt)       // go thru command line..
+        private void ProcessCommandLineOptions(Action<string, BaseUtils.CommandArgs, bool> getopt)       // go thru command line..
         {
             string[] cmdlineopts = Environment.GetCommandLineArgs().ToArray();
             BaseUtils.CommandArgs ca = new BaseUtils.CommandArgs(cmdlineopts,1);
             //System.Diagnostics.Debug.WriteLine("Command Line:");
             while (ca.More)
             {
-                getopt(ca.Next().ToLowerInvariant(), ca);
+                getopt(ca.Next().ToLowerInvariant(), ca, false);
             }
         }
 
-        private void ProcessOption(string optname, BaseUtils.CommandArgs ca)
+        private void ProcessOption(string optname, BaseUtils.CommandArgs ca, bool toeol)
         {
             optname = optname.ToLowerInvariant();
             //System.Diagnostics.Debug.WriteLine("     Option " + optname);
@@ -227,19 +227,19 @@ namespace EDDiscovery
             }
             else if (optname == "-userdbpath")
             {
-                UserDatabasePath = ca.NextEmpty();
+                UserDatabasePath = toeol ? ca.Rest() : ca.NextEmpty();
             }
             else if (optname == "-systemsdbpath")
             {
-                SystemDatabasePath = ca.NextEmpty();
+                SystemDatabasePath = toeol ? ca.Rest() : ca.NextEmpty();
             }
             else if (optname == "-iconspath")
             {
-                IconsPath = ca.NextEmpty();
+                IconsPath = toeol ? ca.Rest() : ca.NextEmpty();
             }
             else if (optname == "-tracelog")
             {
-                TraceLog = ca.NextEmpty();
+                TraceLog = toeol ? ca.Rest() : ca.NextEmpty();
             }
             else if (optname.StartsWith("-"))
             {
@@ -281,7 +281,7 @@ namespace EDDiscovery
             }
             else
             {
-                System.Diagnostics.Debug.WriteLine($"Unrecognized non option -{optname}");
+                System.Diagnostics.Debug.WriteLine($"Unrecognized non option {optname}");
             }
         }
 
@@ -294,7 +294,7 @@ namespace EDDiscovery
             string optval = Path.Combine(ExeDirectory(), "options.txt");      // options in the exe folder.
             if (File.Exists(optval))   // try options.txt in the base folder..
             {
-                ProcessOptionFile(optval, (optname, ca) =>              //FIRST pass thru options.txt options looking
+                ProcessOptionFile(optval, (optname, ca, toeol) =>              //FIRST pass thru options.txt options looking
                 {                                                           //JUST for -appfolder
                     if (optname == "-appfolder" && ca.More)
                     {

--- a/EDDiscovery/EDDOptions.cs
+++ b/EDDiscovery/EDDOptions.cs
@@ -220,13 +220,6 @@ namespace EDDiscovery
             {
                 ca.Remove();   // waste it
             }
-            else if (optname == "-appfolder")
-            {
-                if (AppDataDirectory == null) // Only override AppFolder if AppDataDirectory has not been set
-                {
-                    AppFolder = ca.NextEmpty();
-                }
-            }
             else if (optname == "-translationfolder")
             {
                 translationfolder = ca.NextEmpty();
@@ -300,7 +293,17 @@ namespace EDDiscovery
 
             string optval = Path.Combine(ExeDirectory(), "options.txt");      // options in the exe folder.
             if (File.Exists(optval))   // try options.txt in the base folder..
+            {
+                ProcessOptionFile(optval, (optname, ca) =>              //FIRST pass thru options.txt options looking
+                {                                                           //JUST for -appfolder
+                    if (optname == "-appfolder" && ca.More)
+                    {
+                        AppFolder = ca.Rest();
+                        System.Diagnostics.Debug.WriteLine("App Folder to " + AppFolder);
+                    }
+                });
                 ProcessOptionFile(optval, ProcessOption);
+            }
 
             SetAppDataDirectory();      // set the app directory, now we have given base dir options to override appfolder, and we have given any -optionfiles on the command line
 

--- a/EDDiscovery/EDDOptions.cs
+++ b/EDDiscovery/EDDOptions.cs
@@ -97,7 +97,7 @@ namespace EDDiscovery
             {                                                           //JUST for -appfolder
                 if (optname == "-appfolder" && ca.More)
                 {
-                    AppFolder = ca.Next;
+                    AppFolder = ca.Next();
                     System.Diagnostics.Debug.WriteLine("App Folder to " + AppFolder);
                 }
             });
@@ -172,7 +172,7 @@ namespace EDDiscovery
             {                                                           //JUST for -optionsfile
                 if (optname == "-optionsfile" && ca.More)
                 {
-                    string filepath = ca.Next;
+                    string filepath = ca.Next();
 
                     if (!File.Exists(filepath) && !Path.IsPathRooted(filepath))  // if it does not exist on its own, may be relative to base folder ..
                         filepath = Path.Combine(basefolder, filepath);
@@ -195,7 +195,7 @@ namespace EDDiscovery
                     //string[] cmds = line.Split(new char[] { ' ' }, 2).Select(s => s.Trim()).ToArray();    // old version..
                     string[] cmds = BaseUtils.StringParser.ParseWordList(line, separ: ' ').ToArray();
                     BaseUtils.CommandArgs ca = new BaseUtils.CommandArgs(cmds);
-                    getopt("-" + ca.Next.ToLowerInvariant(), ca);
+                    getopt("-" + ca.Next().ToLowerInvariant(), ca);
                 }
             }
         }
@@ -207,7 +207,7 @@ namespace EDDiscovery
             //System.Diagnostics.Debug.WriteLine("Command Line:");
             while (ca.More)
             {
-                getopt(ca.Next.ToLowerInvariant(), ca);
+                getopt(ca.Next().ToLowerInvariant(), ca);
             }
         }
 
@@ -224,29 +224,29 @@ namespace EDDiscovery
             {
                 if (AppDataDirectory == null) // Only override AppFolder if AppDataDirectory has not been set
                 {
-                    AppFolder = ca.NextEmpty;
+                    AppFolder = ca.NextEmpty();
                 }
             }
             else if (optname == "-translationfolder")
             {
-                translationfolder = ca.NextEmpty;
-                TranslatorDirectoryIncludeSearchUpDepth = ca.Int;
+                translationfolder = ca.NextEmpty();
+                TranslatorDirectoryIncludeSearchUpDepth = ca.Int();
             }
             else if (optname == "-userdbpath")
             {
-                UserDatabasePath = ca.NextEmpty;
+                UserDatabasePath = ca.NextEmpty();
             }
             else if (optname == "-systemsdbpath")
             {
-                SystemDatabasePath = ca.NextEmpty;
+                SystemDatabasePath = ca.NextEmpty();
             }
             else if (optname == "-iconspath")
             {
-                IconsPath = ca.NextEmpty;
+                IconsPath = ca.NextEmpty();
             }
             else if (optname == "-tracelog")
             {
-                TraceLog = ca.NextEmpty;
+                TraceLog = ca.NextEmpty();
             }
             else if (optname.StartsWith("-"))
             {

--- a/TestNetLogEntry/Journal.cs
+++ b/TestNetLogEntry/Journal.cs
@@ -24,7 +24,7 @@ namespace NetLogEntry
             {
                 CommandArgs args = new CommandArgs(argsentry);
 
-                string eventtype = args.Next.ToLower();
+                string eventtype = args.Next().ToLower();
 
                 Random rnd = new Random();
 
@@ -54,15 +54,15 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("commitcrime"))
                 {
-                    string f = args.Next;
-                    int id = args.Int;
+                    string f = args.Next();
+                    int id = args.Int();
                     lineout = "{ " + TimeStamp() + F("event", "CommitCrime") + F("CrimeType", "collidedAtSpeedInNoFireZone") + F("Faction", f) + FF("Fine", id) + " }";
                 }
                 else if (eventtype.Equals("missionaccepted") && args.Left == 3)
                 {
-                    string f = args.Next;
-                    string vf = args.Next;
-                    int id = args.Int;
+                    string f = args.Next();
+                    string vf = args.Next();
+                    int id = args.Int();
 
                     lineout = "{ " + TimeStamp() + F("event", "MissionAccepted") + F("Faction", f) +
                             F("Name", "Mission_Assassinate_Legal_Corporate") + F("TargetType", "$MissionUtil_FactionTag_PirateLord;") + F("TargetType_Localised", "Pirate lord") + F("TargetFaction", vf)
@@ -71,9 +71,9 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("missioncompleted") && args.Left == 3)
                 {
-                    string f = args.Next;
-                    string vf = args.Next;
-                    int id = args.Int;
+                    string f = args.Next();
+                    string vf = args.Next();
+                    int id = args.Int();
 
                     lineout = "{ " + TimeStamp() + F("event", "MissionCompleted") + F("Faction", f) +
                         F("Name", "Mission_Assassinate_Legal_Corporate") + F("TargetType", "$MissionUtil_FactionTag_PirateLord;") + F("TargetType_Localised", "Pirate lord") + F("TargetFaction", vf) +
@@ -81,16 +81,16 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("missionredirected") && args.Left == 3)
                 {
-                    string sysn = args.Next;
-                    string stationn = args.Next;
-                    int id = args.Int;
+                    string sysn = args.Next();
+                    string stationn = args.Next();
+                    int id = args.Int();
                     lineout = "{ " + TimeStamp() + F("event", "MissionRedirected") + F("MissionID", id) + F("MissionName", "Mission_Assassinate_Legal_Corporate") +
                         F("NewDestinationStation", stationn) + F("OldDestinationStation", "Cuffey Orbital") +
                         F("NewDestinationSystem", sysn) + FF("OldDestinationSystem", "Vequess") + " }";
                 }
                 else if (eventtype.Equals("missions") && args.Left == 1)
                 {
-                    int id = args.Int;
+                    int id = args.Int();
                     BaseUtils.QuickJSONFormatter qj = new QuickJSONFormatter();
 
                     qj.Object().UTC("timestamp").V("event", "Missions");
@@ -111,9 +111,9 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("marketbuy") && args.Left == 3)
                 {
-                    string name = args.Next;
-                    int count = args.Int;
-                    int price = args.Int;
+                    string name = args.Next();
+                    int count = args.Int();
+                    int price = args.Int();
 
                     BaseUtils.QuickJSONFormatter qj = new QuickJSONFormatter();
 
@@ -122,17 +122,17 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("bounty"))
                 {
-                    string f = args.Next;
-                    int rw = args.Int;
+                    string f = args.Next();
+                    int rw = args.Int();
 
                     lineout = "{ " + TimeStamp() + F("event", "Bounty") + F("VictimFaction", f) + F("VictimFaction_Localised", f + "_Loc") +
                         F("TotalReward", rw, true) + "}";
                 }
                 else if (eventtype.Equals("factionkillbond"))
                 {
-                    string f = args.Next;
-                    string vf = args.Next;
-                    int rw = args.Int;
+                    string f = args.Next();
+                    string vf = args.Next();
+                    int rw = args.Int();
 
                     lineout = "{ " + TimeStamp() + F("event", "FactionKillBond") + F("VictimFaction", vf) + F("VictimFaction_Localised", vf + "_Loc") +
                         F("AwardingFaction", f) + F("AwardingFaction_Localised", f + "_Loc") +
@@ -140,9 +140,9 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("capshipbond"))
                 {
-                    string f = args.Next;
-                    string vf = args.Next;
-                    int rw = args.Int;
+                    string f = args.Next();
+                    string vf = args.Next();
+                    int rw = args.Int();
 
                     lineout = "{ " + TimeStamp() + F("event", "CapShipBond") + F("VictimFaction", vf) + F("VictimFaction_Localised", vf + "_Loc") +
                         F("AwardingFaction", f) + F("AwardingFaction_Localised", f + "_Loc") +
@@ -150,7 +150,7 @@ namespace NetLogEntry
                 }
                 else if (eventtype.Equals("resurrect"))
                 {
-                    int ct = args.Int;
+                    int ct = args.Int();
 
                     lineout = "{ " + TimeStamp() + F("event", "Resurrect") + F("Option", "Help me") + F("Cost", ct) + FF("Bankrupt", false) + "}";
                 }
@@ -167,7 +167,7 @@ namespace NetLogEntry
                     lineout = "{ " + TimeStamp() + F("event", "NavBeaconScan") + FF("NumBodies", "3") + " }";
                 else if (eventtype.Equals("scanplanet") && args.Left >= 1)
                 {
-                    lineout = "{ " + TimeStamp() + F("event", "Scan") + "\"BodyName\":\"" + args.Next + "x" + repeatcount + "\", \"DistanceFromArrivalLS\":639.245483, \"TidalLock\":true, \"TerraformState\":\"\", \"PlanetClass\":\"Metal rich body\", \"Atmosphere\":\"\", \"AtmosphereType\":\"None\", \"Volcanism\":\"rocky magma volcanism\", \"MassEM\":0.010663, \"Radius\":1163226.500000, \"SurfaceGravity\":3.140944, \"SurfaceTemperature\":1068.794067, \"SurfacePressure\":0.000000, \"Landable\":true, \"Materials\":[ { \"Name\":\"iron\", \"Percent\":36.824127 }, { \"Name\":\"nickel\", \"Percent\":27.852226 }, { \"Name\":\"chromium\", \"Percent\":16.561033 }, { \"Name\":\"zinc\", \"Percent\":10.007420 }, { \"Name\":\"selenium\", \"Percent\":2.584032 }, { \"Name\":\"tin\", \"Percent\":2.449526 }, { \"Name\":\"molybdenum\", \"Percent\":2.404594 }, { \"Name\":\"technetium\", \"Percent\":1.317050 } ], \"SemiMajorAxis\":1532780800.000000, \"Eccentricity\":0.000842, \"OrbitalInclination\":-1.609496, \"Periapsis\":179.381393, \"OrbitalPeriod\":162753.062500, \"RotationPeriod\":162754.531250, \"AxialTilt\":0.033219 }";
+                    lineout = "{ " + TimeStamp() + F("event", "Scan") + "\"BodyName\":\"" + args.Next() + "x" + repeatcount + "\", \"DistanceFromArrivalLS\":639.245483, \"TidalLock\":true, \"TerraformState\":\"\", \"PlanetClass\":\"Metal rich body\", \"Atmosphere\":\"\", \"AtmosphereType\":\"None\", \"Volcanism\":\"rocky magma volcanism\", \"MassEM\":0.010663, \"Radius\":1163226.500000, \"SurfaceGravity\":3.140944, \"SurfaceTemperature\":1068.794067, \"SurfacePressure\":0.000000, \"Landable\":true, \"Materials\":[ { \"Name\":\"iron\", \"Percent\":36.824127 }, { \"Name\":\"nickel\", \"Percent\":27.852226 }, { \"Name\":\"chromium\", \"Percent\":16.561033 }, { \"Name\":\"zinc\", \"Percent\":10.007420 }, { \"Name\":\"selenium\", \"Percent\":2.584032 }, { \"Name\":\"tin\", \"Percent\":2.449526 }, { \"Name\":\"molybdenum\", \"Percent\":2.404594 }, { \"Name\":\"technetium\", \"Percent\":1.317050 } ], \"SemiMajorAxis\":1532780800.000000, \"Eccentricity\":0.000842, \"OrbitalInclination\":-1.609496, \"Periapsis\":179.381393, \"OrbitalPeriod\":162753.062500, \"RotationPeriod\":162754.531250, \"AxialTilt\":0.033219 }";
                 }
                 else if (eventtype.Equals("scanstar"))
                 {
@@ -186,8 +186,8 @@ namespace NetLogEntry
 
                 else if (eventtype.Equals("searchandrescue") && args.Left == 2)
                 {
-                    string name = args.Next;
-                    int count = args.Int;
+                    string name = args.Next();
+                    int count = args.Int();
                     BaseUtils.QuickJSONFormatter qj = new QuickJSONFormatter();
                     lineout = qj.Object().UTC("timestamp").V("event", "SearchAndRescue").V("MarketID", 29029292)
                                 .V("Name", name).V("Name_Localised", name + "loc").V("Count", count).V("Reward", 10234).Get();
@@ -206,11 +206,11 @@ namespace NetLogEntry
                 else if (eventtype.Equals("musicgalmap"))
                     lineout = "{ " + TimeStamp() + F("event", "Music") + FF("MusicTrack", "GalaxyMap") + " }";
                 else if (eventtype.Equals("friends") && args.Left >= 1)
-                    lineout = "{ " + TimeStamp() + F("event", "Friends") + F("Status", "Online") + FF("Name", args.Next) + " }";
+                    lineout = "{ " + TimeStamp() + F("event", "Friends") + F("Status", "Online") + FF("Name", args.Next()) + " }";
                 else if (eventtype.Equals("fuelscoop") && args.Left >= 2)
                 {
-                    string scoop = args.Next;
-                    string total = args.Next;
+                    string scoop = args.Next();
+                    string total = args.Next();
                     lineout = "{ " + TimeStamp() + F("event", "FuelScoop") + F("Scooped", scoop) + FF("Total", total) + " }";
                 }
                 else if (eventtype.Equals("jetconeboost"))
@@ -226,19 +226,19 @@ namespace NetLogEntry
                 else if (eventtype.Equals("launchdrone"))
                     lineout = "{ " + TimeStamp() + F("event", "LaunchDrone") + FF("Type", "FuelTransfer") + " }";
                 else if (eventtype.Equals("market"))
-                    lineout = Market(Path.GetDirectoryName(filename), args.Next);
+                    lineout = Market(Path.GetDirectoryName(filename), args.Next());
                 else if (eventtype.Equals("moduleinfo"))
-                    lineout = ModuleInfo(Path.GetDirectoryName(filename), args.Next);
+                    lineout = ModuleInfo(Path.GetDirectoryName(filename), args.Next());
                 else if (eventtype.Equals("outfitting"))
-                    lineout = Outfitting(Path.GetDirectoryName(filename), args.Next);
+                    lineout = Outfitting(Path.GetDirectoryName(filename), args.Next());
                 else if (eventtype.Equals("shipyard"))
-                    lineout = Shipyard(Path.GetDirectoryName(filename), args.Next);
+                    lineout = Shipyard(Path.GetDirectoryName(filename), args.Next());
                 else if (eventtype.Equals("powerplay"))
                     lineout = "{ " + TimeStamp() + F("event", "PowerPlay") + F("Power", "Fred") + F("Rank", 10) + F("Merits", 10) + F("Votes", 2) + FF("TimePledged", 433024) + " }";
                 else if (eventtype.Equals("underattack"))
                     lineout = "{ " + TimeStamp() + F("event", "UnderAttack") + FF("Target", "Fighter") + " }";
                 else if (eventtype.Equals("promotion") && args.Left==2)
-                    lineout = "{ " + TimeStamp() + F("event", "Promotion") + FF(args.Next, args.Int) + " }";
+                    lineout = "{ " + TimeStamp() + F("event", "Promotion") + FF(args.Next(), args.Int()) + " }";
                 else if (eventtype.Equals("cargodepot"))
                     lineout = CargoDepot(args);
                 else
@@ -303,9 +303,9 @@ namespace NetLogEntry
             }
 
             double x = double.NaN, y = 0, z = 0;
-            string starnameroot = args.Next;
+            string starnameroot = args.Next();
 
-            if (!double.TryParse(args.Next, out x) || !double.TryParse(args.Next, out y) || !double.TryParse(args.Next, out z))
+            if (!double.TryParse(args.Next(), out x) || !double.TryParse(args.Next(), out y) || !double.TryParse(args.Next(), out z))
             {
                 Console.WriteLine("X,y,Z must be numbers");
                 return null;
@@ -344,9 +344,9 @@ namespace NetLogEntry
             }
 
             double x = double.NaN, y = 0, z = 0;
-            string starnameroot = args.Next;
+            string starnameroot = args.Next();
 
-            if (!double.TryParse(args.Next, out x) || !double.TryParse(args.Next, out y) || !double.TryParse(args.Next, out z))
+            if (!double.TryParse(args.Next(), out x) || !double.TryParse(args.Next(), out y) || !double.TryParse(args.Next(), out z))
             {
                 Console.WriteLine("** X,Y,Z must be numbers");
                 return null;
@@ -373,11 +373,11 @@ namespace NetLogEntry
 
             double x = double.NaN, y = 0, z = 0, dx = 0, dy = 0, dz = 0;
             double percent = 0;
-            string starnameroot = args.Next;
+            string starnameroot = args.Next();
 
-            if (!double.TryParse(args.Next, out x) || !double.TryParse(args.Next, out y) || !double.TryParse(args.Next, out z) ||
-                !double.TryParse(args.Next, out dx) || !double.TryParse(args.Next, out dy) || !double.TryParse(args.Next, out dz) ||
-                !double.TryParse(args.Next, out percent))
+            if (!double.TryParse(args.Next(), out x) || !double.TryParse(args.Next(), out y) || !double.TryParse(args.Next(), out z) ||
+                !double.TryParse(args.Next(), out dx) || !double.TryParse(args.Next(), out dy) || !double.TryParse(args.Next(), out dz) ||
+                !double.TryParse(args.Next(), out percent))
             {
                 Console.WriteLine("** X,Y,Z,dx,dy,dz,percent must be numbers");
                 return null;
@@ -425,11 +425,11 @@ namespace NetLogEntry
         {
             try
             {
-                int missid = int.Parse(args.Next);
-                string type = args.Next;
-                int countcol = int.Parse(args.Next);
-                int countdel = int.Parse(args.Next);
-                int total = int.Parse(args.Next);
+                int missid = int.Parse(args.Next());
+                string type = args.Next();
+                int countcol = int.Parse(args.Next());
+                int countdel = int.Parse(args.Next());
+                int total = int.Parse(args.Next());
 
                 return "{ " + TimeStamp() + F("event", "CargoDepot") + F("MissionID", missid) + F("UpdateType", type) +
                                 F("StartMarketID", 12) + F("EndMarketID", 13) +

--- a/TestNetLogEntry/Program.cs
+++ b/TestNetLogEntry/Program.cs
@@ -27,7 +27,7 @@ namespace NetLogEntry
                     else if (opt.Equals("-repeat", StringComparison.InvariantCultureIgnoreCase) && args.Left >= 1)
                     {
                         args.Remove();
-                        if (!int.TryParse(args.Next, out repeatdelay))
+                        if (!int.TryParse(args.Next(), out repeatdelay))
                         {
                             Console.WriteLine("Bad repeat delay\n");
                             return;
@@ -40,7 +40,7 @@ namespace NetLogEntry
                     break;
             }
 
-            string arg1 = args.Next;
+            string arg1 = args.Next();
 
             if (arg1 == null)
             {
@@ -68,32 +68,32 @@ namespace NetLogEntry
 
             if (arg1.Equals("EDDBSTARS", StringComparison.InvariantCultureIgnoreCase))
             {
-                EDDB.EDDBLog(args.Next, "\"Star\"", "\"spectral_class\"", "Star class ");
+                EDDB.EDDBLog(args.Next(), "\"Star\"", "\"spectral_class\"", "Star class ");
             }
             else if (arg1.Equals("EDDBPLANETS", StringComparison.InvariantCultureIgnoreCase))
             {
-                EDDB.EDDBLog(args.Next, "\"Planet\"", "\"type_name\"", "Planet class");
+                EDDB.EDDBLog(args.Next(), "\"Planet\"", "\"type_name\"", "Planet class");
             }
             else if (arg1.Equals("EDDBSTARNAMES", StringComparison.InvariantCultureIgnoreCase))
             {
-                EDDB.EDDBLog(args.Next, "\"Star\"", "\"name\"", "Star Name");
+                EDDB.EDDBLog(args.Next(), "\"Star\"", "\"name\"", "Star Name");
             }
             else if (arg1.Equals("voicerecon", StringComparison.InvariantCultureIgnoreCase))
             {
-                BindingsFile.Bindings(args.Next);
+                BindingsFile.Bindings(args.Next());
             }
             else if (arg1.Equals("devicemappings", StringComparison.InvariantCultureIgnoreCase))
             {
-                BindingsFile.DeviceMappings(args.Next);
+                BindingsFile.DeviceMappings(args.Next());
             }
             else if (arg1.Equals("Phoneme", StringComparison.InvariantCultureIgnoreCase))
             {
                 if (args.Left >= 1)
-                    Speech.Phoneme(args.Next, args.Next);
+                    Speech.Phoneme(args.Next(), args.Next());
             }
             else if (arg1.Equals("Corolisships", StringComparison.InvariantCultureIgnoreCase))
             {
-                FileInfo[] allFiles = Directory.EnumerateFiles(args.Next, "*.json", SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
+                FileInfo[] allFiles = Directory.EnumerateFiles(args.Next(), "*.json", SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
 
 
                 string ret = CorolisData.ProcessShips(allFiles);
@@ -101,7 +101,7 @@ namespace NetLogEntry
             }
             else if (arg1.Equals("Corolisship", StringComparison.InvariantCultureIgnoreCase))
             {
-                FileInfo[] allFiles = Directory.EnumerateFiles(".", args.Next, SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
+                FileInfo[] allFiles = Directory.EnumerateFiles(".", args.Next(), SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
 
 
                 string ret = CorolisData.ProcessShips(allFiles);
@@ -109,33 +109,33 @@ namespace NetLogEntry
             }
             else if (arg1.Equals("Corolismodules", StringComparison.InvariantCultureIgnoreCase))
             {
-                FileInfo[] allFiles = Directory.EnumerateFiles(args.Next, "*.json", SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
+                FileInfo[] allFiles = Directory.EnumerateFiles(args.Next(), "*.json", SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
 
                 string ret = CorolisData.ProcessModules(allFiles);
                 Console.WriteLine(ret);
             }
             else if (arg1.Equals("Corolismodule", StringComparison.InvariantCultureIgnoreCase))
             {
-                FileInfo[] allFiles = Directory.EnumerateFiles(".", args.Next, SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
+                FileInfo[] allFiles = Directory.EnumerateFiles(".", args.Next(), SearchOption.AllDirectories).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
 
                 string ret = CorolisData.ProcessModules(allFiles);
                 Console.WriteLine(ret);
             }
             else if (arg1.Equals("FrontierData", StringComparison.InvariantCultureIgnoreCase))
             {
-                string ret = FrontierData.Process(args.Next);
+                string ret = FrontierData.Process(args.Next());
                 Console.WriteLine(ret);
             }
             else if (arg1.Equals("scantranslate", StringComparison.InvariantCultureIgnoreCase))
             {
-                string path = args.Next;
+                string path = args.Next();
                 FileInfo[] allFiles = Directory.EnumerateFiles(".", path, SearchOption.TopDirectoryOnly).Select(f => new FileInfo(f)).OrderBy(p => p.FullName).ToArray();
                 bool combine = false;
                 bool showrepeat = false;
 
                 while( args.More )
                 {
-                    string a = args.Next.ToLowerInvariant();
+                    string a = args.Next().ToLowerInvariant();
                     if (a == "combine")
                         combine = true;
                     if (a == "showrepeats" )
@@ -147,7 +147,7 @@ namespace NetLogEntry
             }
             else
             {
-                Journal.JournalEntry(arg1, args.Next, args, repeatdelay);
+                Journal.JournalEntry(arg1, args.Next(), args, repeatdelay);
             }
         }
 

--- a/TestNetLogEntry/Status.cs
+++ b/TestNetLogEntry/Status.cs
@@ -67,10 +67,10 @@ namespace NetLogEntry
             double headstep = 1;
             int steptime = 100;
 
-            if (!double.TryParse(args.Next, out latitude) || !double.TryParse(args.Next, out longitude) ||
-                !double.TryParse(args.Next, out latstep) || !double.TryParse(args.Next, out longstep) ||
-                !double.TryParse(args.Next, out heading) || !double.TryParse(args.Next, out headstep) ||
-                !int.TryParse(args.Next, out steptime))
+            if (!double.TryParse(args.Next(), out latitude) || !double.TryParse(args.Next(), out longitude) ||
+                !double.TryParse(args.Next(), out latstep) || !double.TryParse(args.Next(), out longstep) ||
+                !double.TryParse(args.Next(), out heading) || !double.TryParse(args.Next(), out headstep) ||
+                !int.TryParse(args.Next(), out steptime))
             {
                 Console.WriteLine("** More/Wrong parameters: statusjson lat long latstep lonstep heading headstep steptimems");
                 return;
@@ -106,7 +106,7 @@ namespace NetLogEntry
             long flags = 0;
 
             string v;
-            while ((v = args.Next) != null)
+            while ((v = args.Next()) != null)
             {
                 if (Enum.TryParse<StatusFlagsShip>(v, true, out StatusFlagsShip s))
                 {


### PR DESCRIPTION
Getters should be idempotent.  The `Next`, `NextEmpty` and `Int` getters are not idempotent, and modify the state of the `CommandArgs` object.  Convert them to methods.

AppFolder processing from options.txt was also bypassed.  Re-enable it in a way that won't accidentally be bypassed again.