### PR TITLE
Update key used in ByShip tab in Stats panel

### DIFF
--- a/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlStats.cs
@@ -1004,7 +1004,7 @@ namespace EDDiscovery.UserControls
                 strarr[5] = hl.GetTonnesBought(si.Key).ToString("N0");
                 strarr[6] = hl.GetTonnesSold(si.Key).ToString("N0");
                 strarr[7] = hl.GetDeathCount(si.Key).ToString();
-                StatToDGV(dataGridViewByShip, (si.Value.ShipType ?? "Unknown".T(EDTx.Unknown)) + $" ({si.Value.ID})", strarr);
+                StatToDGV(dataGridViewByShip, (si.Value.ShipType ?? "Unknown".T(EDTx.Unknown)) + $" ({si.Key})", strarr);
             }
 
             if (sortcol < dataGridViewByShip.Columns.Count)


### PR DESCRIPTION
Using ShipKey ensures ships with same Id dont overwrite each other - In certain cases 2 ships can have same Id, and overwrite each other in the view.