### PR TITLE
Sector systems shouldn't return systems from other sectors that start with the current sector name

### DIFF
--- a/EliteDangerous/EDSM/EDSMClass.cs
+++ b/EliteDangerous/EDSM/EDSMClass.cs
@@ -214,7 +214,7 @@ namespace EliteDangerousCore.EDSM
 
         public List<string> GetUnknownSystemsForSector(string sectorName)
         {
-            string query = $"api-v1/systems?systemName={HttpUtility.UrlEncode(sectorName)}&onlyUnknownCoordinates=1";
+            string query = $"api-v1/systems?systemName={HttpUtility.UrlEncode(sectorName)}%20&onlyUnknownCoordinates=1";
             // 5s is occasionally slightly short for core sectors returning the max # systems (1000)
             return getSystemsForQuery(query, 10000);
         }


### PR DESCRIPTION
Prevent current sector system query returning systems for sectors that start with the current sector e.g. returning systems for Lyrongou when in Lyrongo