### PR TITLE
Avoid ambiguity by using an enum for route metric

### DIFF
--- a/EDDiscovery/UserControls/RoutesExpeditions/UserControlRoute.cs
+++ b/EDDiscovery/UserControls/RoutesExpeditions/UserControlRoute.cs
@@ -57,8 +57,8 @@ namespace EDDiscovery.UserControls
             toupdatetimer.Interval = 500;
             toupdatetimer.Tick += ToUpdateTick;
 
-            for (int i = 0; i < RoutePlotter.metric_options.Length; i++)
-                comboBoxRoutingMetric.Items.Add(RoutePlotter.metric_options[i]);
+            foreach (RoutePlotter.Metric values in Enum.GetValues(typeof(RoutePlotter.Metric)))
+                comboBoxRoutingMetric.Items.Insert((int)values, RoutePlotter.GetMetricName(values));
 
             textBox_From.SetAutoCompletor(SystemCache.ReturnSystemAdditionalListForAutoComplete, true);
             textBox_To.SetAutoCompletor(SystemCache.ReturnSystemAdditionalListForAutoComplete , true);
@@ -76,7 +76,9 @@ namespace EDDiscovery.UserControls
             bool tostate = EliteDangerousCore.DB.UserDatabase.Instance.GetSettingBool(DbSave("RouteToState"), false);
 
             int metricvalue = EliteDangerousCore.DB.UserDatabase.Instance.GetSettingInt(DbSave("RouteMetric"), 0);
-            comboBoxRoutingMetric.SelectedIndex = (metricvalue >= 0 && metricvalue < comboBoxRoutingMetric.Items.Count) ? metricvalue : SystemsDB.metric_waypointdev2;
+            comboBoxRoutingMetric.SelectedIndex = Enum.IsDefined(typeof(RoutePlotter.Metric), metricvalue)
+                ? metricvalue
+                : (int) RoutePlotter.Metric.IterativeNearestWaypoint;
 
             SeleteToCoords(tostate);
             UpdateTo(true);
@@ -208,7 +210,7 @@ namespace EDDiscovery.UserControls
                 GetCoordsTo(out plotter.Coordsto);
                 plotter.FromSystem = textBox_From.Text;
                 plotter.ToSystem = textBox_To.Text;
-                plotter.RouteMethod = comboBoxRoutingMetric.SelectedIndex;
+                plotter.RouteMethod = (RoutePlotter.Metric) comboBoxRoutingMetric.SelectedIndex;
                 plotter.UseFsdBoost = checkBox_FsdBoost.Checked;
 
                 if (textBox_From.ReadOnly == true)

--- a/EliteDangerous/EliteDangerous/RoutePlotter.cs
+++ b/EliteDangerous/EliteDangerous/RoutePlotter.cs
@@ -17,6 +17,7 @@
 using EMK.LightGeometry;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace EliteDangerousCore
@@ -29,18 +30,41 @@ namespace EliteDangerousCore
         public Point3D Coordsto;
         public string FromSystem;
         public string ToSystem;
-        public int RouteMethod;
+        public Metric RouteMethod;
         public bool UseFsdBoost;
 
-        // METRICs defined by systemclass GetSystemNearestTo function
-        public static string[] metric_options = {
+        private static readonly string[] MetricNames = {
             "Nearest to Waypoint",
             "Minimum Deviation from Path",
             "Nearest to Waypoint with dev<=100ly",
             "Nearest to Waypoint with dev<=250ly",
             "Nearest to Waypoint with dev<=500ly",
-            "Nearest to Waypoint + Deviation / 2"
+            "Nearest to Waypoint + Deviation / 2",
         };
+
+        /// <summary>
+        /// Returns the string representation of a Metric enum value.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">The int representation of the variable metric has to be smaller than the length of the static MetricNames array.</exception>
+        /// <param name="metric">The metric enum value.</param>
+        public static string GetMetricName(Metric metric)
+        {
+            Debug.Assert(Enum.GetNames(typeof(Metric)).Length == MetricNames.Length);
+            if ((int) metric >= MetricNames.Length)
+                throw new ArgumentOutOfRangeException(nameof(metric));
+
+            return MetricNames[(int) metric];
+        }
+
+        public enum Metric
+        {
+            IterativeNearestWaypoint,
+            IterativeMinDevFromPath,
+            IterativeMaximumDev100Ly,
+            IterativeMaximumDev250Ly,
+            IterativeMaximumDev500Ly,
+            IterativeWaypointDevHalf,
+        }
 
         public class ReturnInfo
         {
@@ -61,7 +85,7 @@ namespace EliteDangerousCore
         {
             double traveldistance = Point3D.DistanceBetween(Coordsfrom, Coordsto);      // its based on a percentage of the traveldistance
             List<ISystem> routeSystems = new List<ISystem>();
-            System.Diagnostics.Debug.WriteLine("From " + FromSystem + " to  " + ToSystem);
+            System.Diagnostics.Debug.WriteLine("From " + FromSystem + " to  " + ToSystem + ", using metric " + GetMetricName(RouteMethod));
 
             routeSystems.Add(new SystemClass(FromSystem, Coordsfrom.X, Coordsfrom.Y, Coordsfrom.Z));
 

--- a/EliteDangerous/SystemDB/SystemCache.cs
+++ b/EliteDangerous/SystemDB/SystemCache.cs
@@ -257,7 +257,7 @@ namespace EliteDangerousCore.DB
                                                  Point3D wantedpos,
                                                  double maxfromcurpos,
                                                  double maxfromwanted,
-                                                 int routemethod,
+                                                 RoutePlotter.Metric routemethod,
                                                  int limitto)
         {
             if (SystemsDatabase.Instance.RebuildRunning)    // return from cache is rebuild is running
@@ -291,7 +291,7 @@ namespace EliteDangerousCore.DB
                                                  Point3D wantedpos,
                                                  double maxfromcurpos,
                                                  double maxfromwanted,
-                                                 int routemethod , 
+                                                 RoutePlotter.Metric routemethod,
                                                  int limitto, 
                                                  SystemsDatabaseConnection cn)
         {

--- a/EliteDangerous/SystemDB/SystemsDBGetByDistance.cs
+++ b/EliteDangerous/SystemDB/SystemsDBGetByDistance.cs
@@ -132,19 +132,11 @@ namespace EliteDangerousCore.DB
         }
 
         /////////////////////////////////////////////// Nearest to a point determined by a metric
-
-        public const int metric_nearestwaypoint = 0;     // easiest way to synchronise metric selection..
-        public const int metric_mindevfrompath = 1;
-        public const int metric_maximum100ly = 2;
-        public const int metric_maximum250ly = 3;
-        public const int metric_maximum500ly = 4;
-        public const int metric_waypointdev2 = 5;
-
         internal static ISystem GetSystemNearestTo(Point3D currentpos,
                                                   Point3D wantedpos,
                                                   double maxfromcurpos,
                                                   double maxfromwanted,
-                                                  int routemethod,
+                                                  RoutePlotter.Metric routemethod,
                                                   SQLiteConnectionSystem cn,
                                                   Action<ISystem> LookedUp = null,
                                                   int limitto = 1000)
@@ -193,7 +185,7 @@ namespace EliteDangerousCore.DB
                                                    Point3D wantedpos,
                                                    double maxfromcurpos,
                                                    double maxfromwanted,
-                                                   int routemethod)
+                                                   RoutePlotter.Metric routemethod)
         {
             double bestmindistance = double.MaxValue;
             ISystem nearestsystem = null;
@@ -207,7 +199,7 @@ namespace EliteDangerousCore.DB
                 // ENSURE its withing the circles now
                 if (distancefromcurposx2 <= (maxfromcurpos * maxfromcurpos) && distancefromwantedx2 <= (maxfromwanted * maxfromwanted))
                 {
-                    if (routemethod == metric_nearestwaypoint)
+                    if (routemethod == RoutePlotter.Metric.IterativeNearestWaypoint)
                     {
                         if (distancefromwantedx2 < bestmindistance)
                         {
@@ -221,16 +213,18 @@ namespace EliteDangerousCore.DB
                         double deviation = Point3D.DistanceBetween(interceptpoint, syspos);
                         double metric = 1E39;
 
-                        if (routemethod == metric_mindevfrompath)
+                        if (routemethod == RoutePlotter.Metric.IterativeMinDevFromPath)
                             metric = deviation;
-                        else if (routemethod == metric_maximum100ly)
+                        else if (routemethod == RoutePlotter.Metric.IterativeMaximumDev100Ly)
                             metric = (deviation <= 100) ? distancefromwantedx2 : metric;        // no need to sqrt it..
-                        else if (routemethod == metric_maximum250ly)
+                        else if (routemethod == RoutePlotter.Metric.IterativeMaximumDev250Ly)
                             metric = (deviation <= 250) ? distancefromwantedx2 : metric;
-                        else if (routemethod == metric_maximum500ly)
+                        else if (routemethod == RoutePlotter.Metric.IterativeMaximumDev500Ly)
                             metric = (deviation <= 500) ? distancefromwantedx2 : metric;
-                        else if (routemethod == metric_waypointdev2)
+                        else if (routemethod == RoutePlotter.Metric.IterativeWaypointDevHalf)
                             metric = Math.Sqrt(distancefromwantedx2) + deviation / 2;
+                        else
+                            throw new ArgumentOutOfRangeException(nameof(routemethod));
 
                         if (metric < bestmindistance)
                         {


### PR DESCRIPTION
With the previous approach it was very hard to make sure that a selection from the ComboBox is guaranteed to be the selected metric.

This PR is kind of a helper for a follow-up PR of mine.

I moved the enum definition into `RoutePlotter` as this was the best place I could think of. Any suggestions?

Before this PR the enum was once in `EliteDangerousCore.RouterPlotter` and once in `EliteDangerousCore.DB.SystemsDB` as it was needed by `SystemsDB.GetSystemNearestTo()`. From my naive point of view, these constants have nothing to do with a DB though.
`GetSystemNearestTo()` could also easily be moved into any other place as it has no dependency on the DB or anywhere else, except the new enum. The best way might be to move this method into maybe a helper class which collects all "systems calculations/metrics" and some plotting helpers. Is it worth the refactoring?