### PR TITLE
Prevent runtime error when calling GetLastHistoryEntry with a null frominclusive parameter

### DIFF
--- a/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
@@ -100,16 +100,16 @@ namespace EDDiscovery.UserControls
         }
 
         public override void InitialDisplay() =>
-            Stats(uctg.GetCurrentHistoryEntry, discoveryform.history,true);
+            Stats(uctg.GetCurrentHistoryEntry, discoveryform.history, true);
 
         public void TravelGridChanged(HistoryEntry he, HistoryList hl, bool selectedEntry) =>
-            Stats(he, hl,false);
+            Stats(he, hl, false);
 
         private void AddNewEntry(HistoryEntry he, HistoryList hl) =>
-            Stats(he, hl,false);
+            Stats(he, hl, false);
 
         private void tabControlCustomStats_SelectedIndexChanged(object sender, EventArgs e) =>
-            Stats(last_he, last_hl,true);
+            Stats(last_he, last_hl, true);
 
         private HistoryEntry last_he = null;
         private HistoryList last_hl = null;
@@ -542,7 +542,7 @@ namespace EDDiscovery.UserControls
         {
             dataGridViewTravel.Rows.Clear();        // reset all
             dataGridViewTravel.Columns.Clear();
-            Stats(last_he, last_hl,true);
+            Stats(last_he, last_hl, true);
         }
 
         #endregion
@@ -767,7 +767,7 @@ namespace EDDiscovery.UserControls
             if (collapseExpand.Length < 13)
                 collapseExpand += new string('Y', 13);
 
-            HistoryEntry hestats = (he != null) ? hl.GetLastHistoryEntry(x => x.EntryType == JournalTypeEnum.Statistics, he) : hl.GetLastHistoryEntry(x => x.EntryType == JournalTypeEnum.Statistics);
+            HistoryEntry hestats = hl.GetLastHistoryEntry(x => x.EntryType == JournalTypeEnum.Statistics, he);
 
             JournalStatistics stats = hestats?.journalEntry as JournalStatistics;
 

--- a/EliteDangerous/HistoryList/HistoryList.cs
+++ b/EliteDangerous/HistoryList/HistoryList.cs
@@ -286,6 +286,9 @@ namespace EliteDangerousCore
 
         public HistoryEntry GetLastHistoryEntry(Predicate<HistoryEntry> where, HistoryEntry frominclusive)
         {
+            if (frominclusive is null)
+                return GetLastHistoryEntry(where);
+
             int hepos = historylist.FindIndex(x => x.Journalid == frominclusive.Journalid);
             if (hepos != -1)
                 hepos = historylist.FindLastIndex(hepos, where);


### PR DESCRIPTION
Noticed this could happen from an Outfitting panel, protected generally (and removed the now redundant protection from the stats panel)

Format on save continuing to apply work code standards for spaces... :)