### PR TITLE
Removed trailing space after pop-out window title.

### DIFF
--- a/EDDiscovery/TabsPanelsAndPopOuts/PopOuts.cs
+++ b/EDDiscovery/TabsPanelsAndPopOuts/PopOuts.cs
@@ -109,7 +109,7 @@ namespace EDDiscovery
 
                 // we make up the title and refname based on how many previously opened of this type
                 int numopened = usercontrolsforms.CountOf(selected) + 1;
-                string windowtitle = poi.WindowTitle + " " + ((numopened > 1) ? numopened.ToString() : "");
+                string windowtitle = poi.WindowTitle + ((numopened > 1) ? $" {numopened}" : "");
                 string refname = poi.WindowRefName + numopened.ToString();
 
                 System.Diagnostics.Trace.WriteLine($"Popout Init UCF `{windowtitle}` rn {refname}");


### PR DESCRIPTION
When you create a pop-out window, the first one has a trailing space after its name.  This for some reason breaks tools like Desktop+ from re-detecting the window properly.  This pull-request simply removes the extra trailing space.