### PR TITLE
Defer loading journal view until visible

### DIFF
--- a/EDDiscovery/UserControls/History/UserControlJournalGrid.Designer.cs
+++ b/EDDiscovery/UserControls/History/UserControlJournalGrid.Designer.cs
@@ -417,6 +417,7 @@ namespace EDDiscovery.UserControls
             this.Controls.Add(this.panelTop);
             this.Name = "UserControlJournalGrid";
             this.Size = new System.Drawing.Size(804, 716);
+            this.VisibleChanged += new System.EventHandler(this.UserControlJournalGrid_VisibleChanged);
             this.dataViewScrollerPanel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewJournal)).EndInit();
             this.historyContextMenu.ResumeLayout(false);


### PR DESCRIPTION
First 1k rows are always added to the grid so something will be there when brought into view, and events since initialisation are prioritised over populating the tail end of the view.

Will only impact journal views that are initialised in background tabs on start up, anything opened during a session will behave as before.

