### PR TITLE
Test IGAU Data shipping

### DIFF
--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1134,10 +1134,8 @@
       </ZipFiles>
       <Zipfiles Include="$(OutDir)x64\SQLite.Interop.dll">
         <Name>x64\SQLite.Interop.dll</Name>
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Zipfiles>
       <Zipfiles Include="$(OutDir)x86\SQLite.Interop.dll">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <Name>x86\SQLite.Interop.dll</Name>
       </Zipfiles>
     </ItemGroup>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1134,8 +1134,10 @@
       </ZipFiles>
       <Zipfiles Include="$(OutDir)x64\SQLite.Interop.dll">
         <Name>x64\SQLite.Interop.dll</Name>
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Zipfiles>
       <Zipfiles Include="$(OutDir)x86\SQLite.Interop.dll">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <Name>x86\SQLite.Interop.dll</Name>
       </Zipfiles>
     </ItemGroup>

--- a/EliteDangerous/IGAU/IGAUClass.cs
+++ b/EliteDangerous/IGAU/IGAUClass.cs
@@ -44,12 +44,20 @@ namespace EliteDangerousCore.IGAU
             App_Version = assemblyFullName.Split(',')[1].Split('=')[1];
         }
 
+        public string Name_Stripped { get; private set; }
+        public string Name_Lower { get; private set; }
+
         public JObject CreateIGAUMessage(string timestamp, long EntryID, string Name, string Name_Localised, string System, long SystemAddress)
         {
+            Name_Stripped = Name.Replace("$", string.Empty).Replace(";", string.Empty);
+            // IGAUClass.cs(53,41,53,54): error CS1503: Argument 1: cannot convert from 'string' to 'System.Globalization.CultureInfo'
+            // Name_Lower = string.ToLower(Name_Stripped);
             JObject detail = new JObject();
             detail["input_1"] = timestamp;
             detail["input_2"] = EntryID;
-            detail["input_3"] = Name;
+            //detail["input_3"] = Name;
+            detail["input_3"] = Name_Stripped;
+            //detail["input_3"] = Name_Lower;
             detail["input_4"] = Name_Localised;
             detail["input_5"] = System;
             detail["input_6"] = SystemAddress;

--- a/EliteDangerous/IGAU/IGAUSync.cs
+++ b/EliteDangerous/IGAU/IGAUSync.cs
@@ -90,9 +90,9 @@ namespace EliteDangerousCore.IGAU
 
                         // comment ball the ack in when your ready to try!
 
-                        //igau.PostMessage(msg, out bool accepted);
-                        //if (!accepted)
-                        //  logger?.Invoke("IGAU Message rejected " + he.EventTimeUTC.ToStringZulu());
+                        igau.PostMessage(msg, out bool accepted);
+                        if (!accepted)
+                        logger?.Invoke("IGAU Message rejected " + he.EventTimeUTC.ToStringZulu());
 
                         eventcount++;
                     }


### PR DESCRIPTION
I had to make a change to the .csproj file for the project to build and run. Thanks, StackExchange! 

Uncommented lines in IGAUSync.cs

Added a line to strip info from raw name field. 
Attempting to string.ToLower results in an error. (see commented line)

The build loads and runs fine, however when I right click in history and attempt to process a CodexEntry line, I get this debug error in the lower right hand pane:
`Exception Object reference not set to an instance of an object.
   at EliteDangerousCore.IGAU.IGAUClass.PostMessage(JObject msg, Boolean& recordSet) in \EDDiscovery\EliteDangerous\IGAU\IGAUClass.cs:line 84
   at EliteDangerousCore.IGAU.IGAUSync.SyncThread() in \EDDiscovery\EliteDangerous\IGAU\IGAUSync.cs:line 93`

