### PR TITLE
Circumstellar zones

### DIFF
--- a/EDDiscovery.sln.DotSettings.user
+++ b/EDDiscovery.sln.DotSettings.user
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Circumstellar/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
@@ -48,6 +48,11 @@ namespace EDDiscovery.UserControls
 			this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.showSystemInformationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showMetalRichPlanetsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showWaterWorldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showEarthLikeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showAmmoniaWorldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showIcyPlanetsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItemTargetLine = new System.Windows.Forms.ToolStripMenuItem();
 			this.EDSMButtonToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItemTime = new System.Windows.Forms.ToolStripMenuItem();
@@ -64,6 +69,7 @@ namespace EDDiscovery.UserControls
 			this.showNothingWhenDockedtoolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.dontshowwhenInGalaxyPanelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.dontshowwhenInSystemMapPanelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
 			this.completelyHideThePanelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.OrdertoolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.orderDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -96,7 +102,6 @@ namespace EDDiscovery.UserControls
 			this.buttonExt10 = new ExtendedControls.ButtonExt();
 			this.buttonExt11 = new ExtendedControls.ButtonExt();
 			this.buttonExt12 = new ExtendedControls.ButtonExt();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
 			((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
 			this.contextMenuStrip.SuspendLayout();
 			this.SuspendLayout();
@@ -135,7 +140,7 @@ namespace EDDiscovery.UserControls
             this.surfaceScanDetailsToolStripMenuItem,
             this.showInPositionToolStripMenuItem});
 			this.contextMenuStrip.Name = "contextMenuStripConfig";
-			this.contextMenuStrip.Size = new System.Drawing.Size(347, 444);
+			this.contextMenuStrip.Size = new System.Drawing.Size(359, 466);
 			// 
 			// showSystemInformationToolStripMenuItem
 			// 
@@ -143,7 +148,7 @@ namespace EDDiscovery.UserControls
 			this.showSystemInformationToolStripMenuItem.CheckOnClick = true;
 			this.showSystemInformationToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showSystemInformationToolStripMenuItem.Name = "showSystemInformationToolStripMenuItem";
-			this.showSystemInformationToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showSystemInformationToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showSystemInformationToolStripMenuItem.Text = "Show System Information";
 			this.showSystemInformationToolStripMenuItem.Click += new System.EventHandler(this.showSystemInformationToolStripMenuItem_Click);
 			// 
@@ -152,10 +157,56 @@ namespace EDDiscovery.UserControls
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Checked = true;
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckOnClick = true;
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.showMetalRichPlanetsToolStripMenuItem,
+            this.showWaterWorldsToolStripMenuItem,
+            this.showEarthLikeToolStripMenuItem,
+            this.showAmmoniaWorldsToolStripMenuItem,
+            this.showIcyPlanetsToolStripMenuItem});
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Name = "showHabitationMinimumAndMaximumDistanceToolStripMenuItem";
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Text = "Show Habitation Minimum and Maximum Distance";
 			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Click += new System.EventHandler(this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem_Click);
+			// 
+			// showMetalRichPlanetsToolStripMenuItem
+			// 
+			this.showMetalRichPlanetsToolStripMenuItem.CheckOnClick = true;
+			this.showMetalRichPlanetsToolStripMenuItem.Name = "showMetalRichPlanetsToolStripMenuItem";
+			this.showMetalRichPlanetsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.showMetalRichPlanetsToolStripMenuItem.Text = "Metal Rich Planets";
+			this.showMetalRichPlanetsToolStripMenuItem.Click += new System.EventHandler(this.showMetalRichPlanetsToolStripMenuItem_Click);
+			// 
+			// showWaterWorldsToolStripMenuItem
+			// 
+			this.showWaterWorldsToolStripMenuItem.CheckOnClick = true;
+			this.showWaterWorldsToolStripMenuItem.Name = "showWaterWorldsToolStripMenuItem";
+			this.showWaterWorldsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.showWaterWorldsToolStripMenuItem.Text = "Water Worlds";
+			this.showWaterWorldsToolStripMenuItem.Click += new System.EventHandler(this.showWaterWorldsToolStripMenuItem_Click);
+			// 
+			// showEarthLikeToolStripMenuItem
+			// 
+			this.showEarthLikeToolStripMenuItem.CheckOnClick = true;
+			this.showEarthLikeToolStripMenuItem.Name = "showEarthLikeToolStripMenuItem";
+			this.showEarthLikeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.showEarthLikeToolStripMenuItem.Text = "Earth Like";
+			this.showEarthLikeToolStripMenuItem.Click += new System.EventHandler(this.showEarthLikeToolStripMenuItem_Click);
+			// 
+			// showAmmoniaWorldsToolStripMenuItem
+			// 
+			this.showAmmoniaWorldsToolStripMenuItem.CheckOnClick = true;
+			this.showAmmoniaWorldsToolStripMenuItem.Name = "showAmmoniaWorldsToolStripMenuItem";
+			this.showAmmoniaWorldsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.showAmmoniaWorldsToolStripMenuItem.Text = "Ammonia Worlds";
+			this.showAmmoniaWorldsToolStripMenuItem.Click += new System.EventHandler(this.showAmmoniaWorldsToolStripMenuItem_Click);
+			// 
+			// showIcyPlanetsToolStripMenuItem
+			// 
+			this.showIcyPlanetsToolStripMenuItem.CheckOnClick = true;
+			this.showIcyPlanetsToolStripMenuItem.Name = "showIcyPlanetsToolStripMenuItem";
+			this.showIcyPlanetsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.showIcyPlanetsToolStripMenuItem.Text = "Icy Planets";
+			this.showIcyPlanetsToolStripMenuItem.Click += new System.EventHandler(this.showIcyPlanetsToolStripMenuItem_Click);
 			// 
 			// toolStripMenuItemTargetLine
 			// 
@@ -163,7 +214,7 @@ namespace EDDiscovery.UserControls
 			this.toolStripMenuItemTargetLine.CheckOnClick = true;
 			this.toolStripMenuItemTargetLine.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.toolStripMenuItemTargetLine.Name = "toolStripMenuItemTargetLine";
-			this.toolStripMenuItemTargetLine.Size = new System.Drawing.Size(346, 22);
+			this.toolStripMenuItemTargetLine.Size = new System.Drawing.Size(358, 22);
 			this.toolStripMenuItemTargetLine.Text = "Show Target Line";
 			this.toolStripMenuItemTargetLine.Click += new System.EventHandler(this.toolStripMenuItemTargetLine_Click);
 			// 
@@ -173,7 +224,7 @@ namespace EDDiscovery.UserControls
 			this.EDSMButtonToolStripMenuItem.CheckOnClick = true;
 			this.EDSMButtonToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.EDSMButtonToolStripMenuItem.Name = "EDSMButtonToolStripMenuItem";
-			this.EDSMButtonToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.EDSMButtonToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.EDSMButtonToolStripMenuItem.Text = "EDSM Button";
 			this.EDSMButtonToolStripMenuItem.Click += new System.EventHandler(this.EDSMButtonToolStripMenuItem_Click);
 			// 
@@ -183,7 +234,7 @@ namespace EDDiscovery.UserControls
 			this.toolStripMenuItemTime.CheckOnClick = true;
 			this.toolStripMenuItemTime.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.toolStripMenuItemTime.Name = "toolStripMenuItemTime";
-			this.toolStripMenuItemTime.Size = new System.Drawing.Size(346, 22);
+			this.toolStripMenuItemTime.Size = new System.Drawing.Size(358, 22);
 			this.toolStripMenuItemTime.Text = "Show Time";
 			this.toolStripMenuItemTime.Click += new System.EventHandler(this.toolStripMenuItemTime_Click);
 			// 
@@ -193,7 +244,7 @@ namespace EDDiscovery.UserControls
 			this.iconToolStripMenuItem.CheckOnClick = true;
 			this.iconToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.iconToolStripMenuItem.Name = "iconToolStripMenuItem";
-			this.iconToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.iconToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.iconToolStripMenuItem.Text = "Show Event Icon";
 			this.iconToolStripMenuItem.Click += new System.EventHandler(this.iconToolStripMenuItem_Click);
 			// 
@@ -203,7 +254,7 @@ namespace EDDiscovery.UserControls
 			this.showDescriptionToolStripMenuItem.CheckOnClick = true;
 			this.showDescriptionToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showDescriptionToolStripMenuItem.Name = "showDescriptionToolStripMenuItem";
-			this.showDescriptionToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showDescriptionToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showDescriptionToolStripMenuItem.Text = "Show Description";
 			this.showDescriptionToolStripMenuItem.Click += new System.EventHandler(this.showDescriptionToolStripMenuItem_Click);
 			// 
@@ -213,7 +264,7 @@ namespace EDDiscovery.UserControls
 			this.showInformationToolStripMenuItem.CheckOnClick = true;
 			this.showInformationToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showInformationToolStripMenuItem.Name = "showInformationToolStripMenuItem";
-			this.showInformationToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showInformationToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showInformationToolStripMenuItem.Text = "Show Information";
 			this.showInformationToolStripMenuItem.Click += new System.EventHandler(this.showInformationToolStripMenuItem_Click);
 			// 
@@ -223,7 +274,7 @@ namespace EDDiscovery.UserControls
 			this.showNotesToolStripMenuItem.CheckOnClick = true;
 			this.showNotesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showNotesToolStripMenuItem.Name = "showNotesToolStripMenuItem";
-			this.showNotesToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showNotesToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showNotesToolStripMenuItem.Text = "Show Notes";
 			this.showNotesToolStripMenuItem.Click += new System.EventHandler(this.showNotesToolStripMenuItem_Click);
 			// 
@@ -233,7 +284,7 @@ namespace EDDiscovery.UserControls
 			this.showXYZToolStripMenuItem.CheckOnClick = true;
 			this.showXYZToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showXYZToolStripMenuItem.Name = "showXYZToolStripMenuItem";
-			this.showXYZToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showXYZToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showXYZToolStripMenuItem.Text = "Show XYZ";
 			this.showXYZToolStripMenuItem.Click += new System.EventHandler(this.showXYZToolStripMenuItem_Click);
 			// 
@@ -243,7 +294,7 @@ namespace EDDiscovery.UserControls
 			this.showTargetToolStripMenuItem.CheckOnClick = true;
 			this.showTargetToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showTargetToolStripMenuItem.Name = "showTargetToolStripMenuItem";
-			this.showTargetToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showTargetToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showTargetToolStripMenuItem.Text = "Show Target Distance per Star";
 			this.showTargetToolStripMenuItem.Click += new System.EventHandler(this.showTargetToolStripMenuItem_Click);
 			// 
@@ -253,7 +304,7 @@ namespace EDDiscovery.UserControls
 			this.blackBoxAroundTextToolStripMenuItem.CheckOnClick = true;
 			this.blackBoxAroundTextToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.blackBoxAroundTextToolStripMenuItem.Name = "blackBoxAroundTextToolStripMenuItem";
-			this.blackBoxAroundTextToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.blackBoxAroundTextToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.blackBoxAroundTextToolStripMenuItem.Text = "Show black box around text";
 			this.blackBoxAroundTextToolStripMenuItem.Click += new System.EventHandler(this.blackBoxAroundTextToolStripMenuItem_Click);
 			// 
@@ -263,7 +314,7 @@ namespace EDDiscovery.UserControls
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.CheckOnClick = true;
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Name = "showDistancesOnFSDJumpsOnlyToolStripMenuItem";
-			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Text = "Show Distances/Coords on FSD Jumps Only";
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Click += new System.EventHandler(this.showDistancesOnFSDJumpsOnlyToolStripMenuItem_Click);
 			// 
@@ -273,7 +324,7 @@ namespace EDDiscovery.UserControls
 			this.expandTextOverEmptyColumnsToolStripMenuItem.CheckOnClick = true;
 			this.expandTextOverEmptyColumnsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.expandTextOverEmptyColumnsToolStripMenuItem.Name = "expandTextOverEmptyColumnsToolStripMenuItem";
-			this.expandTextOverEmptyColumnsToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.expandTextOverEmptyColumnsToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.expandTextOverEmptyColumnsToolStripMenuItem.Text = "Expand text over empty columns";
 			this.expandTextOverEmptyColumnsToolStripMenuItem.Click += new System.EventHandler(this.expandTextOverEmptyColumnsToolStripMenuItem_Click);
 			// 
@@ -286,7 +337,7 @@ namespace EDDiscovery.UserControls
             this.toolStripSeparator1,
             this.completelyHideThePanelToolStripMenuItem});
 			this.dontShowInformationWhenToolStripMenuItem.Name = "dontShowInformationWhenToolStripMenuItem";
-			this.dontShowInformationWhenToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.dontShowInformationWhenToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.dontShowInformationWhenToolStripMenuItem.Text = "Don\'t show information when..";
 			// 
 			// showNothingWhenDockedtoolStripMenuItem
@@ -295,7 +346,7 @@ namespace EDDiscovery.UserControls
 			this.showNothingWhenDockedtoolStripMenuItem.CheckOnClick = true;
 			this.showNothingWhenDockedtoolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showNothingWhenDockedtoolStripMenuItem.Name = "showNothingWhenDockedtoolStripMenuItem";
-			this.showNothingWhenDockedtoolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+			this.showNothingWhenDockedtoolStripMenuItem.Size = new System.Drawing.Size(234, 22);
 			this.showNothingWhenDockedtoolStripMenuItem.Text = ".. when docked or landed";
 			this.showNothingWhenDockedtoolStripMenuItem.Click += new System.EventHandler(this.showNothingWhenDockedtoolStripMenuItem_Click);
 			// 
@@ -305,7 +356,7 @@ namespace EDDiscovery.UserControls
 			this.dontshowwhenInGalaxyPanelToolStripMenuItem.CheckOnClick = true;
 			this.dontshowwhenInGalaxyPanelToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.dontshowwhenInGalaxyPanelToolStripMenuItem.Name = "dontshowwhenInGalaxyPanelToolStripMenuItem";
-			this.dontshowwhenInGalaxyPanelToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+			this.dontshowwhenInGalaxyPanelToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
 			this.dontshowwhenInGalaxyPanelToolStripMenuItem.Text = ".. when in Galaxy Panel";
 			this.dontshowwhenInGalaxyPanelToolStripMenuItem.Click += new System.EventHandler(this.dontshowwhenInGalaxyPanelToolStripMenuItem_Click);
 			// 
@@ -315,15 +366,20 @@ namespace EDDiscovery.UserControls
 			this.dontshowwhenInSystemMapPanelToolStripMenuItem.CheckOnClick = true;
 			this.dontshowwhenInSystemMapPanelToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.dontshowwhenInSystemMapPanelToolStripMenuItem.Name = "dontshowwhenInSystemMapPanelToolStripMenuItem";
-			this.dontshowwhenInSystemMapPanelToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+			this.dontshowwhenInSystemMapPanelToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
 			this.dontshowwhenInSystemMapPanelToolStripMenuItem.Text = ".. when in System Map Panel";
 			this.dontshowwhenInSystemMapPanelToolStripMenuItem.Click += new System.EventHandler(this.dontshowwhenInSystemPanelToolStripMenuItem_Click);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.toolStripSeparator1.Size = new System.Drawing.Size(231, 6);
 			// 
 			// completelyHideThePanelToolStripMenuItem
 			// 
 			this.completelyHideThePanelToolStripMenuItem.CheckOnClick = true;
 			this.completelyHideThePanelToolStripMenuItem.Name = "completelyHideThePanelToolStripMenuItem";
-			this.completelyHideThePanelToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+			this.completelyHideThePanelToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
 			this.completelyHideThePanelToolStripMenuItem.Text = "Completely hide the Panel";
 			this.completelyHideThePanelToolStripMenuItem.Click += new System.EventHandler(this.completelyHideThePanelToolStripMenuItem_Click);
 			// 
@@ -334,41 +390,41 @@ namespace EDDiscovery.UserControls
             this.orderNotesAfterXYZToolStripMenuItem,
             this.orderTargetDistanceXYZNotesToolStripMenuItem});
 			this.OrdertoolStripMenuItem.Name = "OrdertoolStripMenuItem";
-			this.OrdertoolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.OrdertoolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.OrdertoolStripMenuItem.Text = "Column Order..";
 			// 
 			// orderDefaultToolStripMenuItem
 			// 
 			this.orderDefaultToolStripMenuItem.Name = "orderDefaultToolStripMenuItem";
-			this.orderDefaultToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+			this.orderDefaultToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
 			this.orderDefaultToolStripMenuItem.Text = "Default";
 			this.orderDefaultToolStripMenuItem.Click += new System.EventHandler(this.defaultToolStripMenuItem_Click);
 			// 
 			// orderNotesAfterXYZToolStripMenuItem
 			// 
 			this.orderNotesAfterXYZToolStripMenuItem.Name = "orderNotesAfterXYZToolStripMenuItem";
-			this.orderNotesAfterXYZToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+			this.orderNotesAfterXYZToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
 			this.orderNotesAfterXYZToolStripMenuItem.Text = "Notes after XYZ";
 			this.orderNotesAfterXYZToolStripMenuItem.Click += new System.EventHandler(this.notesAfterXYZToolStripMenuItem_Click);
 			// 
 			// orderTargetDistanceXYZNotesToolStripMenuItem
 			// 
 			this.orderTargetDistanceXYZNotesToolStripMenuItem.Name = "orderTargetDistanceXYZNotesToolStripMenuItem";
-			this.orderTargetDistanceXYZNotesToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+			this.orderTargetDistanceXYZNotesToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
 			this.orderTargetDistanceXYZNotesToolStripMenuItem.Text = "Target Distance,XYZ,Notes";
 			this.orderTargetDistanceXYZNotesToolStripMenuItem.Click += new System.EventHandler(this.targetDistanceXYZNotesToolStripMenuItem_Click);
 			// 
 			// configureEventFilterToolStripMenuItem
 			// 
 			this.configureEventFilterToolStripMenuItem.Name = "configureEventFilterToolStripMenuItem";
-			this.configureEventFilterToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.configureEventFilterToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.configureEventFilterToolStripMenuItem.Text = "Configure Event Filter..";
 			this.configureEventFilterToolStripMenuItem.Click += new System.EventHandler(this.configureEventFilterToolStripMenuItem_Click);
 			// 
 			// configureFieldFilterToolStripMenuItem
 			// 
 			this.configureFieldFilterToolStripMenuItem.Name = "configureFieldFilterToolStripMenuItem";
-			this.configureFieldFilterToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.configureFieldFilterToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.configureFieldFilterToolStripMenuItem.Text = "Configure Field Filter..";
 			this.configureFieldFilterToolStripMenuItem.Click += new System.EventHandler(this.configureFieldFilterToolStripMenuItem_Click);
 			// 
@@ -381,7 +437,7 @@ namespace EDDiscovery.UserControls
             this.scan60sToolStripMenuItem,
             this.scanUntilNextToolStripMenuItem});
 			this.surfaceScanDetailsToolStripMenuItem.Name = "surfaceScanDetailsToolStripMenuItem";
-			this.surfaceScanDetailsToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.surfaceScanDetailsToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.surfaceScanDetailsToolStripMenuItem.Text = "Configure Scan Display..";
 			// 
 			// scanNoToolStripMenuItem
@@ -390,7 +446,7 @@ namespace EDDiscovery.UserControls
 			this.scanNoToolStripMenuItem.CheckOnClick = true;
 			this.scanNoToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.scanNoToolStripMenuItem.Name = "scanNoToolStripMenuItem";
-			this.scanNoToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
+			this.scanNoToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.scanNoToolStripMenuItem.Text = "Do Not Show";
 			this.scanNoToolStripMenuItem.Click += new System.EventHandler(this.scanNoToolStripMenuItem_Click);
 			// 
@@ -398,7 +454,7 @@ namespace EDDiscovery.UserControls
 			// 
 			this.scan15sToolStripMenuItem.CheckOnClick = true;
 			this.scan15sToolStripMenuItem.Name = "scan15sToolStripMenuItem";
-			this.scan15sToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
+			this.scan15sToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.scan15sToolStripMenuItem.Text = "Show for 15s";
 			this.scan15sToolStripMenuItem.Click += new System.EventHandler(this.scan15sToolStripMenuItem_Click);
 			// 
@@ -406,7 +462,7 @@ namespace EDDiscovery.UserControls
 			// 
 			this.scan30sToolStripMenuItem.CheckOnClick = true;
 			this.scan30sToolStripMenuItem.Name = "scan30sToolStripMenuItem";
-			this.scan30sToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
+			this.scan30sToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.scan30sToolStripMenuItem.Text = "Show for 30s";
 			this.scan30sToolStripMenuItem.Click += new System.EventHandler(this.scan30sToolStripMenuItem_Click);
 			// 
@@ -414,7 +470,7 @@ namespace EDDiscovery.UserControls
 			// 
 			this.scan60sToolStripMenuItem.CheckOnClick = true;
 			this.scan60sToolStripMenuItem.Name = "scan60sToolStripMenuItem";
-			this.scan60sToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
+			this.scan60sToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.scan60sToolStripMenuItem.Text = "Show for 60s";
 			this.scan60sToolStripMenuItem.Click += new System.EventHandler(this.scan60sToolStripMenuItem_Click);
 			// 
@@ -422,7 +478,7 @@ namespace EDDiscovery.UserControls
 			// 
 			this.scanUntilNextToolStripMenuItem.CheckOnClick = true;
 			this.scanUntilNextToolStripMenuItem.Name = "scanUntilNextToolStripMenuItem";
-			this.scanUntilNextToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
+			this.scanUntilNextToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.scanUntilNextToolStripMenuItem.Text = "Show until next scan";
 			this.scanUntilNextToolStripMenuItem.Click += new System.EventHandler(this.scanUntilNextToolStripMenuItem_Click);
 			// 
@@ -435,20 +491,20 @@ namespace EDDiscovery.UserControls
             this.scanBelowMenuItem,
             this.scanOnTopMenuItem});
 			this.showInPositionToolStripMenuItem.Name = "showInPositionToolStripMenuItem";
-			this.showInPositionToolStripMenuItem.Size = new System.Drawing.Size(346, 22);
+			this.showInPositionToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
 			this.showInPositionToolStripMenuItem.Text = "Set Scan Position..";
 			// 
 			// scanRightMenuItem
 			// 
 			this.scanRightMenuItem.Name = "scanRightMenuItem";
-			this.scanRightMenuItem.Size = new System.Drawing.Size(115, 22);
+			this.scanRightMenuItem.Size = new System.Drawing.Size(119, 22);
 			this.scanRightMenuItem.Text = "To right";
 			this.scanRightMenuItem.Click += new System.EventHandler(this.scanRightMenuItem_Click);
 			// 
 			// scanLeftMenuItem
 			// 
 			this.scanLeftMenuItem.Name = "scanLeftMenuItem";
-			this.scanLeftMenuItem.Size = new System.Drawing.Size(115, 22);
+			this.scanLeftMenuItem.Size = new System.Drawing.Size(119, 22);
 			this.scanLeftMenuItem.Text = "To left";
 			this.scanLeftMenuItem.Click += new System.EventHandler(this.scanLeftMenuItem_Click);
 			// 
@@ -456,21 +512,21 @@ namespace EDDiscovery.UserControls
 			// 
 			this.scanAboveMenuItem.DoubleClickEnabled = true;
 			this.scanAboveMenuItem.Name = "scanAboveMenuItem";
-			this.scanAboveMenuItem.Size = new System.Drawing.Size(115, 22);
+			this.scanAboveMenuItem.Size = new System.Drawing.Size(119, 22);
 			this.scanAboveMenuItem.Text = "Above";
 			this.scanAboveMenuItem.Click += new System.EventHandler(this.scanAboveMenuItem_Click);
 			// 
 			// scanBelowMenuItem
 			// 
 			this.scanBelowMenuItem.Name = "scanBelowMenuItem";
-			this.scanBelowMenuItem.Size = new System.Drawing.Size(115, 22);
+			this.scanBelowMenuItem.Size = new System.Drawing.Size(119, 22);
 			this.scanBelowMenuItem.Text = "Below";
 			this.scanBelowMenuItem.Click += new System.EventHandler(this.scanBelowMenuItem_Click);
 			// 
 			// scanOnTopMenuItem
 			// 
 			this.scanOnTopMenuItem.Name = "scanOnTopMenuItem";
-			this.scanOnTopMenuItem.Size = new System.Drawing.Size(115, 22);
+			this.scanOnTopMenuItem.Size = new System.Drawing.Size(119, 22);
 			this.scanOnTopMenuItem.Text = "On top";
 			this.scanOnTopMenuItem.Click += new System.EventHandler(this.scanOnTopMenuItem_Click);
 			// 
@@ -695,11 +751,6 @@ namespace EDDiscovery.UserControls
 			this.buttonExt12.MouseMove += new System.Windows.Forms.MouseEventHandler(this.divider_MouseMove);
 			this.buttonExt12.MouseUp += new System.Windows.Forms.MouseEventHandler(this.divider_MouseUp);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(222, 6);
-			// 
 			// UserControlSpanel
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -782,5 +833,10 @@ namespace EDDiscovery.UserControls
         private System.Windows.Forms.ToolStripMenuItem dontshowwhenInSystemMapPanelToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem completelyHideThePanelToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private System.Windows.Forms.ToolStripMenuItem showMetalRichPlanetsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem showWaterWorldsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem showEarthLikeToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem showAmmoniaWorldsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem showIcyPlanetsToolStripMenuItem;
 	}
 }

--- a/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.Designer.cs
@@ -47,7 +47,7 @@ namespace EDDiscovery.UserControls
 			this.pictureBox = new ExtendedControls.PictureBoxHotspot();
 			this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.showSystemInformationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showCircumstellarZonesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.showMetalRichPlanetsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.showWaterWorldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.showEarthLikeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -120,7 +120,7 @@ namespace EDDiscovery.UserControls
 			// 
 			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showSystemInformationToolStripMenuItem,
-            this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem,
+            this.showCircumstellarZonesToolStripMenuItem,
             this.toolStripMenuItemTargetLine,
             this.EDSMButtonToolStripMenuItem,
             this.toolStripMenuItemTime,
@@ -140,7 +140,7 @@ namespace EDDiscovery.UserControls
             this.surfaceScanDetailsToolStripMenuItem,
             this.showInPositionToolStripMenuItem});
 			this.contextMenuStrip.Name = "contextMenuStripConfig";
-			this.contextMenuStrip.Size = new System.Drawing.Size(359, 466);
+			this.contextMenuStrip.Size = new System.Drawing.Size(316, 444);
 			// 
 			// showSystemInformationToolStripMenuItem
 			// 
@@ -148,25 +148,25 @@ namespace EDDiscovery.UserControls
 			this.showSystemInformationToolStripMenuItem.CheckOnClick = true;
 			this.showSystemInformationToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showSystemInformationToolStripMenuItem.Name = "showSystemInformationToolStripMenuItem";
-			this.showSystemInformationToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showSystemInformationToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showSystemInformationToolStripMenuItem.Text = "Show System Information";
 			this.showSystemInformationToolStripMenuItem.Click += new System.EventHandler(this.showSystemInformationToolStripMenuItem_Click);
 			// 
-			// showHabitationMinimumAndMaximumDistanceToolStripMenuItem
+			// showCircumstellarZonesToolStripMenuItem
 			// 
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Checked = true;
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckOnClick = true;
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.showCircumstellarZonesToolStripMenuItem.Checked = true;
+			this.showCircumstellarZonesToolStripMenuItem.CheckOnClick = true;
+			this.showCircumstellarZonesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.showCircumstellarZonesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showMetalRichPlanetsToolStripMenuItem,
             this.showWaterWorldsToolStripMenuItem,
             this.showEarthLikeToolStripMenuItem,
             this.showAmmoniaWorldsToolStripMenuItem,
             this.showIcyPlanetsToolStripMenuItem});
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Name = "showHabitationMinimumAndMaximumDistanceToolStripMenuItem";
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Text = "Show Habitation Minimum and Maximum Distance";
-			this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Click += new System.EventHandler(this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem_Click);
+			this.showCircumstellarZonesToolStripMenuItem.Name = "showCircumstellarZonesToolStripMenuItem";
+			this.showCircumstellarZonesToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
+			this.showCircumstellarZonesToolStripMenuItem.Text = "Show Circumstellar Zones";
+			this.showCircumstellarZonesToolStripMenuItem.Click += new System.EventHandler(this.showHabitationMinimumAndMaximumDistanceToolStripMenuItem_Click);
 			// 
 			// showMetalRichPlanetsToolStripMenuItem
 			// 
@@ -214,7 +214,7 @@ namespace EDDiscovery.UserControls
 			this.toolStripMenuItemTargetLine.CheckOnClick = true;
 			this.toolStripMenuItemTargetLine.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.toolStripMenuItemTargetLine.Name = "toolStripMenuItemTargetLine";
-			this.toolStripMenuItemTargetLine.Size = new System.Drawing.Size(358, 22);
+			this.toolStripMenuItemTargetLine.Size = new System.Drawing.Size(315, 22);
 			this.toolStripMenuItemTargetLine.Text = "Show Target Line";
 			this.toolStripMenuItemTargetLine.Click += new System.EventHandler(this.toolStripMenuItemTargetLine_Click);
 			// 
@@ -224,7 +224,7 @@ namespace EDDiscovery.UserControls
 			this.EDSMButtonToolStripMenuItem.CheckOnClick = true;
 			this.EDSMButtonToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.EDSMButtonToolStripMenuItem.Name = "EDSMButtonToolStripMenuItem";
-			this.EDSMButtonToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.EDSMButtonToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.EDSMButtonToolStripMenuItem.Text = "EDSM Button";
 			this.EDSMButtonToolStripMenuItem.Click += new System.EventHandler(this.EDSMButtonToolStripMenuItem_Click);
 			// 
@@ -234,7 +234,7 @@ namespace EDDiscovery.UserControls
 			this.toolStripMenuItemTime.CheckOnClick = true;
 			this.toolStripMenuItemTime.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.toolStripMenuItemTime.Name = "toolStripMenuItemTime";
-			this.toolStripMenuItemTime.Size = new System.Drawing.Size(358, 22);
+			this.toolStripMenuItemTime.Size = new System.Drawing.Size(315, 22);
 			this.toolStripMenuItemTime.Text = "Show Time";
 			this.toolStripMenuItemTime.Click += new System.EventHandler(this.toolStripMenuItemTime_Click);
 			// 
@@ -244,7 +244,7 @@ namespace EDDiscovery.UserControls
 			this.iconToolStripMenuItem.CheckOnClick = true;
 			this.iconToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.iconToolStripMenuItem.Name = "iconToolStripMenuItem";
-			this.iconToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.iconToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.iconToolStripMenuItem.Text = "Show Event Icon";
 			this.iconToolStripMenuItem.Click += new System.EventHandler(this.iconToolStripMenuItem_Click);
 			// 
@@ -254,7 +254,7 @@ namespace EDDiscovery.UserControls
 			this.showDescriptionToolStripMenuItem.CheckOnClick = true;
 			this.showDescriptionToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showDescriptionToolStripMenuItem.Name = "showDescriptionToolStripMenuItem";
-			this.showDescriptionToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showDescriptionToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showDescriptionToolStripMenuItem.Text = "Show Description";
 			this.showDescriptionToolStripMenuItem.Click += new System.EventHandler(this.showDescriptionToolStripMenuItem_Click);
 			// 
@@ -264,7 +264,7 @@ namespace EDDiscovery.UserControls
 			this.showInformationToolStripMenuItem.CheckOnClick = true;
 			this.showInformationToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showInformationToolStripMenuItem.Name = "showInformationToolStripMenuItem";
-			this.showInformationToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showInformationToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showInformationToolStripMenuItem.Text = "Show Information";
 			this.showInformationToolStripMenuItem.Click += new System.EventHandler(this.showInformationToolStripMenuItem_Click);
 			// 
@@ -274,7 +274,7 @@ namespace EDDiscovery.UserControls
 			this.showNotesToolStripMenuItem.CheckOnClick = true;
 			this.showNotesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showNotesToolStripMenuItem.Name = "showNotesToolStripMenuItem";
-			this.showNotesToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showNotesToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showNotesToolStripMenuItem.Text = "Show Notes";
 			this.showNotesToolStripMenuItem.Click += new System.EventHandler(this.showNotesToolStripMenuItem_Click);
 			// 
@@ -284,7 +284,7 @@ namespace EDDiscovery.UserControls
 			this.showXYZToolStripMenuItem.CheckOnClick = true;
 			this.showXYZToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showXYZToolStripMenuItem.Name = "showXYZToolStripMenuItem";
-			this.showXYZToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showXYZToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showXYZToolStripMenuItem.Text = "Show XYZ";
 			this.showXYZToolStripMenuItem.Click += new System.EventHandler(this.showXYZToolStripMenuItem_Click);
 			// 
@@ -294,7 +294,7 @@ namespace EDDiscovery.UserControls
 			this.showTargetToolStripMenuItem.CheckOnClick = true;
 			this.showTargetToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showTargetToolStripMenuItem.Name = "showTargetToolStripMenuItem";
-			this.showTargetToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showTargetToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showTargetToolStripMenuItem.Text = "Show Target Distance per Star";
 			this.showTargetToolStripMenuItem.Click += new System.EventHandler(this.showTargetToolStripMenuItem_Click);
 			// 
@@ -304,7 +304,7 @@ namespace EDDiscovery.UserControls
 			this.blackBoxAroundTextToolStripMenuItem.CheckOnClick = true;
 			this.blackBoxAroundTextToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.blackBoxAroundTextToolStripMenuItem.Name = "blackBoxAroundTextToolStripMenuItem";
-			this.blackBoxAroundTextToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.blackBoxAroundTextToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.blackBoxAroundTextToolStripMenuItem.Text = "Show black box around text";
 			this.blackBoxAroundTextToolStripMenuItem.Click += new System.EventHandler(this.blackBoxAroundTextToolStripMenuItem_Click);
 			// 
@@ -314,7 +314,7 @@ namespace EDDiscovery.UserControls
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.CheckOnClick = true;
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Name = "showDistancesOnFSDJumpsOnlyToolStripMenuItem";
-			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Text = "Show Distances/Coords on FSD Jumps Only";
 			this.showDistancesOnFSDJumpsOnlyToolStripMenuItem.Click += new System.EventHandler(this.showDistancesOnFSDJumpsOnlyToolStripMenuItem_Click);
 			// 
@@ -324,7 +324,7 @@ namespace EDDiscovery.UserControls
 			this.expandTextOverEmptyColumnsToolStripMenuItem.CheckOnClick = true;
 			this.expandTextOverEmptyColumnsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.expandTextOverEmptyColumnsToolStripMenuItem.Name = "expandTextOverEmptyColumnsToolStripMenuItem";
-			this.expandTextOverEmptyColumnsToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.expandTextOverEmptyColumnsToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.expandTextOverEmptyColumnsToolStripMenuItem.Text = "Expand text over empty columns";
 			this.expandTextOverEmptyColumnsToolStripMenuItem.Click += new System.EventHandler(this.expandTextOverEmptyColumnsToolStripMenuItem_Click);
 			// 
@@ -337,7 +337,7 @@ namespace EDDiscovery.UserControls
             this.toolStripSeparator1,
             this.completelyHideThePanelToolStripMenuItem});
 			this.dontShowInformationWhenToolStripMenuItem.Name = "dontShowInformationWhenToolStripMenuItem";
-			this.dontShowInformationWhenToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.dontShowInformationWhenToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.dontShowInformationWhenToolStripMenuItem.Text = "Don\'t show information when..";
 			// 
 			// showNothingWhenDockedtoolStripMenuItem
@@ -390,7 +390,7 @@ namespace EDDiscovery.UserControls
             this.orderNotesAfterXYZToolStripMenuItem,
             this.orderTargetDistanceXYZNotesToolStripMenuItem});
 			this.OrdertoolStripMenuItem.Name = "OrdertoolStripMenuItem";
-			this.OrdertoolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.OrdertoolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.OrdertoolStripMenuItem.Text = "Column Order..";
 			// 
 			// orderDefaultToolStripMenuItem
@@ -417,14 +417,14 @@ namespace EDDiscovery.UserControls
 			// configureEventFilterToolStripMenuItem
 			// 
 			this.configureEventFilterToolStripMenuItem.Name = "configureEventFilterToolStripMenuItem";
-			this.configureEventFilterToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.configureEventFilterToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.configureEventFilterToolStripMenuItem.Text = "Configure Event Filter..";
 			this.configureEventFilterToolStripMenuItem.Click += new System.EventHandler(this.configureEventFilterToolStripMenuItem_Click);
 			// 
 			// configureFieldFilterToolStripMenuItem
 			// 
 			this.configureFieldFilterToolStripMenuItem.Name = "configureFieldFilterToolStripMenuItem";
-			this.configureFieldFilterToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.configureFieldFilterToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.configureFieldFilterToolStripMenuItem.Text = "Configure Field Filter..";
 			this.configureFieldFilterToolStripMenuItem.Click += new System.EventHandler(this.configureFieldFilterToolStripMenuItem_Click);
 			// 
@@ -437,7 +437,7 @@ namespace EDDiscovery.UserControls
             this.scan60sToolStripMenuItem,
             this.scanUntilNextToolStripMenuItem});
 			this.surfaceScanDetailsToolStripMenuItem.Name = "surfaceScanDetailsToolStripMenuItem";
-			this.surfaceScanDetailsToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.surfaceScanDetailsToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.surfaceScanDetailsToolStripMenuItem.Text = "Configure Scan Display..";
 			// 
 			// scanNoToolStripMenuItem
@@ -491,7 +491,7 @@ namespace EDDiscovery.UserControls
             this.scanBelowMenuItem,
             this.scanOnTopMenuItem});
 			this.showInPositionToolStripMenuItem.Name = "showInPositionToolStripMenuItem";
-			this.showInPositionToolStripMenuItem.Size = new System.Drawing.Size(358, 22);
+			this.showInPositionToolStripMenuItem.Size = new System.Drawing.Size(315, 22);
 			this.showInPositionToolStripMenuItem.Text = "Set Scan Position..";
 			// 
 			// scanRightMenuItem
@@ -826,7 +826,7 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ButtonExt buttonExt12;
         private System.Windows.Forms.ToolStripMenuItem iconToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showSystemInformationToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem showHabitationMinimumAndMaximumDistanceToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showCircumstellarZonesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem dontShowInformationWhenToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showNothingWhenDockedtoolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem dontshowwhenInGalaxyPanelToolStripMenuItem;

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -48,7 +48,7 @@ namespace EDDiscovery.UserControls
         private List<int> columnpos;
 
         private Font displayfont;
-
+		
         HistoryList current_historylist;
 
         private Timer dividercheck = new Timer();
@@ -136,7 +136,7 @@ namespace EDDiscovery.UserControls
             expandTextOverEmptyColumnsToolStripMenuItem.Checked = Config(Configuration.showExpandOverColumns);
             showNothingWhenDockedtoolStripMenuItem.Checked = Config(Configuration.showNothingWhenDocked);
             showSystemInformationToolStripMenuItem.Checked = Config(Configuration.showSystemInformation);
-            showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Checked = Config(Configuration.showHabInformation);
+            showCircumstellarZonesToolStripMenuItem.Checked = Config(Configuration.showHabInformation);
 			showMetalRichPlanetsToolStripMenuItem.Checked = Config(Configuration.showMetalRichZone);
 			showWaterWorldsToolStripMenuItem.Checked = Config(Configuration.showWaterWrldZone);
 			showEarthLikeToolStripMenuItem.Checked = Config(Configuration.showEarthLikeZone);
@@ -330,7 +330,16 @@ namespace EDDiscovery.UserControls
                             if ( sn != null && sn.starnodes.Count>0 && sn.starnodes.Values[0].ScanData != null )
                             {
                                 JournalScan js = sn.starnodes.Values[0].ScanData;
-                                res.AppendFormat(js.HabZoneString().Replace("\r\n", " "));
+
+                                //res.AppendFormat(js.CircumstellarZonesString().Replace("\r\n", " "));
+
+								if (showCircumstellarZonesToolStripMenuItem.Checked)
+								{
+									res.AppendFormat("Goldilocks, {0} ({1}-{2} AU),\n".Tx(this),
+													 js.GetHabZoneStringLs(),
+													 (js.HabitableZoneInner.Value / JournalScan.oneAU_LS).ToString("N2"),
+													 (js.HabitableZoneOuter.Value / JournalScan.oneAU_LS).ToString("N2"));
+								}
 
 								if (showMetalRichPlanetsToolStripMenuItem.Checked)
 								{

--- a/EDDiscovery/UserControls/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/UserControlSpanel.cs
@@ -95,7 +95,12 @@ namespace EDDiscovery.UserControls
             public const long showNothingWhenSysmap = 1L << 34;
             public const long showNothingWhenGalmap = 1L << 35;
 			public const long showNoTitleWhenHidden = 1L << 36;
-        }
+			public const long showMetalRichZone = 1L << 40;
+			public const long showWaterWrldZone = 1L << 41;
+			public const long showEarthLikeZone = 1L << 42;
+			public const long showAmmonWrldZone = 1L << 43;
+			public const long showIcyPlanetZone = 1L << 44;
+		}
 
         long config = Configuration.showTargetLine | Configuration.showEDSMButton | Configuration.showIcon | 
                                                 Configuration.showTime | Configuration.showDescription |
@@ -132,6 +137,11 @@ namespace EDDiscovery.UserControls
             showNothingWhenDockedtoolStripMenuItem.Checked = Config(Configuration.showNothingWhenDocked);
             showSystemInformationToolStripMenuItem.Checked = Config(Configuration.showSystemInformation);
             showHabitationMinimumAndMaximumDistanceToolStripMenuItem.Checked = Config(Configuration.showHabInformation);
+			showMetalRichPlanetsToolStripMenuItem.Checked = Config(Configuration.showMetalRichZone);
+			showWaterWorldsToolStripMenuItem.Checked = Config(Configuration.showWaterWrldZone);
+			showEarthLikeToolStripMenuItem.Checked = Config(Configuration.showEarthLikeZone);
+			showAmmoniaWorldsToolStripMenuItem.Checked = Config(Configuration.showAmmonWrldZone);
+			showIcyPlanetsToolStripMenuItem.Checked = Config(Configuration.showIcyPlanetZone);
             dontshowwhenInGalaxyPanelToolStripMenuItem.Checked = Config(Configuration.showNothingWhenGalmap);
             dontshowwhenInSystemMapPanelToolStripMenuItem.Checked = Config(Configuration.showNothingWhenSysmap);
 			completelyHideThePanelToolStripMenuItem.Checked = Config(Configuration.showNoTitleWhenHidden);
@@ -249,6 +259,7 @@ namespace EDDiscovery.UserControls
                 {
                     int rowpos = scanpostextoffset.Y;
                     int rowheight = Config(Configuration.showIcon) ? 26 : 20;
+					int habrowheight = Config(Configuration.showIcon) ? 26 : 20;
 
 					// Check if need to hide the UI
                     if (Config(Configuration.showNothingWhenDocked) && 
@@ -309,18 +320,53 @@ namespace EDDiscovery.UserControls
 
                             StarScan.SystemNode sn = scan.FindSystem(last.System, true);    // EDSM look up here..
 
-                            string res = null;
+                            StringBuilder res = new StringBuilder();
+
+							void expandRowHeight()
+							{
+								habrowheight += 20;
+							}
 
                             if ( sn != null && sn.starnodes.Count>0 && sn.starnodes.Values[0].ScanData != null )
                             {
                                 JournalScan js = sn.starnodes.Values[0].ScanData;
-                                res = js.HabZoneString().Replace("\r\n", " ");
+                                res.AppendFormat(js.HabZoneString().Replace("\r\n", " "));
+
+								if (showMetalRichPlanetsToolStripMenuItem.Checked)
+								{
+									res.AppendFormat(js.MetalRichZoneString());
+									expandRowHeight();
+								}
+
+								if (showWaterWorldsToolStripMenuItem.Checked)
+								{
+									res.AppendFormat((js.WaterWorldZoneString()));
+									expandRowHeight();
+								}
+
+								if (showEarthLikeToolStripMenuItem.Checked)
+								{
+									res.AppendFormat(js.EarthLikeZoneString());
+									expandRowHeight();
+								}
+
+								if (showAmmoniaWorldsToolStripMenuItem.Checked)
+								{
+									res.AppendFormat(js.AmmoniaWorldZoneString());
+									expandRowHeight();
+								}
+
+								if (showIcyPlanetsToolStripMenuItem.Checked)
+								{
+									res.AppendFormat(js.IcyPlanetsZoneString());
+									expandRowHeight();
+								}
                             }
 
                             if (res != null)
                             {
-                                AddColText(0, 0, rowpos, rowheight, res, textcolour, backcolour, null);
-                                rowpos += rowheight;
+                                AddColText(0, 0, rowpos, habrowheight, res.ToString(), textcolour, backcolour, null);
+                                rowpos += habrowheight;
                             }
                         }
 
@@ -810,6 +856,31 @@ namespace EDDiscovery.UserControls
             FlipConfig(Configuration.showHabInformation, ((ToolStripMenuItem)sender).Checked, true);
         }
 
+		private void showMetalRichPlanetsToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			FlipConfig(Configuration.showMetalRichZone, ((ToolStripMenuItem)sender).Checked, true);
+		}
+
+		private void showWaterWorldsToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			FlipConfig(Configuration.showWaterWrldZone, ((ToolStripMenuItem)sender).Checked, true);
+		}
+
+		private void showEarthLikeToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			FlipConfig(Configuration.showEarthLikeZone, ((ToolStripMenuItem)sender).Checked, true);
+		}
+
+		private void showAmmoniaWorldsToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			FlipConfig(Configuration.showAmmonWrldZone, ((ToolStripMenuItem)sender).Checked, true);
+		}
+
+		private void showIcyPlanetsToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			FlipConfig(Configuration.showIcyPlanetZone, ((ToolStripMenuItem)sender).Checked, true);
+		}
+
         private void toolStripMenuItemTargetLine_Click(object sender, EventArgs e)
         {
             FlipConfig(Configuration.showTargetLine, ((ToolStripMenuItem)sender).Checked, true);
@@ -929,8 +1000,7 @@ namespace EDDiscovery.UserControls
         {
             SetSurfaceScanBehaviour(Configuration.showScanIndefinite);
         }
-
-
+		
         private void scanRightMenuItem_Click(object sender, EventArgs e)
         {
             SetScanPosition(Configuration.showScanRight);
@@ -1070,8 +1140,7 @@ namespace EDDiscovery.UserControls
                 Display(current_historylist);
             }
         }
-
-
+		
 		#endregion
 	}
 }

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -704,7 +704,7 @@ namespace EliteDangerousCore.JournalEvents
 		{
 			if (IsStar && IcyPlanetZoneInner.HasValue && IcyPlanetZoneOuter != null)
 			{
-				return $"{IcyPlanetZoneInner:N0}-{IcyPlanetZoneOuter:N0}ls";
+				return $"{IcyPlanetZoneInner:N0}ls to {IcyPlanetZoneOuter:N0}";
 			}
 			else
 			{
@@ -717,10 +717,10 @@ namespace EliteDangerousCore.JournalEvents
 			if (IsStar && IcyPlanetZoneInner.HasValue && IcyPlanetZoneOuter != null)
 			{
 				StringBuilder habZone = new StringBuilder();
-				habZone.AppendFormat("Icy Planets: {0} ({1}-{2} AU)\n".Tx(this),
+				habZone.AppendFormat("Icy Planets: {0} ({1} AU to {2})\n".Tx(this),
 									 GetIcyPlanetsZoneStringLs(), 
-									 (IcyPlanetZoneInner.Value / oneAU_LS).ToString("N2"), 
-									 (IcyPlanetZoneOuter));
+									 (IcyPlanetZoneInner.Value / oneAU_LS).ToString("N2"),
+									 IcyPlanetZoneOuter);
 				return habZone.ToNullSafeString();
 			}
 			else

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -51,6 +51,16 @@ namespace EliteDangerousCore.JournalEvents
         public double? nAge { get; set; }                           // direct
         public double? HabitableZoneInner { get; set; }             // calculated
         public double? HabitableZoneOuter { get; set; }             // calculated
+		public double? MetalRichZoneInner { get; set; }
+		public double? MetalRichZoneOuter { get; set; }
+		public double? WaterWrldZoneInner { get; set; }
+		public double? WaterWrldZoneOuter { get; set; }
+		public double? EarthLikeZoneInner { get; set; }
+		public double? EarthLikeZoneOuter { get; set; }
+		public double? AmmonWrldZoneInner { get; set; }
+		public double? AmmonWrldZoneOuter { get; set; }
+		public double? IcyPlanetZoneInner { get; set; }
+		public string IcyPlanetZoneOuter { get; set; }
 
         // All orbiting bodies (Stars/Planets), not main star
         public double? nSemiMajorAxis;                              // direct
@@ -230,9 +240,21 @@ namespace EliteDangerousCore.JournalEvents
 
                 if (nRadius.HasValue && nSurfaceTemperature.HasValue)
                 {
-                    HabitableZoneInner = DistanceForBlackBodyTemperature(315);
+					// values initially calculated by Jackie Silver (https://forums.frontier.co.uk/member.php/37962-Jackie-Silver)
+
+                    HabitableZoneInner = DistanceForBlackBodyTemperature(315); // this is the goldilocks zone, where is possible to expect to find planets with liquid water. 
                     HabitableZoneOuter = DistanceForBlackBodyTemperature(223);
-                }
+					MetalRichZoneInner = DistanceForNoMaxTemperatureBody(solarRadius_m); // we don't know the maximum temperature that the galaxy simulation take as possible...
+					MetalRichZoneOuter = DistanceForBlackBodyTemperature(1100);
+					WaterWrldZoneInner = DistanceForBlackBodyTemperature(307);
+					WaterWrldZoneOuter = DistanceForBlackBodyTemperature(156);
+					EarthLikeZoneInner = DistanceForBlackBodyTemperature(281); // I enlarged a bit the range to fit my and other CMDRs discoveries.
+					EarthLikeZoneOuter = DistanceForBlackBodyTemperature(227);
+					AmmonWrldZoneInner = DistanceForBlackBodyTemperature(193);
+					AmmonWrldZoneOuter = DistanceForBlackBodyTemperature(117);
+					IcyPlanetZoneInner = DistanceForBlackBodyTemperature(150);
+					IcyPlanetZoneOuter = "\u221E"; // practically infinite, at least until the body suffer from the gravitational bond with its host star
+				}
             }
             else if (PlanetClass != null)
             {
@@ -544,14 +566,21 @@ namespace EliteDangerousCore.JournalEvents
                 StringBuilder habZone = new StringBuilder();
                 habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n".Tx(this), GetHabZoneStringLs(),
                                                                                   (HabitableZoneInner.Value / oneAU_LS).ToString("N2"), (HabitableZoneOuter.Value / oneAU_LS).ToString("N2"));
-                if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
-                    habZone.AppendFormat(" (Others stars not considered)\n".Tx(this));
-
                 return habZone.ToNullSafeString();
             }
             else
                 return null;
         }
+
+		// string which tell us that other stars are not considered in the habitable zone calculations.
+		public string HabZoneAddendOtherStars()
+		{
+			StringBuilder habZoneAddend = new StringBuilder();
+			if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
+				habZoneAddend.AppendFormat(" (Others stars not considered)\n".Tx(this));
+			
+			return habZoneAddend.ToNullSafeString();
+		}
 
         // optionally, show material counts at the historic point and current.
         public string DisplayMaterials(int indent = 0, MaterialCommoditiesList historicmatlist = null, MaterialCommoditiesList currentmatlist = null)
@@ -765,7 +794,7 @@ namespace EliteDangerousCore.JournalEvents
             return null;
         }
 
-        // Habitable zone calculations, formulae cribbed from JackieSilver's HabZone Calculator with permission
+        // Habitable zone calculations, formula cribbed from JackieSilver's HabZone Calculator with permission
         private double DistanceForBlackBodyTemperature(double targetTemp)
         {
             double top = Math.Pow(nRadius.Value, 2.0) * Math.Pow(nSurfaceTemperature.Value, 4.0);
@@ -774,6 +803,11 @@ namespace EliteDangerousCore.JournalEvents
             return radius_metres / oneLS_m;
         }
 
+		private double DistanceForNoMaxTemperatureBody(double radius)
+		{
+			return radius / oneLS_m;
+		}
+		
         private int CalculateEstimatedValue()
         {
             if (EventTimeUTC < new DateTime(2017, 4, 11, 12, 0, 0, 0, DateTimeKind.Utc))

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -567,10 +567,38 @@ namespace EliteDangerousCore.JournalEvents
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {
                 StringBuilder habZone = new StringBuilder();
-                habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n".Tx(this),
-									 GetHabZoneStringLs(), 
-									 (HabitableZoneInner.Value / oneAU_LS).ToString("N2"), 
+
+				habZone.Append("Inferred Circumstellar zones:\n");
+
+				habZone.AppendFormat(" - Goldilocks, {0} ({1}-{2} AU),\n".Tx(this),
+									 GetHabZoneStringLs(),
+									 (HabitableZoneInner.Value / oneAU_LS).ToString("N2"),
 									 (HabitableZoneOuter.Value / oneAU_LS).ToString("N2"));
+
+				habZone.AppendFormat(" - Metal Rich planets, {0} ({1}-{2} AU),\n".Tx(this),
+									 GetMetalRichZoneStringLs(),
+									 (MetalRichZoneInner.Value / oneAU_LS).ToString("N2"),
+									 (MetalRichZoneInner.Value / oneAU_LS).ToString("N2"));
+				
+				habZone.AppendFormat(" - Water Worlds, {0} ({1}-{2} AU),\n".Tx(this),
+									 GetWaterWorldZoneStringLs(),
+									 (WaterWrldZoneInner.Value / oneAU_LS).ToString("N2"),
+									 (WaterWrldZoneOuter.Value / oneAU_LS).ToString("N2"));
+				
+				habZone.AppendFormat(" - Earth Like Worlds, {0} ({1}-{2} AU),\n".Tx(this),
+									 GetEarthLikeZoneStringLs(),
+									 (EarthLikeZoneInner.Value / oneAU_LS).ToString("N2"),
+									 (EarthLikeZoneOuter.Value / oneAU_LS).ToString("N2"));
+				
+				habZone.AppendFormat(" - Ammonia Worlds, {0} ({1}-{2} AU),\n".Tx(this),
+									 GetAmmoniaWorldZoneStringLs(),
+									 (AmmonWrldZoneInner.Value / oneAU_LS).ToString("N2"),
+									 (AmmonWrldZoneOuter.Value / oneAU_LS).ToString("N2"));
+				
+				habZone.AppendFormat(" - Icy Planets, {0} (from {1} AU)\n\n".Tx(this),
+									 GetIcyPlanetsZoneStringLs(),
+				(IcyPlanetZoneInner.Value / oneAU_LS).ToString("N2"));
+
                 return habZone.ToNullSafeString();
             }
             else

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -534,7 +534,7 @@ namespace EliteDangerousCore.JournalEvents
             if (CircumstellarZonesString() != null)
                 scanText.Append("\n" + CircumstellarZonesString());
 
-			if (HabZoneOtherStarsString() != null)
+			if (IsStar && HabZoneOtherStarsString() != null)
 				scanText.Append(HabZoneOtherStarsString());
 			
             if (scanText.Length > 0 && scanText[scanText.Length - 1] == '\n')
@@ -570,7 +570,7 @@ namespace EliteDangerousCore.JournalEvents
 
 				habZone.Append("Inferred Circumstellar zones:\n");
 
-				habZone.AppendFormat(" - Goldilocks, {0} ({1}-{2} AU),\n".Tx(this),
+				habZone.AppendFormat(" - Habitable Zone, {0} ({1}-{2} AU),\n".Tx(this),
 									 GetHabZoneStringLs(),
 									 (HabitableZoneInner.Value / oneAU_LS).ToString("N2"),
 									 (HabitableZoneOuter.Value / oneAU_LS).ToString("N2"));

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -549,6 +549,7 @@ namespace EliteDangerousCore.JournalEvents
             return scanText.ToNullSafeString().Replace("\n", "\n" + inds);
         }
 
+		// goldilocks zone
         public string GetHabZoneStringLs()
         {
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
@@ -566,8 +567,10 @@ namespace EliteDangerousCore.JournalEvents
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {
                 StringBuilder habZone = new StringBuilder();
-                habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n".Tx(this), GetHabZoneStringLs(),
-                                                                                  (HabitableZoneInner.Value / oneAU_LS).ToString("N2"), (HabitableZoneOuter.Value / oneAU_LS).ToString("N2"));
+                habZone.AppendFormat("Habitable Zone Approx. {0} ({1}-{2} AU)\n".Tx(this),
+									 GetHabZoneStringLs(), 
+									 (HabitableZoneInner.Value / oneAU_LS).ToString("N2"), 
+									 (HabitableZoneOuter.Value / oneAU_LS).ToString("N2"));
                 return habZone.ToNullSafeString();
             }
             else
@@ -582,6 +585,146 @@ namespace EliteDangerousCore.JournalEvents
 				habZoneAddend.Append("(Others stars not considered)\n\n".Tx(this));
 			
 			return habZoneAddend.ToNullSafeString();
+		}
+
+		// metal rich zone
+		public string GetMetalRichZoneStringLs()
+		{
+			if (IsStar && MetalRichZoneInner.HasValue && MetalRichZoneOuter.HasValue)
+			{
+				return $"{MetalRichZoneInner:N0}-{MetalRichZoneOuter:N0}ls";
+			}
+			else
+			{
+				return string.Empty;
+			}
+		}
+
+		public string MetalRichZoneString()
+		{
+			if (IsStar && MetalRichZoneInner.HasValue && MetalRichZoneOuter.HasValue)
+			{
+				StringBuilder habZone = new StringBuilder();
+				habZone.AppendFormat("Metal Rich Planets: {0} ({1}-{2} AU)\n".Tx(this),
+									 GetMetalRichZoneStringLs(), 
+									 (MetalRichZoneInner.Value / oneAU_LS).ToString("N2"), 
+									 (MetalRichZoneOuter.Value / oneAU_LS).ToString("N2"));
+				return habZone.ToNullSafeString();
+			}
+			else
+				return null;
+		}
+
+		// water world zone
+		public string GetWaterWorldZoneStringLs()
+		{
+			if (IsStar && WaterWrldZoneInner.HasValue && WaterWrldZoneOuter.HasValue)
+			{
+				return $"{WaterWrldZoneInner:N0}-{WaterWrldZoneOuter:N0}ls";
+			}
+			else
+			{
+				return string.Empty;
+			}
+		}
+
+		public string WaterWorldZoneString()
+		{
+			if (IsStar && WaterWrldZoneInner.HasValue && WaterWrldZoneOuter.HasValue)
+			{
+				StringBuilder habZone = new StringBuilder();
+				habZone.AppendFormat("Water Worlds: {0} ({1}-{2} AU)\n".Tx(this),
+									 GetWaterWorldZoneStringLs(), 
+									 (WaterWrldZoneInner.Value / oneAU_LS).ToString("N2"), 
+									 (WaterWrldZoneOuter.Value / oneAU_LS).ToString("N2"));
+				return habZone.ToNullSafeString();
+			}
+			else
+				return null;
+		}
+
+		// earth like world zone
+		public string GetEarthLikeZoneStringLs()
+		{
+			if (IsStar && EarthLikeZoneInner.HasValue && EarthLikeZoneOuter.HasValue)
+			{
+				return $"{EarthLikeZoneInner:N0}-{EarthLikeZoneOuter:N0}ls";
+			}
+			else
+			{
+				return string.Empty;
+			}
+		}
+
+		public string EarthLikeZoneString()
+		{
+			if (IsStar && EarthLikeZoneInner.HasValue && EarthLikeZoneOuter.HasValue)
+			{
+				StringBuilder habZone = new StringBuilder();
+				habZone.AppendFormat("Earth Like Worlds: {0} ({1}-{2} AU)\n".Tx(this),
+									 GetEarthLikeZoneStringLs(), 
+									 (EarthLikeZoneInner.Value / oneAU_LS).ToString("N2"), 
+									 (EarthLikeZoneOuter.Value / oneAU_LS).ToString("N2"));
+				return habZone.ToNullSafeString();
+			}
+			else
+				return null;
+		}
+
+		// ammonia world zone
+		public string GetAmmoniaWorldZoneStringLs()
+		{
+			if (IsStar && AmmonWrldZoneInner.HasValue && AmmonWrldZoneOuter.HasValue)
+			{
+				return $"{AmmonWrldZoneInner:N0}-{AmmonWrldZoneOuter:N0}ls";
+			}
+			else
+			{
+				return string.Empty;
+			}
+		}
+
+		public string AmmoniaWorldZoneString()
+		{
+			if (IsStar && AmmonWrldZoneInner.HasValue && AmmonWrldZoneOuter.HasValue)
+			{
+				StringBuilder habZone = new StringBuilder();
+				habZone.AppendFormat("Ammonia Worlds: {0} ({1}-{2} AU)\n".Tx(this),
+									 GetAmmoniaWorldZoneStringLs(), 
+									 (AmmonWrldZoneInner.Value / oneAU_LS).ToString("N2"), 
+									 (AmmonWrldZoneOuter.Value / oneAU_LS).ToString("N2"));
+				return habZone.ToNullSafeString();
+			}
+			else
+				return null;
+		}
+
+		// icy planets zone
+		public string GetIcyPlanetsZoneStringLs()
+		{
+			if (IsStar && IcyPlanetZoneInner.HasValue && IcyPlanetZoneOuter != null)
+			{
+				return $"{IcyPlanetZoneInner:N0}-{IcyPlanetZoneOuter:N0}ls";
+			}
+			else
+			{
+				return string.Empty;
+			}
+		}
+
+		public string IcyPlanetsZoneString()
+		{
+			if (IsStar && IcyPlanetZoneInner.HasValue && IcyPlanetZoneOuter != null)
+			{
+				StringBuilder habZone = new StringBuilder();
+				habZone.AppendFormat("Icy Planets: {0} ({1}-{2} AU)\n".Tx(this),
+									 GetIcyPlanetsZoneStringLs(), 
+									 (IcyPlanetZoneInner.Value / oneAU_LS).ToString("N2"), 
+									 (IcyPlanetZoneOuter));
+				return habZone.ToNullSafeString();
+			}
+			else
+				return null;
 		}
 
         // optionally, show material counts at the historic point and current.

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -531,10 +531,12 @@ namespace EliteDangerousCore.JournalEvents
                 scanText.Append("\n" + DisplayMaterials(2, historicmatlist , currentmatlist) + "\n");
             }
 
-            string habzonestring = HabZoneString();
-            if (habzonestring != null)
-                scanText.Append("\n" + habzonestring);
+            if (HabZoneString() != null)
+                scanText.Append("\n" + HabZoneString());
 
+			if (HabZoneOtherStarsString() != null)
+				scanText.Append(HabZoneOtherStarsString());
+			
             if (scanText.Length > 0 && scanText[scanText.Length - 1] == '\n')
                 scanText.Remove(scanText.Length - 1, 1);
 
@@ -573,11 +575,11 @@ namespace EliteDangerousCore.JournalEvents
         }
 
 		// string which tell us that other stars are not considered in the habitable zone calculations.
-		public string HabZoneAddendOtherStars()
+		public string HabZoneOtherStarsString()
 		{
 			StringBuilder habZoneAddend = new StringBuilder();
 			if (nSemiMajorAxis.HasValue && nSemiMajorAxis.Value > 0)
-				habZoneAddend.AppendFormat(" (Others stars not considered)\n".Tx(this));
+				habZoneAddend.Append("(Others stars not considered)\n\n".Tx(this));
 			
 			return habZoneAddend.ToNullSafeString();
 		}

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -531,8 +531,8 @@ namespace EliteDangerousCore.JournalEvents
                 scanText.Append("\n" + DisplayMaterials(2, historicmatlist , currentmatlist) + "\n");
             }
 
-            if (HabZoneString() != null)
-                scanText.Append("\n" + HabZoneString());
+            if (CircumstellarZonesString() != null)
+                scanText.Append("\n" + CircumstellarZonesString());
 
 			if (HabZoneOtherStarsString() != null)
 				scanText.Append(HabZoneOtherStarsString());
@@ -562,7 +562,7 @@ namespace EliteDangerousCore.JournalEvents
             }
         }
 
-        public string HabZoneString()
+        public string CircumstellarZonesString()
         {
             if (IsStar && HabitableZoneInner.HasValue && HabitableZoneOuter.HasValue)
             {


### PR DESCRIPTION
Added circumstellar zones properties for metal rich planets, water worlds, earth like worlds, ammonia worlds and icy planets.

Added context menu entries in Spanel for new zones, which can show/hide at will, and which states is saved in the db.