### PR TITLE
Fix exception on 29 Feb game time

### DIFF
--- a/EDDiscovery/EDDConfig.cs
+++ b/EDDiscovery/EDDConfig.cs
@@ -151,7 +151,7 @@ namespace EDDiscovery
             {
                 t = t.AddYears(1286);  
                 if (!DateTimeInRangeForGame(t))
-                    t = new DateTime(DateTime.UtcNow.Year+1286, DateTime.UtcNow.Month, DateTime.UtcNow.Day);
+                    t = DateTime.UtcNow.AddYears(1286);
                 return t;
             }
             else                                 // local


### PR DESCRIPTION
29 Feb 3306 is not representable as a DateTime

This should fix the crash in #2730, though 29 Feb will be converted to 01 Mar when converting to game time.