### PR TITLE
Change longs to string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 /EDDiscovery.VC.VC.opendb
 */Properties/ExtraVersion.cs
 /EDDiscovery/GlobalSuppressions.cs
+BaseUtilities

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ Thumbs.db
 /EDDiscovery.VC.VC.opendb
 */Properties/ExtraVersion.cs
 /EDDiscovery/GlobalSuppressions.cs
-BaseUtilities

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1134,10 +1134,8 @@
       </ZipFiles>
       <Zipfiles Include="$(OutDir)x64\SQLite.Interop.dll">
         <Name>x64\SQLite.Interop.dll</Name>
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Zipfiles>
       <Zipfiles Include="$(OutDir)x86\SQLite.Interop.dll">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <Name>x86\SQLite.Interop.dll</Name>
       </Zipfiles>
     </ItemGroup>

--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1134,8 +1134,10 @@
       </ZipFiles>
       <Zipfiles Include="$(OutDir)x64\SQLite.Interop.dll">
         <Name>x64\SQLite.Interop.dll</Name>
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Zipfiles>
       <Zipfiles Include="$(OutDir)x86\SQLite.Interop.dll">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <Name>x86\SQLite.Interop.dll</Name>
       </Zipfiles>
     </ItemGroup>

--- a/EliteDangerous/IGAU/IGAUClass.cs
+++ b/EliteDangerous/IGAU/IGAUClass.cs
@@ -47,22 +47,19 @@ namespace EliteDangerousCore.IGAU
         public string Name_Stripped { get; private set; }
         public string Name_Lower { get; private set; }
 
-        public JObject CreateIGAUMessage(string timestamp, long EntryID, string Name, string Name_Localised, string System, long SystemAddress)
+        public JObject CreateIGAUMessage(string timestamp, string EntryID, string Name, string Name_Localised, string System, string SystemAddress)
         {
             Name_Stripped = Name.Replace("$", string.Empty).Replace(";", string.Empty);
-            // IGAUClass.cs(53,41,53,54): error CS1503: Argument 1: cannot convert from 'string' to 'System.Globalization.CultureInfo'
-            // Name_Lower = string.ToLower(Name_Stripped);
+
             JObject detail = new JObject();
-            detail["input_1"] = timestamp;
-            detail["input_2"] = EntryID;
-            //detail["input_3"] = Name;
-            detail["input_3"] = Name_Stripped;
-            //detail["input_3"] = Name_Lower;
-            detail["input_4"] = Name_Localised;
-            detail["input_5"] = System;
-            detail["input_6"] = SystemAddress;
-            detail["input_7"] = App_Name;
-            detail["input_8"] = App_Version;
+            detail["timestamp"] = timestamp;
+            detail["EntryID"] = (EntryID).ToString();
+            detail["Name"] = (Name_Stripped).ToLower();
+            detail["Name_Localised"] = Name_Localised;
+            detail["System"] = System;
+            detail["SystemAddress"] = (SystemAddress).ToString();
+            detail["App_Name"] = App_Name;
+            detail["App_Version"] = App_Version;
             JObject msg = new JObject();
             msg["input_values"] = detail;
             return msg;

--- a/EliteDangerous/IGAU/IGAUClass.cs
+++ b/EliteDangerous/IGAU/IGAUClass.cs
@@ -44,12 +44,20 @@ namespace EliteDangerousCore.IGAU
             App_Version = assemblyFullName.Split(',')[1].Split('=')[1];
         }
 
+        public string Name_Stripped { get; private set; }
+        public string Name_Lower { get; private set; }
+
         public JObject CreateIGAUMessage(string timestamp, long EntryID, string Name, string Name_Localised, string System, long SystemAddress)
         {
+            Name_Stripped = Name.Replace("$", string.Empty).Replace(";", string.Empty);
+            // IGAUClass.cs(53,41,53,54): error CS1503: Argument 1: cannot convert from 'string' to 'System.Globalization.CultureInfo'
+            // Name_Lower = string.ToLower(Name_Stripped);
             JObject detail = new JObject();
             detail["input_1"] = timestamp;
             detail["input_2"] = EntryID;
-            detail["input_3"] = Name;
+            //detail["input_3"] = Name;
+            detail["input_3"] = Name_Stripped;
+            //detail["input_3"] = Name_Lower;
             detail["input_4"] = Name_Localised;
             detail["input_5"] = System;
             detail["input_6"] = SystemAddress;

--- a/EliteDangerous/IGAU/IGAUSync.cs
+++ b/EliteDangerous/IGAU/IGAUSync.cs
@@ -84,7 +84,7 @@ namespace EliteDangerousCore.IGAU
                         JournalCodexEntry c = he.journalEntry as JournalCodexEntry;
 
                         var msg = igau.CreateIGAUMessage(he.EventTimeUTC.ToStringZulu(),
-                                                              c.EntryID, c.Name, c.Name_Localised, c.System, c.SystemAddress ?? 0);
+                                                              c.EntryID.ToString(), c.Name, c.Name_Localised, c.System, c.SystemAddress.ToString() ?? 0);
 
                         System.Diagnostics.Debug.WriteLine("IGAU Post " + msg.ToString(Newtonsoft.Json.Formatting.Indented));
 

--- a/EliteDangerous/IGAU/IGAUSync.cs
+++ b/EliteDangerous/IGAU/IGAUSync.cs
@@ -90,9 +90,9 @@ namespace EliteDangerousCore.IGAU
 
                         // comment ball the ack in when your ready to try!
 
-                        //igau.PostMessage(msg, out bool accepted);
-                        //if (!accepted)
-                        //  logger?.Invoke("IGAU Message rejected " + he.EventTimeUTC.ToStringZulu());
+                        igau.PostMessage(msg, out bool accepted);
+                        if (!accepted)
+                        logger?.Invoke("IGAU Message rejected " + he.EventTimeUTC.ToStringZulu());
 
                         eventcount++;
                     }


### PR DESCRIPTION
I was able to run a breakpoint, and DynamoDB was complaining that EntryID and SystemAddress weren't strings, which is as I had suspected.  

The API endpoint expects an HTTP POST stream with all data as strings. 

IGAUClass.cs loads fine without any errors.  I tried updating line 87 in IGAUSync.cs to be strings as well, but it breaks the "??" operator? 

` c.EntryID.ToString(), c.Name, c.Name_Localised, c.System, c.SystemAddress.ToString() ?? 0);`

`IGAUSync.cs(87,121,87,152): error CS0019: Operator '??' cannot be applied to operands of type 'string' and 'int'`