### PR TITLE
Change EDSM full sync to use GZ files instead

### DIFF
--- a/EDDiscovery/EDDiscoveryControllerSync.cs
+++ b/EDDiscovery/EDDiscoveryControllerSync.cs
@@ -125,9 +125,11 @@ namespace EDDiscovery
                             // Download new systems
                             try
                             {
-                                string edsmsystems = Path.Combine(EliteConfigInstance.InstanceOptions.AppDataDirectory, "edsmsystems.json");
+                                string edsmsystems = Path.Combine(EliteConfigInstance.InstanceOptions.AppDataDirectory, "edsmsystems.json.gz");
 
                                 ReportSyncProgress("Performing full download of EDSM Database from server");
+
+                                Debug.WriteLine(BaseUtils.AppTicks.TickCountLap() + " Full sync using URL " + EliteConfigInstance.InstanceConfig.EDSMFullSystemsURL);
 
                                 bool success = BaseUtils.DownloadFile.HTTPDownloadFile(EliteConfigInstance.InstanceConfig.EDSMFullSystemsURL, edsmsystems, false, out bool newfile);
 

--- a/EDDiscovery/Properties/Resources.resx
+++ b/EDDiscovery/Properties/Resources.resx
@@ -179,7 +179,7 @@
     <value>https://eddiscovery.space/eddb/systems_populated.jsonl</value>
   </data>
   <data name="URLEDSMFullSystems" xml:space="preserve">
-    <value>https://www.edsm.net/dump/systemsWithCoordinates.json</value>
+    <value>https://www.edsm.net/dump/systemsWithCoordinates.json.gz</value>
   </data>
   <data name="URLEDDBSystem" xml:space="preserve">
     <value>http://eddb.io/system/</value>

--- a/EliteDangerous/SystemDB/SystemsDBEDSMStore.cs
+++ b/EliteDangerous/SystemDB/SystemsDBEDSMStore.cs
@@ -22,6 +22,7 @@ using SQLLiteExtensions;
 using System.Data.Common;
 using System.Data;
 using Newtonsoft.Json.Linq;
+using System.IO.Compression;
 
 namespace EliteDangerousCore.DB
 {
@@ -31,6 +32,23 @@ namespace EliteDangerousCore.DB
 
         public static long ParseEDSMJSONFile(string filename, bool[] grididallow, ref DateTime date, Func<bool> cancelRequested, Action<string> reportProgress, string tableposfix, bool presumeempty = false, string debugoutputfile = null)
         {
+            // if the filename ends in .gz, then decompress it on the fly
+            if (filename.EndsWith("gz"))
+            {
+                using (FileStream originalFileStream = new FileStream(filename, FileMode.Open, FileAccess.Read))
+                {
+                    using (GZipStream gz = new GZipStream(originalFileStream, CompressionMode.Decompress))
+                    {
+                        using (StreamReader sr = new StreamReader(gz))
+                        {
+                            return ParseEDSMJSON(sr, grididallow, ref date, cancelRequested, reportProgress, tableposfix, presumeempty, debugoutputfile);
+                        }
+                    }
+                }
+
+
+            }
+
             using (StreamReader sr = new StreamReader(filename))         // read directly from file..
                 return ParseEDSMJSON(sr, grididallow, ref date, cancelRequested, reportProgress, tableposfix, presumeempty, debugoutputfile);
         }


### PR DESCRIPTION
Changes URL for EDSM full system sync to GZ and handles the decompression on the fly.

See also issue:  #2686
