### PR TITLE
Move safe mode start out of main UI

### DIFF
--- a/EDDiscovery/EDDApplicationContext.cs
+++ b/EDDiscovery/EDDApplicationContext.cs
@@ -71,6 +71,8 @@ namespace EDDiscovery
         /// </summary>
         public static EDDiscoveryForm EDDMainForm { get; private set; } = null;
 
+        public static bool RestartInSafeMode { get; set; } = false;
+
         #endregion
 
         #region Implementation

--- a/EDDiscovery/Program.cs
+++ b/EDDiscovery/Program.cs
@@ -62,10 +62,22 @@ namespace EDDiscovery
                      * TODO: show a dialog and/or bring the current instance's window to the foreground.
                      */
                 }
+                catch (ThreadAbortException)
+                {
+                    if (EDDApplicationContext.RestartInSafeMode)
+                    {
+                        System.Diagnostics.Process.Start(Application.ExecutablePath, "-safemode");
+                    }
+                }
                 finally
                 {
                     EliteDangerousCore.DB.UserDatabase.Instance.Stop();     // need everything closed before we can shut down the DBs threads
                     EliteDangerousCore.DB.SystemsDatabase.Instance.Stop();
+
+                    if (EDDApplicationContext.RestartInSafeMode)
+                    {
+                        System.Diagnostics.Process.Start(Application.ExecutablePath, "-safemode");
+                    }
                 }
             }
         }

--- a/EDDiscovery/UserControls/Settings/UserControlSettings.cs
+++ b/EDDiscovery/UserControls/Settings/UserControlSettings.cs
@@ -586,8 +586,17 @@ namespace EDDiscovery.UserControls
         {
             if (ExtendedControls.MessageBoxTheme.Show(this, "Confirm restart to safe mode".T(EDTx.UserControlSettings_CSM), "Safe Mode".T(EDTx.UserControlSettings_SM), MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
             {
-                Application.Exit();
-                System.Diagnostics.Process.Start(Application.ExecutablePath, "-safemode");
+                bool force = EDDApplicationContext.RestartInSafeMode;
+                EDDApplicationContext.RestartInSafeMode = true;
+
+                if (!force)
+                {
+                    Application.Exit();
+                }
+                else
+                {
+                    System.Threading.Thread.CurrentThread.Abort();
+                }
             }
         }
 


### PR DESCRIPTION
Re-execute in safe mode after database threads have exited.
Clicking a second time will terminate the application.