### PR TITLE
Add a secondary monobuild script for macOS to fix windows.forms segfault

### DIFF
--- a/monobuildmac
+++ b/monobuildmac
@@ -1,0 +1,2 @@
+#Builds native x86 Mono executable for macOS Mojave and earlier Mac systems, to allow windows.forms to work properly. Doesn't work on Catalina or later
+msbuild /p:Configuration=Debug EDDiscovery.sln "/p:DefineConstants=\"NO_SYSTEM_SPEECH;MONO;DEBUG;TRACE\";Platform=x86;PlatformTarget=x86"


### PR DESCRIPTION
The current `monobuild` script will build an executable that immediately segfaults on later macOS versions. This is due to Mono using an implementation of `windows.forms` that [does not work on x64](https://www.mono-project.com/docs/about-mono/supported-platforms/macos/#windowsforms). We can create a workaround by having a secondary `monobuild` script that builds for x86, and this _should_ run on Mojave or earlier macOS versions (Catalina or later will not work because they dropped support for x86 and by extension `mono32`).

The [wiki page](https://github.com/EDDiscovery/EDDiscovery/wiki/MAC-and-EDD) should also be updated to reflect this.