### PR TITLE
Fix duplication in Market Data Panel

### DIFF
--- a/EDDiscovery/UserControls/StationData/UserControlMarketData.cs
+++ b/EDDiscovery/UserControls/StationData/UserControlMarketData.cs
@@ -191,7 +191,7 @@ namespace EDDiscovery.UserControls
                 List<MaterialCommodities> notfound = new List<MaterialCommodities>();
                 foreach (MaterialCommodities m in mclist)
                 {
-                    int index = list.FindIndex(x => x.fdname.EqualsAlphaNumOnlyNoCase(m.Details.Name));   // try and match, remove any spaces/_ and lower case it for matching
+                    int index = list.FindIndex(x => x.fdname.EqualsAlphaNumOnlyNoCase(m.Details.FDName));   // try and match, remove any spaces/_ and lower case it for matching
                     if (index >= 0)
                         list[index].CargoCarried = m.Count; // found it, set cargo count..
                     else


### PR DESCRIPTION
This should fix the duplication of commodities in the market data panel when the symbol does not match the english name.  Examples are Low Temperature Diamonds (symbol lowtemperaturediamond) and Viod Opal (symbol opal).

This should fix #2805 