### PR TITLE
Add galmap and journal systems to system cache

### DIFF
--- a/EliteDangerous/EDSM/GalacticMapSystem.cs
+++ b/EliteDangerous/EDSM/GalacticMapSystem.cs
@@ -4,12 +4,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace EliteDangerousCore.EDSM
 {
     public class GalacticMapSystem : SystemClass
     {
+        private Regex EDSMIdRegex = new Regex("/system/id/([0-9]+)/");
+
         public GalacticMapObject GalMapObject { get; set; }
 
         public GalacticMapSystem(ISystem sys, GalacticMapObject gmo) : base(sys)
@@ -24,6 +27,17 @@ namespace EliteDangerousCore.EDSM
             this.Y = gmo.points[0].Y;
             this.Z = gmo.points[0].Z;
             this.GalMapObject = gmo;
+
+            if (gmo.galMapUrl != null)
+            {
+                var rematch = EDSMIdRegex.Match(gmo.galMapUrl);
+
+                long edsmid;
+                if (rematch != null && long.TryParse(rematch.Groups[1].Value, out edsmid))
+                {
+                    this.EDSMID = edsmid;
+                }
+            }
         }
     }
 }

--- a/EliteDangerous/EDSM/GalacticMapping.cs
+++ b/EliteDangerous/EDSM/GalacticMapping.cs
@@ -91,6 +91,12 @@ namespace EliteDangerousCore.EDSM
 
                         galobject.galMapType = ty;
                         gmobjects.Add(galobject);
+
+                        if (galobject.points.Count == 1 && galobject.galMapSearch != null && galobject.galMapUrl != null)
+                        {
+                            var gms = new GalacticMapSystem(galobject);
+                            SystemCache.FindCachedJournalSystem(gms);
+                        }
                     }
 
                     galacticMapObjects = gmobjects;

--- a/EliteDangerous/HistoryList/HistoryEntry.cs
+++ b/EliteDangerous/HistoryList/HistoryEntry.cs
@@ -163,6 +163,8 @@ namespace EliteDangerousCore
                         source = jl.StarPosFromEDSM ? SystemSource.FromEDSM : SystemSource.FromJournal,
                     };
 
+                    SystemCache.FindCachedJournalSystem(newsys);
+
                     // If it was a new system, pass the coords back to the StartJump
                     if (prev != null && prev.journalEntry is JournalStartJump)
                     {

--- a/EliteDangerous/SystemDB/SystemCache.cs
+++ b/EliteDangerous/SystemDB/SystemCache.cs
@@ -68,33 +68,9 @@ namespace EliteDangerousCore.DB
         {
             ISystem orgsys = find;
 
-            List<ISystem> foundlist = new List<ISystem>();
+            ISystem found = FindCachedSystem(find);
 
-            lock (systemsByEdsmId)          // Rob seen instances of it being locked together in multiple star distance threads, we need to serialise access to these two dictionaries
-            {                               // Concurrent dictionary no good, they could both be about to add the same thing at the same time and pass the contains test.
-
-                if (find.EDSMID > 0 && systemsByEdsmId.ContainsKey(find.EDSMID))        // add to list
-                {
-                    ISystem s = systemsByEdsmId[find.EDSMID];
-                    foundlist.Add(s);
-                }
-
-                if (systemsByName.ContainsKey(find.Name))            // and all names cached
-                {
-                    List<ISystem> s = systemsByName[find.Name];
-                    foundlist.AddRange(s);
-                }
-            }
-
-            ISystem found = null;
-
-            if (find.HasCoordinate && foundlist.Count > 0)           // if sys has a co-ord, find the best match within 0.5 ly
-                found = NearestTo(foundlist, find, 0.5);
-
-            if (found == null && foundlist.Count == 1 && !find.HasCoordinate) // if we did not find one, but we have only 1 candidate, use it.
-                found = foundlist[0];
-
-            if (found == null && cn != null && !SystemsDatabase.Instance.RebuildRunning)   // not cached, connection and not rebuilding, try db
+            if ((found == null || found.source != SystemSource.FromEDSM) && cn != null && !SystemsDatabase.Instance.RebuildRunning)   // not cached, connection and not rebuilding, try db
             {
                 //System.Diagnostics.Debug.WriteLine("Look up from DB " + sys.name + " " + sys.id_edsm);
 
@@ -141,11 +117,64 @@ namespace EliteDangerousCore.DB
             }
             else
             {                                               // FROM CACHE
+                if (found != null)
+                {
+                    return found;
+                }
+
+                if (find.source == SystemSource.FromJournal && find.Name != null && find.HasCoordinate == true)
+                {
+                    AddToCache(find);
+                    return find;
+                }
+
                 //System.Diagnostics.Trace.WriteLine($"Cached reference to {found.name} {found.id_edsm}");
                 return found;       // no need for extra work.
             }
         }
 
+        private static ISystem FindCachedSystem(ISystem find)
+        {
+            List<ISystem> foundlist = new List<ISystem>();
+            ISystem found = null;
+
+            lock (systemsByEdsmId)          // Rob seen instances of it being locked together in multiple star distance threads, we need to serialise access to these two dictionaries
+            {                               // Concurrent dictionary no good, they could both be about to add the same thing at the same time and pass the contains test.
+
+                if (find.EDSMID > 0 && systemsByEdsmId.ContainsKey(find.EDSMID))        // add to list
+                {
+                    ISystem s = systemsByEdsmId[find.EDSMID];
+                    foundlist.Add(s);
+                }
+
+                if (systemsByName.ContainsKey(find.Name))            // and all names cached
+                {
+                    List<ISystem> s = systemsByName[find.Name];
+                    foundlist.AddRange(s);
+                }
+            }
+
+            if (find.HasCoordinate && foundlist.Count > 0)           // if sys has a co-ord, find the best match within 0.5 ly
+                found = NearestTo(foundlist, find, 0.5);
+
+            if (found == null && foundlist.Count == 1 && !find.HasCoordinate) // if we did not find one, but we have only 1 candidate, use it.
+                found = foundlist[0];
+
+            return found;
+        }
+
+        public static ISystem FindCachedJournalSystem(ISystem system)
+        {
+            var found = FindCachedSystem(system);
+
+            if ((found == null || (found.source != SystemSource.FromJournal && found.source != SystemSource.FromEDSM)) && system.HasCoordinate == true && system.Name != "")
+            {
+                AddToCache(system, found);
+                found = system;
+            }
+
+            return found;
+        }
 
         public static List<ISystem> FindSystemWildcard(string name, int limit = int.MaxValue)
         {
@@ -392,16 +421,44 @@ namespace EliteDangerousCore.DB
 
         static private void AddToCache(ISystem found, ISystem orgsys = null)
         {
-            if (found.EDSMID > 0)
-                systemsByEdsmId[found.EDSMID] = found;  // must be definition the best ID found.. and if the update date of sys is better, its now been updated
-
-            if (systemsByName.ContainsKey(found.Name))
+            lock (systemsByEdsmId)
             {
-                if ( !systemsByName[found.Name].Contains(found))
-                    systemsByName[found.Name].Add(found);   // add to list..
+                if (found.EDSMID > 0)
+                    systemsByEdsmId[found.EDSMID] = found;  // must be definition the best ID found.. and if the update date of sys is better, its now been updated
+
+                List<ISystem> byname;
+
+                if (!systemsByName.TryGetValue(found.Name, out byname))
+                {
+                    systemsByName[found.Name] = byname = new List<ISystem>();
+                }
+
+                int idx = -1;
+
+                if (found.EDSMID > 0)
+                {
+                    idx = byname.FindIndex(e => e.EDSMID == found.EDSMID);
+                }
+
+                if (idx < 0)
+                {
+                    idx = byname.FindIndex(e => e.Xi == found.Xi && e.Yi == found.Yi && e.Zi == found.Zi);
+                }
+
+                if (idx < 0 && orgsys != null)
+                {
+                    idx = byname.FindIndex(e => e.Xi == orgsys.Xi && e.Yi == orgsys.Yi && e.Zi == orgsys.Zi);
+                }
+
+                if (idx >= 0)
+                {
+                    byname[idx] = found;
+                }
+                else
+                {
+                    byname.Add(found);
+                }
             }
-            else
-                systemsByName[found.Name] = new List<ISystem> { found }; // or make list
         }
 
         static private ISystem NearestTo(List<ISystem> list, ISystem comparesystem, double mindist)


### PR DESCRIPTION
This should make controls that rely on the system cache at least partially usable when the full system database is unavailable.