### PR TITLE
Improve gravity display on Organics

### DIFF
--- a/EDDiscovery/UserControls/Overlays/UserControlOrganics.cs
+++ b/EDDiscovery/UserControls/Overlays/UserControlOrganics.cs
@@ -229,7 +229,7 @@ namespace EDDiscovery.UserControls
                     if (node.ScanData != null)
                     {
                         l += string.Format(", {0}, Radius {1}, {2}, {3}, Bio Signals: {4}{5}".T(EDTx.UserControlOrganics_sysinfo), node.ScanData.PlanetTypeText, node.ScanData.RadiusText,
-                                                (node.ScanData.nSurfaceGravityG?.ToString("N1") ?? "?") + "G", node.ScanData.Atmosphere, node.CountBioSignals.ToString(), ((node.Genuses != null && node.CountBioSignals > 0) ? ": " + String.Join(", ", node.Genuses?.Select(x => x.Genus_Localised).ToArray()) : ""));
+                                                (Math.Round(node.ScanData.nSurfaceGravityG.Value, 2, MidpointRounding.AwayFromZero).ToString() ?? "?") + " g", node.ScanData.Atmosphere, node.CountBioSignals.ToString(), ((node.Genuses != null && node.CountBioSignals > 0) ? ": " + String.Join(", ", node.Genuses?.Select(x => x.Genus_Localised).ToArray()) : ""));
                     }
 
                     string s = node.Organics != null ? JournalScanOrganic.OrganicList(node.Organics) : "No organic scanned";


### PR DESCRIPTION
Make gravity use the same precision as other panels, make it impossible to show 0 gravity on bodies with more than zero gravity by rounding away from zero, change G (gravitational constant) to g (gravitational acceleration)