### PR TITLE
Fix tests

### DIFF
--- a/EDDiscoveryTests/Tests.csproj
+++ b/EDDiscoveryTests/Tests.csproj
@@ -108,6 +108,10 @@
       <Project>{6EE10D92-E3E4-44D9-8E6B-851801B0B510}</Project>
       <Name>EDDiscovery</Name>
     </ProjectReference>
+    <ProjectReference Include="..\EliteDangerousCore\EliteDangerous\EliteDangerous.csproj">
+      <Project>{019917a4-7342-4f67-8aaf-9e20c016a935}</Project>
+      <Name>EliteDangerous</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/EDDiscoveryTests/Tests.csproj
+++ b/EDDiscoveryTests/Tests.csproj
@@ -104,6 +104,10 @@
     <Compile Include="TravelHistoryFilterTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\BaseUtilities\BaseUtilities\BaseUtils.csproj">
+      <Project>{c657c881-f3e1-45ba-aca5-966348010414}</Project>
+      <Name>BaseUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EDDiscovery\EDDiscovery.csproj">
       <Project>{6EE10D92-E3E4-44D9-8E6B-851801B0B510}</Project>
       <Name>EDDiscovery</Name>

--- a/EDDiscoveryTests/Tests.csproj
+++ b/EDDiscoveryTests/Tests.csproj
@@ -108,6 +108,10 @@
       <Project>{c657c881-f3e1-45ba-aca5-966348010414}</Project>
       <Name>BaseUtils</Name>
     </ProjectReference>
+    <ProjectReference Include="..\EDDIcons\EDDIcons.csproj">
+      <Project>{646f71be-f102-444e-9254-818e5a320ab8}</Project>
+      <Name>EDDIcons</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EDDiscovery\EDDiscovery.csproj">
       <Project>{6EE10D92-E3E4-44D9-8E6B-851801B0B510}</Project>
       <Name>EDDiscovery</Name>

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -36,7 +36,14 @@ namespace EDDiscoveryTests
 
         public TravelHistoryFilterTests()
         {
+            EDDiscovery.Icons.ForceInclusion.Include();      // Force the assembly into the project by a empty call
             BaseUtils.Icons.IconSet.CreateSingleton();
+            System.Reflection.Assembly iconasm = BaseUtils.ResourceHelpers.GetAssemblyByName("EDDiscovery.Icons");
+            BaseUtils.Icons.IconSet.Instance.LoadIconsFromAssembly(iconasm);
+            BaseUtils.Icons.IconSet.Instance.AddAlias("settings", "Controls.Main.Tools.Settings");             // from use by action system..
+            BaseUtils.Icons.IconSet.Instance.AddAlias("missioncompleted", "Journal.MissionCompleted");
+            BaseUtils.Icons.IconSet.Instance.AddAlias("speaker", "Legacy.speaker");
+            BaseUtils.Icons.IconSet.Instance.AddAlias("Default", "Legacy.star");        // MUST be present
         }
 
         [Test]

--- a/EDDiscoveryTests/TravelHistoryFilterTests.cs
+++ b/EDDiscoveryTests/TravelHistoryFilterTests.cs
@@ -34,6 +34,11 @@ namespace EDDiscoveryTests
             Z = 0
         };
 
+        public TravelHistoryFilterTests()
+        {
+            BaseUtils.Icons.IconSet.CreateSingleton();
+        }
+
         [Test]
         public void No_filter_does_not_filter_anything()
         {


### PR DESCRIPTION
Fixes 52b62384eae357bbd0594ee9da9adb6eba48fd4f Submodule EliteDangerousCore

EliteDangerousCore was incorrectly removed as a dependency of EDDiscoveryTests, resulting in CI build failures