### PR TITLE
Feature/action tweaks

### DIFF
--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionEvent.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionEvent.cs
@@ -230,15 +230,15 @@ namespace EDDiscovery.Actions
                         }
                         else if (cmdname.Equals("setstartmarker"))
                         {
-                            he.journalEntry.SetStartMarker();
+                            he.journalEntry.SetStartFlag();
                         }
                         else if (cmdname.Equals("setstopmarker"))
                         {
-                            he.journalEntry.SetStopMarker();
+                            he.journalEntry.SetEndFlag();
                         }
                         else if (cmdname.Equals("clearstartstopmarker"))
                         {
-                            he.journalEntry.ClearStartStopMarker();
+                            he.journalEntry.ClearStartEndFlag();
                         }
                         else if (cmdname.Equals("note"))
                         {

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionTarget.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionTarget.cs
@@ -54,7 +54,7 @@ namespace EDDiscovery.Actions
 
                     if (prefix == null)
                     {
-                        ap.ReportError("Missing name after Prefix in Target");
+                        ap.ReportError("Missing name after Prefix in Target");                        
                         return true;
                     }
 
@@ -82,6 +82,17 @@ namespace EDDiscovery.Actions
                             }
                         }
                     }
+                    else if (cmdname.Equals("GET", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        bool tset = EliteDangerousCore.DB.TargetClass.IsTargetSet();
+                        ap[prefix + "TargetClear"] = tset.ToStringIntValue();
+                        if (tset)
+                        {
+                            TargetClass.ClearTarget();
+                        }
+                    }
+
+
                     else
                     {
                         string name = sp.NextQuotedWord();

--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionTarget.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionTarget.cs
@@ -82,7 +82,7 @@ namespace EDDiscovery.Actions
                             }
                         }
                     }
-                    else if (cmdname.Equals("GET", StringComparison.InvariantCultureIgnoreCase))
+                    else if (cmdname.Equals("CLEAR", StringComparison.InvariantCultureIgnoreCase))
                     {
                         bool tset = EliteDangerousCore.DB.TargetClass.IsTargetSet();
                         ap[prefix + "TargetClear"] = tset.ToStringIntValue();

--- a/EDDiscovery/UserControls/Overlays/UserControlTrippanel.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlTrippanel.cs
@@ -295,12 +295,12 @@ namespace EDDiscovery.UserControls
                     if (he.StartMarker)
                         return;
 
-                    he.journalEntry.SetStartMarker(); 
+                    he.journalEntry.SetStartFlag(); 
 
                     if (list.Count() > 1 && he.isTravelling)
                     {
                         he = list.ToArray()[1];
-                        he.journalEntry.SetStopMarker();
+                        he.journalEntry.SetEndFlag();
                     }
 
                     discoveryform.RefreshHistoryAsync();

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -832,11 +832,11 @@ namespace EliteDangerousCore
                 if (hs == he)
                 {
                     if (he.StartMarker || he.StopMarker)
-                        hs.journalEntry.ClearStartStopMarker();
+                        hs.journalEntry.ClearStartEndFlag();
                     else if (started == false)
-                        hs.journalEntry.SetStartMarker();
+                        hs.journalEntry.SetStartFlag();
                     else
-                        hs.journalEntry.SetStopMarker();
+                        hs.journalEntry.SetEndFlag();
 
                     break;
                 }

--- a/EliteDangerous/Journal/JournalEntry.cs
+++ b/EliteDangerous/Journal/JournalEntry.cs
@@ -103,17 +103,17 @@ namespace EliteDangerousCore
 
         #region Setters - db is updated
 
-        public void SetStartMarker(SQLiteConnectionUser cn = null, DbTransaction txn = null)
+        public void SetStartFlag(SQLiteConnectionUser cn = null, DbTransaction txn = null)
         {
             UpdateSyncFlagBit(SyncFlags.StartMarker, true, SyncFlags.StopMarker, false, cn, txn);
         }
 
-        public void SetStopMarker(SQLiteConnectionUser cn = null, DbTransaction txn = null)
+        public void SetEndFlag(SQLiteConnectionUser cn = null, DbTransaction txn = null)
         {
             UpdateSyncFlagBit(SyncFlags.StartMarker, false, SyncFlags.StopMarker, true, cn, txn);
         }
 
-        public void ClearStartStopMarker(SQLiteConnectionUser cn = null, DbTransaction txn = null)
+        public void ClearStartEndFlag(SQLiteConnectionUser cn = null, DbTransaction txn = null)
         {
             UpdateSyncFlagBit(SyncFlags.StartMarker, false, SyncFlags.StopMarker, false, cn, txn);
         }


### PR DESCRIPTION
It add clear action for the target command
Renamed marker to flag, to avoid collisions with multicrew frontier tag (/mc)
Renamed stopmarker to endmarker, to avoid collision with startmarker abbreviation (both will abbreviate to /fs...)