### PR TITLE
Fix missed update for second audio channel

### DIFF
--- a/EDDiscovery/EDD/EDDiscoveryForm.cs
+++ b/EDDiscovery/EDD/EDDiscoveryForm.cs
@@ -390,7 +390,8 @@ namespace EDDiscovery
                 speechsynth = new AudioExtensions.SpeechSynthesizer(new AudioExtensions.DummySpeechEngine());
             }
 #else
-            audiodriverwave = new AudioExtensions.AudioDriverDummy();
+            audiodriverwave1 = new AudioExtensions.AudioDriverDummy();
+            audiodriverwave2 = new AudioExtensions.AudioDriverDummy();
             audiodriverspeech = new AudioExtensions.AudioDriverDummy();
             speechsynth = new AudioExtensions.SpeechSynthesizer(new AudioExtensions.DummySpeechEngine());
 #endif


### PR DESCRIPTION
The `#if NO_SYSTEM_SPEECH` section was missed in 74fe30d