### PR TITLE
Add option to change chart base

### DIFF
--- a/EDDiscovery/Translations/EDDiscoveryTranslations.cs
+++ b/EDDiscovery/Translations/EDDiscoveryTranslations.cs
@@ -931,6 +931,8 @@ namespace EDDiscovery
         UserControlMiningOverlay_extCheckBoxZeroRefined_ToolTip, // ToolTip 'Display items with zero refined items'
         UserControlMiningOverlay_buttonExtExcel_ToolTip, // ToolTip 'Export'
         UserControlMiningOverlay_extComboBoxChartOptions_ToolTip, // ToolTip 'Select chart options'
+        UserControlMiningOverlay_extCheckBoxChartBase_ToolTip, // ToolTip 'Default shows distribution of asteroids that actually contain the material'
+        UserControlMiningOverlay_extCheckBoxChartBase_Text, // Text 'Base chart on all asteroids'
         UserControlMiningOverlay_Limcargo, // discrete
         UserControlMiningOverlay_Proscoll, // discrete
         UserControlMiningOverlay_ref, // discrete

--- a/EDDiscovery/UserControls/Overlays/UserControlMiningOverlay.Designer.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlMiningOverlay.Designer.cs
@@ -46,6 +46,7 @@ namespace EDDiscovery.UserControls
             this.components = new System.ComponentModel.Container();
             this.pictureBox = new ExtendedControls.ExtPictureBox();
             this.extPanelRollUp = new ExtendedControls.ExtPanelRollUp();
+            this.extCheckBoxChartBase = new System.Windows.Forms.CheckBox();
             this.extCheckBoxZeroRefined = new ExtendedControls.ExtCheckBox();
             this.buttonExtExcel = new ExtendedControls.ExtButton();
             this.extComboBoxChartOptions = new ExtendedControls.ExtComboBox();
@@ -67,6 +68,7 @@ namespace EDDiscovery.UserControls
             this.extPanelRollUp.AutoHeight = false;
             this.extPanelRollUp.AutoHeightWidthDisable = false;
             this.extPanelRollUp.AutoWidth = false;
+            this.extPanelRollUp.Controls.Add(this.extCheckBoxChartBase);
             this.extPanelRollUp.Controls.Add(this.extCheckBoxZeroRefined);
             this.extPanelRollUp.Controls.Add(this.buttonExtExcel);
             this.extPanelRollUp.Controls.Add(this.extComboBoxChartOptions);
@@ -83,6 +85,17 @@ namespace EDDiscovery.UserControls
             this.extPanelRollUp.Size = new System.Drawing.Size(894, 34);
             this.extPanelRollUp.TabIndex = 2;
             this.extPanelRollUp.UnrollHoverDelay = 1000;
+            // 
+            // extCheckBoxChartBase
+            // 
+            this.extCheckBoxChartBase.AutoSize = true;
+            this.extCheckBoxChartBase.Location = new System.Drawing.Point(295, 7);
+            this.extCheckBoxChartBase.Name = "extCheckBoxChartBase";
+            this.extCheckBoxChartBase.Size = new System.Drawing.Size(150, 17);
+            this.extCheckBoxChartBase.TabIndex = 62;
+            this.extCheckBoxChartBase.Text = "Base chart on all asteroids";
+            this.toolTip.SetToolTip(this.extCheckBoxChartBase, "Default shows distribution of asteroids that actually contain the material");
+            this.extCheckBoxChartBase.UseVisualStyleBackColor = true;
             // 
             // extCheckBoxZeroRefined
             // 
@@ -169,5 +182,6 @@ namespace EDDiscovery.UserControls
         private ExtendedControls.ExtButton buttonExtExcel;
         private ExtendedControls.ExtCheckBox extCheckBoxZeroRefined;
         private System.Windows.Forms.ToolTip toolTip;
+        private System.Windows.Forms.CheckBox extCheckBoxChartBase;
     }
 }

--- a/EDDiscovery/UserControls/Overlays/UserControlMiningOverlay.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlMiningOverlay.cs
@@ -27,6 +27,7 @@ namespace EDDiscovery.UserControls
         private string dbChart = "ChartSel";
         private string dbZeroRefined = "ZeroRefined";
         private string dbRolledUp = "RolledUp";
+        private string dbChartBase = "ChartBase";
 
         #region Init
 
@@ -41,7 +42,7 @@ namespace EDDiscovery.UserControls
 
             UpdateComboBox(null);
 
-            var enumlisttt = new Enum[] { EDTx.UserControlMiningOverlay_extCheckBoxZeroRefined_ToolTip, EDTx.UserControlMiningOverlay_buttonExtExcel_ToolTip, EDTx.UserControlMiningOverlay_extComboBoxChartOptions_ToolTip };
+            var enumlisttt = new Enum[] { EDTx.UserControlMiningOverlay_extCheckBoxZeroRefined_ToolTip, EDTx.UserControlMiningOverlay_buttonExtExcel_ToolTip, EDTx.UserControlMiningOverlay_extComboBoxChartOptions_ToolTip, EDTx.UserControlMiningOverlay_extCheckBoxChartBase_ToolTip, EDTx.UserControlMiningOverlay_extCheckBoxChartBase_Text };
             BaseUtils.Translator.Instance.TranslateTooltip(toolTip, enumlisttt, this);
             extPanelRollUp.SetToolTip(toolTip);
 
@@ -49,6 +50,8 @@ namespace EDDiscovery.UserControls
             extCheckBoxZeroRefined.Checked = GetSetting(dbZeroRefined, false);
             extCheckBoxZeroRefined.CheckedChanged += new System.EventHandler(this.extCheckBoxZeroRefined_CheckedChanged);
             extPanelRollUp.PinState = GetSetting(dbRolledUp, true);
+            extCheckBoxChartBase.Checked = GetSetting(dbChartBase, false);
+            extCheckBoxChartBase.CheckedChanged += new System.EventHandler(this.extCheckBoxChartBase_CheckedChanged);
 
             timetimer = new Timer();
             timetimer.Interval = 1000;
@@ -477,23 +480,43 @@ namespace EDDiscovery.UserControls
                             int mi = 0;
                             foreach (var m in matdata)
                             {
-                                Series series = new Series();
-                                series.Name = m.friendlyname;
-                                series.ChartArea = "ChartArea1";
-                                series.ChartType = SeriesChartType.Line;
-                                series.Color = LineC[mi];
-                                series.Legend = "Legend1";
+                                
+                                    Series series = new Series();
+                                    series.Name = m.friendlyname;
+                                    series.ChartArea = "ChartArea1";
+                                    series.ChartType = SeriesChartType.Line;
+                                    series.Color = LineC[mi];
+                                    series.Legend = "Legend1";
 
-                                int i = 0;
-                                for (i = 0; i < CFDbMax; i++)        // 0 - fixed
-                                {
-                                    int numberabove = m.prospectedamounts.Count(x => x >= i);
-                                    series.Points.Add(new DataPoint(i, (double)numberabove / m.prospectednoasteroids * 100.0));
-                                    series.Points[i].AxisLabel = i.ToString();
+                                    int i = 0;
+                                    if (!extCheckBoxChartBase.Checked)
+                                    {
+                                        for (i = 0; i < CFDbMax; i++)        // 0 - fixed
+                                        {
+                                            int numberabove = m.prospectedamounts.Count(x => x >= i);
+                                            series.Points.Add(new DataPoint(i, ((double)numberabove) / m.prospectednoasteroids * 100.0));
+                                            series.Points[i].AxisLabel = i.ToString();
+                                        }
+                                    }
+                                    else
+                                    {
+                                        for (i = 0; i < CFDbMax; i++)        // 0 - fixed
+                                        {
+                                            int numberabove = m.prospectedamounts.Count(x => x >= i);
+                                            if (i < (int)m.prospectedamounts.Min())
+                                            {
+                                                series.Points.Add(new DataPoint(i + 1, 100.0)); // +1 makes it go straight up instead of moving to the previous i
+                                            }
+                                        else
+                                            {
+                                                series.Points.Add(new DataPoint(i, ((double)numberabove) / prospected * 100.0));
+                                            }
+                                                series.Points[i].AxisLabel = i.ToString();
+                                    }
                                 }
-
-                                chart.Series.Add(series);
-                                mi++;
+                                    chart.Series.Add(series);
+                                    mi++;
+                                
                             }
 
                             chart.EndInit();
@@ -614,6 +637,12 @@ namespace EDDiscovery.UserControls
         private void extCheckBoxZeroRefined_CheckedChanged(object sender, EventArgs e)
         {
             PutSetting(dbZeroRefined, extCheckBoxZeroRefined.Checked);
+            Display();
+        }
+
+        private void extCheckBoxChartBase_CheckedChanged(object sender, EventArgs e)
+        {
+            PutSetting(dbChartBase, extCheckBoxChartBase.Checked);
             Display();
         }
 


### PR DESCRIPTION
Currently the chart uses the number of asteroids that contain the charted material, second chart uses all prospected asteroids as base to show the real chance of finding the material in that asteroid field