### PR TITLE
Await on EDSM Bodies fetch to free up UI

### DIFF
--- a/EDDiscovery/Actions/ActionsEDDCmds/ActionScanStar.cs
+++ b/EDDiscovery/Actions/ActionsEDDCmds/ActionScanStar.cs
@@ -81,7 +81,7 @@ namespace EDDiscovery.Actions
                         sc.EDSMID = 0;
                     }
 
-                    StarScan.SystemNode sn = scan.FindSystem(sc, edsm);
+                    StarScan.SystemNode sn = scan.FindSystemSynchronous(sc, edsm);
 
                     System.Globalization.CultureInfo ct = System.Globalization.CultureInfo.InvariantCulture;
 

--- a/EDDiscovery/Forms/SurfaceBookmarksUC.cs
+++ b/EDDiscovery/Forms/SurfaceBookmarksUC.cs
@@ -148,14 +148,15 @@ namespace EDDiscovery.Forms
             }
         }
 
-        private void UpdateComboBox(string systemName)
+        private async void UpdateComboBox(string systemName)
         {
             ISystem thisSystem = EDDApplicationContext.EDDMainForm.history.FindSystem(systemName);
 
             BodyName.Items.Clear();
             if (thisSystem != null)
             {
-                var landables = EDDApplicationContext.EDDMainForm.history.starscan.FindSystem(thisSystem, true)?.Bodies?.Where(b => b.ScanData != null && b.ScanData.IsLandable)?.Select(b => b.fullname);
+                var lookup = await EDDApplicationContext.EDDMainForm.history.starscan.FindSystemAsync(thisSystem, true);
+                var landables = lookup?.Bodies?.Where(b => b.ScanData != null && b.ScanData.IsLandable)?.Select(b => b.fullname);
 
                 if (landables != null)
                 {

--- a/EDDiscovery/UserControls/EngineeringSynthesis/UserControlShoppingList.cs
+++ b/EDDiscovery/UserControls/EngineeringSynthesis/UserControlShoppingList.cs
@@ -183,7 +183,7 @@ namespace EDDiscovery.UserControls
             Display();
         }
         
-        private void Display()
+        private async void Display()
         {
             HistoryEntry last_he = userControlSynthesis.CurrentHistoryEntry;        // sync with what its showing
 
@@ -230,7 +230,7 @@ namespace EDDiscovery.UserControls
                 }
                 if (!last_he.IsLanded && showSystemAvailability)
                 {
-                    last_sn = discoveryform.history.starscan.FindSystem(last_he.System, useEDSMForSystemAvailability);
+                    last_sn = await discoveryform.history.starscan.FindSystemAsync(last_he.System, useEDSMForSystemAvailability);
                 }
 
                 StringBuilder wantedList = new StringBuilder();

--- a/EDDiscovery/UserControls/Helpers/ScanDisplayForm.cs
+++ b/EDDiscovery/UserControls/Helpers/ScanDisplayForm.cs
@@ -24,7 +24,7 @@ namespace EDDiscovery.UserControls
 {
     public static class ScanDisplayForm
     {
-        public static void ShowScanOrMarketForm(Form parent, Object tag, bool checkedsm, HistoryList hl)     // tag can be a Isystem or an He.. output depends on it.
+        public static async void ShowScanOrMarketForm(Form parent, Object tag, bool checkedsm, HistoryList hl)     // tag can be a Isystem or an He.. output depends on it.
         {
             if (tag == null)
                 return;
@@ -59,7 +59,8 @@ namespace EDDiscovery.UserControls
                 sd.SetSize( selsize );
                 sd.Size = infosize;
 
-                StarScan.SystemNode data = sd.FindSystem(sys, hl);
+                StarScan.SystemNode data = await hl.starscan.FindSystemAsync(sys, sd.CheckEDSM);    // look up system async
+                    
                 if ( data != null )
                 {
                     long value = data.ScanValue(sd.CheckEDSM);

--- a/EDDiscovery/UserControls/Helpers/ScanDisplayUserControl.cs
+++ b/EDDiscovery/UserControls/Helpers/ScanDisplayUserControl.cs
@@ -74,11 +74,6 @@ namespace EDDiscovery.UserControls
 
         #region Display
 
-        public StarScan.SystemNode FindSystem(ISystem showing_system, HistoryList hl)
-        {
-            return showing_system != null ? hl.starscan.FindSystem(showing_system, CheckEDSM, byname: true) : null;
-        }
-
         // draw scannode (may be null), 
         // curmats may be null
         public void DrawSystem(StarScan.SystemNode scannode, MaterialCommoditiesList curmats, HistoryList hl, string opttext = null, string[] filter=  null ) 

--- a/EDDiscovery/UserControls/History/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/History/UserControlStarList.cs
@@ -328,7 +328,7 @@ namespace EDDiscovery.UserControls
                     if ( rowpresent != null )       // only need to do something if its displayed
                     {
                         List<HistoryEntry> syslist = (List<HistoryEntry>)rowpresent.Tag;
-                        var node = discoveryform.history.starscan?.FindSystem(syslist[0].System, false); // may be null
+                        var node = discoveryform.history.starscan?.FindSystemSynchronous(syslist[0].System, false); // may be null
                         string info = Infoline(syslist, node);  // lookup node, using star name, no EDSM lookup.
                         rowpresent.Cells[3].Value = info;   // update info
                         rowpresent.Cells[4].Value = node?.ScanValue(true).ToString("N0") ?? "0"; // update scan value
@@ -346,7 +346,7 @@ namespace EDDiscovery.UserControls
             DateTime time = EDDiscoveryForm.EDDConfig.ConvertTimeToSelectedFromUTC(he.EventTimeUTC);
             string visits = $"{syslist.Count:N0}";
 
-            var node = discoveryform.history.starscan?.FindSystem(syslist[0].System, false); // may be null
+            var node = discoveryform.history.starscan?.FindSystemSynchronous(syslist[0].System, false); // may be null
 
             string info = Infoline(syslist, node);  // lookup node, using star name, no EDSM lookup.
 
@@ -635,11 +635,11 @@ namespace EDDiscovery.UserControls
                 CheckEDSM(dataGridViewStarList.CurrentRow);
         }
 
-        public void CheckEDSM(DataGridViewRow row)
+        public async void CheckEDSM(DataGridViewRow row)
         {
             List<HistoryEntry> syslist = row.Tag as List<HistoryEntry>;
 
-            var node = discoveryform.history.starscan?.FindSystem(syslist[0].System, true);  // try an EDSM lookup, cache data, then redisplay.
+            var node = await discoveryform.history.starscan?.FindSystemAsync(syslist[0].System, true);  // try an EDSM lookup, cache data, then redisplay.
             row.Cells[StarHistoryColumns.OtherInformation].Value = Infoline(syslist,node);
             row.Cells[StarHistoryColumns.SystemValue].Value = node?.ScanValue(true).ToString("N0") ?? "";
         }

--- a/EDDiscovery/UserControls/Overlays/UserControlSpanel.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSpanel.cs
@@ -233,7 +233,7 @@ namespace EDDiscovery.UserControls
             Display(discoveryform.history);
         }
 
-        private void Display(HistoryList hl)            
+        private async void Display(HistoryList hl)            
         {
             pictureBox.ClearImageList();
 
@@ -318,7 +318,7 @@ namespace EDDiscovery.UserControls
                         {
                             StarScan scan = hl.starscan;
 
-                            StarScan.SystemNode sn = scan.FindSystem(last.System, true);    // EDSM look up here..
+                            StarScan.SystemNode sn = await scan.FindSystemAsync(last.System, true);    // EDSM look up here..
 
                             StringBuilder res = new StringBuilder();
 

--- a/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
@@ -198,7 +198,7 @@ namespace EDDiscovery.UserControls
 
         #region Main
 
-        private void DrawSystem(ISystem sys, string tt = null)
+        async private void DrawSystem(ISystem sys, string tt = null)
         {
             if ( tt != null )
             {
@@ -233,7 +233,7 @@ namespace EDDiscovery.UserControls
                     vpos += i.Location.Height;
                 }
 
-                StarScan.SystemNode systemnode = discoveryform.history.starscan.FindSystem(sys, checkEDSMForInformationToolStripMenuItem.Checked, true);        // get data with EDSM
+                StarScan.SystemNode systemnode = await discoveryform.history.starscan.FindSystemAsync(sys, checkEDSMForInformationToolStripMenuItem.Checked, true);        // get data with EDSM
 
                 if (systemnode != null)     // no data, clear display, clear any last_he so samesys is false next time
                 {

--- a/EDDiscovery/UserControls/RoutesExpeditions/UserControlExploration.cs
+++ b/EDDiscovery/UserControls/RoutesExpeditions/UserControlExploration.cs
@@ -160,7 +160,7 @@ namespace EDDiscovery.UserControls
 
                     dataGridViewExplore[idxVisits, rowindex].Value = discoveryform.history.GetVisitsCount(sysname).ToString();
 
-                    StarScan.SystemNode sysnode = discoveryform.history.starscan.FindSystem(sys,false);
+                    StarScan.SystemNode sysnode = discoveryform.history.starscan.FindSystemSynchronous(sys,false);
                     
                     if ( sysnode != null)
                     {

--- a/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.Designer.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.Designer.cs
@@ -43,13 +43,21 @@ namespace EDDiscovery.UserControls
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.dataViewScrollerPanel2 = new ExtendedControls.ExtPanelDataGridViewScroll();
             this.vScrollBarCustom2 = new ExtendedControls.ExtScrollBar();
             this.dataGridViewEstimatedValues = new System.Windows.Forms.DataGridView();
             this.BodyName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EDSM = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.EstValue = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.checkBoxEDSM = new ExtendedControls.ExtCheckBox();
+            this.extPanelRollUp = new ExtendedControls.ExtPanelRollUp();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.dataViewScrollerPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEstimatedValues)).BeginInit();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.extPanelRollUp.SuspendLayout();
             this.SuspendLayout();
             // 
             // dataViewScrollerPanel2
@@ -58,9 +66,9 @@ namespace EDDiscovery.UserControls
             this.dataViewScrollerPanel2.Controls.Add(this.dataGridViewEstimatedValues);
             this.dataViewScrollerPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataViewScrollerPanel2.InternalMargin = new System.Windows.Forms.Padding(0);
-            this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 0);
+            this.dataViewScrollerPanel2.Location = new System.Drawing.Point(0, 30);
             this.dataViewScrollerPanel2.Name = "dataViewScrollerPanel2";
-            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(572, 572);
+            this.dataViewScrollerPanel2.Size = new System.Drawing.Size(572, 542);
             this.dataViewScrollerPanel2.TabIndex = 25;
             this.dataViewScrollerPanel2.VerticalScrollBarDockRight = true;
             // 
@@ -76,13 +84,13 @@ namespace EDDiscovery.UserControls
             this.vScrollBarCustom2.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.vScrollBarCustom2.HideScrollBar = true;
             this.vScrollBarCustom2.LargeChange = 0;
-            this.vScrollBarCustom2.Location = new System.Drawing.Point(559, 0);
+            this.vScrollBarCustom2.Location = new System.Drawing.Point(556, 0);
             this.vScrollBarCustom2.Maximum = -1;
             this.vScrollBarCustom2.Minimum = 0;
             this.vScrollBarCustom2.MouseOverButtonColor = System.Drawing.Color.Green;
             this.vScrollBarCustom2.MousePressedButtonColor = System.Drawing.Color.Red;
             this.vScrollBarCustom2.Name = "vScrollBarCustom2";
-            this.vScrollBarCustom2.Size = new System.Drawing.Size(13, 572);
+            this.vScrollBarCustom2.Size = new System.Drawing.Size(16, 542);
             this.vScrollBarCustom2.SliderColor = System.Drawing.Color.DarkGray;
             this.vScrollBarCustom2.SmallChange = 1;
             this.vScrollBarCustom2.TabIndex = 24;
@@ -102,13 +110,14 @@ namespace EDDiscovery.UserControls
             this.dataGridViewEstimatedValues.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridViewEstimatedValues.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.BodyName,
+            this.EDSM,
             this.EstValue});
             this.dataGridViewEstimatedValues.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.dataGridViewEstimatedValues.Location = new System.Drawing.Point(0, 0);
             this.dataGridViewEstimatedValues.Name = "dataGridViewEstimatedValues";
             this.dataGridViewEstimatedValues.RowHeadersVisible = false;
             this.dataGridViewEstimatedValues.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            this.dataGridViewEstimatedValues.Size = new System.Drawing.Size(559, 572);
+            this.dataGridViewEstimatedValues.Size = new System.Drawing.Size(556, 542);
             this.dataGridViewEstimatedValues.TabIndex = 23;
             // 
             // BodyName
@@ -118,23 +127,96 @@ namespace EDDiscovery.UserControls
             this.BodyName.MinimumWidth = 50;
             this.BodyName.Name = "BodyName";
             // 
+            // EDSM
+            // 
+            this.EDSM.FillWeight = 20F;
+            this.EDSM.HeaderText = "EDSM";
+            this.EDSM.Name = "EDSM";
+            // 
             // EstValue
             // 
-            this.EstValue.FillWeight = 15F;
+            this.EstValue.FillWeight = 20F;
             this.EstValue.HeaderText = "Est Value";
             this.EstValue.MinimumWidth = 50;
             this.EstValue.Name = "EstValue";
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.Controls.Add(this.checkBoxEDSM);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(572, 30);
+            this.flowLayoutPanel1.TabIndex = 5;
+            // 
+            // checkBoxEDSM
+            // 
+            this.checkBoxEDSM.Appearance = System.Windows.Forms.Appearance.Button;
+            this.checkBoxEDSM.BackColor = System.Drawing.SystemColors.Control;
+            this.checkBoxEDSM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.checkBoxEDSM.CheckBoxColor = System.Drawing.Color.White;
+            this.checkBoxEDSM.CheckBoxDisabledScaling = 0.5F;
+            this.checkBoxEDSM.CheckBoxInnerColor = System.Drawing.Color.White;
+            this.checkBoxEDSM.CheckColor = System.Drawing.Color.DarkBlue;
+            this.checkBoxEDSM.Cursor = System.Windows.Forms.Cursors.Default;
+            this.checkBoxEDSM.FlatAppearance.BorderColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.checkBoxEDSM.FlatAppearance.CheckedBackColor = System.Drawing.Color.Green;
+            this.checkBoxEDSM.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
+            this.checkBoxEDSM.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver;
+            this.checkBoxEDSM.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.checkBoxEDSM.Image = global::EDDiscovery.Icons.Controls.Scan_FetchEDSMBodies;
+            this.checkBoxEDSM.ImageButtonDisabledScaling = 0.5F;
+            this.checkBoxEDSM.ImageIndeterminate = null;
+            this.checkBoxEDSM.ImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.checkBoxEDSM.ImageUnchecked = null;
+            this.checkBoxEDSM.Location = new System.Drawing.Point(8, 1);
+            this.checkBoxEDSM.Margin = new System.Windows.Forms.Padding(8, 1, 4, 1);
+            this.checkBoxEDSM.MouseOverColor = System.Drawing.Color.CornflowerBlue;
+            this.checkBoxEDSM.Name = "checkBoxEDSM";
+            this.checkBoxEDSM.Size = new System.Drawing.Size(28, 28);
+            this.checkBoxEDSM.TabIndex = 4;
+            this.checkBoxEDSM.TickBoxReductionRatio = 0.75F;
+            this.toolTip.SetToolTip(this.checkBoxEDSM, "Get and show information from EDSM");
+            this.checkBoxEDSM.UseVisualStyleBackColor = false;
+            // 
+            // extPanelRollUp
+            // 
+            this.extPanelRollUp.AutoSize = true;
+            this.extPanelRollUp.Controls.Add(this.flowLayoutPanel1);
+            this.extPanelRollUp.Dock = System.Windows.Forms.DockStyle.Top;
+            this.extPanelRollUp.HiddenMarkerWidth = 400;
+            this.extPanelRollUp.Location = new System.Drawing.Point(0, 0);
+            this.extPanelRollUp.Name = "extPanelRollUp";
+            this.extPanelRollUp.PinState = true;
+            this.extPanelRollUp.RolledUpHeight = 5;
+            this.extPanelRollUp.RollUpAnimationTime = 500;
+            this.extPanelRollUp.RollUpDelay = 1000;
+            this.extPanelRollUp.SecondHiddenMarkerWidth = 0;
+            this.extPanelRollUp.ShowHiddenMarker = true;
+            this.extPanelRollUp.Size = new System.Drawing.Size(572, 30);
+            this.extPanelRollUp.TabIndex = 25;
+            this.extPanelRollUp.UnrollHoverDelay = 1000;
+            // 
+            // toolTip
+            // 
+            this.toolTip.ShowAlways = true;
             // 
             // UserControlEstimatedValues
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.dataViewScrollerPanel2);
+            this.Controls.Add(this.extPanelRollUp);
             this.Name = "UserControlEstimatedValues";
             this.Size = new System.Drawing.Size(572, 572);
             this.dataViewScrollerPanel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEstimatedValues)).EndInit();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.extPanelRollUp.ResumeLayout(false);
+            this.extPanelRollUp.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -143,6 +225,11 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ExtScrollBar vScrollBarCustom2;
         private System.Windows.Forms.DataGridView dataGridViewEstimatedValues;
         private System.Windows.Forms.DataGridViewTextBoxColumn BodyName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn EDSM;
         private System.Windows.Forms.DataGridViewTextBoxColumn EstValue;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private ExtendedControls.ExtCheckBox checkBoxEDSM;
+        private ExtendedControls.ExtPanelRollUp extPanelRollUp;
+        private System.Windows.Forms.ToolTip toolTip;
     }
 }

--- a/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.cs
@@ -24,6 +24,8 @@ namespace EDDiscovery.UserControls
     {
         private HistoryEntry last_he = null;
 
+        private string DbEDSM { get { return DBName("EstimatedValueEDSM"); } }
+
         public UserControlEstimatedValues()
         {
             InitializeComponent();
@@ -34,6 +36,9 @@ namespace EDDiscovery.UserControls
         {
             discoveryform.OnNewEntry += NewEntry;
             BaseUtils.Translator.Instance.Translate(this);
+
+            checkBoxEDSM.Checked = EliteDangerousCore.DB.UserDatabase.Instance.GetSettingBool(DbEDSM, false);
+            checkBoxEDSM.CheckedChanged += CheckBoxEDSM_CheckedChanged;
         }
 
         public override void LoadLayout()
@@ -56,7 +61,7 @@ namespace EDDiscovery.UserControls
 
         public override void InitialDisplay()
         {
-            Display(uctg.GetCurrentHistoryEntry, discoveryform.history);
+            Display(uctg.GetCurrentHistoryEntry, discoveryform.history , true);
         }
 
         public void NewEntry(HistoryEntry he, HistoryList hl)               // called when a new entry is made.. check to see if its a scan update
@@ -69,9 +74,6 @@ namespace EDDiscovery.UserControls
             }
         }
 
-        private void Display(HistoryEntry he, HistoryList hl) =>
-            Display(he, hl, true);
-
         private void Display(HistoryEntry he, HistoryList hl, bool selectedEntry)            // Called at first start or hooked to change cursor
         {
             if (he != null && (last_he == null || he.System != last_he.System))
@@ -81,7 +83,7 @@ namespace EDDiscovery.UserControls
             }
         }
 
-        void DrawSystem()   // draw last_sn, last_he
+        async void DrawSystem()   // draw last_he
         {
             dataGridViewEstimatedValues.Rows.Clear();
 
@@ -91,41 +93,27 @@ namespace EDDiscovery.UserControls
                 return;
             }
 
-            StarScan.SystemNode last_sn = discoveryform.history.starscan.FindSystem(last_he.System, true);
+            StarScan.SystemNode last_sn = await discoveryform.history.starscan.FindSystemAsync(last_he.System, checkBoxEDSM.Checked);
 
             SetControlText((last_sn == null) ? "No Scan".T(EDTx.NoScan) : string.Format("Estimated Scan Values for {0}".T(EDTx.UserControlEstimatedValues_SV), last_sn.system.Name));
 
             if (last_sn != null)
             {
-                List<StarScan.ScanNode> all_nodes = new List<StarScan.ScanNode>();
-                foreach (StarScan.ScanNode starnode in last_sn.starnodes.Values)
+                foreach( var bodies in last_sn.Bodies )
                 {
-                    all_nodes = Flatten(starnode, all_nodes);
+                    if ( bodies.ScanData != null && bodies.ScanData.BodyName != null && (checkBoxEDSM.Checked || !bodies.ScanData.IsEDSMBody))     // if check edsm, or not edsm body, with scandata
+                    {
+                        dataGridViewEstimatedValues.Rows.Add(new object[] { bodies.ScanData.BodyName, bodies.ScanData.IsEDSMBody ? "EDSM" : "", bodies.ScanData.EstimatedValue });
+                    }
                 }
-
-                // flatten tree of scan nodes to prepare for listing
-                foreach(StarScan.ScanNode sn in all_nodes)
-                {
-                    if ( sn.ScanData != null && sn.ScanData.BodyName != null )
-                        dataGridViewEstimatedValues.Rows.Add(new object[] { sn.ScanData.BodyName, sn.ScanData.EstimatedValue});
-                }
-
                 dataGridViewEstimatedValues.Sort(this.EstValue, ListSortDirection.Descending);
             }
         }
 
-        private List<StarScan.ScanNode> Flatten(StarScan.ScanNode sn, List<StarScan.ScanNode> flattened)
+        private void CheckBoxEDSM_CheckedChanged(object sender, System.EventArgs e)
         {
-            flattened.Add(sn);
-            if (sn.children != null)
-            {
-                foreach (StarScan.ScanNode node in sn.children.Values)
-                {
-                    Flatten(node, flattened);
-                }
-            }
-            return flattened;
+            EliteDangerousCore.DB.UserDatabase.Instance.PutSettingBool(DbEDSM, checkBoxEDSM.Checked);
+            DrawSystem();
         }
-
     }
 }

--- a/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.resx
+++ b/EDDiscovery/UserControls/ScansStars/UserControlEstimatedValues.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="EDSM.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/EDDiscovery/UserControls/ScansStars/UserControlScan.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlScan.cs
@@ -30,7 +30,7 @@ namespace EDDiscovery.UserControls
 {
     public partial class UserControlScan : UserControlCommonBase
     {
-        private string DbSave { get { return DBName("ScanPanel" ); } }
+        private string DbSave { get { return DBName("ScanPanel"); } }
 
         HistoryEntry last_he = null;
 
@@ -180,11 +180,11 @@ namespace EDDiscovery.UserControls
             DrawSystem();
         }
 
-        void DrawSystem()   // draw showing_system (may be null), showing_matcomds (may be null)
+        async void DrawSystem()   // draw showing_system (may be null), showing_matcomds (may be null)
         {
             panelStars.HideInfo();
 
-            StarScan.SystemNode data = panelStars.FindSystem(showing_system, discoveryform.history);
+            StarScan.SystemNode data = showing_system != null ? await discoveryform.history.starscan.FindSystemAsync(showing_system, panelStars.CheckEDSM) : null;
 
             string control_text = "No System";
 
@@ -493,7 +493,8 @@ namespace EDDiscovery.UserControls
                                         ISystem sys = SystemCache.FindSystem(system);
                                         if (sys!=null)
                                         {
-                                            List<JournalScan> sysscans = EDSMClass.GetBodiesList(sys.EDSMID);
+                                            var jl = EDSMClass.GetBodiesList(sys);
+                                            List<JournalScan> sysscans = jl.Item1;
                                             if (sysscans != null)
                                                 scans.AddRange(sysscans);
                                         }

--- a/EDDiscovery/UserControls/ScansStars/UserControlScanGrid.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlScanGrid.cs
@@ -163,7 +163,7 @@ namespace EDDiscovery.UserControls
             public bool landable, materials, volcanism, mapped;     // all false on creation
         }
 
-        private void DrawSystem(HistoryEntry he, bool force)
+        private async void DrawSystem(HistoryEntry he, bool force)
         {
             StarScan.SystemNode scannode = null;
 
@@ -180,7 +180,7 @@ namespace EDDiscovery.UserControls
             }
             else
             {
-                scannode = discoveryform.history.starscan.FindSystem(he.System, true);        // get data with EDSM
+                scannode = await discoveryform.history.starscan.FindSystemAsync(he.System, true);        // get data with EDSM
 
                 if (scannode == null)     // no data, clear display, clear any last_he so samesys is false next time
                 {


### PR DESCRIPTION
A big one.  Now uses an async pattern to get EDSM body data using starscan Find system.
This means the UI is not frozen during these web lookups and is more fluid.
Since async functions can't lock, the only lock to prevent multiple web lookups of the same data (from multiple panels) is in the task.  The task locks and allows only 1 lookup, futher lookups is stalled in their tasks. The first task completes, further tasks will see the data in the dictionary caches and not lookup.
C# (research shows) frees up awaits in order, so the first one runs first, sees it was not in the cache, and adds the data.  The secoond on sees it was from the cache, and does not add it in.
This appears to be working - lots of debug is left in for now to test this.

Also cleaned up UserControlEstimatedValues to give it an EDSM on/off button and a column saying if the data is from EDSM.