### PR TITLE
Replace backslashes with forward-slashes in portable zip

### DIFF
--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -1299,6 +1299,8 @@
                         name = Path.GetFileName(filename);
                   }
 
+                  name = name.Replace('\\', '/');
+
                   Console.WriteLine(".. zip up '" + filename  +"' m:'" + metaname + "' -> '" + name + "'");
 
                   using (Stream fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read))


### PR DESCRIPTION
From the zip spec <https://pkwaredownloads.blob.core.windows.net/pkware-general/Documentation/APPNOTE-6.3.9.TXT>:

> 4.4.17.1 The name of the file, with optional relative path. 
>        The path stored MUST NOT contain a drive or device letter, or a leading slash.  All slashes MUST be forward slashes '/' as opposed to backwards slashes '\\' for compatibility with Amiga and UNIX file systems etc

This should fix future portable zips for #3754