### PR TITLE
Make ScanSummary hideable

### DIFF
--- a/EDDiscovery/Translations/EDDiscoveryTranslations.cs
+++ b/EDDiscovery/Translations/EDDiscoveryTranslations.cs
@@ -993,6 +993,7 @@ namespace EDDiscovery
         UserControlSurveyor_dontHideInFSSModeToolStripMenuItem,
         UserControlSurveyor_hideAlreadyMappedBodiesToolStripMenuItem,
         UserControlSurveyor_showSystemInfoOnScreenWhenInTransparentModeToolStripMenuItem,
+        UserControlSurveyor_showScanSummaryOnScreenWhenInTransparentModeToolStripMenuItem,
         UserControlSurveyor_showDividersToolStripMenuItem,
         UserControlSurveyor_textAlignToolStripMenuItem_leftToolStripMenuItem,
         UserControlSurveyor_textAlignToolStripMenuItem_centerToolStripMenuItem,

--- a/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlSurveyor.cs
@@ -218,7 +218,8 @@ namespace EDDiscovery.UserControls
             }
 
             //System.Diagnostics.Debug.WriteLine($"Surveyor Visibility uimode {uimode} uistate {uistate} Visibility {showit} route {currentRoute!=null}");
-            extPictureBoxScanSummary.Visible = extPictureBoxScroll.Visible = showit;
+            extPictureBoxScroll.Visible = showit;
+            extPictureBoxScanSummary.Visible = IsSet(CtrlList.showscansum) && showit;
             extPictureBoxTitle.Visible = IsSet(CtrlList.showsysinfo) && showit;
             extPictureBoxRoute.Visible = currentRoute != null && showit;
             extPictureBoxTarget.Visible = showit && IsSet(RouteControl.showtarget) && TargetClass.IsTargetSet();
@@ -895,7 +896,7 @@ namespace EDDiscovery.UserControls
             // 18
             allstars, beltclusters,
             // 20
-            showValues, moreinfo, showGravity, atmos, temp, volcanism, showsignals, autohide, donthidefssmode, hideMapped, showsysinfo, showstarclass, showdividers,
+            showValues, moreinfo, showGravity, atmos, temp, volcanism, showsignals, autohide, donthidefssmode, hideMapped, showsysinfo, showscansum, showstarclass, showdividers,
             // 31
             alignleft, aligncenter, alignright
         };
@@ -996,6 +997,7 @@ namespace EDDiscovery.UserControls
             displayfilter.AddStandardOption(CtrlList.donthidefssmode.ToString(), "Don't hide in FSS Mode".TxID(EDTx.UserControlSurveyor_dontHideInFSSModeToolStripMenuItem));
             displayfilter.AddStandardOption(CtrlList.hideMapped.ToString(), "Hide already mapped bodies".TxID(EDTx.UserControlSurveyor_hideAlreadyMappedBodiesToolStripMenuItem));
             displayfilter.AddStandardOption(CtrlList.showsysinfo.ToString(), "Show system info always".TxID(EDTx.UserControlSurveyor_showSystemInfoOnScreenWhenInTransparentModeToolStripMenuItem));
+            displayfilter.AddStandardOption(CtrlList.showscansum.ToString(), "Show scan summary always".TxID(EDTx.UserControlSurveyor_showScanSummaryOnScreenWhenInTransparentModeToolStripMenuItem));
             displayfilter.AddStandardOption(CtrlList.showstarclass.ToString(), "Show star class in system info".TxID(EDTx.UserControlSurveyor_showstarclassToolStripMenuItem));
             displayfilter.AddStandardOption(CtrlList.showdividers.ToString(), "Show dividers".TxID(EDTx.UserControlSurveyor_showDividersToolStripMenuItem));
 

--- a/EDDiscovery/UserControls/Translations/translation-deutsch-uc.tlp
+++ b/EDDiscovery/UserControls/Translations/translation-deutsch-uc.tlp
@@ -421,6 +421,7 @@ SECTION UserControlSurveyor
 .dontHideInFSSModeToolStripMenuItem: "Don't hide in FSS Mode" => "Im FSS-Modus nicht verbergen"
 .hideAlreadyMappedBodiesToolStripMenuItem: "Hide already mapped bodies" => "Verbirg bereits kartographierte Körper"
 .showSystemInfoOnScreenWhenInTransparentModeToolStripMenuItem: "Show system info always" => "Systeminformation immer anzeigen"
+.showScanSummaryOnScreenWhenInTransparentModeToolStripMenuItem: "Show scan summary always" => "Scanzusammenfassung immer anzeigen"
 .showstarclassToolStripMenuItem: "Show star class in system info" => "Zeige Sternenklasse in Systeminformation"
 .showDividersToolStripMenuItem: "Show dividers" => "Zeige Unterteiler"
 .extButtonPlanets.ToolTip: "Planet Filter" => "Planetenfilter"

--- a/EDDiscovery/UserControls/Translations/translation-example-uc.tlp
+++ b/EDDiscovery/UserControls/Translations/translation-example-uc.tlp
@@ -457,6 +457,7 @@ SECTION UserControlSurveyor
 .dontHideInFSSModeToolStripMenuItem: "Don't hide in FSS Mode" @
 .hideAlreadyMappedBodiesToolStripMenuItem: "Hide already mapped bodies" @
 .showSystemInfoOnScreenWhenInTransparentModeToolStripMenuItem: "Show system info always" @
+.showScanSummaryOnScreenWhenInTransparentModeToolStripMenuItem: "Show scan summary always" @
 .showstarclassToolStripMenuItem: "Show star class in system info" @
 .showDividersToolStripMenuItem: "Show dividers" @
 


### PR DESCRIPTION
I got many Surveyor popouts that are set to show very rare things, they weren't completely invisible and that annoyed me.

![Screenshot 2023-04-03 230726](https://user-images.githubusercontent.com/59618179/229628308-09b98a8d-9b1f-45b1-80fa-ed56ed4a7915.png)
![Screenshot 2023-04-03 230704](https://user-images.githubusercontent.com/59618179/229628310-bda82998-8fcc-4408-b5f1-136795834e2b.png)
![Screenshot 2023-04-03 230645](https://user-images.githubusercontent.com/59618179/229628311-8f904540-f062-4c05-883d-ac7cbd567ccd.png)
