### PR TITLE
Cruento Mucrone and Iain Ross are the same person.

### DIFF
--- a/EDDiscovery/Forms/AboutForm.resx
+++ b/EDDiscovery/Forms/AboutForm.resx
@@ -128,7 +128,7 @@ Languages Translations:
 Potatossuaro, Zafford, Andrea Spada, Goscickiw
 
 Previous Contributors:
-Phroggie, Finwen, Cruento Mucrone, Corbin Moran, Myshka, Zed, Marlon Blake, Smacker, Jason Thorpe, Greg Malcolm,  Majkl578, MWerle..</value>
+Phroggie, Finwen, Corbin Moran, Myshka, Zed, Marlon Blake, Smacker, Jason Thorpe, Greg Malcolm,  Majkl578, MWerle..</value>
   </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>


### PR DESCRIPTION
Both are I