### PR TITLE
Fixed Total Fired count in crew statistics

### DIFF
--- a/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
@@ -881,7 +881,7 @@ namespace EDDiscovery.UserControls
                 TreeNode crew = treeViewStats.Nodes.Add("Crew"); 
                 AddChildNode(crew, "Total Wages".Tx(this), stats.Crew?.TotalWages.ToString("N0", System.Globalization.CultureInfo.CurrentCulture), "Cr");
                 AddChildNode(crew, "Total Hired".Tx(this), stats.Crew?.Hired.ToString("N0", System.Globalization.CultureInfo.CurrentCulture));
-                AddChildNode(crew, "Total Fired".Tx(this), stats.Crew?.Hired.ToString("N0", System.Globalization.CultureInfo.CurrentCulture));
+                AddChildNode(crew, "Total Fired".Tx(this), stats.Crew?.Fired.ToString("N0", System.Globalization.CultureInfo.CurrentCulture));
                 AddChildNode(crew, "Died in Line of Duty".Tx(this), stats.Crew?.Died.ToString("N0", System.Globalization.CultureInfo.CurrentCulture));
                 if (collapseExpand.Substring(10,1) == "Y") crew.Expand();
 


### PR DESCRIPTION
Fixed Total Fired count displaying the same as Total Hired count. Compiled and tested by hiring and firing another NPC. Seems to work fine.