### PR TITLE
Don't re-enter PlayJournalList loop

### DIFF
--- a/EDDiscovery/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDDiscoveryForm.cs
@@ -672,6 +672,17 @@ namespace EDDiscovery
             // all notes committed
             SystemNoteClass.CommitDirtyNotes((snc) => { if (EDCommander.Current.SyncToEdsm && snc.FSDEntry) EDSMClass.SendComments(snc.SystemName, snc.Note, snc.EdsmId, he.Commander); });
 
+            var lastent = history.GetLast;
+            if (!object.ReferenceEquals(he, lastent))
+            {
+                LogLineHighlight(string.Format("Current history entry is not last in history - possible re-entrancy.\nAlert the EDDiscovery developers using either discord or Github (see help) and attach log file {0}", BaseUtils.TraceLog.LogFileName));
+                Trace.WriteLine($"Current history entry is not last in history");
+                Trace.WriteLine($"Current entry: {he.journalEntry?.GetJson()?.ToString()}");
+                Trace.WriteLine($"Last entry: {lastent.journalEntry?.GetJson()?.ToString()}");
+                Trace.WriteLine($"Stack Trace:");
+                Trace.WriteLine(new StackTrace(true).ToString());
+            }
+
             // HERE PERFORM CAPI.. DOCKED
 
             if (he.IsFSDJump)


### PR DESCRIPTION
This should prevent journal events from being processed in reverse order when event processing exceeds the delay timer interval.

This should fix the cause of the out-of-order events discovered in EDSM-NET/FrontEnd#331