### PR TITLE
Update build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/EDDiscovery/EDDiscovery/master/LICENSE.md)
-[![Appveyor status](https://img.shields.io/appveyor/ci/EDDiscovery/EDDiscovery/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/EDDiscovery/eddiscovery/branch/master)
-[![Travis CI](https://img.shields.io/travis/EDDiscovery/EDDiscovery/master.svg?label=Mono%20build)](https://travis-ci.org/EDDiscovery/EDDiscovery/branches)
+[![Appveyor status](https://img.shields.io/appveyor/ci/EDDiscovery/EDDiscovery/master.svg?label=AppVeyor%20build)](https://ci.appveyor.com/project/EDDiscovery/eddiscovery/branch/master)
 
 EDDiscovery is a captain's log and 2D/3D map for Elite Dangerous players. Find more information in the [EDDiscovery wiki](https://github.com/EDDiscovery/EDDiscovery/wiki).
 


### PR DESCRIPTION
As AppVeyor now handles both Windows and Linux builds, and Travis is no longer connected, this removes the Mono build badge and changes "Windows build" to "AppVeyor Build"