### PR TITLE
Remove SquadronFaction (not PlayerFaction) and HomeSystem

### DIFF
--- a/EliteDangerous/EDDN/EDDNClass.cs
+++ b/EliteDangerous/EDDN/EDDNClass.cs
@@ -134,7 +134,6 @@ namespace EliteDangerousCore.EDDN
                     ["Government"] = true,
                     ["FactionState"] = true,
                     ["Happiness"] = true,
-                    ["HomeSystem"] = true,
                     ["Influence"] = true,
                     ["ActiveStates"] = new JArray
                     {
@@ -393,7 +392,8 @@ namespace EliteDangerousCore.EDDN
                 foreach (JObject faction in factions)
                 {
                     faction.Remove("MyReputation");
-                    faction.Remove("PlayerFaction");
+                    faction.Remove("SquadronFaction");
+                    faction.Remove("HomeSystem");
                     faction.Remove("HappiestSystem");
                     RemoveCommonKeys(faction);
                 }


### PR DESCRIPTION
Journal manual says the property is SquadronFaction, not PlayerFaction.  Also remove HomeSystem, as this is only present if the player is in a squadron aligned to that faction, and the current system is the home system of that faction.