### PR TITLE
Use journal timestamp for EDDN commodity messages

### DIFF
--- a/EliteDangerous/EDDN/EDDNSync.cs
+++ b/EliteDangerous/EDDN/EDDNSync.cs
@@ -204,7 +204,7 @@ namespace EliteDangerousCore.EDDN
             else if (je.EventTypeID == JournalTypeEnum.Market)
             {
                 JournalMarket jm = je as JournalMarket;
-                msg = eddn.CreateEDDNCommodityMessage(jm.Commodities, jm.StarSystem, jm.Station, jm.MarketID, DateTime.UtcNow);      // if its devoid of data, null returned
+                msg = eddn.CreateEDDNCommodityMessage(jm.Commodities, jm.StarSystem, jm.Station, jm.MarketID, jm.EventTimeUTC);      // if its devoid of data, null returned
             }
 
             if (msg != null)


### PR DESCRIPTION
This should fix the small number (about 0.7%) of messages sent to EDDN with the wrong time.