### PR TITLE
Make UCs populate when travel history is completely filtered

### DIFF
--- a/EDDiscovery/3DMap/FormMap.cs
+++ b/EDDiscovery/3DMap/FormMap.cs
@@ -241,7 +241,7 @@ namespace EDDiscovery
             RequestPaint();
         }
 
-        private void PrimaryCursor_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl)
+        private void PrimaryCursor_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             UpdateHistorySystem(he.System);
         }

--- a/EDDiscovery/UserControls/CurrentState/UserControlMaterialCommodities.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlMaterialCommodities.cs
@@ -103,7 +103,10 @@ namespace EDDiscovery.UserControls
             Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
         }
 
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             //if ( he != null ) System.Diagnostics.Debug.WriteLine("Hash displayed" + he.MaterialCommodity.DataHash());
 

--- a/EDDiscovery/UserControls/CurrentState/UserControlMissions.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlMissions.cs
@@ -128,7 +128,11 @@ namespace EDDiscovery.UserControls
         }
 
         HistoryEntry last_he = null;
-        private void Display(HistoryEntry he, HistoryList hl)
+
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             last_he = he;
             Display();

--- a/EDDiscovery/UserControls/CurrentState/UserControlModules.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlModules.cs
@@ -131,7 +131,10 @@ namespace EDDiscovery.UserControls
         HistoryEntry last_he = null;
         ShipInformation last_si = null;
 
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if ( comboBoxShips.Items.Count == 0 )
                 UpdateComboBox(hl);

--- a/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
@@ -86,7 +86,10 @@ namespace EDDiscovery.UserControls
             SizeControls();         // need to size controls here as well.. goes tabstrip.. create user control.. calls updatestats with incorrect size.. added to UC panel.. relayout
         }
 
-        public void TravelGridChanged(HistoryEntry he, HistoryList hl)
+        private void TravelGridChanged(HistoryEntry he, HistoryList hl) =>
+            TravelGridChanged(he, hl, true);
+
+        public void TravelGridChanged(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             Stats(he, hl);
         }
@@ -107,7 +110,7 @@ namespace EDDiscovery.UserControls
             if (hl == null)
                 hl = last_hl;
 
-            if (he == null || hl == null)
+            if (hl == null)
                 return;
 
             last_hl = hl;

--- a/EDDiscovery/UserControls/EngineeringSynthesis/UserControlEngineering.cs
+++ b/EDDiscovery/UserControls/EngineeringSynthesis/UserControlEngineering.cs
@@ -187,7 +187,7 @@ namespace EDDiscovery.UserControls
         }
 
         HistoryEntry last_he = null;
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if (isHistoric || last_he == null)
             {

--- a/EDDiscovery/UserControls/EngineeringSynthesis/UserControlSynthesis.cs
+++ b/EDDiscovery/UserControls/EngineeringSynthesis/UserControlSynthesis.cs
@@ -183,7 +183,7 @@ namespace EDDiscovery.UserControls
         }
 
         HistoryEntry last_he = null;
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if (isHistoric || last_he == null)
             {

--- a/EDDiscovery/UserControls/History/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlJournalGrid.cs
@@ -697,8 +697,7 @@ namespace EDDiscovery.UserControls
             {
                 int row = dataGridViewJournal.CurrentCell.RowIndex;
                 //System.Diagnostics.Debug.WriteLine("Fire Change Sel row" + row);
-                if (OnTravelSelectionChanged != null)
-                    OnTravelSelectionChanged(dataGridViewJournal.Rows[row].Cells[JournalHistoryColumns.HistoryTag].Tag as HistoryEntry, current_historylist);
+                OnTravelSelectionChanged?.Invoke(dataGridViewJournal.Rows[row].Cells[JournalHistoryColumns.HistoryTag].Tag as HistoryEntry, current_historylist, true);
             }
         }
     }

--- a/EDDiscovery/UserControls/History/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/History/UserControlStarList.cs
@@ -652,8 +652,7 @@ namespace EDDiscovery.UserControls
             {
                 int row = dataGridViewStarList.CurrentCell.RowIndex;
                 //System.Diagnostics.Debug.WriteLine("Fire Change Sel row" + row);
-                if (OnTravelSelectionChanged != null)
-                    OnTravelSelectionChanged((dataGridViewStarList.Rows[row].Tag as List<HistoryEntry>)[0], current_historylist);
+                OnTravelSelectionChanged?.Invoke((dataGridViewStarList.Rows[row].Tag as List<HistoryEntry>)[0], current_historylist, true);
             }
         }
 

--- a/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
@@ -484,10 +484,10 @@ namespace EDDiscovery.UserControls
             {
                 int row = dataGridViewTravel.CurrentCell.RowIndex;
                 //System.Diagnostics.Debug.WriteLine("TG:Fire Change Sel row" + row);
-                OnTravelSelectionChanged?.Invoke(dataGridViewTravel.Rows[row].Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry, current_historylist);
+                OnTravelSelectionChanged?.Invoke(dataGridViewTravel.Rows[row].Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry, current_historylist, true);
             }
             else if (current_historylist != null && current_historylist.Count > 0)
-                OnTravelSelectionChanged?.Invoke(current_historylist.Last(), current_historylist);
+                OnTravelSelectionChanged?.Invoke(current_historylist.Last(), current_historylist, false);
         }
 
         private void dataGridViewTravel_CellClick(object sender, DataGridViewCellEventArgs e)

--- a/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
@@ -484,9 +484,10 @@ namespace EDDiscovery.UserControls
             {
                 int row = dataGridViewTravel.CurrentCell.RowIndex;
                 //System.Diagnostics.Debug.WriteLine("TG:Fire Change Sel row" + row);
-                if (OnTravelSelectionChanged != null)
-                    OnTravelSelectionChanged(dataGridViewTravel.Rows[row].Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry, current_historylist);
+                OnTravelSelectionChanged?.Invoke(dataGridViewTravel.Rows[row].Cells[TravelHistoryColumns.HistoryTag].Tag as HistoryEntry, current_historylist);
             }
+            else if (current_historylist != null && current_historylist.Count > 0)
+                OnTravelSelectionChanged?.Invoke(current_historylist.Last(), current_historylist);
         }
 
         private void dataGridViewTravel_CellClick(object sender, DataGridViewCellEventArgs e)

--- a/EDDiscovery/UserControls/IHistoryCursor.cs
+++ b/EDDiscovery/UserControls/IHistoryCursor.cs
@@ -19,7 +19,7 @@ namespace EDDiscovery.UserControls
 {
     // Any UCs wanting to be a cursor, must implement this interface
 
-    public delegate void ChangedSelectionHEHandler(HistoryEntry he, HistoryList hl);
+    public delegate void ChangedSelectionHEHandler(HistoryEntry he, HistoryList hl, bool selectedEntry);
 
     public interface IHistoryCursor
     {

--- a/EDDiscovery/UserControls/Overlays/UserControlNotePanel.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlNotePanel.cs
@@ -82,7 +82,10 @@ namespace EDDiscovery.UserControls
             uctg.OnTravelSelectionChanged += DisplaySelected;
         }
 
-        private void DisplaySelected(HistoryEntry he, HistoryList hl)
+        private void DisplaySelected(HistoryEntry he, HistoryList hl) =>
+            DisplaySelected(he, hl, true);
+
+        private void DisplaySelected(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if (he != null && he.EntryType == JournalTypeEnum.FSDJump)
                 Display(he);

--- a/EDDiscovery/UserControls/Overlays/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSysInfo.cs
@@ -156,7 +156,10 @@ namespace EDDiscovery.UserControls
         bool neverdisplayed = true;
         HistoryEntry last_he = null;
 
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             //System.Diagnostics.Debug.WriteLine("SI:Display ");
 

--- a/EDDiscovery/UserControls/RoutesExpeditions/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/RoutesExpeditions/UserControlExploration.cs
@@ -91,7 +91,7 @@ namespace EDDiscovery.UserControls
             UpdateSystemRows();
         }
 
-        private void Display(HistoryEntry he, HistoryList hl)            // when user clicks around..
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)            // when user clicks around..
         {
             UpdateSystemRows();
         }

--- a/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.cs
@@ -79,8 +79,10 @@ namespace EDDiscovery.UserControls
             }
         }
 
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
 
-        private void Display(HistoryEntry he, HistoryList hl)            // Called at first start or hooked to change cursor
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)            // Called at first start or hooked to change cursor
         {
             if (he != null && (last_he == null || he.System != last_he.System))
             {

--- a/EDDiscovery/UserControls/ScansStars/UserControlLocalMap.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlLocalMap.cs
@@ -105,7 +105,7 @@ namespace EDDiscovery.UserControls
             KickComputation(uctg.GetCurrentHistoryEntry);
         }
 
-        private void Uctg_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl)
+        private void Uctg_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             KickComputation(he);
             RefreshMap();

--- a/EDDiscovery/UserControls/ScansStars/UserControlPlot.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlPlot.cs
@@ -124,7 +124,7 @@ namespace EDDiscovery.UserControls
             KickComputation(uctg.GetCurrentHistoryEntry);
         }
 
-        private void Uctg_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl)
+        private void Uctg_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             KickComputation(he);
 

--- a/EDDiscovery/UserControls/ScansStars/UserControlScan.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlScan.cs
@@ -140,7 +140,10 @@ namespace EDDiscovery.UserControls
             Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
         }
 
-        private void Display(HistoryEntry he, HistoryList hl)            // when user clicks around..
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)            // when user clicks around..
         {
             if (he != null && (last_he == null || he.System != last_he.System))
             {

--- a/EDDiscovery/UserControls/ScansStars/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlScanGrid.cs
@@ -147,7 +147,7 @@ namespace EDDiscovery.UserControls
         /// </summary>
         /// <param name="he">HistoryEntry</param>
         /// <param name="hl">HistoryList</param>
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             ResetDefaults();
             DrawSystem(he, false);

--- a/EDDiscovery/UserControls/ScansStars/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlStarDistance.cs
@@ -99,7 +99,7 @@ namespace EDDiscovery.UserControls
             KickComputation(obj.GetLast);   // copes with getlast = null
         }
 
-        private void Uctg_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl)
+        private void Uctg_OnTravelSelectionChanged(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             KickComputation(he);
         }

--- a/EDDiscovery/UserControls/Screenshots/UserControlScreenshot.cs
+++ b/EDDiscovery/UserControls/Screenshots/UserControlScreenshot.cs
@@ -76,7 +76,10 @@ namespace EDDiscovery.UserControls
             Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
         }
 
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if (he != null)
             {

--- a/EDDiscovery/UserControls/StationData/UserControlMarketData.cs
+++ b/EDDiscovery/UserControls/StationData/UserControlMarketData.cs
@@ -99,7 +99,10 @@ namespace EDDiscovery.UserControls
 
         List<HistoryEntry> comboboxentries = new List<HistoryEntry>(); // filled by combobox
 
-        private void OnChanged(HistoryEntry he, HistoryList hl)
+        private void OnChanged(HistoryEntry he, HistoryList hl) =>
+            OnChanged(he, hl, true);
+
+        private void OnChanged(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if (!Object.ReferenceEquals(he, last_he) )       // if last was null, or he has changed, we have a possible change..
             {

--- a/EDDiscovery/UserControls/StationData/UserControlOutfitting.cs
+++ b/EDDiscovery/UserControls/StationData/UserControlOutfitting.cs
@@ -125,7 +125,10 @@ namespace EDDiscovery.UserControls
 
         HistoryEntry last_he = null;
 
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if ( comboBoxYards.Items.Count == 0 )
                 UpdateComboBox(hl);

--- a/EDDiscovery/UserControls/StationData/UserControlShipYards.cs
+++ b/EDDiscovery/UserControls/StationData/UserControlShipYards.cs
@@ -124,7 +124,10 @@ namespace EDDiscovery.UserControls
 
         HistoryEntry last_he = null;
 
-        private void Display(HistoryEntry he, HistoryList hl)
+        private void Display(HistoryEntry he, HistoryList hl) =>
+            Display(he, hl, true);
+
+        private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)
         {
             if ( comboBoxYards.Items.Count == 0 )
                 UpdateComboBox(hl);


### PR DESCRIPTION
Makes most recent HE the default if everything is filtered out, rather than no change at all being notified to dependent UCs (or no initial load happening if loading fully filtered by a time window)