### PR TITLE
Add MapColor to JournalCarrierJump

### DIFF
--- a/EDDiscovery/3DMap/DatasetBuilder.cs
+++ b/EDDiscovery/3DMap/DatasetBuilder.cs
@@ -711,9 +711,9 @@ namespace EDDiscovery._3DMap
                         }
                         else if (sp.IsLocOrJump && sp.System.HasCoordinate)
                         {
-                            if (sp.IsFSDJump)
+                            if (sp.journalEntry is IJournalJumpColor)
                             {
-                                drawcolour = Color.FromArgb((sp.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                                drawcolour = Color.FromArgb(((IJournalJumpColor)sp.journalEntry).MapColor);
                                 if (drawcolour.GetBrightness() < 0.05)
                                     drawcolour = Color.Red;
                             }
@@ -741,9 +741,9 @@ namespace EDDiscovery._3DMap
                     {
                         if (vs.System.HasCoordinate)
                         {
-                            if (vs.IsFSDJump)
+                            if (vs.journalEntry is IJournalJumpColor)
                             {
-                                drawcolour = Color.FromArgb((vs.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                                drawcolour = Color.FromArgb(((IJournalJumpColor)vs.journalEntry).MapColor);
                                 if (drawcolour.GetBrightness() < 0.05)
                                     drawcolour = Color.Red;
                             }

--- a/EDDiscovery/Forms/Form2DMap.cs
+++ b/EDDiscovery/Forms/Form2DMap.cs
@@ -134,9 +134,9 @@ namespace EDDiscovery
             {
                 for (int ii = 0; ii < jumps.Count-1; ii++)
                 {
-                    if (jumps[ii].IsFSDJump)
+                    if (jumps[ii].journalEntry is IJournalJumpColor)
                     {
-                        drawcolour = Color.FromArgb((jumps[ii].journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                        drawcolour = Color.FromArgb(((IJournalJumpColor)jumps[ii].journalEntry).MapColor);
                         if (drawcolour.GetBrightness() < 0.05)
                             drawcolour = Color.Red;
                     }

--- a/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlTravelGrid.cs
@@ -669,9 +669,9 @@ namespace EDDiscovery.UserControls
             e.Graphics.DrawImage(he.journalEntry.Icon, new Rectangle(hstart, top, size, size));
             hstart += size + padding;
 
-            if (he.IsFSDJump && showfsdmapcolour)
+            if (he.journalEntry is IJournalJumpColor && showfsdmapcolour)
             {
-                Color c = Color.FromArgb((he.journalEntry as EliteDangerousCore.JournalEvents.JournalFSDJump).MapColor);
+                Color c = Color.FromArgb(((IJournalJumpColor)he.journalEntry).MapColor);
 
                 using (Brush b = new SolidBrush(c))
                 {

--- a/EliteDangerous/HistoryList/HistoryTravel.cs
+++ b/EliteDangerous/HistoryList/HistoryTravel.cs
@@ -83,7 +83,7 @@ namespace EliteDangerousCore
 
             if ( !hecur.MultiPlayer )           // multiplayer bits don't count, but we need a fresh entry because we are now monitoring for shutdown.
             { 
-                if (hecur.IsFSDJump )   // if jump, and not multiplayer..
+                if (hecur.journalEntry is JournalFSDJump )   // if jump, and not multiplayer..
                 {
                     double dist = ((JournalFSDJump)hecur.journalEntry).JumpDist;
                     if (dist <= 0)

--- a/EliteDangerous/Journal/JournalEntryInterfaces.cs
+++ b/EliteDangerous/Journal/JournalEntryInterfaces.cs
@@ -73,4 +73,8 @@ namespace EliteDangerousCore
 
     }
 
+    public interface IJournalJumpColor
+    {
+        int MapColor { get; set; }
+    }
 }

--- a/EliteDangerous/JournalEvents/JournalFSDLocation.cs
+++ b/EliteDangerous/JournalEvents/JournalFSDLocation.cs
@@ -408,7 +408,7 @@ namespace EliteDangerousCore.JournalEvents
 
     //When written: when jumping with a fleet carrier
     [JournalEntryType(JournalTypeEnum.CarrierJump)]
-    public class JournalCarrierJump : JournalLocOrJump, ISystemStationEntry, IBodyNameAndID
+    public class JournalCarrierJump : JournalLocOrJump, ISystemStationEntry, IBodyNameAndID, IJournalJumpColor
     {
         public JournalCarrierJump(JObject evt) : base(evt, JournalTypeEnum.CarrierJump)
         {
@@ -444,6 +444,11 @@ namespace EliteDangerousCore.JournalEvents
                                                                       // tbd bug in journal over FactionState - its repeated twice..
             StationServices = evt["StationServices"]?.ToObjectProtected<string[]>();
             StationEconomyList = evt["StationEconomies"]?.ToObjectProtected<JournalDocked.Economies[]>();
+
+            JToken jm = evt["EDDMapColor"];
+            MapColor = jm.Int(EDCommander.Current.MapColour);
+            if (jm.Empty())
+                evt["EDDMapColor"] = EDCommander.Current.MapColour;      // new entries get this default map colour if its not already there
         }
 
         public bool Docked { get; set; }
@@ -459,6 +464,7 @@ namespace EliteDangerousCore.JournalEvents
         public double? Longitude { get; set; }
 
         public long? MarketID { get; set; }
+        public int MapColor { get; set; }
 
         public string StationFaction { get; set; }
         public string StationFactionState { get; set; }
@@ -518,7 +524,7 @@ namespace EliteDangerousCore.JournalEvents
     }
 
     [JournalEntryType(JournalTypeEnum.FSDJump)]
-    public class JournalFSDJump : JournalLocOrJump, IShipInformation, ISystemStationEntry
+    public class JournalFSDJump : JournalLocOrJump, IShipInformation, ISystemStationEntry, IJournalJumpColor
     {
         public JournalFSDJump(JObject evt) : base(evt, JournalTypeEnum.FSDJump)
         {


### PR DESCRIPTION
This fixes the errors caused by the breaking of the assumption that `IsFSDJump == true` means that `journalEntry is JournalFSDJump`

This should fix #2833