### PR TITLE
Only Invoke on UI thread if not on UI thread

### DIFF
--- a/EDDiscovery/ScreenShots/ScreenShotConverter.cs
+++ b/EDDiscovery/ScreenShots/ScreenShotConverter.cs
@@ -113,8 +113,12 @@ namespace EDDiscovery.ScreenShots
 
         private void CallWithConverter(Action<ScreenShotImageConverter> cb)           // called by Watcher with a function to run in the UI main thread..
         {
-            discoveryform.Invoke(new Action(() => {     // on discovery form UI thread, action..
-
+            if (discoveryform.InvokeRequired) // on discovery form UI thread, action..
+            {
+                discoveryform.Invoke(new Action(() => CallWithConverter(cb)));
+            }
+            else
+            {
                 if (AutoConvert)
                 {
                     ScreenShotImageConverter p = new ScreenShotImageConverter();
@@ -134,8 +138,7 @@ namespace EDDiscovery.ScreenShots
 
                     cb(p);                                  // call the processor the system wants. Function needs an image converter.  Back to processScreenshot
                 }
-
-            }));
+            }
         }
 
         private void ConvertCompleted(ScreenShotImageConverter cp) // Called by the watcher when a convert had completed, in UI thread

--- a/EDDiscovery/WebServer/WebServer.cs
+++ b/EDDiscovery/WebServer/WebServer.cs
@@ -246,11 +246,15 @@ namespace EDDiscovery.WebServer
             }
 
             private JToken MakeResponse(int startindex, int length, string rt)     // generate a response over this range
-            { 
-                JToken response = null;
-
-                discoveryform.Invoke((MethodInvoker)delegate
+            {
+                if (discoveryform.InvokeRequired)
                 {
+                    return (JToken)discoveryform.Invoke(new Func<JToken>(() => MakeResponse(startindex, length, rt)));
+                }
+                else
+                {
+                    JToken response;
+
                     var hl = discoveryform.history;
                     if (hl.Count == 0)
                     {
@@ -267,9 +271,9 @@ namespace EDDiscovery.WebServer
                     }
 
                     response["Commander"] = EDCommander.Current.Name;
-                });
 
-                return response;
+                    return response;
+                }
             }
 
             public JToken NewJRec(HistoryList hl, string type, int startindex, int length)
@@ -326,11 +330,15 @@ namespace EDDiscovery.WebServer
             }
 
             private JToken MakeResponse(int entry, string rt)
-            { 
-                JToken response = null;
-
-                discoveryform.Invoke((MethodInvoker)delegate
+            {
+                if (discoveryform.InvokeRequired)
                 {
+                    return (JToken)discoveryform.Invoke(new Func<JToken>(() => MakeResponse(entry, rt)));
+                }
+                else
+                {
+                    JToken response = null;
+
                     var hl = discoveryform.history;
                     if (hl.Count == 0)
                     {
@@ -345,9 +353,9 @@ namespace EDDiscovery.WebServer
 
                         response = NewSRec(hl, rt, entry);
                     }
-                });
 
-                return response;
+                    return response;
+                }
             }
 
             public JToken NewSRec(EliteDangerousCore.HistoryList hl, string type, int entry)       // entry = -1 means latest


### PR DESCRIPTION
It appears that `Form.Invoke` may introduce an unintended message loop when called from the UI thread.