### PR TITLE
Fix Surveyor showing count of EDSM bodies if EDSM check isn't checked

### DIFF
--- a/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
@@ -280,6 +280,11 @@ namespace EDDiscovery.UserControls
 
                     int scanned = systemnode.StarPlanetsScanned();
 
+                    if (!checkEDSMForInformationToolStripMenuItem.Checked)
+                    {
+                        scanned = systemnode.StarPlanetsScannednonEDSM();
+                    }
+
                     if (scanned > 0)
                     {
                         infoline = "Scan".T(EDTx.UserControlSurveyor_Scan) + " " + scanned.ToString() + (systemnode.FSSTotalBodies != null ? (" / " + systemnode.FSSTotalBodies.Value.ToString()) : "");


### PR DESCRIPTION
Needs https://github.com/EDDiscovery/EliteDangerousCore/pull/73/commits/0a65d0d5d833f4f9c62cffdfcc8b9925b0a06bd8 to work