### PR TITLE
Add panel that tracks powerplay merits earned, sums for reporting

### DIFF
--- a/EDDiscovery/EDDiscovery.csproj
+++ b/EDDiscovery/EDDiscovery.csproj
@@ -302,6 +302,12 @@
     <Compile Include="UserControls\CurrentState\UserControlStatistics.Designer.cs">
       <DependentUpon>UserControlStatistics.cs</DependentUpon>
     </Compile>
+    <Compile Include="UserControls\CurrentState\UserControlPPMerits.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\CurrentState\UserControlPPMerits.Designer.cs">
+      <DependentUpon>UserControlPPMerits.cs</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\EngineeringSynthesis\EngineerStatus.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/EDDiscovery/TabsPanelsAndPopOuts/Panels.cs
+++ b/EDDiscovery/TabsPanelsAndPopOuts/Panels.cs
@@ -92,6 +92,7 @@ namespace EDDiscovery
             DockingPanel = 64,
             TravelPanel = 66,
             // ****** ADD More here DO NOT RENUMBER *****
+            PowerplayMerits = 67,
         };
 
         public const int DLLUserPanelsStart = 20000;
@@ -116,6 +117,7 @@ namespace EDDiscovery
             { new PanelInfo( PanelIDs.Ledger, typeof(UserControlLedger), "Ledger", "Ledger", "Ledger of cash related entries") },
             { new PanelInfo( PanelIDs.Missions, typeof(UserControlMissions), "Missions", "Missions", "Mission list") },
             { new PanelInfo( PanelIDs.Factions, typeof(UserControlFactions), "Factions", "Factions", "Faction rewards and trading tally") },
+            { new PanelInfo( PanelIDs.PowerplayMerits, typeof(UserControlPPMerits), "Powerplay Merits", "PowerplayMerits", "Track powerplay merits by cycle, session, system") },
             { new PanelInfo( PanelIDs.Modules, typeof(UserControlModules), "Ships/Loadout", "Modules", "Ships and their loadouts plus stored modules") },
             { new PanelInfo( PanelIDs.Statistics, typeof(UserControlStats), "Statistics", "Stats", "Statistics Information") },
             { new PanelInfo( PanelIDs.SuitsWeapons, typeof(UserControlSuitsWeapons), "Suits & Weapons", "SuitsWeapons", "Suits, Loadouts, Weapons") },

--- a/EDDiscovery/UserControls/CurrentState/UserControlPPMerits.Designer.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlPPMerits.Designer.cs
@@ -1,0 +1,129 @@
+using System.Windows.Forms;
+using EDDiscovery.UserControls;
+using ExtendedControls;
+
+namespace EDDiscovery.UserControls
+{
+    partial class UserControlPPMerits
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.checkCycle = new CheckBox();
+            this.checkSession = new CheckBox();
+            this.checkSystem = new CheckBox();
+            this.grid = new DataGridView();
+            this.contextMenuGrid = new ContextMenuStrip(this.components);
+            this.findInJournalToolStripMenuItem = new ToolStripMenuItem();
+            this.copyMeritsToolStripMenuItem = new ToolStripMenuItem();
+            this.copyMeritsReportToolStripMenuItem = new ToolStripMenuItem();
+            this.copySystemNameToolStripMenuItem = new ToolStripMenuItem();
+
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).BeginInit();
+            this.contextMenuGrid.SuspendLayout();
+            this.SuspendLayout();
+
+            // checkCycle
+            this.checkCycle.Text = "Cycle";
+            this.checkCycle.AutoSize = true;
+            this.checkCycle.Checked = true;
+            this.checkCycle.Location = new System.Drawing.Point(3, 6);
+
+            // checkSession
+            this.checkSession.Text = "Session";
+            this.checkSession.AutoSize = true;
+            this.checkSession.Checked = true;
+            this.checkSession.Location = new System.Drawing.Point(70, 6);
+
+            // checkSystem
+            this.checkSystem.Text = "System";
+            this.checkSystem.AutoSize = true;
+            this.checkSystem.Checked = true;
+            this.checkSystem.Location = new System.Drawing.Point(150, 6);
+
+            // grid
+            this.grid.AllowUserToAddRows = false;
+            this.grid.AllowUserToDeleteRows = false;
+            this.grid.AllowUserToOrderColumns = true;
+            this.grid.ReadOnly = true;
+            this.grid.RowHeadersVisible = false;
+            this.grid.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            this.grid.Location = new System.Drawing.Point(3, 32);
+            this.grid.Size = new System.Drawing.Size(794, 465);
+            this.grid.ContextMenuStrip = this.contextMenuGrid;
+            this.grid.MouseDown += new MouseEventHandler(this.grid_MouseDown);
+
+            var col0 = new DataGridViewTextBoxColumn(); col0.HeaderText = "Time"; col0.Width = 160;
+            var col1 = new DataGridViewTextBoxColumn(); col1.HeaderText = "Power"; col1.Width = 140;
+            var col2 = new DataGridViewTextBoxColumn(); col2.HeaderText = "Merits"; col2.Width = 80;
+            var col3 = new DataGridViewTextBoxColumn(); col3.HeaderText = "Total"; col3.Width = 100;
+            var col4 = new DataGridViewTextBoxColumn(); col4.HeaderText = "System"; col4.Width = 160;
+
+            this.grid.Columns.AddRange(new DataGridViewColumn[] { col0, col1, col2, col3, col4 });
+
+            // contextMenuGrid
+            this.contextMenuGrid.Items.AddRange(new ToolStripItem[] { 
+                this.findInJournalToolStripMenuItem,
+                this.copyMeritsToolStripMenuItem,
+                this.copyMeritsReportToolStripMenuItem,
+                this.copySystemNameToolStripMenuItem
+            });
+            this.contextMenuGrid.Name = "contextMenuGrid";
+            this.contextMenuGrid.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuGrid_Opening);
+
+            // findInJournalToolStripMenuItem
+            this.findInJournalToolStripMenuItem.Name = "findInJournalToolStripMenuItem";
+            this.findInJournalToolStripMenuItem.Text = "Find in Journal";
+            this.findInJournalToolStripMenuItem.Click += new System.EventHandler(this.findInJournalToolStripMenuItem_Click);
+
+            // copyMeritsToolStripMenuItem
+            this.copyMeritsToolStripMenuItem.Name = "copyMeritsToolStripMenuItem";
+            this.copyMeritsToolStripMenuItem.Text = "Copy Merits";
+            this.copyMeritsToolStripMenuItem.Click += new System.EventHandler(this.copyMeritsToolStripMenuItem_Click);
+
+            // copyMeritsReportToolStripMenuItem
+            this.copyMeritsReportToolStripMenuItem.Name = "copyMeritsReportToolStripMenuItem";
+            this.copyMeritsReportToolStripMenuItem.Text = "Copy Merits Report";
+            this.copyMeritsReportToolStripMenuItem.Click += new System.EventHandler(this.copyMeritsReportToolStripMenuItem_Click);
+
+            // copySystemNameToolStripMenuItem
+            this.copySystemNameToolStripMenuItem.Name = "copySystemNameToolStripMenuItem";
+            this.copySystemNameToolStripMenuItem.Text = "Copy System Name";
+            this.copySystemNameToolStripMenuItem.Click += new System.EventHandler(this.copySystemNameToolStripMenuItem_Click);
+
+            // UserControlPPMerits
+            this.Controls.Add(this.checkCycle);
+            this.Controls.Add(this.checkSession);
+            this.Controls.Add(this.checkSystem);
+            this.Controls.Add(this.grid);
+            this.Name = "UserControlPPMerits";
+            this.Size = new System.Drawing.Size(800, 500);
+
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).EndInit();
+            this.contextMenuGrid.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private CheckBox checkCycle;
+        private CheckBox checkSession;
+        private CheckBox checkSystem;
+        private DataGridView grid;
+        private ContextMenuStrip contextMenuGrid;
+        private ToolStripMenuItem findInJournalToolStripMenuItem;
+        private ToolStripMenuItem copyMeritsToolStripMenuItem;
+        private ToolStripMenuItem copyMeritsReportToolStripMenuItem;
+        private ToolStripMenuItem copySystemNameToolStripMenuItem;
+    }
+}

--- a/EDDiscovery/UserControls/CurrentState/UserControlPPMerits.cs
+++ b/EDDiscovery/UserControls/CurrentState/UserControlPPMerits.cs
@@ -1,0 +1,591 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using EliteDangerousCore;
+using EliteDangerousCore.JournalEvents;
+using ExtendedControls;
+
+namespace EDDiscovery.UserControls
+{
+    public partial class UserControlPPMerits : UserControlCommonBase
+    {
+        #region Inner Classes
+
+        private class MeritRow
+        {
+            public DateTime TimeUTC;
+            public string Power;
+            public int MeritsGained;
+            public int TotalMerits;
+            public string SystemName;
+            public string CycleKey;
+            public int SessionId;
+            public HistoryEntry HE;
+        }
+
+        private class GroupingLevel
+        {
+            public Func<MeritRow, string> KeySelector;
+            public Func<string, string> LabelFormatter;
+        }
+
+        private class GroupRow
+        {
+            public string Path;
+            public bool Expanded;
+            public bool HasChildren;
+            public int Level;
+        }
+
+        #endregion
+
+        #region Fields
+
+        private readonly List<MeritRow> meritRows = new List<MeritRow>();
+        private readonly Dictionary<string, bool> expandStates = new Dictionary<string, bool>();
+        private int nextSessionId = 0;
+        private MeritRow rightClickMeritRow = null;
+        private GroupRow rightClickGroupRow = null;
+        private System.Windows.Forms.Timer redrawDebounceTimer;
+        private bool pendingRedraw;
+        private DateTime? lastAddedMeritTime;
+
+        #endregion
+
+        #region Initialization
+
+        public UserControlPPMerits()
+        {
+            InitializeComponent();
+            DBBaseName = "PPMerits";
+
+            redrawDebounceTimer = new System.Windows.Forms.Timer();
+            redrawDebounceTimer.Interval = 150; // ms
+            redrawDebounceTimer.Tick += (s, e) =>
+            {
+                redrawDebounceTimer.Stop();
+                if (pendingRedraw)
+                {
+                    pendingRedraw = false;
+                    Redraw();
+                }
+            };
+        }
+
+        protected override void Init()
+        {
+            checkCycle.CheckedChanged += (s, e) => { PutSetting("GroupCycle", checkCycle.Checked ? 1 : 0); Redraw(); };
+            checkSession.CheckedChanged += (s, e) => { PutSetting("GroupSession", checkSession.Checked ? 1 : 0); Redraw(); };
+            checkSystem.CheckedChanged += (s, e) => { PutSetting("GroupSystem", checkSystem.Checked ? 1 : 0); Redraw(); };
+
+            grid.CellClick += Grid_CellClick;
+            grid.MouseDown += grid_MouseDown;
+
+            DiscoveryForm.OnNewEntry += DiscoveryForm_OnNewEntry;
+            DiscoveryForm.OnHistoryChange += DiscoveryForm_OnHistoryChange_Handler;
+        }
+
+        protected override void LoadLayout()
+        {
+            checkCycle.Checked = GetSetting("GroupCycle", 1) != 0;
+            checkSession.Checked = GetSetting("GroupSession", 1) != 0;
+            checkSystem.Checked = GetSetting("GroupSystem", 1) != 0;
+        }
+
+        protected override void InitialDisplay()
+        {
+            BuildFromHistory();
+        }
+
+        protected override void Closing()
+        {
+            DiscoveryForm.OnNewEntry -= DiscoveryForm_OnNewEntry;
+            DiscoveryForm.OnHistoryChange -= DiscoveryForm_OnHistoryChange_Handler;
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private void DiscoveryForm_OnHistoryChange_Handler()
+        {
+            BuildFromHistory();
+        }
+
+        private void DiscoveryForm_OnNewEntry(HistoryEntry he)
+        {
+            if (he == null || he.journalEntry == null)
+                return;
+
+            if (he.journalEntry is JournalPowerplayMerits ppm)
+            {
+                AddMerit(he, ppm);
+                // Debounce redraws to avoid flicker on burst updates
+                pendingRedraw = true;
+                redrawDebounceTimer.Stop();
+                redrawDebounceTimer.Start();
+            }
+            else if (he.journalEntry is JournalLoadGame)
+            {
+                nextSessionId++;
+            }
+            else if (he.journalEntry is JournalShutdown)
+            {
+                // Session ends; next LoadGame will increment session ID
+            }
+        }
+
+        private void Grid_CellClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0 || e.RowIndex >= grid.Rows.Count)
+                return;
+
+            if (grid.Rows[e.RowIndex].Tag is GroupRow groupRow && groupRow.HasChildren)
+            {
+                expandStates[groupRow.Path] = !groupRow.Expanded;
+                Redraw();
+            }
+        }
+
+        private void grid_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Right)
+                return;
+
+            var hitTest = grid.HitTest(e.X, e.Y);
+            if (hitTest.RowIndex >= 0 && hitTest.RowIndex < grid.Rows.Count)
+            {
+                rightClickMeritRow = grid.Rows[hitTest.RowIndex].Tag as MeritRow;
+                rightClickGroupRow = grid.Rows[hitTest.RowIndex].Tag as GroupRow;
+            }
+            else
+            {
+                rightClickMeritRow = null;
+                rightClickGroupRow = null;
+            }
+        }
+
+        #endregion
+
+        #region Data Building
+
+        private void BuildFromHistory()
+        {
+            meritRows.Clear();
+            nextSessionId = 0;
+
+            foreach (var he in DiscoveryForm.History.EntryOrder())
+            {
+                if (he.journalEntry is JournalLoadGame)
+                {
+                    nextSessionId++;
+                }
+
+                if (he.journalEntry is JournalPowerplayMerits ppm)
+                {
+                    AddMerit(he, ppm);
+                }
+            }
+
+            Redraw();
+        }
+
+        private void AddMerit(HistoryEntry he, JournalPowerplayMerits ppm)
+        {
+            var row = new MeritRow
+            {
+                TimeUTC = he.EventTimeUTC,
+                Power = ppm.Power,
+                MeritsGained = (int)ppm.MeritsGained,
+                TotalMerits = (int)ppm.TotalMerits,
+                SystemName = he.System != null ? he.System.Name : string.Empty,
+                CycleKey = ComputeCycleKey(he.EventTimeUTC),
+                SessionId = nextSessionId,
+                HE = he
+            };
+            meritRows.Add(row);
+            lastAddedMeritTime = row.TimeUTC;
+        }
+
+        #endregion
+
+        #region Rendering
+
+        private void Redraw()
+        {
+            grid.SuspendLayout();
+            grid.Rows.Clear();
+
+            var levels = new List<GroupingLevel>();
+
+            if (checkCycle.Checked)
+            {
+                levels.Add(new GroupingLevel
+                {
+                    KeySelector = r => r.CycleKey,
+                    LabelFormatter = key => "Cycle " + key,
+                });
+            }
+
+            if (checkSession.Checked)
+            {
+                levels.Add(new GroupingLevel
+                {
+                    KeySelector = r => $"Session {r.SessionId}",
+                    LabelFormatter = key => key,
+                });
+            }
+
+            if (checkSystem.Checked)
+            {
+                levels.Add(new GroupingLevel
+                {
+                    KeySelector = r => string.IsNullOrEmpty(r.SystemName) ? "Unknown System" : r.SystemName,
+                    LabelFormatter = key => key,
+                });
+            }
+
+            if (levels.Count > 0)
+            {
+                // Calculate current and previous cycle keys for default expansion
+                HashSet<string> defaultExpandCycles = new HashSet<string>();
+                if (checkCycle.Checked && meritRows.Count > 0)
+                {
+                    var distinctCycles = meritRows.Select(r => new { r.CycleKey, r.TimeUTC })
+                        .GroupBy(x => x.CycleKey)
+                        .Select(g => new { CycleKey = g.Key, Latest = g.Max(x => x.TimeUTC) })
+                        .OrderByDescending(x => x.Latest)
+                        .Take(2)
+                        .Select(x => x.CycleKey)
+                        .ToList();
+                    
+                    foreach (var cycle in distinctCycles)
+                        defaultExpandCycles.Add(cycle);
+                }
+                
+                RenderGrouped(meritRows, levels, 0, 0, "", defaultExpandCycles);
+            }
+            else
+            {
+                foreach (var r in meritRows.OrderByDescending(x => x.TimeUTC))
+                {
+                    int idx = grid.Rows.Add();
+                    var row = grid.Rows[idx];
+                    row.Cells[0].Value = r.TimeUTC.ToString();
+                    row.Cells[1].Value = r.Power;
+                    row.Cells[2].Value = r.MeritsGained;
+                    row.Cells[3].Value = r.TotalMerits;
+                    row.Cells[4].Value = r.SystemName;
+                    row.Tag = r;
+
+                    // Highlight newly added row
+                    if (lastAddedMeritTime.HasValue && r.TimeUTC == lastAddedMeritTime.Value)
+                    {
+                        row.DefaultCellStyle.BackColor = System.Drawing.Color.FromArgb(255, 245, 225);
+                    }
+                }
+            }
+
+            grid.ResumeLayout();
+
+            // Auto-scroll to latest merit within expanded current cycle
+            if (lastAddedMeritTime.HasValue && grid.Rows.Count > 0)
+            {
+                for (int i = 0; i < grid.Rows.Count; i++)
+                {
+                    var tag = grid.Rows[i].Tag as MeritRow;
+                    if (tag != null && tag.TimeUTC == lastAddedMeritTime.Value)
+                    {
+                        grid.FirstDisplayedScrollingRowIndex = Math.Max(0, i - 3);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private void RenderGrouped(IEnumerable<MeritRow> rows, IReadOnlyList<GroupingLevel> levels, int levelIndex, int indent, string path, HashSet<string> defaultExpandCycles)
+        {
+            var level = levels[levelIndex];
+
+            var grouped = rows
+                .GroupBy(level.KeySelector)
+                .Select(g => new
+                {
+                    Key = g.Key,
+                    Rows = g,
+                    Latest = g.Max(r => r.TimeUTC)
+                })
+                .OrderByDescending(g => g.Latest)
+                .ToList();
+
+            foreach (var group in grouped)
+            {
+                string nodePath = string.IsNullOrEmpty(path) ? group.Key : path + "|" + group.Key;
+
+                bool defaultExpanded = GetDefaultExpandedState(levelIndex, group, defaultExpandCycles);
+                bool expanded = expandStates.TryGetValue(nodePath, out bool stored) ? stored : defaultExpanded;
+                bool hasChildren = levelIndex < levels.Count - 1 || group.Rows.Any();
+
+                int meritsTotal = group.Rows.Sum(r => r.MeritsGained);
+                int indexHeader = grid.Rows.Add();
+                var header = grid.Rows[indexHeader];
+
+                string indicator = hasChildren ? (expanded ? "[-] " : "[+] ") : "    ";
+                header.Cells[0].Value = new string(' ', indent * 2) + indicator + level.LabelFormatter(group.Key);
+                header.Cells[1].Value = "Group Total";
+                header.Cells[2].Value = meritsTotal;
+                header.Cells[3].Value = "";
+                header.Cells[4].Value = "";
+                header.Tag = new GroupRow { Path = nodePath, Expanded = expanded, HasChildren = hasChildren, Level = levelIndex };
+
+                if (expanded)
+                {
+                    if (levelIndex < levels.Count - 1)
+                    {
+                        RenderGrouped(group.Rows, levels, levelIndex + 1, indent + 1, nodePath, defaultExpandCycles);
+                    }
+                    else
+                    {
+                        foreach (var r in group.Rows.OrderByDescending(x => x.TimeUTC))
+                        {
+                            int idx = grid.Rows.Add();
+                            var row = grid.Rows[idx];
+                            row.Cells[0].Value = new string(' ', (indent + 1) * 2) + r.TimeUTC.ToString();
+                            row.Cells[1].Value = r.Power;
+                            row.Cells[2].Value = r.MeritsGained;
+                            row.Cells[3].Value = r.TotalMerits;
+                            row.Cells[4].Value = r.SystemName;
+                            row.Tag = r;
+
+                            // Highlight newly added row
+                            if (lastAddedMeritTime.HasValue && r.TimeUTC == lastAddedMeritTime.Value)
+                            {
+                                row.DefaultCellStyle.BackColor = System.Drawing.Color.FromArgb(255, 245, 225);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Context Menu
+
+        private void contextMenuGrid_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            findInJournalToolStripMenuItem.Visible = rightClickMeritRow != null;
+            copyMeritsToolStripMenuItem.Visible = IsSystemLevelGroupRow(rightClickGroupRow);
+            copyMeritsReportToolStripMenuItem.Visible = rightClickGroupRow != null;
+            copySystemNameToolStripMenuItem.Visible = rightClickMeritRow != null || IsSystemLevelGroupRow(rightClickGroupRow);
+        }
+
+        private void findInJournalToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (rightClickMeritRow?.HE == null)
+                return;
+
+            // Switch to Journal tab and navigate to entry
+            DiscoveryForm.SelectTabPage(PanelInformation.PanelIDs.Journal, true, false);
+            Application.DoEvents();
+
+            var result = RequestPanelOperation?.Invoke(this, new UserControlJournalGrid.GotoJournalEntryRequest 
+            {
+                JournalID = rightClickMeritRow.HE.Journalid 
+            });
+
+            if (result != PanelActionState.Success)
+            {
+                MessageBoxTheme.Show(FindForm(), "Could not navigate to journal entry", "Warning");
+            }
+        }
+
+        private void copyMeritsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (rightClickGroupRow == null)
+                return;
+
+            var merits = GetMeritsForGroupPath(rightClickGroupRow.Path);
+            Clipboard.SetText(merits.Sum(m => m.MeritsGained).ToString());
+        }
+
+        private void copyMeritsReportToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (rightClickGroupRow == null)
+                return;
+
+            var merits = GetMeritsForGroupPath(rightClickGroupRow.Path);
+            Clipboard.SetText(GenerateMeritsReport(merits));
+        }
+
+        private void copySystemNameToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            string systemName = null;
+
+            if (rightClickMeritRow != null)
+            {
+                systemName = rightClickMeritRow.SystemName;
+            }
+            else if (IsSystemLevelGroupRow(rightClickGroupRow))
+            {
+                // Extract system name from the group path
+                var pathParts = rightClickGroupRow.Path.Split('|');
+                int systemLevelIndex = (checkCycle.Checked ? 1 : 0) + (checkSession.Checked ? 1 : 0);
+                if (pathParts.Length > systemLevelIndex)
+                {
+                    systemName = pathParts[systemLevelIndex];
+                }
+            }
+
+            if (!string.IsNullOrEmpty(systemName) && systemName != "Unknown System")
+            {
+                Clipboard.SetText(systemName);
+            }
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private string ComputeCycleKey(DateTime timeUtc)
+        {
+            var monday = timeUtc.Date.AddDays(-(int)timeUtc.Date.DayOfWeek + (int)DayOfWeek.Monday);
+            return $"{monday:yyyy-MM-dd}";
+        }
+
+        private bool GetDefaultExpandedState(int levelIndex, dynamic group, HashSet<string> defaultExpandCycles)
+        {
+            if (levelIndex == 0 && checkCycle.Checked)
+            {
+                // At cycle level: only expand current and previous cycles
+                return defaultExpandCycles.Contains(((IEnumerable<MeritRow>)group.Rows).First().CycleKey);
+            }
+            
+            // At session/system level: expand sessions by default
+            return levelIndex == 1;
+        }
+
+        private bool IsSystemLevelGroupRow(GroupRow groupRow)
+        {
+            if (groupRow == null || !checkSystem.Checked)
+                return false;
+
+            int systemLevel = (checkCycle.Checked ? 1 : 0) + (checkSession.Checked ? 1 : 0);
+            return groupRow.Level == systemLevel;
+        }
+
+        private List<MeritRow> GetMeritsForGroupPath(string groupPath)
+        {
+            var pathParts = groupPath.Split('|');
+            var filtered = meritRows.AsEnumerable();
+
+            int levelIndex = 0;
+            if (checkCycle.Checked && levelIndex < pathParts.Length)
+            {
+                string cycleKey = pathParts[levelIndex];
+                filtered = filtered.Where(m => m.CycleKey == cycleKey);
+                levelIndex++;
+            }
+
+            if (checkSession.Checked && levelIndex < pathParts.Length)
+            {
+                string sessionKey = pathParts[levelIndex];
+                int sessionId = int.Parse(sessionKey.Replace("Session ", ""));
+                filtered = filtered.Where(m => m.SessionId == sessionId);
+                levelIndex++;
+            }
+
+            if (checkSystem.Checked && levelIndex < pathParts.Length)
+            {
+                string systemName = pathParts[levelIndex];
+                filtered = filtered.Where(m => (string.IsNullOrEmpty(m.SystemName) ? "Unknown System" : m.SystemName) == systemName);
+            }
+
+            return filtered.ToList();
+        }
+
+        private string GenerateMeritsReport(List<MeritRow> merits)
+        {
+            var sb = new StringBuilder();
+            string cycleHeader = merits.Any() 
+                ? $"Cycle {merits.OrderBy(m => m.TimeUTC).First().CycleKey}" 
+                : "Unknown Cycle";
+
+            sb.AppendLine($"__**Powerplay report for {cycleHeader}**__");
+            sb.AppendLine();
+
+            // Group by system
+            var systemGroups = merits
+                .GroupBy(m => string.IsNullOrEmpty(m.SystemName) ? "Unknown System" : m.SystemName)
+                .OrderBy(g => g.Key);
+
+            foreach (var sysGroup in systemGroups)
+            {
+                sb.AppendLine($"> **{sysGroup.Key}**");
+                sb.AppendLine($">    Merits Earned : {sysGroup.Sum(m => m.MeritsGained):N0}");
+
+                var (itemsDelivered, itemsCollected) = GetPowerplayItems(sysGroup);
+
+                if (itemsDelivered.Any())
+                {
+                    sb.AppendLine(">    Items Delivered :");
+                    foreach (var item in itemsDelivered.OrderBy(kvp => kvp.Key))
+                    {
+                        sb.AppendLine($">        {item.Key} | {item.Value:N0}");
+                    }
+                }
+
+                if (itemsCollected.Any())
+                {
+                    sb.AppendLine(">    Items Collected :");
+                    foreach (var item in itemsCollected.OrderBy(kvp => kvp.Key))
+                    {
+                        sb.AppendLine($">        {item.Key} | {item.Value:N0}");
+                    }
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private (Dictionary<string, int> delivered, Dictionary<string, int> collected) GetPowerplayItems(IGrouping<string, MeritRow> systemGroup)
+        {
+            var delivered = new Dictionary<string, int>();
+            var collected = new Dictionary<string, int>();
+
+            foreach (var merit in systemGroup.Where(m => m.HE != null))
+            {
+                var nearbyEntries = DiscoveryForm.History.EntryOrder()
+                    .Where(he => Math.Abs((he.EventTimeUTC - merit.HE.EventTimeUTC).TotalMinutes) < 5)
+                    .Where(he => he.System?.Name == merit.SystemName || string.IsNullOrEmpty(merit.SystemName));
+
+                foreach (var he in nearbyEntries)
+                {
+                    switch (he.journalEntry)
+                    {
+                        case JournalPowerplayCollect collect:
+                            AddOrUpdate(collected, collect.Type_Localised, collect.Count);
+                            break;
+                        case JournalPowerplayDeliver deliver:
+                            AddOrUpdate(delivered, deliver.Type_Localised, deliver.Count);
+                            break;
+                    }
+                }
+            }
+
+            return (delivered, collected);
+        }
+
+        private void AddOrUpdate(Dictionary<string, int> dict, string key, int value)
+        {
+            if (dict.ContainsKey(key))
+                dict[key] += value;
+            else
+                dict[key] = value;
+        }
+
+        #endregion
+    }
+}

--- a/EDDiscovery/UserControls/CurrentState/UserControlPPMerits.resx
+++ b/EDDiscovery/UserControls/CurrentState/UserControlPPMerits.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/EDDiscovery/UserControls/History/UserControlJournalGrid.cs
+++ b/EDDiscovery/UserControls/History/UserControlJournalGrid.cs
@@ -416,9 +416,18 @@ namespace EDDiscovery.UserControls
                 sender.CallPerformPanelOperation(this, he);         // direct send back to sender so we don't wake up lots of panels
                 return PanelActionState.Success;
             }
+            else if (actionobj is GotoJournalEntryRequest gjr)
+            {
+                return GotoPosByJID(gjr.JournalID) ? PanelActionState.Success : PanelActionState.Failed;
+            }
 
 
             return PanelActionState.NotHandled;
+        }
+
+        public class GotoJournalEntryRequest
+        {
+            public long JournalID;
         }
 
         public bool GotoPosByJID(long jid)


### PR DESCRIPTION
This pull request introduces a new "Powerplay Merits" panel to the application, allowing users to track powerplay merits by cycle, session, and system. It adds the necessary UI components, integrates the new panel into the application's panel system, and includes supporting resource and designer files. Additionally, it enhances the journal grid panel with a new operation to jump directly to a specific journal entry.

**Powerplay Merits Panel Integration:**

* Added new `UserControlPPMerits` user control and its designer/resource files to the project, implementing a data grid view and checkboxes for filtering by cycle, session, and system, as well as a context menu for journal lookup and copying data. (`UserControlPPMerits.cs`, `UserControlPPMerits.Designer.cs`, `UserControlPPMerits.resx`) [[1]](diffhunk://#diff-324a8cb5b644968b573c1d2ec6d7f41c88f035a28c51b51010f31e0e8429e9e4R1-R129) [[2]](diffhunk://#diff-031d3f5583cc332e5ef2d917461928299f357af0bd33330bac565523a2e831baR1-R120) [[3]](diffhunk://#diff-de97077b5405cc5fd19d5844745f9d04b7b0835f25c58f37e255567e498abdd6R305-R310)
* Registered the new panel in the `PanelIDs` enum as `PowerplayMerits` and added a corresponding `PanelInfo` entry, making it available in the application's UI. (`Panels.cs`) [[1]](diffhunk://#diff-bfcc6799aa370ae6a5d17f34366db9a86b25196824a4ca3a5994f4ff27c1f6c7R95) [[2]](diffhunk://#diff-bfcc6799aa370ae6a5d17f34366db9a86b25196824a4ca3a5994f4ff27c1f6c7R120)

**Journal Grid Enhancements:**

* Added a new `GotoJournalEntryRequest` class and logic to allow the journal grid panel to jump directly to a specific journal entry by its ID, improving navigation and integration with other panels. (`UserControlJournalGrid.cs`)