### PR TITLE
Prob 2232 Remove LocalAppData files from installer

### DIFF
--- a/EDDiscovery/EDDOptions.cs
+++ b/EDDiscovery/EDDOptions.cs
@@ -60,7 +60,8 @@ namespace EDDiscovery
         public bool DontAskGithubForPacks { get; private set; }
         public bool DisableBetaCommanderCheck { get; private set; }
         public bool ForceBetaOnCommander { get; private set; }
-        public bool CheckGithubFilesInDebug { get; private set; }
+        public bool CheckRelease { get; private set; }
+        public bool CheckGithubFiles { get; private set; }
         public bool ResetLanguage { get; set; }
 
         public string SubAppDirectory(string subfolder)     // ensures its there.. name without \ slashes
@@ -256,8 +257,10 @@ namespace EDDiscovery
                     case "nosystems": NoSystemsLoad = true; break;
                     case "logexceptions": LogExceptions = true; break;
                     case "nogithubpacks": DontAskGithubForPacks = true; break;
-                    case "checkrelease": CheckGithubFilesInDebug = true; break;
-                    case "checkgithub": CheckGithubFilesInDebug = true; break;
+                    case "checkrelease": CheckRelease = true; break;
+                    case "checkgithub": CheckGithubFiles = true; break;
+                    case "nocheckrelease": CheckRelease = false; break;
+                    case "nocheckgithub": CheckGithubFiles = false; break;
                     case "edsmbeta":
                         EDSMClass.ServerAddress = "http://beta.edsm.net:8080/";
                         break;
@@ -289,6 +292,11 @@ namespace EDDiscovery
 
         public void Init()
         {
+#if !DEBUG
+            CheckGithubFiles = true;
+            CheckRelease = true;
+#endif
+
             ProcessConfigVariables();
 
             ProcessCommandLineForOptionsFile(ExeDirectory(), ProcessOption);     // go thru the command line looking for -optionfile, use relative base dir

--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -552,23 +552,21 @@ namespace EDDiscovery
             Debug.WriteLine(BaseUtils.AppTicks.TickCountLap() + " Check systems");
             ReportSyncProgress(-1, "");
 
+            bool checkGithub = EDDOptions.Instance.CheckGithubFiles;
+            if (checkGithub)      // not normall in debug, due to git hub chokeing
+            {
+                // Async load of maps in another thread
+                DownloadMaps(() => PendingClose);
+
+                // and Expedition data
+                DownloadExpeditions(() => PendingClose);
+
+                // and Exploration data
+                DownloadExploration(() => PendingClose);
+            }
+
             if (!EDDOptions.Instance.NoSystemsLoad)
             {
-                bool check = true;
-#if DEBUG
-                check = EDDOptions.Instance.CheckGithubFilesInDebug;
-#endif 
-                if (check)      // not normall in debug, due to git hub chokeing
-                {
-                    // Async load of maps in another thread
-                    DownloadMaps(() => PendingClose);
-
-                    // and Expedition data
-                    DownloadExpeditions(() => PendingClose);
-
-                    // and Exploration data
-                    DownloadExploration(() => PendingClose);
-                }
 
                 // Former CheckSystems, reworked to accomodate new switches..
                 // Check to see what sync refreshes we need

--- a/EDDiscovery/Installer.cs
+++ b/EDDiscovery/Installer.cs
@@ -55,9 +55,9 @@ namespace EDDiscovery
             return Task.Factory.StartNew(() =>
             {
                 bool check = true;
-#if DEBUG
-                check = EDDOptions.Instance.CheckGithubFilesInDebug;
+                check = EDDOptions.Instance.CheckRelease;
 
+#if DEBUG
                 // for debugging it
                 //callbackinthread?.Invoke(new BaseUtils.GitHubRelease("Test","10.9.1.9","http", "2018-09-25T09:17:02Z", "Test","1.exe","2.msi","portable.zip"));
 #endif 

--- a/EDDiscovery/Notifications.cs
+++ b/EDDiscovery/Notifications.cs
@@ -129,10 +129,7 @@ namespace EDDiscovery
         {
             return Task.Factory.StartNew(() =>
             {
-                bool check = true;
-#if DEBUG
-                check = EDDOptions.Instance.CheckGithubFilesInDebug;
-#endif
+                bool check = EDDOptions.Instance.CheckGithubFiles;
                 string notificationsdir = EDDOptions.Instance.NotificationsAppDirectory();
 
                 if (check)      // if download from github first..

--- a/Installer/EDDiscovery.aip
+++ b/Installer/EDDiscovery.aip
@@ -36,7 +36,9 @@
   <COMPONENT cid="caphyon.advinst.msicomp.MsiDirsComponent">
     <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1"/>
     <ROW Directory="EDDiscovery_Dir" Directory_Parent="ProgramMenuFolder" DefaultDir="EDDISC~1|EDDiscovery"/>
+    <ROW Directory="Exploration_Dir" Directory_Parent="EDDiscovery_Dir" DefaultDir="EXPLOR~1|Exploration"/>
     <ROW Directory="FontsFolder" Directory_Parent="TARGETDIR" DefaultDir="FONTSF~1|FontsFolder" IsPseudoRoot="1"/>
+    <ROW Directory="LocalAppDataFolder" Directory_Parent="TARGETDIR" DefaultDir="LOCALA~1|LocalAppDataFolder" IsPseudoRoot="1"/>
     <ROW Directory="Microsoft.VC100.CRT_Dir" Directory_Parent="x86_Dir" DefaultDir="MICROS~1.CRT|Microsoft.VC100.CRT"/>
     <ROW Directory="ProgramMenuFolder" Directory_Parent="TARGETDIR" DefaultDir="PROGRA~1|ProgramMenuFolder" IsPseudoRoot="1"/>
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
@@ -60,6 +62,7 @@
     <ROW Component="ExtendedControls.dll" ComponentId="{726FCAAF-0CAC-4414-8652-A647AF38EB5D}" Directory_="APPDIR" Attributes="0" KeyPath="ExtendedControls.dll"/>
     <ROW Component="ExtendedForms.dll" ComponentId="{E25DD885-296B-4361-8B8D-EEBA82F72C94}" Directory_="APPDIR" Attributes="0" KeyPath="ExtendedForms.dll"/>
     <ROW Component="InstallLanguage" ComponentId="{E9F59FD4-B1B3-479F-858E-68E75683B873}" Directory_="APPDIR" Attributes="4" KeyPath="InstallLanguage" Options="1"/>
+    <ROW Component="M67.json" ComponentId="{C770A861-605F-4B7A-B952-1155AFA91CFF}" Directory_="Exploration_Dir" Attributes="0" KeyPath="M67.json" Type="0"/>
     <ROW Component="Newtonsoft.Json.dll" ComponentId="{11EF4895-473E-435D-A749-C1CCC6462BF8}" Directory_="APPDIR" Attributes="0" KeyPath="Newtonsoft.Json.dll"/>
     <ROW Component="OpenTK.GLControl.dll" ComponentId="{027B3AD2-A990-44DE-A920-B19144770C02}" Directory_="APPDIR" Attributes="0" KeyPath="OpenTK.GLControl.dll"/>
     <ROW Component="OpenTK.dll" ComponentId="{C4594C03-283B-485A-B97C-6E3B4D128D73}" Directory_="APPDIR" Attributes="0" KeyPath="OpenTK.dll"/>
@@ -80,7 +83,7 @@
     <ROW Feature="AI32BitFiles" Title="32-bit" Description="32-bit Executables and Libraries" Display="5" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage InstallLanguage Newtonsoft.Json.dll OpenTK.GLControl.dll OpenTK.dll SQLite.Interop.dll System.Data.SQLite.dll msvcp100.dll msvcr100.dll"/>
     <ROW Feature="AI64BitFiles" Title="64-bit" Description="64-bit Executables and Libraries" Display="3" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage InstallLanguage SQLite.Interop.dll_1"/>
     <ROW Feature="AIOtherFiles" Title="Common" Description="Shared Resource and Regular Files" Display="7" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage InstallLanguage fround.js"/>
-    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage ActionLanguage.dll Audio.dll BaseUtils.dll CSCore.dll DirectInput.dll EDDiscovery EDDiscovery.Icons.dll EDDiscovery.exe EDDiscovery.exe.config EUROCAPS.TTF EliteDangerous.dll ExtendedControls.dll ExtendedForms.dll InstallLanguage OpenTKUtils.dll OxyPlot.WindowsForms.dll OxyPlot.dll ProductInformation SharpDX.DirectInput.dll SharpDX.dll"/>
+    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage ActionLanguage.dll Audio.dll BaseUtils.dll CSCore.dll DirectInput.dll EDDiscovery EDDiscovery.Icons.dll EDDiscovery.exe EDDiscovery.exe.config EUROCAPS.TTF EliteDangerous.dll ExtendedControls.dll ExtendedForms.dll InstallLanguage M67.json OpenTKUtils.dll OxyPlot.WindowsForms.dll OxyPlot.dll ProductInformation SharpDX.DirectInput.dll SharpDX.dll"/>
     <ATTRIBUTE name="CurrentFeature" value="MainFeature"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
@@ -95,7 +98,7 @@
     <ROW File="DirectInput.pdb" Component_="DirectInput.dll" FileName="DIRECT~1.PDB|DirectInput.pdb" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\DirectInput.pdb" SelfReg="false" NextFile="EDDiscovery.pdb"/>
     <ROW File="EDDiscovery.Icons.dll" Component_="EDDiscovery.Icons.dll" FileName="EDDISC~1.DLL|EDDiscovery.Icons.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.Icons.dll" SelfReg="false" NextFile="OxyPlot.dll"/>
     <ROW File="EDDiscovery.exe" Component_="EDDiscovery.exe" FileName="EDDISC~1.EXE|EDDiscovery.exe" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.exe" SelfReg="false" NextFile="EUROCAPS.TTF" DigSign="true"/>
-    <ROW File="EDDiscovery.exe.config" Component_="EDDiscovery.exe.config" FileName="EDDISC~1.CON|EDDiscovery.exe.config" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.exe.config" SelfReg="false" NextFile="CSCore.dll"/>
+    <ROW File="EDDiscovery.exe.config" Component_="EDDiscovery.exe.config" FileName="EDDISC~1.CON|EDDiscovery.exe.config" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.exe.config" SelfReg="false" NextFile="M67.json"/>
     <ROW File="EDDiscovery.pdb" Component_="EDDiscovery.exe" FileName="EDDISC~1.PDB|EDDiscovery.pdb" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.pdb" SelfReg="false" NextFile="EliteDangerous.pdb"/>
     <ROW File="EUROCAPS.TTF" Component_="EUROCAPS.TTF" FileName="EUROCAPS.TTF" Attributes="0" SourcePath="ExtraFiles\EUROCAPS.TTF" SelfReg="false" NextFile="EDDiscovery.exe.config"/>
     <ROW File="EliteDangerous.dll" Component_="EliteDangerous.dll" FileName="ELITED~1.DLL|EliteDangerous.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EliteDangerous.dll" SelfReg="false" NextFile="DirectInput.dll"/>
@@ -105,12 +108,14 @@
     <ROW File="ExtendedForms.dll" Component_="ExtendedForms.dll" FileName="EXTEND~2.DLL|ExtendedForms.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\ExtendedForms.dll" SelfReg="false" NextFile="BaseUtils.pdb"/>
     <ROW File="ExtendedForms.pdb" Component_="ExtendedForms.dll" FileName="EXTEND~2.PDB|ExtendedForms.pdb" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\ExtendedForms.pdb" SelfReg="false" NextFile="portuguesptbr.tlf"/>
     <ROW File="Installer.txt" Component_="fround.js" FileName="INSTAL~1.TXT|Installer.txt" Attributes="0" SourcePath="Installer.txt" SelfReg="false" NextFile="System.Data.SQLite.dll"/>
+    <ROW File="M67.json" Component_="M67.json" FileName="M67~1.JSO|M67.json" Attributes="0" SourcePath="ExtraFiles\M67.json" SelfReg="false" NextFile="Pleiades.json"/>
     <ROW File="Newtonsoft.Json.dll" Component_="Newtonsoft.Json.dll" FileName="NEWTON~1.DLL|Newtonsoft.Json.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\Newtonsoft.Json.dll" SelfReg="false" NextFile="OpenTK.GLControl.dll"/>
     <ROW File="OpenTK.GLControl.dll" Component_="OpenTK.GLControl.dll" FileName="OPENTK~1.DLL|OpenTK.GLControl.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OpenTK.GLControl.dll" SelfReg="false" NextFile="Installer.txt"/>
     <ROW File="OpenTK.dll" Component_="OpenTK.dll" FileName="OpenTK.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OpenTK.dll" SelfReg="false" NextFile="Newtonsoft.Json.dll"/>
     <ROW File="OpenTKUtils.dll" Component_="OpenTKUtils.dll" FileName="OPENTK~2.DLL|OpenTKUtils.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OpenTKUtils.dll" SelfReg="false" NextFile="translationdeutschje.tlp"/>
     <ROW File="OxyPlot.WindowsForms.dll" Component_="OxyPlot.WindowsForms.dll" FileName="OXYPLO~1.DLL|OxyPlot.WindowsForms.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OxyPlot.WindowsForms.dll" SelfReg="false" NextFile="OpenTKUtils.dll"/>
     <ROW File="OxyPlot.dll" Component_="OxyPlot.dll" FileName="OxyPlot.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OxyPlot.dll" SelfReg="false" NextFile="OxyPlot.WindowsForms.dll"/>
+    <ROW File="Pleiades.json" Component_="M67.json" FileName="PLEIAD~1.JSO|Pleiades.json" Attributes="0" SourcePath="ExtraFiles\Pleiades.json" SelfReg="false" NextFile="CSCore.dll"/>
     <ROW File="SQLite.Interop.dll" Component_="SQLite.Interop.dll" FileName="SQLITE~1.DLL|SQLite.Interop.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\x86\SQLite.Interop.dll" SelfReg="false" NextFile="SQLite.Interop.dll_1"/>
     <ROW File="SQLite.Interop.dll_1" Component_="SQLite.Interop.dll_1" FileName="SQLITE~1.DLL|SQLite.Interop.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\x64\SQLite.Interop.dll" SelfReg="false" NextFile="EDDiscovery.exe"/>
     <ROW File="SharpDX.DirectInput.dll" Component_="SharpDX.DirectInput.dll" FileName="SHARPD~1.DLL|SharpDX.DirectInput.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\SharpDX.DirectInput.dll" SelfReg="false" NextFile="SharpDX.dll"/>

--- a/Installer/EDDiscovery.aip
+++ b/Installer/EDDiscovery.aip
@@ -35,12 +35,8 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiDirsComponent">
     <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1"/>
-    <ROW Directory="Actions_Dir" Directory_Parent="EDDiscovery_1_Dir" DefaultDir="Actions"/>
-    <ROW Directory="EDDiscovery_1_Dir" Directory_Parent="LocalAppDataFolder" DefaultDir="EDDISC~1|EDDiscovery"/>
     <ROW Directory="EDDiscovery_Dir" Directory_Parent="ProgramMenuFolder" DefaultDir="EDDISC~1|EDDiscovery"/>
-    <ROW Directory="Exploration_Dir" Directory_Parent="EDDiscovery_1_Dir" DefaultDir="EXPLOR~1|Exploration"/>
     <ROW Directory="FontsFolder" Directory_Parent="TARGETDIR" DefaultDir="FONTSF~1|FontsFolder" IsPseudoRoot="1"/>
-    <ROW Directory="LocalAppDataFolder" Directory_Parent="TARGETDIR" DefaultDir="LOCALA~1|LocalAppDataFolder" IsPseudoRoot="1"/>
     <ROW Directory="Microsoft.VC100.CRT_Dir" Directory_Parent="x86_Dir" DefaultDir="MICROS~1.CRT|Microsoft.VC100.CRT"/>
     <ROW Directory="ProgramMenuFolder" Directory_Parent="TARGETDIR" DefaultDir="PROGRA~1|ProgramMenuFolder" IsPseudoRoot="1"/>
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
@@ -51,7 +47,6 @@
     <ROW Component="AI_ExePath" ComponentId="{109A35C7-F83F-4943-A79E-CFE792394CE4}" Directory_="APPDIR" Attributes="4" KeyPath="AI_ExePath"/>
     <ROW Component="AI_InstallLanguage" ComponentId="{F07C9C71-86CA-4FBD-870D-B68CB290510D}" Directory_="APPDIR" Attributes="260" KeyPath="AI_InstallLanguage" Options="1"/>
     <ROW Component="ActionLanguage.dll" ComponentId="{282C679E-267C-4D95-A914-C124C8DBC60A}" Directory_="APPDIR" Attributes="0" KeyPath="ActionLanguage.dll"/>
-    <ROW Component="Actions" ComponentId="{D8B1D85C-5FC3-4DAD-8112-62A5C2DE7CF6}" Directory_="Actions_Dir" Attributes="0"/>
     <ROW Component="Audio.dll" ComponentId="{6AF8596E-C99A-4CC9-8193-686150A0176E}" Directory_="APPDIR" Attributes="0" KeyPath="Audio.dll"/>
     <ROW Component="BaseUtils.dll" ComponentId="{DCDE5516-0864-4A3F-853B-B96EED144060}" Directory_="APPDIR" Attributes="0" KeyPath="BaseUtils.dll"/>
     <ROW Component="CSCore.dll" ComponentId="{D8B173BA-81A1-436A-9B1A-72FE76408586}" Directory_="APPDIR" Attributes="0" KeyPath="CSCore.dll"/>
@@ -65,7 +60,6 @@
     <ROW Component="ExtendedControls.dll" ComponentId="{726FCAAF-0CAC-4414-8652-A647AF38EB5D}" Directory_="APPDIR" Attributes="0" KeyPath="ExtendedControls.dll"/>
     <ROW Component="ExtendedForms.dll" ComponentId="{E25DD885-296B-4361-8B8D-EEBA82F72C94}" Directory_="APPDIR" Attributes="0" KeyPath="ExtendedForms.dll"/>
     <ROW Component="InstallLanguage" ComponentId="{E9F59FD4-B1B3-479F-858E-68E75683B873}" Directory_="APPDIR" Attributes="4" KeyPath="InstallLanguage" Options="1"/>
-    <ROW Component="M67.json" ComponentId="{C770A861-605F-4B7A-B952-1155AFA91CFF}" Directory_="Exploration_Dir" Attributes="0" KeyPath="M67.json" Type="0"/>
     <ROW Component="Newtonsoft.Json.dll" ComponentId="{11EF4895-473E-435D-A749-C1CCC6462BF8}" Directory_="APPDIR" Attributes="0" KeyPath="Newtonsoft.Json.dll"/>
     <ROW Component="OpenTK.GLControl.dll" ComponentId="{027B3AD2-A990-44DE-A920-B19144770C02}" Directory_="APPDIR" Attributes="0" KeyPath="OpenTK.GLControl.dll"/>
     <ROW Component="OpenTK.dll" ComponentId="{C4594C03-283B-485A-B97C-6E3B4D128D73}" Directory_="APPDIR" Attributes="0" KeyPath="OpenTK.dll"/>
@@ -86,7 +80,7 @@
     <ROW Feature="AI32BitFiles" Title="32-bit" Description="32-bit Executables and Libraries" Display="5" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage InstallLanguage Newtonsoft.Json.dll OpenTK.GLControl.dll OpenTK.dll SQLite.Interop.dll System.Data.SQLite.dll msvcp100.dll msvcr100.dll"/>
     <ROW Feature="AI64BitFiles" Title="64-bit" Description="64-bit Executables and Libraries" Display="3" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage InstallLanguage SQLite.Interop.dll_1"/>
     <ROW Feature="AIOtherFiles" Title="Common" Description="Shared Resource and Regular Files" Display="7" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage InstallLanguage fround.js"/>
-    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage ActionLanguage.dll Actions Audio.dll BaseUtils.dll CSCore.dll DirectInput.dll EDDiscovery EDDiscovery.Icons.dll EDDiscovery.exe EDDiscovery.exe.config EUROCAPS.TTF EliteDangerous.dll ExtendedControls.dll ExtendedForms.dll InstallLanguage M67.json OpenTKUtils.dll OxyPlot.WindowsForms.dll OxyPlot.dll ProductInformation SharpDX.DirectInput.dll SharpDX.dll"/>
+    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0" Components="AI_ExePath AI_InstallLanguage ActionLanguage.dll Audio.dll BaseUtils.dll CSCore.dll DirectInput.dll EDDiscovery EDDiscovery.Icons.dll EDDiscovery.exe EDDiscovery.exe.config EUROCAPS.TTF EliteDangerous.dll ExtendedControls.dll ExtendedForms.dll InstallLanguage OpenTKUtils.dll OxyPlot.WindowsForms.dll OxyPlot.dll ProductInformation SharpDX.DirectInput.dll SharpDX.dll"/>
     <ATTRIBUTE name="CurrentFeature" value="MainFeature"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
@@ -101,7 +95,7 @@
     <ROW File="DirectInput.pdb" Component_="DirectInput.dll" FileName="DIRECT~1.PDB|DirectInput.pdb" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\DirectInput.pdb" SelfReg="false" NextFile="EDDiscovery.pdb"/>
     <ROW File="EDDiscovery.Icons.dll" Component_="EDDiscovery.Icons.dll" FileName="EDDISC~1.DLL|EDDiscovery.Icons.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.Icons.dll" SelfReg="false" NextFile="OxyPlot.dll"/>
     <ROW File="EDDiscovery.exe" Component_="EDDiscovery.exe" FileName="EDDISC~1.EXE|EDDiscovery.exe" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.exe" SelfReg="false" NextFile="EUROCAPS.TTF" DigSign="true"/>
-    <ROW File="EDDiscovery.exe.config" Component_="EDDiscovery.exe.config" FileName="EDDISC~1.CON|EDDiscovery.exe.config" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.exe.config" SelfReg="false" NextFile="M67.json"/>
+    <ROW File="EDDiscovery.exe.config" Component_="EDDiscovery.exe.config" FileName="EDDISC~1.CON|EDDiscovery.exe.config" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.exe.config" SelfReg="false" NextFile="CSCore.dll"/>
     <ROW File="EDDiscovery.pdb" Component_="EDDiscovery.exe" FileName="EDDISC~1.PDB|EDDiscovery.pdb" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EDDiscovery.pdb" SelfReg="false" NextFile="EliteDangerous.pdb"/>
     <ROW File="EUROCAPS.TTF" Component_="EUROCAPS.TTF" FileName="EUROCAPS.TTF" Attributes="0" SourcePath="ExtraFiles\EUROCAPS.TTF" SelfReg="false" NextFile="EDDiscovery.exe.config"/>
     <ROW File="EliteDangerous.dll" Component_="EliteDangerous.dll" FileName="ELITED~1.DLL|EliteDangerous.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\EliteDangerous.dll" SelfReg="false" NextFile="DirectInput.dll"/>
@@ -111,14 +105,12 @@
     <ROW File="ExtendedForms.dll" Component_="ExtendedForms.dll" FileName="EXTEND~2.DLL|ExtendedForms.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\ExtendedForms.dll" SelfReg="false" NextFile="BaseUtils.pdb"/>
     <ROW File="ExtendedForms.pdb" Component_="ExtendedForms.dll" FileName="EXTEND~2.PDB|ExtendedForms.pdb" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\ExtendedForms.pdb" SelfReg="false" NextFile="portuguesptbr.tlf"/>
     <ROW File="Installer.txt" Component_="fround.js" FileName="INSTAL~1.TXT|Installer.txt" Attributes="0" SourcePath="Installer.txt" SelfReg="false" NextFile="System.Data.SQLite.dll"/>
-    <ROW File="M67.json" Component_="M67.json" FileName="M67~1.JSO|M67.json" Attributes="0" SourcePath="ExtraFiles\M67.json" SelfReg="false" NextFile="Pleiades.json"/>
     <ROW File="Newtonsoft.Json.dll" Component_="Newtonsoft.Json.dll" FileName="NEWTON~1.DLL|Newtonsoft.Json.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\Newtonsoft.Json.dll" SelfReg="false" NextFile="OpenTK.GLControl.dll"/>
     <ROW File="OpenTK.GLControl.dll" Component_="OpenTK.GLControl.dll" FileName="OPENTK~1.DLL|OpenTK.GLControl.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OpenTK.GLControl.dll" SelfReg="false" NextFile="Installer.txt"/>
     <ROW File="OpenTK.dll" Component_="OpenTK.dll" FileName="OpenTK.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OpenTK.dll" SelfReg="false" NextFile="Newtonsoft.Json.dll"/>
     <ROW File="OpenTKUtils.dll" Component_="OpenTKUtils.dll" FileName="OPENTK~2.DLL|OpenTKUtils.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OpenTKUtils.dll" SelfReg="false" NextFile="translationdeutschje.tlp"/>
     <ROW File="OxyPlot.WindowsForms.dll" Component_="OxyPlot.WindowsForms.dll" FileName="OXYPLO~1.DLL|OxyPlot.WindowsForms.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OxyPlot.WindowsForms.dll" SelfReg="false" NextFile="OpenTKUtils.dll"/>
     <ROW File="OxyPlot.dll" Component_="OxyPlot.dll" FileName="OxyPlot.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\OxyPlot.dll" SelfReg="false" NextFile="OxyPlot.WindowsForms.dll"/>
-    <ROW File="Pleiades.json" Component_="M67.json" FileName="PLEIAD~1.JSO|Pleiades.json" Attributes="0" SourcePath="ExtraFiles\Pleiades.json" SelfReg="false" NextFile="CSCore.dll"/>
     <ROW File="SQLite.Interop.dll" Component_="SQLite.Interop.dll" FileName="SQLITE~1.DLL|SQLite.Interop.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\x86\SQLite.Interop.dll" SelfReg="false" NextFile="SQLite.Interop.dll_1"/>
     <ROW File="SQLite.Interop.dll_1" Component_="SQLite.Interop.dll_1" FileName="SQLITE~1.DLL|SQLite.Interop.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\x64\SQLite.Interop.dll" SelfReg="false" NextFile="EDDiscovery.exe"/>
     <ROW File="SharpDX.DirectInput.dll" Component_="SharpDX.DirectInput.dll" FileName="SHARPD~1.DLL|SharpDX.DirectInput.dll" Attributes="0" SourcePath="..\EDDiscovery\bin\Release\SharpDX.DirectInput.dll" SelfReg="false" NextFile="SharpDX.dll"/>


### PR DESCRIPTION
The installer should not be installing files into the user's LocalAppData - it is up to the program to create these directories and download the files as necessary.

This should fix #2232