### PR TITLE
Prevent stars to being displayed

### DIFF
--- a/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
@@ -311,7 +311,7 @@ namespace EDDiscovery.UserControls
                                     (sd.HasMeaningfulVolcanism && hasVolcanismToolStripMenuItem.Checked) ||
                                     (sd.nEccentricity.HasValue && sd.nEccentricity >= eccentricityLimit && highEccentricityToolStripMenuItem.Checked) ||
                                     (sd.Terraformable && terraformableToolStripMenuItem.Checked) ||
-                                    (lowRadiusToolStripMenuItem.Checked && sd.nRadius.HasValue && sd.nRadius < lowRadiusLimit) ||
+                                    (sd.IsPlanet && lowRadiusToolStripMenuItem.Checked && sd.nRadius.HasValue && sd.nRadius < lowRadiusLimit) ||
                                     (sn.Signals != null && hasSignalsToolStripMenuItem.Checked) ||
                                     (sd.IsStar && showAllStarsToolStripMenuItem.Checked) ||
                                     (sd.IsPlanet && showAllPlanetsToolStripMenuItem.Checked) ||


### PR DESCRIPTION
This has to be a very old bug.
This change prevents naturally tiny stars (neutrons, black holes, ...) from being shown in surveyor when "tiny body" (previously known as "Low Radius") is checked.