### PR TITLE
Move EDSM journal discard list fetch to background

### DIFF
--- a/EliteDangerous/EDSM/EDSMJournalSync.cs
+++ b/EliteDangerous/EDSM/EDSMJournalSync.cs
@@ -167,7 +167,7 @@ namespace EliteDangerousCore.EDSM
 
         // Called by Perform, by Sync, by above.
 
-        public static bool SendEDSMEvents(Action<string> log, IEnumerable<HistoryEntry> helist, bool manual = false)
+        public static void UpdateDiscardList()
         {
             if (lastDiscardFetch < DateTime.UtcNow.AddMinutes(-120))     // check if we need a new discard list
             {
@@ -182,7 +182,10 @@ namespace EliteDangerousCore.EDSM
                     System.Diagnostics.Trace.WriteLine($"Unable to retrieve events to be discarded: {ex.ToString()}");
                 }
             }
+        }
 
+        public static bool SendEDSMEvents(Action<string> log, IEnumerable<HistoryEntry> helist, bool manual = false)
+        {
             System.Diagnostics.Debug.WriteLine("Send " + helist.Count());
 
             int eventCount = 0;
@@ -246,6 +249,8 @@ namespace EliteDangerousCore.EDSM
         {
             try
             {
+                UpdateDiscardList();
+
                 running = 1;
 
                 int manualcount = 0;

--- a/EliteDangerous/EDSM/EDSMJournalSync.cs
+++ b/EliteDangerous/EDSM/EDSMJournalSync.cs
@@ -273,6 +273,10 @@ namespace EliteDangerousCore.EDSM
                             hqe.Logger?.Invoke("Manual EDSM journal sync complete");
                             continue; // Discard end-of-sync event
                         }
+                        else if (discardEvents.Contains(first.EntryType.ToString()))
+                        {
+                            continue;
+                        }
                         else
                         {
                             manualcount++;
@@ -307,6 +311,11 @@ namespace EliteDangerousCore.EDSM
 
                             historylist.TryDequeue(out hqe);
                             historyevent.Reset();
+
+                            if (hqe.HistoryEntry != null && discardEvents.Contains(hqe.HistoryEntry.EntryType.ToString()))
+                            {
+                                continue;
+                            }
 
                             logline = $"Adding {he.EntryType.ToString()} event to EDSM journal sync ({he.EventSummary})";
                             System.Diagnostics.Trace.WriteLine(logline);


### PR DESCRIPTION
This should fix an issue where a slow response from EDSM will cause the UI to freeze when Sync to EDSM is enabled.