### PR TITLE
Fix grids skipping 1500 entries after the first 500

### DIFF
--- a/EDDiscovery/UserControls/History/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlJournalGrid.cs
@@ -179,13 +179,12 @@ namespace EDDiscovery.UserControls
             List<HistoryEntry[]> chunks = new List<HistoryEntry[]>();
 
             int chunksize = 500;
-            for (int i = 0; i < result.Count; i += chunksize)
+            for (int i = 0; i < result.Count; i += chunksize, chunksize = 2000)
             {
                 HistoryEntry[] chunk = new HistoryEntry[i + chunksize > result.Count ? result.Count - i : chunksize];
 
                 result.CopyTo(i, chunk, 0, chunk.Length);
                 chunks.Add(chunk);
-                chunksize = 2000;
             }
 
             todo.Clear();

--- a/EDDiscovery/UserControls/History/UserControlStarList.cs
+++ b/EDDiscovery/UserControls/History/UserControlStarList.cs
@@ -175,13 +175,12 @@ namespace EDDiscovery.UserControls
             List<List<HistoryEntry>[]> syslistchunks = new List<List<HistoryEntry>[]>();
 
             int chunksize = 500;
-            for (int i = 0; i < syslists.Count; i += chunksize)
+            for (int i = 0; i < syslists.Count; i += chunksize, chunksize = 2000)
             {
                 int totake = Math.Min(chunksize, syslists.Count - i);
                 List<HistoryEntry>[] syslistchunk = new List<HistoryEntry>[totake];
                 syslists.CopyTo(i, syslistchunk, 0, totake);
                 syslistchunks.Add(syslistchunk);
-                chunksize = 2000;
             }
 
             todo.Clear();

--- a/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
@@ -230,13 +230,12 @@ namespace EDDiscovery.UserControls
             List<HistoryEntry[]> chunks = new List<HistoryEntry[]>();
 
             int chunksize = 500;
-            for (int i = 0; i < result.Count; i += chunksize)
+            for (int i = 0; i < result.Count; i += chunksize, chunksize = 2000)
             {
                 HistoryEntry[] chunk = new HistoryEntry[i + chunksize > result.Count ? result.Count - i : chunksize];
 
                 result.CopyTo(i, chunk, 0, chunk.Length);
                 chunks.Add(chunk);
-                chunksize = 2000;
             }
 
             todo.Clear();


### PR DESCRIPTION
The post part of a for loop is executed after the last statement in the for loop.  As a result, the loop was processing 500 entries, then incrementing the index by 2000.