### PR TITLE
Move NavRoute spamming fix to EDJournalReader

### DIFF
--- a/EliteDangerous/Journal/EDJournalReader.cs
+++ b/EliteDangerous/Journal/EDJournalReader.cs
@@ -36,6 +36,7 @@ namespace EliteDangerousCore
         JournalEvents.JournalStoredModules laststoredmodules = null;
         JournalEvents.JournalOutfitting lastoutfitting = null;
         JournalEvents.JournalMarket lastmarket = null;
+        JournalEvents.JournalNavRoute lastnavroute = null;
         const int timelimit = 5 * 60;   //seconds.. 5 mins between logs. Note if we undock, we reset the counters.
 
         private Queue<JournalReaderEntry> StartEntries = new Queue<JournalReaderEntry>();
@@ -192,6 +193,17 @@ namespace EliteDangerousCore
                 lastoutfitting = null;
                 laststoredmodules = null;
                 laststoredships = null;
+            }
+            else if (je is JournalEvents.JournalNavRoute)
+            {
+                var route = je as JournalEvents.JournalNavRoute;
+
+                if (lastnavroute != null && (route.EventTimeUTC == lastnavroute.EventTimeUTC || route.EventTimeUTC == lastnavroute.EventTimeUTC.AddSeconds(1)))
+                {
+                    toosoon = true;
+                }
+
+                lastnavroute = route;
             }
 
             if (toosoon)                                                // if seeing repeats, remove

--- a/EliteDangerous/JournalEvents/JournalNavRoute.cs
+++ b/EliteDangerous/JournalEvents/JournalNavRoute.cs
@@ -14,7 +14,6 @@
  * EDDiscovery is not affiliated with Frontier Developments plc.
  */
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,8 +22,6 @@ namespace EliteDangerousCore.JournalEvents
     [JournalEntryType(JournalTypeEnum.NavRoute)]
     public class JournalNavRoute : JournalEntry, IAdditionalFiles
     {
-        private static DateTime LastNavRoute;
-
         public JournalNavRoute(JObject evt) : base(evt, JournalTypeEnum.NavRoute)
         {
             Rescan(evt);
@@ -79,15 +76,6 @@ namespace EliteDangerousCore.JournalEvents
 
         public bool ReadAdditionalFiles(string directory, bool inhistoryparse, ref JObject jo)
         {
-            var lastnavroute = LastNavRoute;
-            LastNavRoute = this.EventTimeUTC;
-
-            // Don't process if the game is spamming the NavRoute event
-            if (EventTimeUTC == lastnavroute || EventTimeUTC == lastnavroute.AddSeconds(1))
-            {
-                return false;
-            }
-
             if (Route == null)
             {
                 JObject jnew = ReadAdditionalFile(System.IO.Path.Combine(directory, "NavRoute.json"), waitforfile: !inhistoryparse, checktimestamptype: true);  // check timestamp..


### PR DESCRIPTION
This will conflict with #2854, so care will be needed when merging it.
This moves the anti-spam from #2851 into EDJournalReader, so the duplicate NavRoute events will not even be processed.