### PR TITLE
SysInfo transparency restored to pre-scrollbar level of functionality

### DIFF
--- a/EDDiscovery/UserControls/Overlays/UserControlSysInfo.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSysInfo.cs
@@ -953,7 +953,7 @@ namespace EDDiscovery.UserControls
         public override Color ColorTransparency { get { return Color.Green; } }
         public override void SetTransparency(bool on, Color curcol)
         {
-            this.BackColor = curcol;
+            BackColor = curcol;
             UpdateSkinny();
         }
 
@@ -963,13 +963,13 @@ namespace EDDiscovery.UserControls
             {
                 foreach (Control c in Controls)
                 {
-                    if (c is ExtendedControls.ExtTextBox)
+                    if (c is ExtendedControls.ExtTextBox b)
                     {
-                        ExtendedControls.ExtTextBox b = c as ExtendedControls.ExtTextBox;
                         b.ControlBackground = Color.Red;
                         b.BorderStyle = BorderStyle.None;
                         b.BorderColor = Color.Transparent;
                     }
+                    c.BackColor = ColorTransparency;
                 }
             }
             else


### PR DESCRIPTION
I like to keep System and Visits floating in the top right and the ExtScrollPanel stuck a big black box round them.  It's far from perfect as an overlay but for a couple of fields it works OK.