### PR TITLE
Send unknown named bodies with EDDN test schema

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -654,6 +654,7 @@ namespace EliteDangerousCore.EDDN
 
             if (!bodydesig.StartsWith(system.Name, StringComparison.InvariantCultureIgnoreCase))  // For now test if its a different name ( a few exception for like sol system with named planets)  To catch a rare out of sync bug in historylist.
             {
+                msg["BodyDesignation"] = journal.BodyDesignation;
                 msg["$schemaRef"] = GetEDDNJournalSchemaRef(true);
             }
 

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -71,9 +71,9 @@ namespace EliteDangerousCore.EDDN
             else return false;
         }
 
-        private string GetEDDNJournalSchemaRef()
+        private string GetEDDNJournalSchemaRef(bool test = false)
         {
-            if (isBeta || commanderName.StartsWith("[BETA]"))
+            if (isBeta || commanderName.StartsWith("[BETA]") || test)
                 return "https://eddn.edcd.io/schemas/journal/1/test";
             else
                 return "https://eddn.edcd.io/schemas/journal/1";
@@ -654,7 +654,7 @@ namespace EliteDangerousCore.EDDN
 
             if (!bodydesig.StartsWith(system.Name, StringComparison.InvariantCultureIgnoreCase))  // For now test if its a different name ( a few exception for like sol system with named planets)  To catch a rare out of sync bug in historylist.
             {
-                return null;
+                msg["$schemaRef"] = GetEDDNJournalSchemaRef(true);
             }
 
 

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -654,7 +654,11 @@ namespace EliteDangerousCore.EDDN
 
             if (!bodydesig.StartsWith(system.Name, StringComparison.InvariantCultureIgnoreCase))  // For now test if its a different name ( a few exception for like sol system with named planets)  To catch a rare out of sync bug in historylist.
             {
-                msg["BodyDesignation"] = journal.BodyDesignation;
+                if (journal.BodyDesignation != null || System.Text.RegularExpressions.Regex.IsMatch(journal.BodyName, " [A-Z][A-Z]-[A-Z] [a-h][0-9]", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+                {
+                    return null;
+                }
+
                 msg["$schemaRef"] = GetEDDNJournalSchemaRef(true);
             }
 

--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -659,6 +659,7 @@ namespace EliteDangerousCore.EDDN
                     return null;
                 }
 
+                msg["IsUnknownBody"] = true;
                 msg["$schemaRef"] = GetEDDNJournalSchemaRef(true);
             }
 


### PR DESCRIPTION
It was brought up that if someone comes across an unknown named body, then EDDiscovery won't send it to EDDN.

Send unknown named systems to EDDN using the test schema instead of straight rejecting them.