### PR TITLE
Compare system name and StarSystem case insensitively

### DIFF
--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -645,11 +645,13 @@ namespace EliteDangerousCore
                 bool updatesyspos = edsmsys.HasCoordinate &&
                                     (edsmsys.Xi != oldsys.Xi || edsmsys.Yi != oldsys.Yi || edsmsys.Zi != oldsys.Zi) &&
                                     oldsys.source != SystemSource.FromJournal; // NEVER EVER EVER OVERRIDE JOURNAL COORDINATES
+                bool updatename = oldsys.source != SystemSource.FromJournal ||
+                                  !oldsys.Name.Equals(edsmsys.Name, StringComparison.InvariantCultureIgnoreCase);
 
                 ISystem newsys = new SystemClass
                 {
                     EDSMID = updateedsmid ? edsmsys.EDSMID : oldsys.EDSMID,
-                    Name = edsmsys.Name,
+                    Name = updatename ? edsmsys.Name : oldsys.Name,
                     X = updatesyspos ? edsmsys.X : oldsys.X,
                     Y = updatesyspos ? edsmsys.Y : oldsys.Y,
                     Z = updatesyspos ? edsmsys.Z : oldsys.Z,

--- a/EliteDangerous/JournalEvents/JournalScan.cs
+++ b/EliteDangerous/JournalEvents/JournalScan.cs
@@ -1123,7 +1123,7 @@ namespace EliteDangerousCore.JournalEvents
         {
             if (StarSystem != null && SystemAddress != null && sysaddr != null)
             {
-                return starname == StarSystem && sysaddr == SystemAddress;
+                return starname.Equals(StarSystem, StringComparison.InvariantCultureIgnoreCase) && sysaddr == SystemAddress;
             }
 
             if (designation == null)

--- a/EliteDangerous/ScarScan/StarScanHelpers.cs
+++ b/EliteDangerous/ScarScan/StarScanHelpers.cs
@@ -217,7 +217,7 @@ namespace EliteDangerousCore
                 return desigmap[system][je.BodyName];
             }
 
-            if (je.IsStar && je.BodyName == system && je.nOrbitalPeriod != null)
+            if (je.IsStar && je.BodyName.Equals(system, StringComparison.InvariantCultureIgnoreCase) && je.nOrbitalPeriod != null)
             {
                 return system + " A";
             }

--- a/EliteDangerous/ScarScan/StarScanJournalScans.cs
+++ b/EliteDangerous/ScarScan/StarScanJournalScans.cs
@@ -58,6 +58,7 @@ namespace EliteDangerousCore
                     else if (jl != null && je.IsStarNameRelated(jl.StarSystem, designation, jl.SystemAddress))
                     {
                         // Ignore scans where the system name has changed
+                        System.Diagnostics.Trace.WriteLine($"Rejecting body {designation} ({je.BodyName}) in system {he.System.Name} => {jl.StarSystem} due to system rename");
                         return false;
                     }
                 }


### PR DESCRIPTION
The system names on EDSM have inconsistent casing for some systems.
Compare the system names case insensitively when assigning bodies to systems.