### PR TITLE
Fix some cases of excessively long DB connections

### DIFF
--- a/EliteDangerous/DB/TravelLogUnit.cs
+++ b/EliteDangerous/DB/TravelLogUnit.cs
@@ -205,22 +205,24 @@ namespace EliteDangerousCore.DB
 
         public static TravelLogUnit Get(long id)
         {
-            return UserDatabase.Instance.ExecuteWithDatabase<TravelLogUnit>(cn =>
+            return UserDatabase.Instance.ExecuteWithDatabase<TravelLogUnit>(cn => Get(id, cn.Connection));
+        }
+
+        internal static TravelLogUnit Get(long id, SQLiteConnectionUser cn)
+        {
+            using (DbCommand cmd = cn.CreateCommand("SELECT * FROM TravelLogUnit WHERE Id = @id ORDER BY Id DESC"))
             {
-                using (DbCommand cmd = cn.Connection.CreateCommand("SELECT * FROM TravelLogUnit WHERE Id = @id ORDER BY Id DESC"))
+                cmd.AddParameterWithValue("@id", id);
+                using (DbDataReader reader = cmd.ExecuteReader())
                 {
-                    cmd.AddParameterWithValue("@id", id);
-                    using (DbDataReader reader = cmd.ExecuteReader())
+                    if (reader.Read())
                     {
-                        if (reader.Read())
-                        {
-                            return new TravelLogUnit(reader);
-                        }
+                        return new TravelLogUnit(reader);
                     }
                 }
+            }
 
-                return null;
-            });
+            return null;
         }
 
         public static bool TryGet(long id, out TravelLogUnit tlu)

--- a/EliteDangerous/Journal/EDJournalMonitorWatcher.cs
+++ b/EliteDangerous/Journal/EDJournalMonitorWatcher.cs
@@ -274,15 +274,15 @@ namespace EliteDangerousCore
 
             for (int i = 0; i < readersToUpdate.Count; i++)
             {
+                EDJournalReader reader = readersToUpdate[i];
+                updateProgress(i * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);
+
+                //System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCountLap("PJF"), i + " read ");
+
+                reader.ReadJournal(out List<JournalReaderEntry> entries, out List<UIEvent> uievents, historyrefreshparsing: true, resetOnError: true);      // this may create new commanders, and may write to the TLU db
+
                 UserDatabase.Instance.ExecuteWithDatabase(cn =>
                 {
-                    EDJournalReader reader = readersToUpdate[i];
-                    updateProgress(i * 100 / readersToUpdate.Count, reader.TravelLogUnit.Name);
-
-                    //System.Diagnostics.Trace.WriteLine(BaseUtils.AppTicks.TickCountLap("PJF"), i + " read ");
-
-                    reader.ReadJournal(out List<JournalReaderEntry> entries, out List<UIEvent> uievents, historyrefreshparsing: true, resetOnError: true);      // this may create new commanders, and may write to the TLU db
-
                     if (entries.Count > 0)
                     {
                         ILookup<DateTime, JournalEntry> existing = JournalEntry.GetAllByTLU(reader.TravelLogUnit.id, cn.Connection).ToLookup(e => e.EventTimeUTC);

--- a/EliteDangerous/Journal/JournalEntryDB.cs
+++ b/EliteDangerous/Journal/JournalEntryDB.cs
@@ -479,7 +479,7 @@ namespace EliteDangerousCore
                
         internal static List<JournalEntry> GetAllByTLU(long tluid, SQLiteConnectionUser cn)
         {
-            TravelLogUnit tlu = TravelLogUnit.Get(tluid);
+            TravelLogUnit tlu = TravelLogUnit.Get(tluid, cn);
             List<JournalEntry> vsc = new List<JournalEntry>();
 
             using (DbCommand cmd = cn.CreateCommand("SELECT * FROM JournalEntries WHERE TravelLogId = @source ORDER BY EventTime ASC"))


### PR DESCRIPTION
* Fix the EDSM log fetch holding the database connection for an excessively long time
* Move the journal log reader out of the DB connection
* Pass the DB connection to tlu.Get in order to eliminate one cause of DB re-entrancy
* Log the DB type in logged re-entrancy / hold time messages