### PR TITLE
Unsubscribe from subscribed events when closing

### DIFF
--- a/EDDiscovery/UserControls/Overlays/UserControlCompass.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlCompass.cs
@@ -80,6 +80,7 @@ namespace EDDiscovery.UserControls
             PutSettingBool(DbHideSave, autoHideTargetCoords);
             discoveryform.OnNewEntry -= OnNewEntry;
             discoveryform.OnNewUIEvent -= OnNewUIEvent;
+            discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
             GlobalBookMarkList.Instance.OnBookmarkChange -= GlobalBookMarkList_OnBookmarkChange;
         }
 

--- a/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
@@ -115,6 +115,8 @@ namespace EDDiscovery.UserControls
         public override void Closing()
         {
             uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            discoveryform.OnNewUIEvent -= Discoveryform_OnNewUIEvent;
+            discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
         }
 
         public override Color ColorTransparency => Color.Green;

--- a/EDDiscovery/WebServer/WebServer.cs
+++ b/EDDiscovery/WebServer/WebServer.cs
@@ -154,6 +154,7 @@ namespace EDDiscovery.WebServer
                 httpws = null;
                 discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
                 discoveryform.OnNewUIEvent -= Discoveryform_OnNewUIEvent;
+                discoveryform.OnNewEntry -= Discoveryform_OnNewEntry;
             }
 
             return true;


### PR DESCRIPTION
This should fix some crashes due to events being handled after the controls are disposed.