### PR TITLE
Remove VS-added random namespace

### DIFF
--- a/EDDiscovery/OptionsAndConfig/EDDOptions.cs
+++ b/EDDiscovery/OptionsAndConfig/EDDOptions.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Windows.Documents;
 
 namespace EDDiscovery
 {


### PR DESCRIPTION
Remove the random `using System.Windows.Documents` added to EDDOptions.cs by Visual Studio