### PR TITLE
Null checks on all of the controls that access the UserControlTravelG…

### DIFF
--- a/EDDiscovery/UserControls/Overlays/UserControlMiningOverlay.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlMiningOverlay.cs
@@ -93,7 +93,10 @@ namespace EDDiscovery.UserControls
         public override void Closing()
         {
             timetimer.Stop();
-            uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            if (uctg != null)
+            {
+                uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            }
             PutSetting(dbRolledUp, extPanelRollUp.PinState);
         }
 

--- a/EDDiscovery/UserControls/Overlays/UserControlMissionOverlay.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlMissionOverlay.cs
@@ -135,7 +135,12 @@ namespace EDDiscovery.UserControls
             discoveryform.OnNewEntry -= Discoveryform_OnNewEntry;
             discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
             if (debug_followcursor)
-                uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            {
+                if (uctg != null)
+                {
+                    uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+                }
+            }
         }
 
         #endregion

--- a/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
@@ -167,7 +167,10 @@ namespace EDDiscovery.UserControls
 
         public override void Closing()
         {
-            uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            if (uctg != null)
+            {
+                uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            }
             discoveryform.OnNewUIEvent -= Discoveryform_OnNewUIEvent;
             discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
         }

--- a/EDDiscovery/UserControls/ScansStars/UserControlScan.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlScan.cs
@@ -107,11 +107,14 @@ namespace EDDiscovery.UserControls
 
         public override void Closing()
         {
+            closing = true;
             PutSetting("PinState", rollUpPanelTop.PinState );
 
-            uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            if (uctg != null)
+            {
+                uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            }
             discoveryform.OnNewEntry -= NewEntry;
-            closing = true;
         }
 
         #endregion

--- a/EDDiscovery/UserControls/ScansStars/UserControlStarDistance.cs
+++ b/EDDiscovery/UserControls/ScansStars/UserControlStarDistance.cs
@@ -78,7 +78,10 @@ namespace EDDiscovery.UserControls
         {
             DGVSaveColumnLayout(dataGridViewNearest);
             discoveryform.OnHistoryChange -= Discoveryform_OnHistoryChange;
-            uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            if (uctg != null)
+            {
+                uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            }
             computer.ShutDown();
             PutSetting("Min", textMinRadius.Value);
             PutSetting("Max", textMaxRadius.Value);

--- a/EDDiscovery/UserControls/Webbrowser/UserControlWebBrowser.cs
+++ b/EDDiscovery/UserControls/Webbrowser/UserControlWebBrowser.cs
@@ -87,7 +87,10 @@ namespace EDDiscovery.UserControls
         {
             isClosing = true;
             PutSetting("PinState", rollUpPanelTop.PinState);
-            uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            if (uctg != null)
+            {
+                uctg.OnTravelSelectionChanged -= Uctg_OnTravelSelectionChanged;
+            }
         }
 
         #endregion


### PR DESCRIPTION
…rid when it may be null.

When using the following triggers to switch between profiles when switching between analysis mode and combat mode in game. The application has a CTD due to an attempt to access a null component.

![image](https://user-images.githubusercontent.com/447138/138561841-c9be2f9e-e4d1-469e-832d-ee8269d308a2.png)

![image](https://user-images.githubusercontent.com/447138/138561856-644928b4-6228-4e1c-8434-beb9fba90c1b.png)

Adding null checks around the access ensure that it is only used when present and doesn't cause a CTD when it is already torn down.

You can see in the watch that the conditional break where utcg is null has triggered and utcg is null in the watch variables. The change prohibits an attempt to set the property of the null object.

![image](https://user-images.githubusercontent.com/447138/138561869-4b78b683-cb79-4640-8bbc-4e33ab22126e.png)
