### PR TITLE
Fix EDSM button tooltip; confirm sync when sync disabled

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.Designer.cs
+++ b/EDDiscovery/EDDiscoveryForm.Designer.cs
@@ -701,7 +701,7 @@ namespace EDDiscovery
             this.buttonExtEDSMSync.Name = "buttonExtEDSMSync";
             this.buttonExtEDSMSync.Size = new System.Drawing.Size(24, 24);
             this.buttonExtEDSMSync.TabIndex = 2;
-            this.toolTip.SetToolTip(this.buttonExtEDSMSync, "Synchronize with EDSM, To and From");
+            this.toolTip.SetToolTip(this.buttonExtEDSMSync, "Send any unsynced logs to EDSM");
             this.buttonExtEDSMSync.UseVisualStyleBackColor = true;
             this.buttonExtEDSMSync.Click += new System.EventHandler(this.buttonExtEDSMSync_Click);
             //

--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -1444,6 +1444,17 @@ namespace EDDiscovery
                 return;
             }
 
+            if (!EDCommander.Current.SyncToEddn)
+            {
+                string dlgtext = "You have disabled sync to EDSM for this commander.  Are you sure you want to send unsynced events to EDSM?".Tx(this, "ConfirmSyncToEDSM");
+                string dlgcapt = "Confirm EDSM sync".Tx(this, "ConfirmSyncToEDSMCaption");
+
+                if (ExtendedControls.MessageBoxTheme.Show(this, dlgtext, dlgcapt, MessageBoxButtons.YesNo) == DialogResult.No)
+                {
+                    return;
+                }
+            }
+
             try
             {
                 EDSMJournalSync.SendEDSMEvents(l => LogLine(l), history, manual: true);


### PR DESCRIPTION
This should clarify the purpose of the EDSM button, and fix #2334 