### PR TITLE
Fix galactic mapping data URL

### DIFF
--- a/EDDiscovery/EDDiscoveryController.cs
+++ b/EDDiscovery/EDDiscoveryController.cs
@@ -579,8 +579,10 @@ namespace EDDiscovery
                 if (DateTime.Now.Subtract(galmaptime).TotalDays > 14)  // Over 14 days do a sync from EDSM for galmap
                 {
                     LogLine("Get galactic mapping from EDSM.".Tx(this,"EDSM"));
-                    galacticMapping.DownloadFromEDSM();
-                    SQLiteConnectionSystem.PutSettingString("EDSMGalMapLast", DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"));
+                    if (galacticMapping.DownloadFromEDSM())
+                    {
+                        SQLiteConnectionSystem.PutSettingString("EDSMGalMapLast", DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"));
+                    }
                 }
 
                 Debug.WriteLine(BaseUtils.AppTicks.TickCountLap() + " Check systems complete");

--- a/EliteDangerous/EDSM/GalacticMapping.cs
+++ b/EliteDangerous/EDSM/GalacticMapping.cs
@@ -48,7 +48,7 @@ namespace EliteDangerousCore.EDSM
             try
             {
                 EDSMClass edsm = new EDSMClass();
-                string url = EDSMClass.ServerAddress + "galactic-mapping/json-edd";
+                string url = EDSMClass.ServerAddress + "en/galactic-mapping/json-edd";
                 bool newfile;
 
                 return BaseUtils.DownloadFileHandler.DownloadFile(url, GalacticMappingFile, out newfile);

--- a/EliteDangerous/EDSM/GalacticMapping.cs
+++ b/EliteDangerous/EDSM/GalacticMapping.cs
@@ -24,7 +24,7 @@ namespace EliteDangerousCore.EDSM
 {
     public class GalacticMapping
     {
-        readonly string GalacticMappingFile = Path.Combine(EliteConfigInstance.InstanceOptions.AppDataDirectory, "galacticmapping.json");
+        private string GalacticMappingFile { get { return Path.Combine(EliteConfigInstance.InstanceOptions.AppDataDirectory, "galacticmapping.json"); } }
 
         public List<GalacticMapObject> galacticMapObjects = null;
         public List<GalMapType> galacticMapTypes = null;


### PR DESCRIPTION
The galactic mapping json on EDSM has been localised (so it now sits under the language-code path on EDSM).  Fetch the English version for the moment.