### PR TITLE
Fix mono issues identified in #2663

### DIFF
--- a/EDDIcons/Controls/Fakes/Controls.resx
+++ b/EDDIcons/Controls/Fakes/Controls.resx
@@ -608,43 +608,43 @@
     <value>..\Bookmarks\Delete.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="firstdiscover" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\sysinfo\firstdiscover.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\SysInfo\firstdiscover.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="notfirstdiscover" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\sysinfo\notfirstdiscover.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\SysInfo\notfirstdiscover.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CaptainsLog_Delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\captainslog\delete.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\CaptainsLog\Delete.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CaptainsLog_New" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\captainslog\new.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\CaptainsLog\New.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CaptainsLog_Tags" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\captainslog\tags.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\CaptainsLog\Tags.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CaptainsLog_Diary" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\captainslog\diary.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\CaptainsLog\Diary.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CaptainsLog_Entries" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\captainslog\entries.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\CaptainsLog\Entries.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="TravelGrid_CursorToTop" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\travelgrid\cursortotop.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\TravelGrid\CursorToTop.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="TravelGrid_EventFilter" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\travelgrid\eventfilter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\TravelGrid\EventFilter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="TravelGrid_FieldFilter" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\travelgrid\fieldfilter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\TravelGrid\FieldFilter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="TravelGrid_Outlines" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\travelgrid\outlines.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\TravelGrid\Outlines.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Scan_Star" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Scan\Star.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Scan_DisplaySystemAlways" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\scan\displaysystemalways.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Scan\DisplaySystemAlways.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="TravelGrid_CursorStill" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\TravelGrid\CursorStill.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/EDDiscovery/Actions/ActionController.cs
+++ b/EDDiscovery/Actions/ActionController.cs
@@ -632,15 +632,13 @@ namespace EDDiscovery.Actions
             inputdevicesactions.Stop();
             inputdevices.Clear();
 
-#if !__MonoCS__
-            if (on)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && on)
             {
                 DirectInputDevices.InputDeviceJoystickWindows.CreateJoysticks(inputdevices, axisevents);
                 DirectInputDevices.InputDeviceKeyboard.CreateKeyboard(inputdevices);              // Created.. not started..
                 DirectInputDevices.InputDeviceMouse.CreateMouse(inputdevices);
                 inputdevicesactions.Start();
             }
-#endif
         }
 
         public string EliteInputList() { return inputdevices.ListDevices(); }

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1151,7 +1151,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
   </Target>
-  <Target Name="Version">
+  <Target Name="Version" BeforeTargets="Build">
     <PropertyGroup Condition=" '$(OS)' != 'Unix' ">
       <GitPath>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\GitForWindows@InstallPath)</GitPath>
       <GitPath Condition=" '$(GitPath)' == '' Or !Exists('$(GitPath)\bin\git.exe') ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\GitForWindows', 'InstallPath', null, RegistryView.Registry64))</GitPath>

--- a/EDDiscovery/Forms/UserControlForm.cs
+++ b/EDDiscovery/Forms/UserControlForm.cs
@@ -49,9 +49,7 @@ namespace EDDiscovery.Forms
         private Timer timer = new Timer();      // timer to monitor for entry into form when transparent.. only sane way in forms
         private bool deftopmost, deftransparent;
 
-#if !__MonoCS__
         private DirectInputDevices.InputDeviceKeyboard idk;     // used to sniff in transparency mode
-#endif
 
         public bool IsTransparencySupported { get { return !transparencycolor.IsFullyTransparent(); } }
 
@@ -99,9 +97,11 @@ namespace EDDiscovery.Forms
 
             displayTitle = EliteDangerousCore.DB.UserDatabase.Instance.GetSettingBool(dbrefname + "ShowTitle", true);
 
-#if !__MonoCS__
-            idk = DirectInputDevices.InputDeviceKeyboard.CreateKeyboard();
-#endif
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                idk = DirectInputDevices.InputDeviceKeyboard.CreateKeyboard();
+            }
+
             UpdateControls();
 
             Invalidate();
@@ -327,11 +327,14 @@ namespace EDDiscovery.Forms
             inpanelshow = true; // in case we go transparent, we need to make sure its on.. since it won't be on if the timer is not running
 
             //nasty.. but nice
-#if !__MonoCS__
-            transparentmode = (TransparencyMode)(((int)transparentmode + 1) % Enum.GetValues(typeof(TransparencyMode)).Length);
-#else
-            transparentmode = (transparentmode == TransparencyMode.Off) ? TransparencyMode.On : TransparencyMode.Off;   // no idea what happens in Mono
-#endif
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                transparentmode = (TransparencyMode)(((int)transparentmode + 1) % Enum.GetValues(typeof(TransparencyMode)).Length);
+            }
+            else
+            {
+                transparentmode = (transparentmode == TransparencyMode.Off) ? TransparencyMode.On : TransparencyMode.Off;   // no idea what happens in Mono
+            }
 
             SetTransparency(transparentmode);
         }
@@ -358,10 +361,11 @@ namespace EDDiscovery.Forms
                     {
                         if (IsClickThruOn)
                         {
-#if !__MonoCS__
-                            if (idk.IsKeyPressed(EDDConfig.Instance.ClickThruKey, recheck: true))
-                                inpanelshow = true;
-#endif
+                            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                            {
+                                if (idk.IsKeyPressed(EDDConfig.Instance.ClickThruKey, recheck: true))
+                                    inpanelshow = true;
+                            }
                         }
                         else
                             inpanelshow = true;


### PR DESCRIPTION
* `__MonoCS__` is no longer defined, as Mono now uses the same compiler (Roslyn) as on Windows.  Use `Environment.OSVersion.Platform` to determine if running on Windows.
* Visual Studio lower-cased some filenames when they were added to Controls.resx.  Fix this so IDEs can be used on case-sensitive filesystems (e.g. on Linux).
* Use `BeforeTargets` on Version target in addition to prepending `Version` to `DefaultTargets`, as the former is ignored by `msbuild` while the latter is ignored by `dotnet build`.

This should fix the additional issues identified in #2663