### PR TITLE
Improve performance of population of potentially large grids

### DIFF
--- a/EDDiscovery/UserControls/CurrentState/UserControlLedger.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlLedger.cs
@@ -120,6 +120,7 @@ namespace EDDiscovery.UserControls
 
                 if (filteredlist.Count > 0)
                 {
+                    var rowsToAdd = new List<DataGridViewRow>(filteredlist.Count);
                     for (int i = filteredlist.Count - 1; i >= 0; i--)
                     {
                         Ledger.Transaction tx = filteredlist[i];
@@ -133,10 +134,13 @@ namespace EDDiscovery.UserControls
                                             (tx.profitperunit!=0) ? tx.profitperunit.ToString("N0") : ""
                                         };
 
-                        dataGridViewLedger.Rows.Add(rowobj);
-                        dataGridViewLedger.Rows[dataGridViewLedger.Rows.Count - 1].Tag = tx.jid;
-
+                        var row = dataGridViewLedger.RowTemplate.Clone() as DataGridViewRow;
+                        row.CreateCells(dataGridViewLedger, rowobj);
+                        row.Tag = tx.jid;
+                        rowsToAdd.Add(row);
                     }
+
+                    dataGridViewLedger.Rows.AddRange(rowsToAdd.ToArray());
 
                     dataGridViewLedger.FilterGridView(textBoxFilter.Text);
                 }

--- a/EDDiscovery/UserControls/CurrentState/UserControlMissions.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlMissions.cs
@@ -13,18 +13,14 @@
  * 
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
+using EDDiscovery.Controls;
+using EliteDangerousCore;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using EDDiscovery.Controls;
-using EliteDangerousCore.DB;
-using EliteDangerousCore;
 
 namespace EDDiscovery.UserControls
 {
@@ -158,6 +154,7 @@ namespace EDDiscovery.UserControls
                 List<MissionState> mcurrent = ml.GetAllCurrentMissions(hetime);
 
                 var totalReward = 0;
+                var currentRows = new List<DataGridViewRow>(mcurrent.Count);
                 foreach (MissionState ms in mcurrent)
                 {
                     object[] rowobj = { JournalFieldNaming.ShortenMissionName(ms.Mission.LocalisedName) ,
@@ -176,9 +173,13 @@ namespace EDDiscovery.UserControls
                         totalReward += ms.Mission.Reward.Value;
                     }
 
-                    int rowno = dataGridViewCurrent.Rows.Add(rowobj);
-                    dataGridViewCurrent.Rows[rowno].Tag = ms;
+                    var row = dataGridViewCurrent.RowTemplate.Clone() as DataGridViewRow;
+                    row.CreateCells(dataGridViewCurrent, rowobj);
+                    row.Tag = ms;
+                    currentRows.Add(row);
                 }
+
+                dataGridViewCurrent.Rows.AddRange(currentRows.ToArray());
 
                 int count = mcurrent.Count();
 
@@ -194,6 +195,7 @@ namespace EDDiscovery.UserControls
 
                 long value = 0;
                 int completed = 0, abandonded = 0, failed = 0;
+                var previousRows = new List<DataGridViewRow>(mprev.Count);
 
                 foreach (MissionState ms in mprev)
                 {
@@ -224,13 +226,17 @@ namespace EDDiscovery.UserControls
                                         ms.MissionInfoColumn()
                                         };
 
-                            int rowno = dataGridViewPrevious.Rows.Add(rowobj);
-                            dataGridViewPrevious.Rows[rowno].Tag = ms;
+                            var row = dataGridViewPrevious.RowTemplate.Clone() as DataGridViewRow;
+                            row.CreateCells(dataGridViewPrevious, rowobj);
+                            row.Tag = ms;
+                            previousRows.Add(row);
 
                             value += ms.Value;
                         }
                     }
                 }
+
+                dataGridViewPrevious.Rows.AddRange(previousRows.ToArray());
 
                 labelValue.Visible = (value != 0);
                 labelValue.Text = "Value: ".T(EDTx.UserControlMissions_ValueC) + value.ToString("N0") + " C:" + completed.ToString("N0") + " A:" + abandonded.ToString("N0") + " F:" + failed.ToString("N0");

--- a/EDDiscovery/UserControls/Overlays/UserControlCombatPanel.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlCombatPanel.cs
@@ -289,11 +289,13 @@ namespace EDDiscovery.UserControls
                 else
                     hel = discoveryform.history.FilterByDateRangeLatestFirst(current.StartTimeUTC, current.EndTimeUTC);
 
-                foreach ( HistoryEntry he in hel )
+                var rows = new List<DataGridViewRow>(hel.Count);
+                foreach (HistoryEntry he in hel)
                 {
                     //System.Diagnostics.Debug.WriteLine("Combat Add {0} {1} {2}", he.EventTimeUTC.ToStringZulu(), he.EventSummary, he.EventDescription);
-                    AddToGrid(he);
+                    rows.Add(createRow(he));
                 }
+                dataGridViewCombat.Rows.AddRange(rows.Where(r => r is object).ToArray());
             }
 
             dataGridViewCombat.Sort(sortcol, (sortorder == SortOrder.Descending) ? ListSortDirection.Descending : ListSortDirection.Ascending);
@@ -318,7 +320,7 @@ namespace EDDiscovery.UserControls
 
                 if (tryadd)
                 {
-                    if (AddToGrid(he, true))        // if did add..
+                    if (insertToGrid(he))        // if did add..
                     {
                         SetLabels();
                     }
@@ -337,27 +339,31 @@ namespace EDDiscovery.UserControls
             SetTarget(he);
         }
 
-        bool AddToGrid(HistoryEntry he , bool ins = false )
+        DataGridViewRow createRow(HistoryEntry he)
         {
-            if (CreateEntry(he, out string summarycol, out string descriptioncol, out string rewardcol))
+            if (CreateEntry(he, out var rewardcol))
             {
                 var rw = dataGridViewCombat.RowTemplate.Clone() as DataGridViewRow;
-                he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
+                he.journalEntry.FillInformation(out var eventDescription, out _);
 
                 rw.CreateCells(dataGridViewCombat, EDDiscoveryForm.EDDConfig.ConvertTimeToSelectedFromUTC(he.EventTimeUTC),
-                    he.EventSummary, EventDescription, rewardcol);
+                    he.EventSummary, eventDescription, rewardcol);
 
                 rw.Tag = he;
-
-                if (ins)
-                    dataGridViewCombat.Rows.Insert(0, rw);
-                else
-                    dataGridViewCombat.Rows.Add(rw);
-
-                return true;
+                return rw;
             }
-            else
+
+            return null;
+        }
+
+        bool insertToGrid(HistoryEntry he)
+        {
+            var row = createRow(he);
+            if (row is null)
                 return false;
+
+            dataGridViewCombat.Rows.Insert(0, row);
+            return true;
         }
 
         static JournalTypeEnum[] jtelist = new JournalTypeEnum[]            // ones to display without any extra detail
@@ -369,14 +375,11 @@ namespace EDDiscovery.UserControls
             JournalTypeEnum.SRVDestroyed
         };
 
-        bool CreateEntry( HistoryEntry he, out string summarycol, out string descriptioncol, out string rewardcol )
+        bool CreateEntry(HistoryEntry he, out string rewardcol)
         {
             rewardcol = "";
 
             he.journalEntry.FillInformation(out string EventDescription, out string EventDetailedInfo);
-
-            summarycol = he.EventSummary;
-            descriptioncol = EventDescription;
 
             MissionState ml = current.MissionKey != null && he.MissionList.Missions.ContainsKey(current.MissionKey) ? he.MissionList.Missions[current.MissionKey] : null;
 


### PR DESCRIPTION
Populates three DataGridView controls that can potentially have a lot of rows by making a list of rows outside the grid and adding as a range to the control rather than adding individually to the control for huge performance benefits when the control is not visible.