### PR TITLE
Sort numeric columns numerically in Scan tab in Stats panel

### DIFF
--- a/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
@@ -737,7 +737,7 @@ namespace EDDiscovery.UserControls
         private void dataGridViewScan_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
         {
             if (e.Column.Tag == null)     // tag null means numeric sort.
-                e.SortDataGridViewColumnDate();
+                e.SortDataGridViewColumnNumeric();
         }
 
         private void userControlStatsTimeScan_DrawModeChanged(object sender, EventArgs e)


### PR DESCRIPTION
Stats Panel Sorting - Change sorting to Numeric rather than Date to fix sort order