### PR TITLE
[11.5] #2853 Ignore events when in CQC

### DIFF
--- a/EliteDangerous/Journal/EDJournalReader.cs
+++ b/EliteDangerous/Journal/EDJournalReader.cs
@@ -37,6 +37,7 @@ namespace EliteDangerousCore
         JournalEvents.JournalOutfitting lastoutfitting = null;
         JournalEvents.JournalMarket lastmarket = null;
         JournalEvents.JournalNavRoute lastnavroute = null;
+        bool cqc = false;
         const int timelimit = 5 * 60;   //seconds.. 5 mins between logs. Note if we undock, we reset the counters.
 
         private Queue<JournalReaderEntry> StartEntries = new Queue<JournalReaderEntry>();
@@ -193,6 +194,16 @@ namespace EliteDangerousCore
                 lastoutfitting = null;
                 laststoredmodules = null;
                 laststoredships = null;
+                cqc = false;
+            }
+            else if (je is JournalEvents.JournalMusic)
+            {
+                var music = je as JournalEvents.JournalMusic;
+                
+                if (music.MusicTrackID == JournalEvents.EDMusicTrackEnum.CQC || music.MusicTrackID == JournalEvents.EDMusicTrackEnum.CQCMenu)
+                {
+                    cqc = true;
+                }
             }
             else if (je is JournalEvents.JournalNavRoute)
             {
@@ -209,6 +220,11 @@ namespace EliteDangerousCore
             if (toosoon)                                                // if seeing repeats, remove
             {
                // System.Diagnostics.Debug.WriteLine("**** Remove as dup " + je.EventTypeStr);
+                return null;
+            }
+
+            if (cqc)  // Ignore events if in CQC
+            {
                 return null;
             }
 


### PR DESCRIPTION
The only indication that we're in CQC is the music track, so use that to detect when we're in CQC.
This should fix #2853 