### PR TITLE
Set ServicePointManager.SecurityProtocol to Tls12

### DIFF
--- a/EDDiscovery/EDDOptions.cs
+++ b/EDDiscovery/EDDOptions.cs
@@ -131,6 +131,7 @@ namespace EDDiscovery
                     case "nolowpriority": LowPriority = false; break;
                     case "backgroundpriority": BackgroundPriority = true; break;
                     case "nobackgroundpriority": BackgroundPriority = false; break;
+                    case "forcetls12": ForceTLS12 = true; break;
                     default:
                         System.Diagnostics.Debug.WriteLine($"Unrecognized option -{opt}");
                         break;
@@ -197,6 +198,7 @@ namespace EDDiscovery
         public string WebServerFolder { get; set; }             // normally empty, so selections zip server
         public bool LowPriority { get; set; }
         public bool BackgroundPriority { get; set; }
+        public bool ForceTLS12 { get; set; }
 
         public string SubAppDirectory(string subfolder)     // ensures its there.. name without \ slashes
         {

--- a/EDDiscovery/EDDiscoveryControllerMain.cs
+++ b/EDDiscovery/EDDiscoveryControllerMain.cs
@@ -161,6 +161,11 @@ namespace EDDiscovery
                 Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
             }
 
+            if (EDDOptions.Instance.ForceTLS12)
+            {
+                System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12 | System.Net.SecurityProtocolType.Tls11;
+            }
+
             msg.Invoke("Checking Databases");
 
             Trace.WriteLine(BaseUtils.AppTicks.TickCountLap() + " Initializing database");


### PR DESCRIPTION
This provides an option to force the TLS version in the case of DotNET misconfiguration (as in #2763)