### PR TITLE
Use html embed for video; open in default browser

### DIFF
--- a/EDDiscovery/Forms/AboutForm.cs
+++ b/EDDiscovery/Forms/AboutForm.cs
@@ -67,14 +67,28 @@ namespace EDDiscovery.Forms
             webbrowser.Dock = DockStyle.Fill;
             webbrowser.Visible = false;
             webbrowser.DocumentCompleted += Webbrowser_DocumentCompleted;
+            webbrowser.NewWindow += Webbrowser_NewWindow;
             webbrowser.ScriptErrorsSuppressed = true;
             panelWebBrowser.Controls.Add(webbrowser);
-            webbrowser.Navigate(Properties.Resources.URLReleaseVideo);
+            webbrowser.DocumentText =
+                "<html>" +
+                "<head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=Edge\"/></head>" +
+                "<body style=\"margin: 0\">" +
+                $"<iframe style=\"display: block; border: none; height: 100vh; width: 100vw\" src=\"{Properties.Resources.URLReleaseVideo}\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>" +
+                "</body>" +
+                "</html>";
 #else
             panelWebBrowser.Visible = false;
             textBoxLicense.Dock = DockStyle.Fill;
 
 #endif
+        }
+
+        private void Webbrowser_NewWindow(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            e.Cancel = true;
+            // Guess that the Youtube button was clicked
+            BaseUtils.BrowserInfo.LaunchBrowser(Properties.Resources.URLReleaseVideo);
         }
 
         private void Webbrowser_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)

--- a/EDDiscovery/Forms/AboutForm.cs
+++ b/EDDiscovery/Forms/AboutForm.cs
@@ -88,7 +88,17 @@ namespace EDDiscovery.Forms
         {
             e.Cancel = true;
             // Guess that the Youtube button was clicked
-            BaseUtils.BrowserInfo.LaunchBrowser(Properties.Resources.URLReleaseVideo);
+            if (Properties.Resources.URLReleaseVideo.StartsWith("https://www.youtube.com/embed/"))
+            {
+                var uri = new Uri(Properties.Resources.URLReleaseVideo);
+                var url = "https://www.youtube.com/watch?v=" + System.Linq.Enumerable.Last(uri.AbsolutePath.Split('/'));
+
+                BaseUtils.BrowserInfo.LaunchBrowser(url);
+            }
+            else
+            {
+                BaseUtils.BrowserInfo.LaunchBrowser(Properties.Resources.URLReleaseVideo);
+            }
         }
 
         private void Webbrowser_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)


### PR DESCRIPTION
This should fix the Youtube button opening in IE instead of the default browser (as the `NewWindow` event has no information on what URL is being browsed to, it assumes that the Youtube button was clicked, and opens the release video URL in the default browser).
It also uses an embed to put it into Edge compatibility mode.